### PR TITLE
[WIP] INTLY-3511 - Watch namespaces with Webapp label and assign default pull secret

### DIFF
--- a/pkg/controller/add_pullsecret.go
+++ b/pkg/controller/add_pullsecret.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/integr8ly/integreatly-operator/pkg/controller/pullsecret"
+)
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, pullsecret.Add)
+}

--- a/pkg/controller/pullsecret/pullsecret_controller.go
+++ b/pkg/controller/pullsecret/pullsecret_controller.go
@@ -2,6 +2,7 @@ package pullsecret
 
 import (
 	"context"
+	"strings"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -23,7 +24,7 @@ import (
 var log = logf.Log.WithName("controller_pullsecret")
 
 const (
-	WebAppLabel = "webapp"
+	WebAppLabel = "wa-"
 )
 
 /**
@@ -91,7 +92,7 @@ func (r *ReconcilePullSecret) Reconcile(request reconcile.Request) (reconcile.Re
 	}
 
 	// Only for namespaces with the webapp label, copy the default pull secret and set as the default pull secret for namespace
-	if _, ok := instance.ObjectMeta.Labels[WebAppLabel]; ok {
+	if isWebAppNS := strings.HasPrefix(instance.ObjectMeta.Name, WebAppLabel); isWebAppNS {
 		reqLogger.Info("Found namespace with webapp label")
 
 		err = resources.CopyDefaultPullSecretToNameSpace(request.Name, resources.DefaultOriginPullSecretName, r.client, context.TODO())

--- a/pkg/controller/pullsecret/pullsecret_controller.go
+++ b/pkg/controller/pullsecret/pullsecret_controller.go
@@ -1,0 +1,107 @@
+package pullsecret
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	// controllerruntime "sigs.k8s.io/controller-runtime"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
+var log = logf.Log.WithName("controller_pullsecret")
+
+const (
+	WebAppLabel = "webapp"
+)
+
+/**
+* USER ACTION REQUIRED: This is a scaffold file intended for the user to modify with their own Controller
+* business logic.  Delete these comments after modifying this file.*
+ */
+
+// Add creates a new PullSecret Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, products []string) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+
+	// new client to avoid caching issues
+	restConfig := controllerruntime.GetConfigOrDie()
+	newClient, _ := client.New(restConfig, client.Options{})
+	return &ReconcilePullSecret{client: newClient, scheme: mgr.GetScheme()}
+}
+
+// add adds a new Controller to mgr with r as the reconcile.Reconciler
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New("pullsecret-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to primary resource
+	err = c.Watch(&source.Kind{Type: &corev1.Namespace{}}, &handler.EnqueueRequestForObject{})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcilePullSecret implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcilePullSecret{}
+
+// ReconcilePullSecret reconciles a PullSecret object
+type ReconcilePullSecret struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+	scheme *runtime.Scheme
+}
+
+// Reconcile will ensure namespaces with the WebApp label has a default pull secret copied and assigned to the namespace
+func (r *ReconcilePullSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
+	reqLogger.Info("Checking namespace for webapp label for pull secret reconciling")
+
+	// Fetch the Namespace instance
+	instance := &corev1.Namespace{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{}, err
+	}
+
+	// Only for namespaces with the webapp label, copy the default pull secret and set as the default pull secret for namespace
+	if _, ok := instance.ObjectMeta.Labels[WebAppLabel]; ok {
+		reqLogger.Info("Found namespace with webapp label")
+
+		err = resources.CopyDefaultPullSecretToNameSpace(request.Name, resources.DefaultOriginPullSecretName, r.client, context.TODO())
+
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		reqLogger.Info("Successfully updated namespace with default pull secret")
+	}
+
+	return reconcile.Result{}, nil
+}

--- a/pkg/controller/pullsecret/pullsecret_controller_test.go
+++ b/pkg/controller/pullsecret/pullsecret_controller_test.go
@@ -1,0 +1,143 @@
+package pullsecret
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testNameSpace = "test-namespace"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	return scheme, err
+}
+
+func basicReconcileRequest() reconcile.Request {
+	return reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: testNameSpace,
+			Name:      testNameSpace,
+		},
+	}
+}
+
+func TestPullSecretReconciler(t *testing.T) {
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	defPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.DefaultOriginPullSecretName,
+			Namespace: resources.DefaultOriginPullSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"test": {'t', 'e', 's', 't'},
+		},
+	}
+
+	scenarios := []struct {
+		Name         string
+		Request      reconcile.Request
+		APINameSpace *corev1.Namespace
+		FakeClient   client.Client
+		Verify       func(client client.Client, res reconcile.Result, err error, t *testing.T)
+	}{
+		{
+			Name:    "Pull Secret Controller does NOT add pull secret to namespace without WebApp label",
+			Request: basicReconcileRequest(),
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNameSpace,
+					Name:      testNameSpace,
+				},
+			}, defPullSecret),
+			Verify: func(c client.Client, res reconcile.Result, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				// Secret should not be created - therefore should return an error when trying to find secret in the namespace
+				s := &corev1.Secret{}
+				err = c.Get(context.TODO(), client.ObjectKey{Name: resources.DefaultOriginPullSecretName, Namespace: testNameSpace}, s)
+
+				if err == nil {
+					t.Fatal("expected err but got none")
+				}
+			},
+		},
+		{
+			Name:    "Pull Secret Controller does add pull secret to namespace with WebApp label",
+			Request: basicReconcileRequest(),
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNameSpace,
+					Name:      testNameSpace,
+					Labels:    map[string]string{WebAppLabel: "true"},
+				},
+			}, defPullSecret),
+			Verify: func(c client.Client, res reconcile.Result, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				// Secret should be created - therefore should not return an error when trying to find secret in the namespace
+				s := &corev1.Secret{}
+				err = c.Get(context.TODO(), client.ObjectKey{Name: resources.DefaultOriginPullSecretName, Namespace: testNameSpace}, s)
+				if err != nil {
+					t.Fatal("expected no error but got one", err)
+				}
+
+				if bytes.Compare(s.Data["test"], defPullSecret.Data["test"]) != 0 {
+					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], s.Data["test"])
+				}
+			},
+		},
+		{
+			Name:    "Test get default pull secert error",
+			Request: basicReconcileRequest(),
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: testNameSpace,
+					Name:      testNameSpace,
+					Labels:    map[string]string{WebAppLabel: "true"},
+				},
+			}),
+			Verify: func(c client.Client, res reconcile.Result, err error, t *testing.T) {
+				if err == nil {
+					t.Fatalf("Expexted secret not found error but was nil")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+
+			reconciler := ReconcilePullSecret{
+				client: scenario.FakeClient,
+				scheme: scheme,
+			}
+
+			res, err := reconciler.Reconcile(scenario.Request)
+			scenario.Verify(scenario.FakeClient, res, err, t)
+		})
+	}
+}

