### PR TITLE
Update unit test script to support travis and prow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,18 @@ env:
     - OPERATOR_NAME=integreatly-operator
 
 stages:
+- test
 - name: push
   if: fork = false AND branch = master
 
 jobs:
   include:
+  - stage: test
+    script:
+    - cd $HOME/gopath/src/github.com/integr8ly/$OPERATOR_NAME && make test/unit
+    - go get github.com/mattn/goveralls
+    - go install github.com/mattn/goveralls
+    - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN
   - stage: push
     script:
     - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ jobs:
     - cd $HOME/gopath/src/github.com/integr8ly/$OPERATOR_NAME && make test/unit
     - go get github.com/mattn/goveralls
     - go install github.com/mattn/goveralls
-    - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN
+    - $HOME/gopath/bin/goveralls -coverprofile=coverage.out -service=travis-ci -repotoken=$COVERALLS_TOKEN || echo "push to coveralls failed"
   - stage: push
     script:
     - docker login --password "$QUAY_PASSWORD" --username "$QUAY_USERNAME" quay.io

--- a/scripts/ci/unit_test.sh
+++ b/scripts/ci/unit_test.sh
@@ -34,11 +34,11 @@ if [[ ! -z "${REPORT_COVERAGE}" ]]; then
     go install -v github.com/mattn/goveralls
 
     if [[ ! -z "${PROW_JOB_ID}" ]]; then
-        report_coverage_prow
+        report_coverage_prow || echo "push to coveralls failed"
     fi
 
     if [[ ! -z "${TRAVIS_BUILD_NUMBER}" ]]; then
-        report_coverage_travis
+        report_coverage_travis || echo "push to coveralls failed"
     fi
 
 fi


### PR DESCRIPTION
Update travis to execute unit tests and report coveralls coverage report.
Stop goveralls failing builds if there is a coveralls backend issue.

There is some weirdness with the coveralls reporting from prow, so reverting back to travis for the moment.

/cc @philbrookes 