### PR TITLE
INTLY-4023 Port all monitoring resources from create_alerts.yml

### DIFF
--- a/pkg/controller/installation/products/amqonline/reconciler.go
+++ b/pkg/controller/installation/products/amqonline/reconciler.go
@@ -3,6 +3,7 @@ package amqonline
 import (
 	"context"
 	"fmt"
+
 	v1alpha12 "github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/monitoring"
 	appsv1 "k8s.io/api/apps/v1"
@@ -33,6 +34,7 @@ const (
 type Reconciler struct {
 	Config        *config.AMQOnline
 	ConfigManager config.ConfigReadWriter
+	extraParams   map[string]string
 	mpm           marketplace.MarketplaceInterface
 	restConfig    *rest.Config
 	logger        *logrus.Entry
@@ -132,6 +134,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 		return phase, err
 	}
 
+	phase, err = r.reconcileTemplates(ctx, inst, serverClient)
+	logrus.Infof("Phase: %s reconcileTemplates", phase)
+	if err != nil || phase != v1alpha1.PhaseCompleted {
+		logrus.Infof("Error: %s", err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileBlackboxTargets(ctx, inst, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
@@ -141,6 +150,43 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	return v1alpha1.PhaseCompleted, nil
+}
+
+// CreateResource Creates a generic kubernetes resource from a template
+func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
+	r.extraParams = map[string]string{}
+	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
+	r.extraParams["Namespace"] = r.Config.GetNamespace()
+
+	templateHelper := monitoring.NewTemplateHelper(inst, r.extraParams)
+	resourceHelper := monitoring.NewResourceHelper(inst, templateHelper)
+	resource, err := resourceHelper.CreateResource(resourceName)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "createResource failed")
+	}
+
+	err = serverClient.Create(ctx, resource)
+	if err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, errors.Wrap(err, "error creating resource")
+		}
+	}
+
+	return resource, nil
+}
+
+func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Installation, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
+	// Interate over template_list
+	for _, template := range r.Config.GetTemplateList() {
+		// create it
+		_, err := r.createResource(ctx, inst, template, serverClient)
+		if err != nil {
+			return v1alpha1.PhaseFailed, errors.Wrap(err, fmt.Sprintf("failed to create/update monitoring template %s", template))
+		}
+		logrus.Infof("Reconciling the monitoring template %s was successful", template)
+	}
 	return v1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/controller/installation/products/config/amqonline.go
+++ b/pkg/controller/installation/products/config/amqonline.go
@@ -26,6 +26,17 @@ func (a *AMQOnline) GetNamespace() string {
 	return a.config["NAMESPACE"]
 }
 
+func (r *AMQOnline) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *AMQOnline) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_amqonline_alerts.yaml",
+	}
+	return template_list
+}
+
 func (a *AMQOnline) SetNamespace(newNamespace string) {
 	a.config["NAMESPACE"] = newNamespace
 }

--- a/pkg/controller/installation/products/config/codeready.go
+++ b/pkg/controller/installation/products/config/codeready.go
@@ -24,6 +24,17 @@ func (c *CodeReady) GetNamespace() string {
 	return c.Config["NAMESPACE"]
 }
 
+func (r *CodeReady) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *CodeReady) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_codeready_alerts.yaml",
+	}
+	return template_list
+}
+
 func (c *CodeReady) SetNamespace(newNamespace string) {
 	c.Config["NAMESPACE"] = newNamespace
 }

--- a/pkg/controller/installation/products/config/fuse.go
+++ b/pkg/controller/installation/products/config/fuse.go
@@ -33,6 +33,17 @@ func (f *Fuse) Read() ProductConfig {
 	return f.config
 }
 
+func (r *Fuse) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *Fuse) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_fuse_online_alerts.yaml",
+	}
+	return template_list
+}
+
 func (f *Fuse) GetProductName() v1alpha1.ProductName {
 	return v1alpha1.ProductFuse
 }