--- a/pkg/resources/pullSecret.go
+++ b/pkg/resources/pullSecret.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Gets the default pull secret for pulling container images from registry
+func GetDefaultPullSecret(client pkgclient.Client, context context.Context) (corev1.Secret, error) {
+	openshiftSecret := corev1.Secret{}
+
+	err := client.Get(context, types.NamespacedName{Name: DefaultOriginPullSecretName, Namespace: DefaultOriginPullSecretNamespace}, &openshiftSecret)
+
+	return openshiftSecret, err
+}
+
+// Copys the default pull secret to a target namespace
+func CopyDefaultPullSecretToNameSpace(nameSpaceToCopy string, nameOfSecret string, client pkgclient.Client, context context.Context) error {
+	openshiftSecret, err := GetDefaultPullSecret(client, context)
+
+	if err != nil {
+		return err
+	}
+
+	componentSecret := &corev1.Secret{
+		Type: corev1.SecretTypeDockerConfigJson,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nameOfSecret,
+			Namespace: nameSpaceToCopy,
+		},
+		Data: openshiftSecret.Data,
+	}
+
+	err = CreateOrUpdate(context, client, componentSecret)
+
+	return err
+}

--- a/pkg/resources/pullSecret_test.go
+++ b/pkg/resources/pullSecret_test.go
@@ -1,0 +1,141 @@
+package resources
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	return scheme, err
+}
+
+func TestGetDefaultPullSecret(t *testing.T) {
+	defPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultOriginPullSecretName,
+			Namespace: DefaultOriginPullSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"test": {'t', 'e', 's', 't'},
+		},
+	}
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	scenarios := []struct {
+		Name       string
+		FakeClient client.Client
+		Verify     func(secret corev1.Secret, err error, t *testing.T)
+	}{
+		{
+			Name:       "Test Default Pull Secret is successfully retrieved",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, defPullSecret),
+			Verify: func(secret corev1.Secret, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				if bytes.Compare(secret.Data["test"], defPullSecret.Data["test"]) != 0 {
+					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], secret.Data["test"])
+				}
+			},
+		},
+		{
+			Name:       "Test Get Default Pull Secret error",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme),
+			Verify: func(secret corev1.Secret, err error, t *testing.T) {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+
+			res, err := GetDefaultPullSecret(scenario.FakeClient, context.TODO())
+			scenario.Verify(res, err, t)
+		})
+	}
+}
+
+func TestCopyDefaultPullSecretToNameSpace(t *testing.T) {
+	defPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultOriginPullSecretName,
+			Namespace: DefaultOriginPullSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"test": {'t', 'e', 's', 't'},
+		},
+	}
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	scenarios := []struct {
+		Name       string
+		FakeClient client.Client
+		Verify     func(client client.Client, err error, t *testing.T)
+	}{
+		{
+			Name: "Test Default Pull Secret is successfully copied over to target namespace",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, defPullSecret, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					Name:      "test-namespace",
+					Labels:    map[string]string{"webapp": "true"},
+				},
+			}),
+			Verify: func(c client.Client, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				s := &corev1.Secret{}
+				err = c.Get(context.TODO(), client.ObjectKey{Name: "new-name-of-secret", Namespace: "test-namespace"}, s)
+
+				if bytes.Compare(s.Data["test"], defPullSecret.Data["test"]) != 0 {
+					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], s.Data["test"])
+				}
+			},
+		},
+		{
+			Name: "Test Get Default Pull Secret error when trying to copy",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					Name:      "test-namespace",
+					Labels:    map[string]string{"webapp": "true"},
+				},
+			}),
+			Verify: func(c client.Client, err error, t *testing.T) {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			err := CopyDefaultPullSecretToNameSpace("test-namespace", "new-name-of-secret", scenario.FakeClient, context.TODO())
+			scenario.Verify(scenario.FakeClient, err, t)
+		})
+	}
+}

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -135,21 +135,8 @@ func (r *Reconciler) ReconcilePullSecret(ctx context.Context, namespace string, 
 		inst.Spec.PullSecret.Namespace = DefaultOriginPullSecretNamespace
 	}
 
