### PR TITLE
fix(perms): update cluster perms with 1.9.8 csv in manifests repo

### DIFF
--- a/deploy/clusterrole.yaml
+++ b/deploy/clusterrole.yaml
@@ -4,8 +4,19 @@ metadata:
   creationTimestamp: null
   name: integreatly-operator
 rules:
+## start backup permissions
 - apiGroups:
-  - batch
+    - "applicationmonitoring.integreatly.org"
+  resources:
+    - "applicationmonitorings"
+    - "blackboxtargets"
+  verbs:
+    - get
+    - create
+    - update
+    - list
+- apiGroups:
+    - batch
   resources:
     - cronjobs
   verbs:
@@ -33,18 +44,27 @@ rules:
   verbs:
     - create
     - update
+  ## end backup permissions
+- apiGroups:
+    - "integreatly.org"
+  resources:
+    - "*"
+  verbs:
+    - "*"
+# This is used to allow the operator to setup the ns needed for each product
 - apiGroups:
     - ""
   resources:
     - namespaces
     - namespaces/finalizers
-    - serviceaccounts
+    - "serviceaccounts"
   verbs:
     - list
     - create
     - watch
     - get
     - update
+# This is used to allow the operator to setup catalog source config and remove it if needed.
 - apiGroups:
     - operators.coreos.com
   resources:
@@ -238,3 +258,32 @@ rules:
     - get
     - create
     - delete
+- apiGroups:
+    - push.aerogear.org
+  resources:
+    - unifiedpushservers
+  verbs:
+    - get
+    - create
+# needed to access db and service crs in the mobile-security-service namespace
+- apiGroups:
+    - mobile-security-service.aerogear.org
+  resources:
+    - '*'
+  verbs:
+    - get
+    - list
+    - watch
+    - update
+    - create
+# permissions for the mdc operator
+- apiGroups:
+    - mdc.aerogear.org
+  resources:
+    - '*'
+  verbs:
+    - get
+    - list
+    - watch
+    - update
+    - create


### PR DESCRIPTION
### What

Cluster permissions on master out of sync with permissions in most recent integreatly-operator csv in manifests repo. This most likely happened due to permissions being manually modified in the csv instead of the csv being auto-generated from the contents of the `deploy/` folder in the this repo. 

This PR updates the clusterrole.yaml file to reflect the permissions in the most recent integreatly-operator csv (1.9.8). (role.yaml permissions were correct and did not need to be fixed).

This PR should only be merged after #155 which corrects a range of issues that were introduced in the e2e tests.