### PR TITLE
Add new make target to install and wait for installation

### DIFF
--- a/deploy/crds/examples/integreatly-installation-cr.yaml
+++ b/deploy/crds/examples/integreatly-installation-cr.yaml
@@ -1,9 +1,9 @@
 apiVersion: integreatly.org/v1alpha1
 kind: Installation
 metadata:
-  name: example-installation
+  name: INSTALLATION_NAME
 spec:
-  type: workshop
+  type: INSTALLATION_TYPE
   namespacePrefix: integreatly-
   routingSubdomain: ROUTING_SUBDOMAIN
   masterUrl: MASTER_URL

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -103,9 +103,18 @@ func integreatlyWorkshopTest(t *testing.T, f *framework.Framework, ctx *framewor
 		"launcher":              "launcher-operator",
 		"middleware-monitoring": "application-monitoring-operator",
 		"nexus":                 "nexus-operator",
-		"solution-explorer":     "tutorial-web-app-operator",
 		"user-sso":              "keycloak-operator",
 		"ups":                   "unifiedpush-operator",
+	}
+	for product, deploymentName := range products {
+		err = waitForProductDeployment(t, f, ctx, product, deploymentName)
+		if err != nil {
+			break
+		}
+	}
+	//SolutionExplorer Stage - verify operators deploy
+	products = map[string]string{
+		"solution-explorer": "tutorial-web-app-operator",
 	}
 	for product, deploymentName := range products {
 		err = waitForProductDeployment(t, f, ctx, product, deploymentName)


### PR DESCRIPTION
* Add new make target to install and wait for installation cluster/deploy/integreatly-installation-cr.yml
* Add new make target to install operator source cluster/prepare/osrc
* Make installation type and name configurable in deploy/integreatly-installation-cr.yml

/cc @philbrookes @StanleyKaleta 

This will allow us to use the same logic to test up status in both jenkins jobs and prow

```
make cluster/deploy/integreatly-installation-cr.yml
```

Will wait until the installation completes or fails.

Added fix for https://github.com/integr8ly/integreatly-operator/pull/125/commits/f5c35c9206a3a2ab802ffec2f760c83a9cebbed0#r335021486

/cc @JameelB 