### PR TITLE
Fix dedicated/setup compatibility with RHPDS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea
+scripts/htpasswd
 # Temporary Build Files
 tmp/_output/bin/integreatly-operator
 cmd/manager/debug

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -4,6 +4,8 @@ PASSWORD=$(openssl rand -base64 12)
 
 echo Setting up htpasswd IDP
 
+oc get secret htpasswd-secret -n openshift-config -o 'go-template={{index .data "htpasswd"}}' | base64 --decode > htpasswd
+
 if [[ ! -f "htpasswd" ]]; then
   echo creating htpasswd file
   touch htpasswd
@@ -15,4 +17,4 @@ htpasswd -b htpasswd cluster-admin ${PASSWORD}
 echo user added customer-admin ${PASSWORD}
 oc delete secret htpasswd-secret -n openshift-config
 oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
-oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "Test Identity Provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
+oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "htpasswd_provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'


### PR DESCRIPTION
OpenShift 4 RHPDS clusters already have htpasswd provider.
This changes will ensure that `make setup/dedicated` will be compatible with RHPDS clusters.

Verification steps:
Get OS4 RHPDS cluster
Login to your cluster via oc and run `make setup/dedicated`
In the web console you should be able to login as opentlc-mgr and customer-admin