### PR TITLE
Change cloud resources subscription name

### DIFF
--- a/pkg/controller/installation/products/cloudresources/reconciler.go
+++ b/pkg/controller/installation/products/cloudresources/reconciler.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	defaultInstallationNamespace = "cloud-resources"
-	defaultSubscriptionName      = "integreatly-cloud-resources"
+	defaultSubscriptionName      = "cloud-resources"
 )
 
 type Reconciler struct {


### PR DESCRIPTION
### Description
Change the subscription name for the cloud resource operator to match the manifests repo.

### Verification 
- Create an operator source pointing to the integreatly registry 
```yml
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: integreatly-operators
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: Integreatly Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: integreatly
type: appregistry
```
- Run the integreatly operator from this branch, and create an installation CR with `useExternalResources` set to tru
- Ensure the `cloud-resources` stage completes
- Verify that the cloud resource operator is running in the `cloud-resources` namespace 