### PR TITLE
Fix OauthResolver errors in e2e test

### DIFF
--- a/pkg/resources/oauthResolver.go
+++ b/pkg/resources/oauthResolver.go
@@ -33,7 +33,7 @@ func (or *OauthResolver) GetOauthEndPoint() (*OauthServerConfig, error) {
 
 	caCert, err := ioutil.ReadFile(rootCAFile)
 	// if running locally, CA certificate isn't available in expected path
-	if os.IsNotExist(err) {
+	if os.IsNotExist(err) || os.Getenv("INTEGREATLY_OPERATOR_DISABLE_ELECTION") != "" {
 		logrus.Warn("GetOauthEndPoint() will skip certificate verification - this is acceptable only if operator is running locally")
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
This should fix following error in e2e tests:
```
failed to get oauth details : failed to get oauth server config from well known endpoint
 https://api.ci-op-k0szkicd-4750b.origin-ci-int-aws.dev.rhcloud.com:6443/.well-known/oauth-authorization-server: 
Get https://api.ci-op-k0szkicd-4750b.origin-ci-int-aws.dev.rhcloud.com:6443/.well-known/oauth-authorization-server: 
x509: certificate signed by unknown authority
```