### PR TITLE
Fuse operator version 1.4.0

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -70,7 +70,7 @@ var (
 	OperatorVersionRHSSO                 = "1.9.4"
 	OperatorVersionRHSSOUser             = "1.9.4"
 	OperatorVersionCodeReadyWorkspaces   = "1.2.2"
-	OperatorVersionFuse                  = "7.4.0"
+	OperatorVersionFuse                  = "1.4.0"
 	OperatorVersion3Scale                = "1.9.8"
 	OperatorVersionNexus                 = "0.9.0"
 	OperatorVersionLauncher              = "0.1.2"


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-3961

Related PR: https://github.com/integr8ly/manifests/pull/84

Currently the latest GA fuse version is on 1.4.0 but the manifest repo is referring to 7.4.0, to fix this the manifest repo needs to be renamed to 1.4.0, the CSV file updated to use the correct version and update the version in the integreatly operator
