### PR TITLE
add precommit git hook to check for unformatted files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,11 @@
+#!/usr/bin/sh
+
+staged_go_files=$(git diff --cached --name-only | grep ".go$" | grep -v "vendor/")
+[ -z "$staged_go_files" ] && exit 0
+
+# Ensure code is formatted correctly
+unformatted_files=$(gofmt -l $staged_go_files)
+[ -z "$unformatted_files" ] && exit 0
+
+echo >&2 "[code/check failed] run 'make code/fix' to fix formatting issues"
+exit 1

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,10 @@ setup/service_account:
 	@oc replace --force -f deploy/clusterrole.yaml -n $(NAMESPACE)
 	@oc replace --force -f deploy/cluster_role_binding.yaml -n $(NAMESPACE)
 
+.PHONY: setup/git/hooks
+setup/git/hooks:
+	git config core.hooksPath .githooks
+
 .PHONY: code/run
 code/run:
 	@operator-sdk up local --namespace=$(NAMESPACE)


### PR DESCRIPTION
## What
Adds a precommit git hook to check if any staged .go files, ignoring `vendor/` files, are not formatted correctly. This should prevent build failures caused by unformatted files. 

https://golang.org/misc/git/pre-commit