### PR TITLE
Remove create namespaces option from installation

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -33,10 +33,9 @@ type InstallationSpec struct {
 	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
-	Type             string `json:"type"`
-	NamespacePrefix  string `json:"namespacePrefix"`
-	CreateNamespaces bool   `json:"createNamespaces"`
-	SelfSignedCerts  bool   `json:"selfSignedCerts"`
+	Type            string `json:"type"`
+	NamespacePrefix string `json:"namespacePrefix"`
+	SelfSignedCerts bool   `json:"selfSignedCerts"`
 }
 
 // InstallationStatus defines the observed state of Installation

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
@@ -15,7 +16,7 @@ import (
 	keycloakv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 	pkgerr "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -109,11 +110,6 @@ func (r *Reconciler) handleReconcile(ctx context.Context, inst *v1alpha1.Install
 }
 
 func (r *Reconciler) reconcileNamespace(ctx context.Context, inst *v1alpha1.Installation) (v1alpha1.StatusPhase, error) {
-	if !inst.Spec.CreateNamespaces {
-		r.logger.Debugf("skipping creating namespace: %s", r.Config.GetNamespace())
-		return v1alpha1.PhaseCreatingSubscription, nil
-	}
-
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: r.Config.GetNamespace(),


### PR DESCRIPTION
### Description
Remove the `CreateNamespaces` boolean from the Installation CR, since any existing namespaces will be used by default anyway 