### PR TITLE
Added back Installation CR example values

### DIFF
--- a/deploy/crds/examples/installation.cr.yaml
+++ b/deploy/crds/examples/installation.cr.yaml
@@ -5,6 +5,6 @@ metadata:
 spec:
   type: workshop
   namespacePrefix: integreatly-
-  routingSubdomain: apps.cluster-pbrookes-1b0d.pbrookes-1b0d.openshiftworkshop.com
-  masterUrl: https://console-openshift-console.apps.cluster-pbrookes-1b0d.pbrookes-1b0d.openshiftworkshop.com
+  routingSubdomain: example.com
+  masterUrl: http://master.example.com
   selfSignedCerts: true


### PR DESCRIPTION
Probably committed by mistake. Example values should be used instead of hard-coded ones in example-installation Installation CR.