### PR TITLE
INTLY-3245 - Bump Solution Explorer Operator Version

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -67,7 +67,7 @@ var (
 	OperatorVersionAMQStreams            = "1.1.0"
 	OperatorVersionAMQOnline             = "1.2.2"
 	OperatorVersionMonitoring            = "0.0.28"
-	OperatorVersionSolutionExplorer      = "0.0.32"
+	OperatorVersionSolutionExplorer      = "0.0.33"
 	OperatorVersionRHSSO                 = "1.9.5"
 	OperatorVersionRHSSOUser             = "1.9.5"
 	OperatorVersionCodeReadyWorkspaces   = "1.2.2"


### PR DESCRIPTION
## Description
Bumps the solution explorer operator version to `0.0.33`

Associated pull requests:
* https://github.com/integr8ly/manifests/pull/85
* https://github.com/integr8ly/tutorial-web-app-operator/pull/72