### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ make cluster/prepare/local
 
 An `Installation` custom resource can now be created which will kick of the installation of the integreatly products, once the operator is running:
 ```sh
+# Create the installation custom resource definition
+oc create -f deploy/crds/installation.crd.yaml   
+
 # Create the installation custom resource
 oc create -f deploy/crds/examples/installation.cr.yaml
 


### PR DESCRIPTION
`oc create -f deploy/crds/examples/installation.cr.yaml`

Resolves: error: unable to recognize "deploy/crds/examples/installation.cr.yaml": no matches for kind "Installation" in version "integreatly.org/v1alpha1"

added instruction to create CRD before deploying CR
` oc create -f deploy/crds/installation.crd.yaml`
