### PR TITLE
Cluster perms fix

### DIFF
--- a/deploy/olm-catalog/integreatly-operator/integreatly-operator-1.9.8/integreatly-operator.v1.9.8.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/integreatly-operator/integreatly-operator-1.9.8/integreatly-operator.v1.9.8.clusterserviceversion.yaml
@@ -34,6 +34,16 @@ spec:
       clusterPermissions:
       - rules:
         - apiGroups:
+          - applicationmonitoring.integreatly.org
+          resources:
+          - applicationmonitorings
+          - blackboxtargets
+          verbs:
+          - get
+          - create
+          - update
+          - list
+        - apiGroups:
           - batch
           resources:
           - cronjobs
@@ -271,6 +281,33 @@ spec:
           - get
           - create
           - delete
+        - apiGroups:
+          - push.aerogear.org
+          resources:
+          - unifiedpushservers
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - mobile-security-service.aerogear.org
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
+        - apiGroups:
+          - mdc.aerogear.org
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+          - create
         serviceAccountName: integreatly-operator
       deployments:
       - name: integreatly-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -60,7 +60,7 @@ metadata:
   creationTimestamp: null
   name: integreatly-operator
 rules:
-  - ## start backup permissions
+  ## start backup permissions
   - apiGroups:
       - "applicationmonitoring.integreatly.org"
     resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -314,3 +314,32 @@ rules:
       - get
       - create
       - delete
+  - apiGroups:
+      - push.aerogear.org
+    resources:
+      - unifiedpushservers
+    verbs:
+      - get
+      - create
+  # needed to access db and service crs in the mobile-security-service namespace
+  - apiGroups:
+      - mobile-security-service.aerogear.org
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create
+  # permissions for the mdc operator
+  - apiGroups:
+      - mdc.aerogear.org
+    resources:
+      - '*'
+    verbs:
+      - get
+      - list
+      - watch
+      - update
+      - create


### PR DESCRIPTION
Correct permissions for integreatly-operator
- syntax error in role.yaml
- cluster perms missing for mdc, mss, push (and monitoring in csv due to previous syntax error)