### PR TITLE
schedule monitoring first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,6 +123,7 @@ cluster/deploy/integreatly-installation-cr.yml: export INSTALLATION_NAME := exam
 cluster/deploy/integreatly-installation-cr.yml: deploy/integreatly-installation-cr.yml
 	oc create -f deploy/integreatly-installation-cr.yml
 	$(call wait_command, oc get Installation $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.bootstrap.phase}' | grep -q completed, bootstrap phase, 5m, 30)
+	$(call wait_command, oc get Installation $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.monitoring.phase}' | grep -q completed, monitoring phase, 10m, 30)
 	$(call wait_command, oc get Installation $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.authentication.phase}' | grep -q completed, authentication phase, 10m, 30)
 	$(call wait_command, oc get Installation $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.products.phase}' | grep -q completed, products phase, 30m, 30)
 	$(call wait_command, oc get Installation $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.solution-explorer.phase}' | grep -q completed, solution-explorer phase, 10m, 30)

--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -26,6 +26,7 @@ var (
 	InstallationTypeManaged  InstallationType = "managed"
 
 	BootstrapStage        StageName = "bootstrap"
+	MonitoringStage       StageName = "monitoring"
 	AuthenticationStage   StageName = "authentication"
 	ProductsStage         StageName = "products"
 	SolutionExplorerStage StageName = "solution-explorer"

--- a/pkg/controller/installation/types.go
+++ b/pkg/controller/installation/types.go
@@ -20,6 +20,12 @@ var (
 			Name: v1alpha1.BootstrapStage,
 		},
 		{
+			Name: v1alpha1.MonitoringStage,
+			Products: map[v1alpha1.ProductName]*v1alpha1.InstallationProductStatus{
+				v1alpha1.ProductMonitoring: {Name: v1alpha1.ProductMonitoring},
+			},
+		},
+		{
 			Name: v1alpha1.AuthenticationStage,
 			Products: map[v1alpha1.ProductName]*v1alpha1.InstallationProductStatus{
 				v1alpha1.ProductRHSSO: {
@@ -37,7 +43,6 @@ var (
 				v1alpha1.ProductAMQOnline:              {Name: v1alpha1.ProductAMQOnline},
 				v1alpha1.Product3Scale:                 {Name: v1alpha1.Product3Scale},
 				v1alpha1.ProductRHSSOUser:              {Name: v1alpha1.ProductRHSSOUser},
-				v1alpha1.ProductMonitoring:             {Name: v1alpha1.ProductMonitoring},
 				v1alpha1.ProductUps:                    {Name: v1alpha1.ProductUps},
 				v1alpha1.ProductMobileSecurityService:  {Name: v1alpha1.ProductMobileSecurityService},
 				v1alpha1.ProductMobileDeveloperConsole: {Name: v1alpha1.ProductMobileDeveloperConsole},
@@ -53,6 +58,12 @@ var (
 	allWorkshopStages = []Stage{
 		{
 			Name: v1alpha1.BootstrapStage,
+		},
+		{
+			Name: v1alpha1.MonitoringStage,
+			Products: map[v1alpha1.ProductName]*v1alpha1.InstallationProductStatus{
+				v1alpha1.ProductMonitoring: {Name: v1alpha1.ProductMonitoring},
+			},
 		},
 		{
 			Name: v1alpha1.AuthenticationStage,
@@ -75,7 +86,6 @@ var (
 				v1alpha1.ProductAMQStreams:             {Name: v1alpha1.ProductAMQStreams},
 				v1alpha1.ProductRHSSOUser:              {Name: v1alpha1.ProductRHSSOUser},
 				v1alpha1.ProductUps:                    {Name: v1alpha1.ProductUps},
-				v1alpha1.ProductMonitoring:             {Name: v1alpha1.ProductMonitoring},
 				v1alpha1.ProductMobileSecurityService:  {Name: v1alpha1.ProductMobileSecurityService},
 				v1alpha1.ProductMobileDeveloperConsole: {Name: v1alpha1.ProductMobileDeveloperConsole},
 			},

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -34,6 +34,7 @@ var (
 	intlyNamespacePrefix             = "intly-"
 	installationName                 = "e2e-managed-installation"
 	bootstrapStage                   = "bootstrap"
+	monitoringStage                  = "monitoring"
 	authenticationStage              = "authentication"
 	productsStage                    = "products"
 	solutionExplorerStage            = "solution-explorer"
@@ -116,6 +117,18 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
+	// wait for middleware-monitoring to deploy
+	err = waitForProductDeployment(t, f, ctx, "middleware-monitoring", "application-monitoring-operator")
+	if err != nil {
+		return err
+	}
+
+	// wait for authentication phase to complete (15 minutes timeout)
+	err = waitForInstallationStageCompletion(t, f, namespace, deploymentRetryInterval, deploymentTimeout, monitoringStage)
+	if err != nil {
+		return err
+	}
+
 	// wait for keycloak-operator to deploy
 	err = waitForProductDeployment(t, f, ctx, "rhsso", "keycloak-operator")
 	if err != nil {
@@ -136,7 +149,6 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		"fuse":                    "syndesis-operator",
 		"launcher":                "launcher-operator",
 		"mdc":                     "mobile-developer-console-operator",
-		"middleware-monitoring":   "application-monitoring-operator",
 		"mobile-security-service": "mobile-security-service-operator",
 		"user-sso":                "keycloak-operator",
 		"ups":                     "unifiedpush-operator",


### PR DESCRIPTION
All components expect to be able to create monitoring resources, so it must be installed before all other components.