--- a/pkg/controller/installation/products/config/launcher.go
+++ b/pkg/controller/installation/products/config/launcher.go
@@ -14,6 +14,17 @@ func (a *Launcher) GetHost() string {
 	return a.config["HOST"]
 }
 
+func (r *Launcher) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *Launcher) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_launcher_alerts.yaml",
+	}
+	return template_list
+}
+
 func (a *Launcher) SetHost(newHost string) {
 	a.config["HOST"] = newHost
 }

--- a/pkg/controller/installation/products/config/monitoring.go
+++ b/pkg/controller/installation/products/config/monitoring.go
@@ -14,12 +14,32 @@ func NewMonitoring(config ProductConfig) *Monitoring {
 	return &Monitoring{Config: config}
 }
 
+func (r *Monitoring) GetExtraParam(key string) string {
+	return r.Config[key]
+}
+
+func (r *Monitoring) SetExtraParam(key string, val string) {
+	r.Config[key] = val
+}
+
 func (r *Monitoring) GetNamespace() string {
 	return r.Config["NAMESPACE"]
 }
 
 func (r *Monitoring) SetNamespace(newNamespace string) {
 	r.Config["NAMESPACE"] = newNamespace
+}
+
+func (r *Monitoring) GetNamespacePrefix() string {
+	return r.Config["NAMESPACE_PREFIX"]
+}
+
+func (r *Monitoring) SetNamespacePrefix(newNamespacePrefix string) {
+	r.Config["NAMESPACE_PREFIX"] = newNamespacePrefix
+}
+
+func (r *Monitoring) GetMonitoringConfigurationNamespace() string {
+	return r.Config["NAMESPACE_PREFIX"] + r.Config["NAMESPACE"] + "-config"
 }
 
 func (r *Monitoring) GetHost() string {
@@ -71,19 +91,23 @@ func (r *Monitoring) GetPrometheusStorageRequest() string {
 }
 
 func (r *Monitoring) GetTemplateList() []string {
-	return []string{}
+	template_list := []string{
+		"kube_state_metrics_alerts.yaml",
+		"kube_state_metrics_monitoring_alerts.yaml",
+		"endpointsdetailed.yaml",
+		"endpointsreport.yaml",
+		"endpointssummary.yaml",
+		"resources-by-namespace.yaml",
+		"resources-by-pod.yaml",
+		"cluster-resources.yaml",
+	}
+	return template_list
 }
 
 func (r *Monitoring) GetJobTemplates() []string {
 	return []string{
-		"jobs/3scale",
-		"jobs/openshift_monitoring_federation",
-		"endpointsdetailed",
-		"endpointsreport",
-		"endpointssummary",
-		"resources-by-namespace",
-		"resources-by-pod",
-		"cluster-resources",
+		"jobs/3scale.yaml",
+		"jobs/openshift_monitoring_federation.yaml",
 	}
 }
 

--- a/pkg/controller/installation/products/config/rhsso.go
+++ b/pkg/controller/installation/products/config/rhsso.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
@@ -39,6 +40,17 @@ func (r *RHSSO) SetHost(newHost string) {
 
 func (r *RHSSO) Read() ProductConfig {
 	return r.Config
+}
+
+func (r *RHSSO) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *RHSSO) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_rhsso_alerts.yaml",
+	}
+	return template_list
 }
 
 func (r *RHSSO) GetProductName() v1alpha1.ProductName {

--- a/pkg/controller/installation/products/config/solutionExplorer.go
+++ b/pkg/controller/installation/products/config/solutionExplorer.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
@@ -27,6 +28,17 @@ func (s *SolutionExplorer) Read() ProductConfig {
 
 func (s *SolutionExplorer) GetHost() string {
 	return s.config["HOST"]
+}
+
+func (r *SolutionExplorer) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *SolutionExplorer) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_solution_explorer_alerts.yaml",
+	}
+	return template_list
 }
 
 func (s *SolutionExplorer) SetHost(newHost string) {

--- a/pkg/controller/installation/products/config/threescale.go
+++ b/pkg/controller/installation/products/config/threescale.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
@@ -23,6 +24,17 @@ func (t *ThreeScale) SetHost(newHost string) {
 
 func (t *ThreeScale) GetNamespace() string {
 	return t.config["NAMESPACE"]
+}
+
+func (r *ThreeScale) GetLabelSelector() string {
+	return "middleware"
+}
+
+func (r *ThreeScale) GetTemplateList() []string {
+	template_list := []string{
+		"kube_state_metrics_3scale_alerts.yaml",
+	}
+	return template_list
 }
 
 func (t *ThreeScale) SetNamespace(newNamespace string) {

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -16,6 +16,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/marketplace"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
+	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/monitoring"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	usersv1 "github.com/openshift/api/user/v1"
 	"github.com/pkg/errors"
@@ -41,6 +42,7 @@ type Reconciler struct {
 	coreClient    kubernetes.Interface
 	Config        *config.Fuse
 	ConfigManager config.ConfigReadWriter
+	extraParams   map[string]string
 	mpm           marketplace.MarketplaceInterface
 	logger        *logrus.Entry
 }
@@ -134,11 +136,55 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 		return phase, err
 	}
 
+	phase, err = r.reconcileTemplates(ctx, inst, serverClient)
+	logrus.Infof("Phase: %s reconcileTemplates", phase)
+	if err != nil || phase != v1alpha1.PhaseCompleted {
+		logrus.Infof("Error: %s", err)
+		return phase, err
+	}
+
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s has reconciled successfully", r.Config.GetProductName())
+	return v1alpha1.PhaseCompleted, nil
+}
+
+// CreateResource Creates a generic kubernetes resource from a template
+func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
+	r.extraParams = map[string]string{}
+	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
+	r.extraParams["Namespace"] = r.Config.GetNamespace()
+
+	templateHelper := monitoring.NewTemplateHelper(inst, r.extraParams)
+	resourceHelper := monitoring.NewResourceHelper(inst, templateHelper)
+	resource, err := resourceHelper.CreateResource(resourceName)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "createResource failed")
+	}
+
+	err = serverClient.Create(ctx, resource)
+	if err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, errors.Wrap(err, "error creating resource")
+		}
+	}
+
+	return resource, nil
+}
+
+func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Installation, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
+	// Interate over template_list
+	for _, template := range r.Config.GetTemplateList() {
+		// create it
+		_, err := r.createResource(ctx, inst, template, serverClient)
+		if err != nil {
+			return v1alpha1.PhaseFailed, errors.Wrap(err, fmt.Sprintf("failed to create/update monitoring template %s", template))
+		}
+		logrus.Infof("Reconciling the monitoring template %s was successful", template)
+	}
 	return v1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/controller/installation/products/launcher/reconciler.go
