### PR TITLE
fix panic when product status is absent

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -143,7 +143,9 @@ func (i *Installation) GetProductStatusObject(product ProductName) *Installation
 			return product
 		}
 	}
-	return nil
+	return &InstallationProductStatus{
+		Name: product,
+	}
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object


### PR DESCRIPTION
operator panics when removing an install with no status blocks for products that have added finalizers.