### PR TITLE
add support for dedicated like setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ setup/moq:
 	dep ensure
 	cd vendor/github.com/matryer/moq/ && go install .
 
+.PHONY: setup/dedicated
+setup/dedicated:
+	cd ./scripts && ./dedicated-setup.sh
+
 .PHONY: setup/travis
 setup/travis:
 	@echo Installing Operator SDK

--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ The username is `admin`, and the password can be retrieved by running:
 oc get dc sso -n integreatly-rhsso -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="SSO_ADMIN_PASSWORD")].value}'
 ```
 
+## Setting up your cluster to be OSD like
+
+To setup your cluster to have dedicated admins run the ```dedicated-setup.sh``` script
+```
+cd scripts
+./dedicated-setup.sh
+
+```
+
+If you want to remove the opertor run
+
+```bash
+cd scripts
+./dedicated-cleanup.sh
+```
 
 ## Deploying to a Cluster with OLM
 

--- a/scripts/dedicated-cleanup.sh
+++ b/scripts/dedicated-cleanup.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+echo this script leaves the htpasswd provider in place and just removed the dedicated-admin-operator. Note it leaves the namespace in place due to issues removing it
+RELEASE=release-4.1
+BASE_HREF=https://raw.githubusercontent.com/openshift/dedicated-admin-operator/${RELEASE}
+
+oc delete -f ${BASE_HREF}/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+oc delete -f ${BASE_HREF}/manifests/00-dedicated-admins-project.ClusterRole.yaml
+oc delete -f ${BASE_HREF}/manifests/01-dedicated-admin-operator.ServiceAccount.yaml
+oc delete -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-admin.ClusterRoleBinding.yaml
+oc delete -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-cluster.ClusterRoleBinding.yaml
+oc delete -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-project.ClusterRoleBinding.yaml
+oc delete -f ${BASE_HREF}/manifests/02-dedicated-admins-cluster.ClusterRoleBinding.yaml
+oc delete -f ${BASE_HREF}/manifests/10-dedicated-admin-operator.Deployment.yaml
+oc delete -f ${BASE_HREF}/manifests/10-dedicated-admin-operator.Role.yaml
+oc delete -f ${BASE_HREF}/manifests/11-dedicated-admin-operator.RoleBinding.yaml

--- a/scripts/dedicated-setup.sh
+++ b/scripts/dedicated-setup.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+
+
+PASSWORD=$(openssl rand -base64 12)
+RELEASE=release-4.1
+BASE_HREF=https://raw.githubusercontent.com/openshift/dedicated-admin-operator/${RELEASE}
+
+echo Targeting $(oc whoami --show-server)
+sleep 1
+
+
+echo Setting up htpasswd IDP
+
+if [[ ! -f "htpasswd" ]]; then
+  echo creating htpasswd file
+  touch htpasswd
+fi
+
+htpasswd -b htpasswd customer-admin ${PASSWORD}
+htpasswd -b htpasswd cluster-admin ${PASSWORD}
+
+echo user added customer-admin ${PASSWORD}
+oc delete secret htpasswd-secret -n openshift-config
+oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
+oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "Test Identity Provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
+
+echo creating dedicated-admins group and adding users
+oc adm groups new dedicated-admins
+oc adm groups add-users dedicated-admins customer-admin
+
+echo Installing dedicated admin operator from release ${RELEASE}
+
+oc apply -f ${BASE_HREF}/manifests/00-dedicated-admins-cluster.ClusterRole.yaml
+oc apply -f ${BASE_HREF}/manifests/00-dedicated-admins-project.ClusterRole.yaml
+oc apply -f ${BASE_HREF}/manifests/00-openshift-dedicated-admin.Namespace.yaml
+oc apply -f ${BASE_HREF}/manifests/01-dedicated-admin-operator.ServiceAccount.yaml
+oc apply -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-admin.ClusterRoleBinding.yaml
+oc apply -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-cluster.ClusterRoleBinding.yaml
+oc apply -f ${BASE_HREF}/manifests/02-dedicated-admin-operator-project.ClusterRoleBinding.yaml
+oc apply -f ${BASE_HREF}/manifests/02-dedicated-admins-cluster.ClusterRoleBinding.yaml
+oc apply -f ${BASE_HREF}/manifests/10-dedicated-admin-operator.Deployment.yaml
+oc apply -f ${BASE_HREF}/manifests/10-dedicated-admin-operator.Role.yaml
+oc apply -f ${BASE_HREF}/manifests/11-dedicated-admin-operator.RoleBinding.yaml


### PR DESCRIPTION
**Verification**

Against an OS 4 cluster create a namespace ```mynamespace``` with an admin user
then run
```
cd scripts
./dedicated-setup.sh
```
once the dedicated operator is up and running
logout of your cluster and login back in using the ```test Identity Provider```
login with the customer-admin user
The password for this user is outputted from the script
You should only be able to see the mynamespace project