-	openshiftSecret := &v1.Secret{}
-	err := client.Get(ctx, pkgclient.ObjectKey{Name: inst.Spec.PullSecret.Name, Namespace: inst.Spec.PullSecret.Namespace}, openshiftSecret)
-	if err != nil {
-		return v1alpha1.PhaseFailed, errors.Wrapf(err, "could not get secret '%s' from namespace '%s'", inst.Spec.PullSecret.Name, inst.Spec.PullSecret.Namespace)
-	}
+	err := CopyDefaultPullSecretToNameSpace(namespace, inst.Spec.PullSecret.Name, client, ctx)
 
-	componentSecret := &v1.Secret{
-		Type: v1.SecretTypeDockerConfigJson,
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      inst.Spec.PullSecret.Name,
-			Namespace: namespace,
-		},
-		Data: openshiftSecret.Data,
-	}
-	err = CreateOrUpdate(ctx, client, componentSecret)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrapf(err, "error creating/updating secret '%s' in namespace: '%s'", inst.Spec.PullSecret.Name, inst.Spec.PullSecret.Namespace)
 	}

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -219,7 +219,7 @@ func TestReconciler_reconcilePullSecret(t *testing.T) {
 		},
 		{
 			Name:   "test pull secret is reconciled successfully",
-			Client: fakeclient.NewFakeClientWithScheme(scheme, customPullSecret),
+			Client: fakeclient.NewFakeClientWithScheme(scheme, defPullSecret, customPullSecret),
 			Installation: &v1alpha1.Installation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testinstall",


### PR DESCRIPTION
## Description
Due to switching to GA images of operators, namespaces created by the web app now require a pull secret for pulling the correctly pull container images from the registry. 

This pull request watches namespaces with a specified prefix, and copies and sets default pull secret. The assocaited changes for the webapp include:
* https://github.com/integr8ly/tutorial-web-app/pull/520
