### PR TITLE
INTLY-3511: refactor reconcile pull secret

### DIFF
--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -83,7 +83,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}
-	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), inst, serverClient)
+	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), defaultFusePullSecret, inst, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -94,10 +94,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, in *v1alpha1.Installation, p
 		return phase, err
 	}
 
-	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), in, serverClient)
+	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), "", in, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}
+
 	version, err := resources.NewVersion(v1alpha1.OperatorVersion3Scale)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "invalid version number for launcher")

--- a/pkg/resources/pullSecret.go
+++ b/pkg/resources/pullSecret.go
@@ -1,0 +1,54 @@
+package resources
+
+import (
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"golang.org/x/net/context"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	DefaultOriginPullSecretName      = "samples-registry-credentials"
+	DefaultOriginPullSecretNamespace = "openshift"
+)
+
+// Gets the default pull secret for pulling container images from registry
+func GetDefaultPullSecret(inst *v1alpha1.Installation, client pkgclient.Client, context context.Context) (corev1.Secret, error) {
+	if inst.Spec.PullSecret.Name == "" {
+		inst.Spec.PullSecret.Name = DefaultOriginPullSecretName
+	}
+	if inst.Spec.PullSecret.Namespace == "" {
+		inst.Spec.PullSecret.Namespace = DefaultOriginPullSecretNamespace
+	}
+
+	openshiftSecret := corev1.Secret{}
+
+	err := client.Get(context, types.NamespacedName{Name: inst.Spec.PullSecret.Name, Namespace: inst.Spec.PullSecret.Namespace}, &openshiftSecret)
+
+	return openshiftSecret, err
+}
+
+// Copys the default pull secret to a target namespace
+func CopyDefaultPullSecretToNameSpace(nameSpaceToCopy string, nameOfSecret string, inst *v1alpha1.Installation, client pkgclient.Client, context context.Context) error {
+	openshiftSecret, err := GetDefaultPullSecret(inst, client, context)
+
+	if err != nil {
+		return err
+	}
+
+	componentSecret := &corev1.Secret{
+		Type: corev1.SecretTypeDockerConfigJson,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      nameOfSecret,
+			Namespace: nameSpaceToCopy,
+		},
+		Data: openshiftSecret.Data,
+	}
+
+	err = CreateOrUpdate(context, client, componentSecret)
+
+	return err
+}

--- a/pkg/resources/pullSecret_test.go
+++ b/pkg/resources/pullSecret_test.go
@@ -1,0 +1,148 @@
+package resources
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	return scheme, err
+}
+
+func TestGetDefaultPullSecret(t *testing.T) {
+	defPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultOriginPullSecretName,
+			Namespace: DefaultOriginPullSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"test": {'t', 'e', 's', 't'},
+		},
+	}
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	scenarios := []struct {
+		Name         string
+		FakeClient   client.Client
+		Installation *v1alpha1.Installation
+		Verify       func(secret corev1.Secret, err error, t *testing.T)
+	}{
+		{
+			Name:         "Test Default Pull Secret is successfully retrieved",
+			FakeClient:   fakeclient.NewFakeClientWithScheme(scheme, defPullSecret),
+			Installation: &v1alpha1.Installation{},
+			Verify: func(secret corev1.Secret, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				if bytes.Compare(secret.Data["test"], defPullSecret.Data["test"]) != 0 {
+					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], secret.Data["test"])
+				}
+			},
+		},
+		{
+			Name:         "Test Get Default Pull Secret error",
+			FakeClient:   fakeclient.NewFakeClientWithScheme(scheme),
+			Installation: &v1alpha1.Installation{},
+			Verify: func(secret corev1.Secret, err error, t *testing.T) {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+
+			res, err := GetDefaultPullSecret(scenario.Installation, scenario.FakeClient, context.TODO())
+			scenario.Verify(res, err, t)
+		})
+	}
+}
+
+func TestCopyDefaultPullSecretToNameSpace(t *testing.T) {
+	defPullSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      DefaultOriginPullSecretName,
+			Namespace: DefaultOriginPullSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"test": {'t', 'e', 's', 't'},
+		},
+	}
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	scenarios := []struct {
+		Name         string
+		FakeClient   client.Client
+		Installation *v1alpha1.Installation
+		Verify       func(client client.Client, err error, t *testing.T)
+	}{
+		{
+			Name: "Test Default Pull Secret is successfully copied over to target namespace",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, defPullSecret, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					Name:      "test-namespace",
+					Labels:    map[string]string{"webapp": "true"},
+				},
+			}),
+			Installation: &v1alpha1.Installation{},
+			Verify: func(c client.Client, err error, t *testing.T) {
+				if err != nil {
+					t.Fatalf("unexpected error: %s", err.Error())
+				}
+
+				s := &corev1.Secret{}
+				err = c.Get(context.TODO(), client.ObjectKey{Name: "new-name-of-secret", Namespace: "test-namespace"}, s)
+
+				if bytes.Compare(s.Data["test"], defPullSecret.Data["test"]) != 0 {
+					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], s.Data["test"])
+				}
+			},
+		},
+		{
+			Name: "Test Get Default Pull Secret error when trying to copy",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-namespace",
+					Name:      "test-namespace",
+					Labels:    map[string]string{"webapp": "true"},
+				},
+			}),
+			Installation: &v1alpha1.Installation{},
+			Verify: func(c client.Client, err error, t *testing.T) {
+				if err == nil {
+					t.Fatal("Expected error but got none")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			err := CopyDefaultPullSecretToNameSpace("test-namespace", "new-name-of-secret", scenario.Installation, scenario.FakeClient, context.TODO())
+			scenario.Verify(scenario.FakeClient, err, t)
+		})
+	}
+}

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
@@ -18,8 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
-	"time"
 )
 
 func basicConfigMock() *config.ConfigReadWriterMock {
@@ -219,7 +220,7 @@ func TestReconciler_reconcilePullSecret(t *testing.T) {
 		},
 		{
 			Name:   "test pull secret is reconciled successfully",
-			Client: fakeclient.NewFakeClientWithScheme(scheme, customPullSecret),
+			Client: fakeclient.NewFakeClientWithScheme(scheme, defPullSecret, customPullSecret),
 			Installation: &v1alpha1.Installation{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testinstall",
@@ -250,7 +251,7 @@ func TestReconciler_reconcilePullSecret(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			testReconciler := NewReconciler(nil)
-			_, err := testReconciler.ReconcilePullSecret(context.TODO(), "test", tc.Installation, tc.Client)
+			_, err := testReconciler.ReconcilePullSecret(context.TODO(), "test", "new-pull-secret-name", tc.Installation, tc.Client)
 			if err != nil {
 				t.Fatal("failed to run pull secret reconcile: ", err)
 			}


### PR DESCRIPTION
Refactors `ReconcilePullSecret`. Logic for copying the secret is moved to `pullSecret.go` under the same package. Also adds support for specifying the name of the pull secret copied into the component namespace.

## Verification Steps
1. Run the operator locally
2. Ensure that a pull secret is created in 3Scale and Fuse
3. Ensure that the pull secret in Fuse is named `syndesis-pull-secret`

/cc @philbrookes 