+++ b/pkg/controller/installation/products/launcher/reconciler.go
@@ -2,6 +2,7 @@ package launcher
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	launcherv1alpha2 "github.com/fabric8-launcher/launcher-operator/pkg/apis/launcher/v1alpha2"
@@ -40,6 +41,7 @@ type Reconciler struct {
 	appsv1Client  appsv1Client.AppsV1Interface
 	Config        *config.Launcher
 	ConfigManager config.ConfigReadWriter
+	extraParams   map[string]string
 	mpm           marketplace.MarketplaceInterface
 }
 
@@ -123,12 +125,55 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 		return phase, err
 	}
 
+	phase, err = r.reconcileTemplates(ctx, inst, serverClient)
+	logrus.Infof("Phase: %s reconcileTemplates", phase)
+	if err != nil || phase != v1alpha1.PhaseCompleted {
+		logrus.Infof("Error: %s", err)
+		return phase, err
+	}
+
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s is successfully reconciled", defaultLauncherName)
 	return phase, err
+}
+
+func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
+	r.extraParams = map[string]string{}
+	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
+	r.extraParams["Namespace"] = r.Config.GetNamespace()
+
+	templateHelper := monitoring.NewTemplateHelper(inst, r.extraParams)
+	resourceHelper := monitoring.NewResourceHelper(inst, templateHelper)
+	resource, err := resourceHelper.CreateResource(resourceName)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "createResource failed")
+	}
+
+	err = serverClient.Create(ctx, resource)
+	if err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, errors.Wrap(err, "error creating resource")
+		}
+	}
+
+	return resource, nil
+}
+
+func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Installation, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
+	// Interate over template_list
+	for _, template := range r.Config.GetTemplateList() {
+		// create it
+		_, err := r.createResource(ctx, inst, template, serverClient)
+		if err != nil {
+			return v1alpha1.PhaseFailed, errors.Wrap(err, fmt.Sprintf("failed to create/update monitoring template %s", template))
+		}
+		logrus.Infof("Reconciling the monitoring template %s was successful", template)
+	}
+	return v1alpha1.PhaseCompleted, nil
 }
 
 func (r *Reconciler) reconcileLauncher(ctx context.Context, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {

--- a/pkg/controller/installation/products/monitoring/resourceHelper.go
+++ b/pkg/controller/installation/products/monitoring/resourceHelper.go
@@ -12,14 +12,14 @@ type ResourceHelper struct {
 	cr             *v1alpha1.Installation
 }
 
-func newResourceHelper(cr *v1alpha1.Installation, th *TemplateHelper) *ResourceHelper {
+func NewResourceHelper(cr *v1alpha1.Installation, th *TemplateHelper) *ResourceHelper {
 	return &ResourceHelper{
 		templateHelper: th,
 		cr:             cr,
 	}
 }
 
-func (r *ResourceHelper) createResource(template string) (runtime.Object, error) {
+func (r *ResourceHelper) CreateResource(template string) (runtime.Object, error) {
 	tpl, err := r.templateHelper.loadTemplate(template)
 	if err != nil {
 		return nil, err

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -3,9 +3,10 @@ package rhsso
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	v1alpha12 "github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/monitoring"
-	"strings"
 
 	aerogearv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
@@ -55,6 +56,7 @@ var CustomerAdminUser = &aerogearv1.KeycloakUser{
 type Reconciler struct {
 	Config        *config.RHSSO
 	ConfigManager config.ConfigReadWriter
+	extraParams   map[string]string
 	mpm           marketplace.MarketplaceInterface
 	installation  *v1alpha1.Installation
 	logger        *logrus.Entry
@@ -137,12 +139,19 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 		return phase, err
 	}
 
-	phase, err = r.reconcileBlackboxTargets(ctx, inst, serverClient)
+	phase, err = r.handleProgressPhase(ctx, inst, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}
 
-	phase, err = r.handleProgressPhase(ctx, inst, serverClient)
+	phase, err = r.reconcileTemplates(ctx, inst, serverClient)
+	logrus.Infof("Phase: %s reconcileTemplates", phase)
+	if err != nil || phase != v1alpha1.PhaseCompleted {
+		logrus.Infof("Error: %s", err)
+		return phase, err
+	}
+
+	phase, err = r.reconcileBlackboxTargets(ctx, inst, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}
@@ -152,6 +161,46 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
+	return v1alpha1.PhaseCompleted, nil
+}
+
+// CreateResource Creates a generic kubernetes resource from a template
+func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
+	r.extraParams = map[string]string{}
+	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
+	r.extraParams["Namespace"] = r.Config.GetNamespace()
+
+	templateHelper := monitoring.NewTemplateHelper(inst, r.extraParams)
+	resourceHelper := monitoring.NewResourceHelper(inst, templateHelper)
+	resource, err := resourceHelper.CreateResource(resourceName)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "createResource failed")
+	}
+
+	err = serverClient.Create(ctx, resource)
+	if err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, errors.Wrap(err, "error creating resource")
+		}
+	}
+
+	return resource, nil
+}
+
+func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Installation, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
+	// Interate over template_list
+	for _, template := range r.Config.GetTemplateList() {
+		// create it
+		_, err := r.createResource(ctx, inst, template, serverClient)
+		if err != nil {
+			return v1alpha1.PhaseFailed, errors.Wrap(err, fmt.Sprintf("failed to create/update monitoring template %s", template))
+		}
+		logrus.Infof("Reconciling the monitoring template %s was successful", template)
+	}
 	return v1alpha1.PhaseCompleted, nil
 }
 

