### PR TITLE
add source to catalogsourceconfig spec

### DIFF
--- a/deploy/operator-source-template.yml
+++ b/deploy/operator-source-template.yml
@@ -25,7 +25,7 @@ objects:
       csPublisher: Red Hat
       packages: integreatly
       targetNamespace: ${NAMESPACE}
-
+      source: ${OPERATOR_SOURCE_NAME}
 parameters:
   - description: The namespace to deploy into
     displayName: Namespace


### PR DESCRIPTION
This field is required for creating the catalog source config in OSD

## Verification Steps
1. Ensure the catalogsourceconfig is created when running `make cluster/prepare/olm`.