### PR TITLE
fix finalizer bug

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -113,6 +113,15 @@ type Installation struct {
 	Status InstallationStatus `json:"status,omitempty"`
 }
 
+func (i *Installation) GetProductStatusObject(product ProductName) *InstallationProductStatus {
+	for _, stage := range i.Status.Stages {
+		if product, ok := stage.Products[product]; ok {
+			return product
+		}
+	}
+	return nil
+}
+
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // InstallationList contains a list of Installation

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -139,7 +139,12 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 
 		// Clean up the products which have finalizers associated to them
 		merr := &multiErr{}
-		for _, product := range resources.FinalizeProducts {
+		for _, productFinalizer := range instance.Finalizers {
+			if !strings.Contains(productFinalizer, "integreatly") {
+				continue
+			}
+			productName := strings.Split(productFinalizer, ".")[1]
+			product := instance.GetProductStatusObject(v1alpha1.ProductName(productName))
 			reconciler, err := products.NewReconciler(product.Name, r.restConfig, configManager, instance)
 			if err != nil {
 				merr.Add(pkgerr.Wrapf(err, "Failed to build reconciler for product %s", product.Name))

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -36,7 +36,6 @@ var (
 	idpAlias                            = "openshift-v4"
 	githubIdpAlias                      = "github"
 	githubOauthAppCredentialsSecretName = "github-oauth-secret"
-	finalizer                           = "finalizer.rhsso.integreatly.org"
 )
 
 var CustomerAdminUser = &aerogearv1.KeycloakUser{
@@ -99,8 +98,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 	logrus.Info("Reconciling rhsso")
 	ns := r.Config.GetNamespace()
 
-	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, finalizer, func() error {
-		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, finalizer, r.getOAuthClientName())
+	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, func() error {
+		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, r.getOAuthClientName())
 	})
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err

--- a/pkg/controller/installation/products/rhsso/reconciler_test.go
+++ b/pkg/controller/installation/products/rhsso/reconciler_test.go
@@ -129,7 +129,7 @@ func TestReconciler_config(t *testing.T) {
 
 			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
 			if err != nil && !tc.ExpectError {
-				t.Fatalf("expected error but got one: %v", err)
+				t.Fatalf("expected no errors, but got one: %v", err)
 			}
 
 			if err == nil && tc.ExpectError {
@@ -415,6 +415,31 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
+	installation := &v1alpha1.Installation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "installation",
+			Namespace:  defaultRhssoNamespace,
+			Finalizers: []string{"finalizer.rhsso.integreatly.org"},
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "installation",
+			APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		},
+		Status: v1alpha1.InstallationStatus{
+			Stages: map[v1alpha1.StageName]*v1alpha1.InstallationStageStatus{
+				"codeready-stage": {
+					Name: "codeready-stage",
+					Products: map[v1alpha1.ProductName]*v1alpha1.InstallationProductStatus{
+						v1alpha1.ProductCodeReadyWorkspaces: {
+							Name:   v1alpha1.ProductCodeReadyWorkspaces,
+							Status: v1alpha1.PhaseCreatingComponents,
+						},
+					},
+				},
+			},
+		},
+	}
+
 	cases := []struct {
 		Name            string
 		ExpectError     bool
@@ -430,7 +455,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:            "test successful reconcile",
 			ExpectedStatus:  v1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(aerogearv1.KeycloakRealmStatus{Phase: aerogearv1.PhaseReconcile}), kc, secret, ns, githubOauthSecret, oauthClientSecrets),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(aerogearv1.KeycloakRealmStatus{Phase: aerogearv1.PhaseReconcile}), kc, secret, ns, githubOauthSecret, oauthClientSecrets, installation),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -498,7 +523,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
 
 			if err != nil && !tc.ExpectError {
-				t.Fatalf("expected error but got one: %v", err)
+				t.Fatalf("expected no errors, but got one: %v", err)
 			}
 
 			if err == nil && tc.ExpectError {

--- a/pkg/controller/installation/products/rhssouser/reconciler.go
+++ b/pkg/controller/installation/products/rhssouser/reconciler.go
@@ -28,7 +28,6 @@ var (
 	keycloakRealmName       = "user-sso"
 	defaultSubscriptionName = "integreatly-rhsso"
 	idpAlias                = "openshift-v4"
-	finalizer               = "finalizer.user-sso.integreatly.org"
 )
 
 type Reconciler struct {
@@ -77,8 +76,8 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	ns := r.Config.GetNamespace()
 
-	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, finalizer, func() error {
-		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, finalizer, r.getOAuthClientName())
+	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, func() error {
+		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, r.getOAuthClientName())
 	})
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err

--- a/pkg/controller/installation/products/solutionexplorer/reconciler.go
+++ b/pkg/controller/installation/products/solutionexplorer/reconciler.go
@@ -34,7 +34,6 @@ const (
 	paramOpenShiftVersion   = "OPENSHIFT_VERSION"
 	paramSSORoute           = "SSO_ROUTE"
 	defaultRouteName        = "tutorial-web-app"
-	finalizer               = "finalizer.webapp.integreatly.org"
 	oauthClientName         = "integreatly-solution-explorer"
 )
 
@@ -92,8 +91,8 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	logrus.Info("Reconciling solution explorer")
 
-	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, finalizer, func() error {
-		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, finalizer, oauthClientName)
+	phase, err := r.ReconcileFinalizer(ctx, serverClient, inst, product, func() error {
+		return resources.RemoveOauthClient(ctx, inst, serverClient, r.oauthv1Client, oauthClientName)
 	})
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err

--- a/pkg/controller/installation/products/threescale/objects_test.go
+++ b/pkg/controller/installation/products/threescale/objects_test.go
@@ -3,6 +3,7 @@ package threescale
 import (
 	"bytes"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 
 	aerogearv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
@@ -172,6 +173,21 @@ var oauthClientSecrets = &corev1.Secret{
 	},
 }
 
+var installation = &v1alpha1.Installation{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:       "test-installation",
+		Namespace:  "integreatly-operator-namespace",
+		Finalizers: []string{"finalizer.3scale.integreatly.org"},
+	},
+	TypeMeta: metav1.TypeMeta{
+		APIVersion: v1alpha1.SchemeGroupVersion.String(),
+	},
+	Spec: v1alpha1.InstallationSpec{
+		MasterURL:        "https://console.apps.example.com",
+		RoutingSubdomain: "apps.example.com",
+	},
+}
+
 func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallationNamepsace string) []runtime.Object {
 	configManagerConfigMap.Namespace = integreatlyOperatorNamespace
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
@@ -180,6 +196,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 	threeScaleServiceDiscoveryConfigMap.Namespace = threeScaleInstallationNamepsace
 	systemEnvConfigMap.Namespace = threeScaleInstallationNamepsace
 	oauthClientSecrets.Namespace = integreatlyOperatorNamespace
+	installation.Namespace = integreatlyOperatorNamespace
 
 	return []runtime.Object{
 		s3BucketSecret,
@@ -192,5 +209,6 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		testDedicatedAdminsGroup,
 		OpenshiftDockerSecret,
 		oauthClientSecrets,
+		installation,
 	}
 }

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -35,7 +35,6 @@ const (
 	s3BucketSecretName           = "s3-bucket"
 	s3CredentialsSecretName      = "s3-credentials"
 	rhssoIntegrationName         = "rhsso"
-	finalizer                    = "finalizer.3scale.integreatly.org"
 )
 
 func NewReconciler(configManager config.ConfigReadWriter, i *v1alpha1.Installation, appsv1Client appsv1Client.AppsV1Interface, oauthv1Client oauthClient.OauthV1Interface, tsClient ThreeScaleInterface, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
@@ -83,8 +82,8 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 func (r *Reconciler) Reconcile(ctx context.Context, in *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	logrus.Infof("Reconciling %s", packageName)
 
-	phase, err := r.ReconcileFinalizer(ctx, serverClient, in, product, finalizer, func() error {
-		return resources.RemoveOauthClient(ctx, in, serverClient, r.oauthv1Client, finalizer, r.getOAuthClientName())
+	phase, err := r.ReconcileFinalizer(ctx, serverClient, in, product, func() error {
+		return resources.RemoveOauthClient(ctx, in, serverClient, r.oauthv1Client, r.getOAuthClientName())
 	})
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -96,7 +96,8 @@ func (r *Reconciler) ReconcileNamespace(ctx context.Context, namespace string, i
 
 type finalizerFunc func() error
 
-func (r *Reconciler) ReconcileFinalizer(ctx context.Context, client pkgclient.Client, inst *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, finalizer string, finalFunc finalizerFunc) (v1alpha1.StatusPhase, error) {
+func (r *Reconciler) ReconcileFinalizer(ctx context.Context, client pkgclient.Client, inst *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, finalFunc finalizerFunc) (v1alpha1.StatusPhase, error) {
+	finalizer := "finalizer." + string(product.Name) + ".integreatly.org"
 	// Add finalizer if not there
 	err := AddFinalizer(ctx, inst, client, product, finalizer)
 	if err != nil {
@@ -115,7 +116,7 @@ func (r *Reconciler) ReconcileFinalizer(ctx context.Context, client pkgclient.Cl
 
 			// Remove the finalizer to allow for deletion of the installation cr
 			logrus.Infof("Removing finalizer: %s", finalizer)
-			err = RemoveFinalizer(ctx, inst, client, finalizer)
+			err = RemoveProductFinalizer(ctx, inst, client, string(product.Name))
 			if err != nil {
 				return v1alpha1.PhaseFailed, err
 			}


### PR DESCRIPTION
fixing a bug where the finalizers are never removed if the installation object is deleted while the operator is not running.

## Verification
- Install stack using this operator
- stop the operator
- delete the installation CR
- start the operator
- see the uninstall function normally.