--- a/templates/monitoring/blackbox/target.yaml
+++ b/templates/monitoring/blackbox/target.yaml
@@ -1,12 +1,12 @@
 apiVersion: applicationmonitoring.integreatly.org/v1alpha1
 kind: BlackboxTarget
 metadata:
-  name: {{ index .ExtraParams "name"  }}
-  namespace: {{ .Namespace }}
+  name: {{ index .Params "name"  }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   blackboxTargets:
-    - service: {{ index .ExtraParams "service"  }}
-      url: {{ index .ExtraParams "url" }}
-      module: {{ index .ExtraParams "module" }}
+    - service: {{ index .Params "service"  }}
+      url: {{ index .Params "url" }}
+      module: {{ index .Params "module" }}

--- a/templates/monitoring/cluster-resources.yaml
+++ b/templates/monitoring/cluster-resources.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: cluster-resources-new
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   name: cluster-resources-new.json
   json: >

--- a/templates/monitoring/endpointsdetailed.yaml
+++ b/templates/monitoring/endpointsdetailed.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: endpointsdetailed
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   plugins:
     - name: "natel-discrete-panel"

--- a/templates/monitoring/endpointsreport.yaml
+++ b/templates/monitoring/endpointsreport.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: endpointsreport
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   json: |
     {

--- a/templates/monitoring/endpointssummary.yaml
+++ b/templates/monitoring/endpointssummary.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: endpointssummary
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   json: |
     {

--- a/templates/monitoring/jobs/3scale.yaml
+++ b/templates/monitoring/jobs/3scale.yaml
@@ -3,7 +3,7 @@
     - role: pod
       namespaces:
         names:
-          - {{ index .ExtraParams "threescale_namespace" }}
+          - {{ index .Params "threescale_namespace" }}
   relabel_configs:
     - action: labelmap
       regex: __meta_kubernetes_pod_label_(.+)

--- a/templates/monitoring/jobs/openshift_monitoring_federation.yaml
+++ b/templates/monitoring/jobs/openshift_monitoring_federation.yaml
@@ -4,7 +4,7 @@
   - role: service
     namespaces:
       names:
-      - {{ index .ExtraParams "openshift_monitoring_namespace" }}
+      - {{ index .Params "openshift_monitoring_namespace" }}
   scrape_interval: 30s
   metrics_path: /federate
   params:
@@ -20,8 +20,8 @@
   tls_config:
     insecure_skip_verify: true
   basic_auth:
-    username: {{ index .ExtraParams "openshift_monitoring_prometheus_username" }}
-    password: {{ index .ExtraParams "openshift_monitoring_prometheus_password" }}
+    username: {{ index .Params "openshift_monitoring_prometheus_username" }}
+    password: {{ index .Params "openshift_monitoring_prometheus_password" }}
   relabel_configs:
   - action: keep
     source_labels:

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -1,0 +1,157 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata: 
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-3scale-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:   
+  groups: 
+    - name: 3scale.rules
+      rules: 
+      - alert: ThreeScaleApicastStagingPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale apicast-staging has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"apicast-staging.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleApicastProductionPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale apicast-production has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"apicast-production.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendWorkerPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale backend-worker has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-worker.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendListenerPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale backend-listener has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-listener.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleBackendRedisPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale backend-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemRedisPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale system-redis has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-redis.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemMySQLPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale system-mysql has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-mysql.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAppPod
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale system-app has no pods in a ready state.
+        expr: |
+          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-app-.*"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleAdminUIBBT
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale Admin UI Blackbox Target: If this console is unavailable,
+            the client is unable to configure or administer their API setup.
+        expr: |
+          absent(probe_success{job="blackbox", service="3scale-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleDeveloperUIBBT
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale Developer UI Blackbox Target: If this console is
+            unavailable, the clients developers are unable signup or perform
+            API management.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-developer-console-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleSystemAdminUIBBT
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: >-
+            3Scale System Admin UI Blackbox Target: If this console is
+            unavailable, the client is unable to perform Account Management,
+            Analytics or Billing.
+        expr: >
+          absent(probe_success{job="blackbox",
+          service="3scale-system-admin-ui"})
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScalePodCount
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 15 pods.
+        expr: |
+          absent(sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) >= 15)
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ThreeScalePodHighMemory
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ index .Params "Namespace" }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
+        for: 15m
+        labels:
+          severity: warning
+      - alert: ThreeScalePodHighCPU
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available CPU for longer than 15 minutes.
+          scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
+        expr: |
+          sum(label_replace(namespace_pod_name_container_name:container_cpu_usage_seconds_total:sum_rate{namespace="{{ index .Params "Namespace" }}"}, 'container', '$1', 'container_name', '(.*)')) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ index .Params "Namespace" }}"}) by (container) * 100 > 90
+        for: 15m
+        labels:
+          severity: warning

--- a/templates/monitoring/kube_state_metrics_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_alerts.yaml
@@ -1,0 +1,110 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: general.rules
+      rules:
+      - alert: KubePodCrashLooping
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }} ({{ "{{" }} $labels.container {{ "}}" }}) is restarting {{ "{{" }} printf "%.2f" $value {{ "}}" }} times every 5 minutes; for the last 15 minutes.
+        expr: |
+          rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"} * 60 * 5 > 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: ESPodCount
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Expected at least Elastic Search 1 pods in namespace {{ "{{" }} $labels.namespace {{ "}}" }}.
+        expr: |
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="openshift-logging", pod=~"logging-es-data-master-.*"})) 
+        for: 5m
+        labels:
+          severity: warning
+      - alert: ESNotReady
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Not all Elastic Search replication controllers are in a ready state.
+        expr: |
+          count(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"}) != sum(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"})
+        for: 5m
+        labels:
+          severity: warning
+      - alert: KubePodNotReady
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }} has been in a non-ready state for longer than 15 minutes.
+        expr: |
+          sum by(pod, namespace) (kube_pod_status_phase{phase=~"Pending|Unknown"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: KubePodImagePullBackOff
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }} has been unable to pull it's image for longer than 5 minutes.
+        expr: |
+          (kube_pod_container_status_waiting_reason{reason="ImagePullBackOff"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: KubePodBadConfig
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }} has been unable to start due to a bad configuration for longer than 5 minutes.
+        expr: |
+          (kube_pod_container_status_waiting_reason{reason="CreateContainerConfigError"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+        for: 5m
+        labels:
+          severity: critical
+      - alert: KubePodStuckCreating
+        annotations:
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+          message: Pod {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.pod {{ "}}" }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.
+        expr: |
+          (kube_pod_container_status_waiting_reason{reason="ContainerCreating"} * on (namespace, namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: ClusterSchedulableMemoryLow
+        annotations:
+          message: The cluster has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of memory requested and unavailable for scheduling for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+           ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_memory_bytes * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_memory_bytes)))))) * 100 > 85
+        for: 15m
+        labels:
+          severity: warning
+      - alert: ClusterSchedulableCPULow
+        annotations:
+          message: The cluster has {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of CPU cores requested and unavailable for scheduling for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+           ((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests_cpu_cores * on(node) group_left() (sum by(node) (kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase="Running"}) == 1)))) / ((sum((kube_node_labels{label_node_role_kubernetes_io_compute="true"} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable_cpu_cores)))))) * 100 > 85
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PVCStorageAvailable
+        annotations:
+          message: The {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} PVC has has been {{ "{{" }} printf "%.0f" $value {{ "}}" }}% full for longer than 15 minutes.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+          ((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"})) * 100 > 85
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PVCStorageMetricsAvailable
+        annotations:
+          message: PVC storage metrics are not available
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc
+        expr: |
+          absent(kubelet_volume_stats_available_bytes) == 1
+        for: 15m
+        labels:
+          severity: warning

--- a/templates/monitoring/kube_state_metrics_amqonline_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_amqonline_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-amqonline-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: amqonline.rules
+      rules:
+        - alert: AMQOnlinePodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 6 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) < 6
+          for: 5m
+          labels:
+            severity: critical
+        - alert: AMQOnlinePodHighMemory
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
+            scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/amq-scaling.md
+          expr: |
+            sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ index .Params "Namespace" }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
+          for: 15m
+          labels:
+            severity: warning

