### PR TITLE
Enable coveralls in prow job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,24 +10,11 @@ env:
     - OPERATOR_NAME=integreatly-operator
 
 stages:
-- test
-- compile
 - name: push
   if: fork = false AND branch = master
 
 jobs:
   include:
-  - stage: test
-    script:
-    - cd $HOME/gopath/src/github.com/integr8ly/$OPERATOR_NAME && make setup/travis code/check
-    - go get github.com/mattn/goveralls
-    - go install github.com/mattn/goveralls
-    - go test -v -covermode=count -coverprofile=coverage.out ./...
-    - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN
-
-  - stage: compile
-    script:
-    - make setup/travis image/build TAG=$(git rev-parse --short ${TRAVIS_COMMIT})
   - stage: push
     script:
     - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io

--- a/Makefile
+++ b/Makefile
@@ -88,8 +88,7 @@ image/build/test:
 
 .PHONY: test/unit
 test/unit:
-	@echo Running tests:
-	go test -v -race -coverprofile=coverage.out ./pkg/...
+	@./scripts/ci/unit_test.sh
 
 .PHONY: test/e2e
 test/e2e:

--- a/scripts/ci/OWNERS
+++ b/scripts/ci/OWNERS
@@ -1,0 +1,7 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- mikenairn
+- pmccarthy
+- maleck13
+- philbrookes

--- a/scripts/ci/unit_test.sh
+++ b/scripts/ci/unit_test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -e
+
+COVER_PROFILE=coverage.out
+
+report_coverage() {
+
+    if [[ -z "${COVERALLS_TOKEN_PATH}" ]]; then
+        COVERALLS_TOKEN_PATH="/usr/local/integr8ly-ci-secrets/INTLY_OPERATOR_COVERALLS_TOKEN"
+    fi
+
+    if [[ -z "${COVERALLS_TOKEN}" ]]; then
+        COVERALLS_TOKEN=$(cat ${COVERALLS_TOKEN_PATH})
+    fi
+
+    go get github.com/mattn/goveralls
+    go install -v github.com/mattn/goveralls
+    # need to override prow's BUILD_NUMBER to "" so it won't be reported as jobID to avoid 5xx error :D
+    BUILD_NUMBER="" PULL_REQUEST_NUMBER=${PULL_NUMBER} goveralls \
+           -coverprofile=$COVER_PROFILE \
+           -service=prow \
+           -repotoken $COVERALLS_TOKEN
+}
+
+echo Running tests:
+go test -v -covermode=count -coverprofile=$COVER_PROFILE ./pkg/...
+
+if [[ -z "${PROW_JOB_ID}" ]]; then
+    echo "Not a CI job, skipping coverage reporting!"
+else
+    report_coverage
+fi


### PR DESCRIPTION
* Add script to run unit tests which also supports coverage reporting to coveralls for CI.
* Removes PR testing with travis since it's no longer required, images should still be pushed to quay on master updates though.

/cc @pmccarthy 