### PR TITLE
bump webapp operator version to 0.0.34

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -67,7 +67,7 @@ var (
 	OperatorVersionAMQStreams            = "1.1.0"
 	OperatorVersionAMQOnline             = "1.2.2"
 	OperatorVersionMonitoring            = "0.0.28"
-	OperatorVersionSolutionExplorer      = "0.0.33"
+	OperatorVersionSolutionExplorer      = "0.0.34"
 	OperatorVersionRHSSO                 = "1.9.5"
 	OperatorVersionRHSSOUser             = "1.9.5"
 	OperatorVersionCodeReadyWorkspaces   = "1.2.2"


### PR DESCRIPTION
Bump webapp operator version to 0.0.34 to point to new CSV in the manifest https://github.com/integr8ly/manifests/pull/88