### PR TITLE
Adding templating support to monitoring reconciler

### DIFF
--- a/pkg/controller/installation/products/config/monitoring.go
+++ b/pkg/controller/installation/products/config/monitoring.go
@@ -66,6 +66,14 @@ func (r *Monitoring) GetPrometheusStorageRequest() string {
 	return "10Gi"
 }
 
+func (r *Monitoring) GetTemplateList() []string {
+	template_list := []string{
+		"test-secret",
+		"test-secret-2",
+	}
+	return template_list
+}
+
 func (f *Monitoring) Validate() error {
 	if f.GetProductName() == "" {
 		return errors.New("config product name is not defined")

--- a/pkg/controller/installation/products/config/monitoring.go
+++ b/pkg/controller/installation/products/config/monitoring.go
@@ -67,10 +67,7 @@ func (r *Monitoring) GetPrometheusStorageRequest() string {
 }
 
 func (r *Monitoring) GetTemplateList() []string {
-	template_list := []string{
-		"test-secret",
-		"test-secret-2",
-	}
+	template_list := []string{}
 	return template_list
 }
 

--- a/pkg/controller/installation/products/monitoring/resourceHelper.go
+++ b/pkg/controller/installation/products/monitoring/resourceHelper.go
@@ -1,0 +1,36 @@
+package monitoring
+
+import (
+	"github.com/ghodss/yaml"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type ResourceHelper struct {
+	templateHelper *TemplateHelper
+	cr             *v1alpha1.Installation
+}
+
+func newResourceHelper(cr *v1alpha1.Installation, th *TemplateHelper) *ResourceHelper {
+	return &ResourceHelper{
+		templateHelper: th,
+		cr:             cr,
+	}
+}
+
+func (r *ResourceHelper) createResource(template string) (runtime.Object, error) {
+	tpl, err := r.templateHelper.loadTemplate(template)
+	if err != nil {
+		return nil, err
+	}
+
+	resource := unstructured.Unstructured{}
+	err = yaml.Unmarshal(tpl, &resource)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &resource, nil
+}

--- a/pkg/controller/installation/products/monitoring/templateHelper.go
+++ b/pkg/controller/installation/products/monitoring/templateHelper.go
@@ -15,11 +15,11 @@ import (
 )
 
 const (
-	Answer = "Yes"
+	Placeholder = "XXX"
 )
 
 type Parameters struct {
-	Answer        string
+	Placeholder   string
 	Namespace     string
 	MonitoringKey string
 	ExtraParams   map[string]string
@@ -35,7 +35,7 @@ type TemplateHelper struct {
 // by the user in the custom resource
 func newTemplateHelper(cr *v1alpha1.Installation, extraParams map[string]string, config *config.Monitoring) *TemplateHelper {
 	param := Parameters{
-		Answer:        Answer,
+		Placeholder:   Placeholder,
 		Namespace:     config.GetNamespace(),
 		MonitoringKey: config.GetLabelSelector(),
 		ExtraParams:   extraParams,

--- a/pkg/controller/installation/products/monitoring/templateHelper.go
+++ b/pkg/controller/installation/products/monitoring/templateHelper.go
@@ -1,0 +1,96 @@
+package monitoring
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"strings"
+	"text/template"
+
+	monitoring_v1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1"
+
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
+)
+
+const (
+	Answer = "Yes"
+)
+
+type Parameters struct {
+	Answer        string
+	Namespace     string
+	MonitoringKey string
+	ExtraParams   map[string]string
+}
+
+type TemplateHelper struct {
+	Parameters   Parameters
+	TemplatePath string
+}
+
+// Creates a new templates helper and populates the values for all
+// templates properties. Some of them (like the hostname) are set
+// by the user in the custom resource
+func newTemplateHelper(cr *v1alpha1.Installation, extraParams map[string]string, config *config.Monitoring) *TemplateHelper {
+	param := Parameters{
+		Answer:        Answer,
+		Namespace:     config.GetNamespace(),
+		MonitoringKey: config.GetLabelSelector(),
+		ExtraParams:   extraParams,
+	}
+
+	templatePath, exists := os.LookupEnv("TEMPLATE_PATH")
+	if !exists {
+		templatePath = "./templates/monitoring"
+	}
+
+	monitoringKey, exists := os.LookupEnv("MONITORING_KEY")
+	if exists {
+		param.MonitoringKey = monitoringKey
+	}
+
+	return &TemplateHelper{
+		Parameters:   param,
+		TemplatePath: templatePath,
+	}
+}
+
+// Takes a list of strings, wraps each string in double quotes and joins them
+// Used for building yaml arrays
+func joinQuote(values []monitoring_v1alpha1.BlackboxtargetData) string {
+	var result []string
+	for _, s := range values {
+		result = append(result, fmt.Sprintf("\"%v@%v@%v\"", s.Module, s.Service, s.Url))
+	}
+	return strings.Join(result, ", ")
+}
+
+// load a templates from a given resource name. The templates must be located
+// under ./templates and the filename must be <resource-name>.yaml
+func (h *TemplateHelper) loadTemplate(name string) ([]byte, error) {
+	path := fmt.Sprintf("%s/%s.yaml", h.TemplatePath, name)
+	tpl, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	parser := template.New("application-monitoring")
+	parser.Funcs(template.FuncMap{
+		"JoinQuote": joinQuote,
+	})
+
+	parsed, err := parser.Parse(string(tpl))
+	if err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	err = parsed.Execute(&buffer, h.Parameters)
+	if err != nil {
+		return nil, err
+	}
+
+	return buffer.Bytes(), nil
+}

--- a/templates/monitoring/test-secret-2.yaml
+++ b/templates/monitoring/test-secret-2.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-stringData:
-  template-test.yaml: |
-    does_it_work: {{ .Answer }}
-kind: Secret
-metadata:
-  name: test-secret-2
-  namespace: {{ .Namespace }}
-  type: Opaque

--- a/templates/monitoring/test-secret-2.yaml
+++ b/templates/monitoring/test-secret-2.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+stringData:
+  template-test.yaml: |
+    does_it_work: {{ .Answer }}
+kind: Secret
+metadata:
+  name: test-secret-2
+  namespace: {{ .Namespace }}
+  type: Opaque

--- a/templates/monitoring/test-secret.yaml
+++ b/templates/monitoring/test-secret.yaml
@@ -1,9 +1,0 @@
-apiVersion: v1
-stringData:
-  template-test.yaml: |
-    does_it_work: {{ .Answer }}
-kind: Secret
-metadata:
-  name: test-secret
-  namespace: {{ .Namespace }}
-  type: Opaque

--- a/templates/monitoring/test-secret.yaml
+++ b/templates/monitoring/test-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+stringData:
+  template-test.yaml: |
+    does_it_work: {{ .Answer }}
+kind: Secret
+metadata:
+  name: test-secret
+  namespace: {{ .Namespace }}
+  type: Opaque


### PR DESCRIPTION
## JIRA: 
- https://issues.jboss.org/browse/INTLY-4076

## Description:
Add templating support to the Integreatly Operator to allow the monitoring reconciler to apply monitoring configuration.

## Verification:
- Authenticate with Openshift
- Create ``integreatly`` namespace
- Create the secrets for preflight checks:
```
# Execute from integreatly-operator dir
oc process -f ./deploy/s3-secrets.yaml -p INSTALLATION_NAMESPACE=integreatly -p AWS_ACCESS_KEY_ID=xxxx -p AWS_SECRET_ACCESS_KEY=xxxx -p AWS_BUCKET=xxxx-test -p AWS_REGION=eu-central-1 | oc create -f -
oc create secret generic github-oauth-secret --from-literal=clientId=xxxx --from-literal=secret=xxx -n integreatly
```
- Visit OperatorHub in the Openshift UI, search for integreatly and install it into the ``integreatly`` namespace. Scale the replicas to 0 in the operator deployment in the ``integreatly`` namespace.
- Run the operator locally: ``operator-sdk up local --namespace "integreatly" --operator-flags "--products=monitoring"``
- Create instance of the installation CR eg:
```
apiVersion: integreatly.org/v1alpha1
kind: Installation
metadata:
  name: example-installation
spec:
  type: workshop
  namespacePrefix: integreatly-
  routingSubdomain: apps.com
  masterUrl: https://someurl.apps.com
  selfSignedCerts: true
```
- Wait for reconcile of the monitoring product to complete
- Check the secrets ``test-secret`` and ``test-secret-2`` have been created in the ``integreatly-middleware-monitoring`` namespace, and that they are owned by the Installation CR in the ``integreatly`` namespace.

![Screenshot from 2019-11-08 13-43-29](https://user-images.githubusercontent.com/1700165/68480982-f7a83000-022d-11ea-833d-c9f3927dacc0.png)

![Screenshot from 2019-11-08 13-45-51](https://user-images.githubusercontent.com/1700165/68481063-1f979380-022e-11ea-829d-775adc331645.png)
