### PR TITLE
fix issue with stale serverclient

### DIFF
--- a/pkg/controller/installation/products/Reconciler_moq.go
+++ b/pkg/controller/installation/products/Reconciler_moq.go
@@ -5,6 +5,7 @@ package products
 
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
 )
 
@@ -46,7 +47,7 @@ type InterfaceMock struct {
 }
 
 // Reconcile calls ReconcileFunc.
-func (mock *InterfaceMock) Reconcile(inst *v1alpha1.Installation) (v1alpha1.StatusPhase, error) {
+func (mock *InterfaceMock) Reconcile(inst *v1alpha1.Installation, serverClient client.Client) (v1alpha1.StatusPhase, error) {
 	if mock.ReconcileFunc == nil {
 		panic("InterfaceMock.ReconcileFunc: method is nil but Interface.Reconcile was just called")
 	}

--- a/pkg/controller/installation/products/amqstreams/reconciler.go
+++ b/pkg/controller/installation/products/amqstreams/reconciler.go
@@ -24,7 +24,7 @@ var (
 	defaultInstallationNamespace = "amq-streams"
 )
 
-func NewReconciler(client pkgclient.Client, rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
 	config, err := configManager.ReadAMQStreams()
 	if err != nil {
 		return nil, err
@@ -32,7 +32,7 @@ func NewReconciler(client pkgclient.Client, rc *rest.Config, coreClient *kuberne
 	if config.GetNamespace() == "" {
 		config.SetNamespace(instance.Spec.NamespacePrefix + defaultInstallationNamespace)
 	}
-	return &Reconciler{client: client,
+	return &Reconciler{
 		coreClient:    coreClient,
 		restConfig:    rc,
 		ConfigManager: configManager,
@@ -42,7 +42,6 @@ func NewReconciler(client pkgclient.Client, rc *rest.Config, coreClient *kuberne
 }
 
 type Reconciler struct {
-	client        pkgclient.Client
 	restConfig    *rest.Config
 	coreClient    *kubernetes.Clientset
 	Config        *config.AMQStreams
@@ -50,13 +49,13 @@ type Reconciler struct {
 	mpm           marketplace.MarketplaceInterface
 }
 
-func (r *Reconciler) Reconcile(inst *v1alpha1.Installation) (v1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(inst *v1alpha1.Installation, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	phase := inst.Status.ProductStatus[r.Config.GetProductName()]
 	switch v1alpha1.StatusPhase(phase) {
 	case v1alpha1.PhaseNone:
-		return r.handleNoPhase()
+		return r.handleNoPhase(serverClient)
 	case v1alpha1.PhaseAwaitingNS:
-		return r.handleAwaitingNSPhase()
+		return r.handleAwaitingNSPhase(serverClient)
 	case v1alpha1.PhaseCreatingSubscription:
 		return r.handleCreatingSubscription()
 	case v1alpha1.PhaseCreatingComponents:
@@ -75,27 +74,27 @@ func (r *Reconciler) Reconcile(inst *v1alpha1.Installation) (v1alpha1.StatusPhas
 	}
 }
 
-func (r *Reconciler) handleNoPhase() (v1alpha1.StatusPhase, error) {
+func (r *Reconciler) handleNoPhase(serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: r.Config.GetNamespace(),
 			Name:      r.Config.GetNamespace(),
 		},
 	}
-	err := r.client.Create(context.TODO(), ns)
+	err := serverClient.Create(context.TODO(), ns)
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return v1alpha1.PhaseFailed, err
 	}
 	return v1alpha1.PhaseAwaitingNS, nil
 }
 
-func (r *Reconciler) handleAwaitingNSPhase() (v1alpha1.StatusPhase, error) {
+func (r *Reconciler) handleAwaitingNSPhase(serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	ns := &v1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: r.Config.GetNamespace(),
 		},
 	}
-	err := r.client.Get(context.TODO(), pkgclient.ObjectKey{Name: r.Config.GetNamespace()}, ns)
+	err := serverClient.Get(context.TODO(), pkgclient.ObjectKey{Name: r.Config.GetNamespace()}, ns)
 	if err != nil {
 		return v1alpha1.PhaseFailed, err
 	}

--- a/pkg/controller/installation/products/amqstreams/reconciler.go
+++ b/pkg/controller/installation/products/amqstreams/reconciler.go
@@ -9,14 +9,12 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
 	errors2 "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -24,7 +22,7 @@ var (
 	defaultInstallationNamespace = "amq-streams"
 )
 
-func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
 	config, err := configManager.ReadAMQStreams()
 	if err != nil {
 		return nil, err
@@ -34,7 +32,6 @@ func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configMana
 	}
 	return &Reconciler{
 		coreClient:    coreClient,
-		restConfig:    rc,
 		ConfigManager: configManager,
 		Config:        config,
 		mpm:           mpm,
@@ -42,7 +39,6 @@ func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configMana
 }
 
 type Reconciler struct {
-	restConfig    *rest.Config
 	coreClient    *kubernetes.Clientset
 	Config        *config.AMQStreams
 	ConfigManager config.ConfigReadWriter
@@ -59,7 +55,7 @@ func (r *Reconciler) Reconcile(inst *v1alpha1.Installation, serverClient pkgclie
 	case v1alpha1.PhaseCreatingSubscription:
 		return r.handleCreatingSubscription()
 	case v1alpha1.PhaseCreatingComponents:
-		return r.handleCreatingComponents()
+		return r.handleCreatingComponents(serverClient)
 	case v1alpha1.PhaseAwaitingOperator:
 		return r.handleAwaitingOperator()
 	case v1alpha1.PhaseInProgress:
@@ -143,13 +139,7 @@ func (r *Reconciler) handleAwaitingOperator() (v1alpha1.StatusPhase, error) {
 	return v1alpha1.PhaseCreatingComponents, nil
 }
 
-func (r *Reconciler) handleCreatingComponents() (v1alpha1.StatusPhase, error) {
-	serverClient, err := pkgclient.New(r.restConfig, pkgclient.Options{})
-	if err != nil {
-		logrus.Infof("Error creating server client")
-		return v1alpha1.PhaseFailed, err
-	}
-
+func (r *Reconciler) handleCreatingComponents(serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	kafka := &kafkav1.Kafka{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: fmt.Sprintf(
@@ -196,8 +186,10 @@ func (r *Reconciler) handleCreatingComponents() (v1alpha1.StatusPhase, error) {
 			},
 		},
 	}
-	err = serverClient.Create(context.TODO(), kafka)
-
+	err := serverClient.Create(context.TODO(), kafka)
+	if err != nil {
+		return v1alpha1.PhaseCreatingComponents, errors2.Wrap(err, "error creating kafka CR")
+	}
 	return v1alpha1.PhaseInProgress, nil
 }
 

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -5,20 +5,18 @@ import (
 	"errors"
 	"fmt"
 
+	chev1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
+	keycloakv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
-	chev1 "github.com/eclipse/che-operator/pkg/apis/org/v1"
-	keycloakv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 	pkgerr "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -29,7 +27,7 @@ const (
 	defaultSubscriptionName      = "codeready-workspaces"
 )
 
-func NewReconciler(rc *rest.Config, coreClient kubernetes.Interface, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, logger *logrus.Entry, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(coreClient kubernetes.Interface, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, logger *logrus.Entry, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
 	config, err := configManager.ReadCodeReady()
 	if err != nil {
 		return nil, pkgerr.Wrap(err, "could not retrieve che config")
@@ -47,7 +45,6 @@ func NewReconciler(rc *rest.Config, coreClient kubernetes.Interface, configManag
 
 	return &Reconciler{
 		coreClient:     coreClient,
-		restConfig:     rc,
 		ConfigManager:  configManager,
 		Config:         config,
 		KeycloakConfig: kcConfig,
@@ -57,7 +54,6 @@ func NewReconciler(rc *rest.Config, coreClient kubernetes.Interface, configManag
 }
 
 type Reconciler struct {
-	restConfig     *rest.Config
 	coreClient     kubernetes.Interface
 	Config         *config.CodeReady
 	KeycloakConfig *config.RHSSO

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -16,7 +16,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/kubernetes"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -27,7 +26,7 @@ const (
 	defaultSubscriptionName      = "codeready-workspaces"
 )
 
-func NewReconciler(coreClient kubernetes.Interface, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, logger *logrus.Entry, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, instance *v1alpha1.Installation, logger *logrus.Entry, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
 	config, err := configManager.ReadCodeReady()
 	if err != nil {
 		return nil, pkgerr.Wrap(err, "could not retrieve che config")
@@ -44,7 +43,6 @@ func NewReconciler(coreClient kubernetes.Interface, configManager config.ConfigR
 	}
 
 	return &Reconciler{
-		coreClient:     coreClient,
 		ConfigManager:  configManager,
 		Config:         config,
 		KeycloakConfig: kcConfig,
@@ -54,7 +52,6 @@ func NewReconciler(coreClient kubernetes.Interface, configManager config.ConfigR
 }
 
 type Reconciler struct {
-	coreClient     kubernetes.Interface
 	Config         *config.CodeReady
 	KeycloakConfig *config.RHSSO
 	ConfigManager  config.ConfigReadWriter

--- a/pkg/controller/installation/products/codeready/reconciler_test.go
+++ b/pkg/controller/installation/products/codeready/reconciler_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 
@@ -389,7 +388,6 @@ func TestCodeready(t *testing.T) {
 		t.Run(scenario.Name, func(*testing.T) {
 			logger := logrus.WithFields(logrus.Fields{"product": string("codeready")})
 			testReconciler, err := NewReconciler(
-				&rest.Config{},
 				scenario.FakeK8sClient,
 				scenario.FakeConfig,
 				scenario.Object,

--- a/pkg/controller/installation/products/codeready/reconciler_test.go
+++ b/pkg/controller/installation/products/codeready/reconciler_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	operatorsv1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
-	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -386,12 +385,9 @@ func TestCodeready(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(*testing.T) {
-			logger := logrus.WithFields(logrus.Fields{"product": string("codeready")})
 			testReconciler, err := NewReconciler(
-				scenario.FakeK8sClient,
 				scenario.FakeConfig,
 				scenario.Object,
-				logger,
 				scenario.FakeMPM,
 			)
 			if err != nil && err.Error() != scenario.ExpectedCreateError {

--- a/pkg/controller/installation/products/codeready/reconciler_test.go
+++ b/pkg/controller/installation/products/codeready/reconciler_test.go
@@ -389,7 +389,6 @@ func TestCodeready(t *testing.T) {
 		t.Run(scenario.Name, func(*testing.T) {
 			logger := logrus.WithFields(logrus.Fields{"product": string("codeready")})
 			testReconciler, err := NewReconciler(
-				scenario.FakeControllerClient,
 				&rest.Config{},
 				scenario.FakeK8sClient,
 				scenario.FakeConfig,
@@ -410,7 +409,7 @@ func TestCodeready(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(scenario.Object)
+			status, err := testReconciler.Reconcile(scenario.Object, scenario.FakeControllerClient)
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error: %v, expected: %v", err, scenario.ExpectedError)
 			}

--- a/pkg/controller/installation/products/reconciler.go
+++ b/pkg/controller/installation/products/reconciler.go
@@ -8,7 +8,6 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/codeready"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/rhsso"
-	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +19,6 @@ type Interface interface {
 }
 
 func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation) (reconciler Interface, err error) {
-	logger := logrus.WithFields(logrus.Fields{"product": string(product)})
 	mpm := marketplace.NewManager(client, rc)
 	switch product {
 	case v1alpha1.ProductAMQStreams:
@@ -28,7 +26,7 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 	case v1alpha1.ProductRHSSO:
 		reconciler, err = rhsso.NewReconciler(coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductCodeReadyWorkspaces:
-		reconciler, err = codeready.NewReconciler(configManager, instance, logger, mpm)
+		reconciler, err = codeready.NewReconciler(configManager, instance, mpm)
 	default:
 		err = errors.New("unknown products: " + string(product))
 		reconciler = &NoOp{}

--- a/pkg/controller/installation/products/reconciler.go
+++ b/pkg/controller/installation/products/reconciler.go
@@ -24,11 +24,11 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 	mpm := marketplace.NewManager(client, rc)
 	switch product {
 	case v1alpha1.ProductAMQStreams:
-		reconciler, err = amqstreams.NewReconciler(rc, coreClient, configManager, instance, mpm)
+		reconciler, err = amqstreams.NewReconciler(coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductRHSSO:
-		reconciler, err = rhsso.NewReconciler(rc, coreClient, configManager, instance, mpm)
+		reconciler, err = rhsso.NewReconciler(coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductCodeReadyWorkspaces:
-		reconciler, err = codeready.NewReconciler(rc, coreClient, configManager, instance, logger, mpm)
+		reconciler, err = codeready.NewReconciler(coreClient, configManager, instance, logger, mpm)
 	default:
 		err = errors.New("unknown products: " + string(product))
 		reconciler = &NoOp{}

--- a/pkg/controller/installation/products/reconciler.go
+++ b/pkg/controller/installation/products/reconciler.go
@@ -16,7 +16,7 @@ import (
 
 //go:generate moq -out Reconciler_moq.go . Interface
 type Interface interface {
-	Reconcile(inst *v1alpha1.Installation) (newPhase v1alpha1.StatusPhase, err error)
+	Reconcile(inst *v1alpha1.Installation, serverClient client.Client) (newPhase v1alpha1.StatusPhase, err error)
 }
 
 func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation) (reconciler Interface, err error) {
@@ -24,11 +24,11 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 	mpm := marketplace.NewManager(client, rc)
 	switch product {
 	case v1alpha1.ProductAMQStreams:
-		reconciler, err = amqstreams.NewReconciler(client, rc, coreClient, configManager, instance, mpm)
+		reconciler, err = amqstreams.NewReconciler(rc, coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductRHSSO:
-		reconciler, err = rhsso.NewReconciler(client, rc, coreClient, configManager, instance, mpm)
+		reconciler, err = rhsso.NewReconciler(rc, coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductCodeReadyWorkspaces:
-		reconciler, err = codeready.NewReconciler(client, rc, coreClient, configManager, instance, logger, mpm)
+		reconciler, err = codeready.NewReconciler(rc, coreClient, configManager, instance, logger, mpm)
 	default:
 		err = errors.New("unknown products: " + string(product))
 		reconciler = &NoOp{}
@@ -39,6 +39,6 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 type NoOp struct {
 }
 
-func (n *NoOp) Reconcile(inst *v1alpha1.Installation) (v1alpha1.StatusPhase, error) {
+func (n *NoOp) Reconcile(inst *v1alpha1.Installation, serverClient client.Client) (v1alpha1.StatusPhase, error) {
 	return v1alpha1.PhaseNone, nil
 }

--- a/pkg/controller/installation/products/reconciler.go
+++ b/pkg/controller/installation/products/reconciler.go
@@ -28,7 +28,7 @@ func NewReconciler(product v1alpha1.ProductName, client client.Client, rc *rest.
 	case v1alpha1.ProductRHSSO:
 		reconciler, err = rhsso.NewReconciler(coreClient, configManager, instance, mpm)
 	case v1alpha1.ProductCodeReadyWorkspaces:
-		reconciler, err = codeready.NewReconciler(coreClient, configManager, instance, logger, mpm)
+		reconciler, err = codeready.NewReconciler(configManager, instance, logger, mpm)
 	default:
 		err = errors.New("unknown products: " + string(product))
 		reconciler = &NoOp{}

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -3,20 +3,18 @@ package rhsso
 import (
 	"context"
 	"errors"
+	"fmt"
 	aerogearv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/rest"
-
-	"fmt"
 	pkgerr "github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -26,7 +24,7 @@ var (
 	keycloakRealmName            = "openshift"
 )
 
-func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(coreClient *kubernetes.Clientset, configManager config.ConfigReadWriter, instance *v1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
 	config, err := configManager.ReadRHSSO()
 	if err != nil {
 		return nil, err
@@ -36,7 +34,6 @@ func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configMana
 	}
 	return &Reconciler{
 		coreClient:    coreClient,
-		restConfig:    rc,
 		ConfigManager: configManager,
 		Config:        config,
 		mpm:           mpm,
@@ -44,7 +41,6 @@ func NewReconciler(rc *rest.Config, coreClient *kubernetes.Clientset, configMana
 }
 
 type Reconciler struct {
-	restConfig    *rest.Config
 	coreClient    *kubernetes.Clientset
 	Config        *config.RHSSO
 	ConfigManager config.ConfigReadWriter


### PR DESCRIPTION
the `r.client` has issues with a stale cache, so I've removed it, and pass it in from the installation_controller, with a fresh client created on each reconcile.