### PR TITLE
Add OWNERS files

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,23 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- mikenairn
+- maleck13
+- philbrookes
+- aidenkeating
+- dimitraz
+- matskiv
+- JameelB
+- trepel
+- austincunningham
+
+reviewers:
+- mikenairn
+- maleck13
+- philbrookes
+- aidenkeating
+- dimitraz
+- matskiv
+- JameelB
+- trepel
+- austincunningham


### PR DESCRIPTION
Adds a top level OWNERS file that will be used by the OpenShift system. More info can be found here https://github.com/kubernetes/community/blob/master/contributors/guide/owners.md