--- a/templates/monitoring/kube_state_metrics_codeready_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_codeready_alerts.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-codeready-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: codeready.rules
+      rules:
+        - alert: CodeReadyPodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 2 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) < 2
+          for: 5m
+          labels:
+            severity: critical

--- a/templates/monitoring/kube_state_metrics_fuse_online_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_fuse_online_alerts.yaml
@@ -1,0 +1,40 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-fuse-online-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: fuseOnline.rules
+      rules:
+        - alert: FuseOnlineSyndesisServerInstanceDown
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: >-
+              Fuse Online Syndesis Server instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
+          expr: >
+            absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"syndesis-server-.*"})
+          for: 5m
+          labels:
+            severity: critical
+        - alert: FuseOnlineSyndesisUIInstanceDown
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: >-
+              Fuse Online Syndesis UI instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
+          expr: >
+            absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"syndesis-ui-.*"})
+          for: 5m
+          labels:
+            severity: critical
+        - alert: FuseOnlinePodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 8 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) < 8
+          for: 5m
+          labels:
+            severity: critical

--- a/templates/monitoring/kube_state_metrics_launcher_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_launcher_alerts.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-launcher-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: launcher.rules
+      rules:
+        - alert: LauncherPodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 6 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 6
+          for: 5m
+          labels:
+            severity: critical

