### PR TITLE
feat: adds cronjob to amq-online for PV backups

### DIFF
--- a/pkg/controller/installation/products/amqonline/reconciler_test.go
+++ b/pkg/controller/installation/products/amqonline/reconciler_test.go
@@ -23,7 +23,10 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,6 +46,9 @@ func buildScheme() *runtime.Scheme {
 	enmassev1.SchemeBuilder.AddToScheme(scheme)
 	enmassev1beta1.SchemeBuilder.AddToScheme(scheme)
 	enmassev1beta2.SchemeBuilder.AddToScheme(scheme)
+	rbacv1.SchemeBuilder.AddToScheme(scheme)
+	batchv1beta1.SchemeBuilder.AddToScheme(scheme)
+	appsv1.SchemeBuilder.AddToScheme(scheme)
 	return scheme
 }
 
@@ -52,6 +58,9 @@ const (
 
 func basicConfigMock() *config.ConfigReadWriterMock {
 	return &config.ConfigReadWriterMock{
+		GetOperatorNamespaceFunc: func() string {
+			return "integreatly-operator"
+		},
 		ReadAMQOnlineFunc: func() (ready *config.AMQOnline, e error) {
 			return config.NewAMQOnline(config.ProductConfig{
 				"NAMESPACE": defaultNamespace,

--- a/pkg/controller/installation/products/config/amqonline.go
+++ b/pkg/controller/installation/products/config/amqonline.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
@@ -39,6 +40,14 @@ func (a *AMQOnline) GetProductName() v1alpha1.ProductName {
 
 func (a *AMQOnline) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionAMQOnline
+}
+
+func (c *AMQOnline) GetBackendSecretName() string {
+	return "s3-credentials"
+}
+
+func (c *AMQOnline) GetBackupSchedule() string {
+	return "30 2 * * *"
 }
 
 func (a *AMQOnline) Validate() error {


### PR DESCRIPTION

Adds a CronJob resource to amq-online for PV backups 

https://issues.jboss.org/browse/INTLY-3025

## Verification steps

1. Run the integreatly-operator locally installing only the amq-online:
`operator-sdk up local --namespace=<integreatly_operator_namespace> --operator-flags=--products=amqonline`

2. Verify if amq-online has successfully reconciled 

3. Get a list of cronjobs available on amq-online namespace:
`oc get cronjob -n integreatly-amq-online` and look for a cronjob named `enmasse-pv-backup `

4. Create a job to test the cronjob manually:
 `oc create job --from=cronjob/enmasse-pv-backup manual-pv-backup-001 -n integreatly-amq-online` 

5. Check if the created job has succeeded, the cmd below should return 1 :
`oc get job manual-pv-backup-001 -n integreatly-amq-online --output=json -o jsonpath='{.status.succeeded}'`