--- a/templates/monitoring/kube_state_metrics_monitoring_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_monitoring_alerts.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-monitoring-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: mointoring.rules
+      rules:
+        - alert: MiddlewareMonitoringPodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 6 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 6
+          for: 5m
+          labels:
+            severity: critical

--- a/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
@@ -1,0 +1,30 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-rhsso-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: rhsso.rules
+      rules:
+        - alert: RHSSOPodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 3 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 3
+          for: 5m
+          labels:
+            severity: critical
+        - alert: RHSSOPodHighMemory
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
+            scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/sso-scaling.md
+          expr: |
+            sum by(container) (label_replace(container_memory_usage_bytes{container_name!="",namespace="{{ index .Params "Namespace" }}"}, "container", "$1", "container_name", "(.*)")) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
+          for: 15m
+          labels:
+            severity: warning

--- a/templates/monitoring/kube_state_metrics_solution_explorer_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_solution_explorer_alerts.yaml
@@ -1,0 +1,20 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    monitoring-key: {{ index .Params "MonitoringKey" }}
+  name: ksm-solution-explorer-alerts
+  namespace: {{ index .Params "Namespace" }}
+spec:
+  groups:
+    - name: solution-explorer.rules
+      rules:
+        - alert: SolutionExplorerPodCount
+          annotations:
+            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 2 pods.
+          expr: |
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 2
+          for: 5m
+          labels:
+            severity: critical

--- a/templates/monitoring/resources-by-namespace.yaml
+++ b/templates/monitoring/resources-by-namespace.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: resources-by-namespace
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   name: resources-by-namespace.json
   json: >

--- a/templates/monitoring/resources-by-pod.yaml
+++ b/templates/monitoring/resources-by-pod.yaml
@@ -2,9 +2,9 @@ apiVersion: integreatly.org/v1alpha1
 kind: GrafanaDashboard
 metadata:
   name: resources-by-pod
-  namespace: {{ .Namespace }}
+  namespace: {{ index .Params "Namespace" }}
   labels:
-    monitoring-key: {{ .MonitoringKey }}
+    monitoring-key: {{ index .Params "MonitoringKey" }}
 spec:
   name: resources-by-pod.json
   json: >

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -33,7 +33,7 @@ var (
 	cleanupRetryInterval             = time.Second * 1
 	cleanupTimeout                   = time.Second * 5
 	installationCleanupRetryInterval = time.Second * 20
-	installationCleanupTimeout       = time.Minute * 4 //Longer timeout required to allow for finalizers to execute
+	installationCleanupTimeout       = time.Minute * 8 //Longer timeout required to allow for finalizers to execute
 	intlyNamespacePrefix             = "intly-"
 	installationName                 = "e2e-managed-installation"
 	bootstrapStage                   = "bootstrap"


### PR DESCRIPTION
JIRA: https://issues.jboss.org/browse/INTLY-4023

## Description
https://github.com/integr8ly/installation/blob/master/roles/middleware_monitoring_config/tasks/main.yml#L2-L8
Porting of monitoring stack configuration 

```
monitoring_prometheusrules_resource_templates:
- kube_state_metrics_alerts.yml
- kube_state_metrics_3scale_alerts.yml
- kube_state_metrics_fuse_online_alerts.yml
```

```
Breaking alerts out into individual product templates:
    kube_state_metrics_3scale_alerts.yaml
    kube_state_metrics_alerts.yaml
    kube_state_metrics_amqonline_alerts.yaml
    kube_state_metrics_codeready_alerts.yaml
    kube_state_metrics_fuse_online_alerts.yaml
    kube_state_metrics_launcher_alerts.yaml
    kube_state_metrics_monitoring_alerts.yaml
    kube_state_metrics_rhsso_alerts.yaml
    kube_state_metrics_solution_explorer_alerts.yaml
    
Removing references to che/enmasse, replaced with codeready/amqonline
```

## Verification
- Authenticate with Openshift
- Create ``integreatly`` namespace
- Create the secrets for preflight checks:
```
# Execute from integreatly-operator dir
oc process -f ./deploy/s3-secrets.yaml -p INSTALLATION_NAMESPACE=integreatly -p AWS_ACCESS_KEY_ID=xxxx -p AWS_SECRET_ACCESS_KEY=xxxx -p AWS_BUCKET=xxxx-test -p AWS_REGION=eu-central-1 | oc create -f -
oc create secret generic github-oauth-secret --from-literal=clientId=xxxx --from-literal=secret=xxx -n integreatly
```
- Run the task in the Makefile: ``make cluster/prepare/local``
- Run the operator locally: ``operator-sdk up local --namespace "integreatly" --operator-flags "--products=monitoring"``
- Create instance of the installation CR eg:
```
apiVersion: integreatly.org/v1alpha1
kind: Installation
metadata:
  name: example-installation
spec:
  type: workshop
  namespacePrefix: integreatly-
  routingSubdomain: apps.com
  masterUrl: https://someurl.apps.com
  selfSignedCerts: true
```
- Wait for reconcile of the monitoring product to complete
- Check the PrometheusRules have been created in the ``integreatly-middleware-monitoring`` namespace: 
1. ``ksm-alerts``
2. ``ksm-monitoring-alerts``