### PR TITLE
INTLY-4131: Create rhmi-admins users group

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -276,8 +276,8 @@ rules:
     resources:
       - "rolebindings"
     verbs:
-      - create #needed for creating rolebinding for dedicated-admins to view fuse
-      - update #needed for updating subject list to match changes to dedicated-admins users
+      - create #needed for creating rolebinding for rhmi-admins to view fuse
+      - update #needed for updating subject list to match changes to rhmi-admins users
   # This is used to allow the operator to create and update the rhmi-developers group with users
   - apiGroups:
       - user.openshift.io

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -3,8 +3,9 @@ package fuse
 import (
 	"context"
 	"fmt"
-	v13 "github.com/openshift/api/image/v1"
 	"strings"
+
+	v13 "github.com/openshift/api/image/v1"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "github.com/openshift/api/route/v1"
@@ -30,7 +31,7 @@ import (
 const (
 	defaultInstallationNamespace = "fuse"
 	defaultSubscriptionName      = "integreatly-syndesis"
-	adminGroupName               = "dedicated-admins"
+	adminGroupName               = "rhmi-admins"
 	defaultFusePullSecret        = "syndesis-pull-secret"
 )
 

--- a/pkg/controller/installation/products/fuse/reconciler_test.go
+++ b/pkg/controller/installation/products/fuse/reconciler_test.go
@@ -348,7 +348,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 	}
 	openshiftAdminGroup := &usersv1.Group{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "dedicated-admins",
+			Name: "rhmi-admins",
 		},
 		Users: []string{
 			test1User.Name,

--- a/pkg/controller/installation/products/fuseonopenshift/reconciler.go
+++ b/pkg/controller/installation/products/fuseonopenshift/reconciler.go
@@ -370,7 +370,7 @@ func (r *Reconciler) updateClusterSampleCR(ctx context.Context, serverClient pkg
 
 	if key == "SkippedImagestreams" {
 		for _, v := range value {
-			if !r.contains(clusterSampleCR.Spec.SkippedImagestreams, v) {
+			if !resources.Contains(clusterSampleCR.Spec.SkippedImagestreams, v) {
 				clusterSampleCR.Spec.SkippedImagestreams = append(clusterSampleCR.Spec.SkippedImagestreams, v)
 			}
 		}
@@ -378,7 +378,7 @@ func (r *Reconciler) updateClusterSampleCR(ctx context.Context, serverClient pkg
 
 	if key == "SkippedTemplates" {
 		for _, v := range value {
-			if !r.contains(clusterSampleCR.Spec.SkippedTemplates, v) {
+			if !resources.Contains(clusterSampleCR.Spec.SkippedTemplates, v) {
 				clusterSampleCR.Spec.SkippedTemplates = append(clusterSampleCR.Spec.SkippedTemplates, v)
 			}
 		}
@@ -404,15 +404,5 @@ func (r *Reconciler) resourceHasLabel(labels map[string]string, key, value strin
 	if val, ok := labels[key]; ok && val == value {
 		return true
 	}
-	return false
-}
-
-func (r *Reconciler) contains(list []string, value string) bool {
-	for _, v := range list {
-		if v == value {
-			return true
-		}
-	}
-
 	return false
 }

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -448,7 +448,7 @@ func syncronizeWithOpenshiftUsers(keycloakUsers []*aerogearv1.KeycloakUser, ctx 
 	}
 
 	openshiftAdminGroup := &usersv1.Group{}
-	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: "dedicated-admins"}, openshiftAdminGroup)
+	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: "rhmi-admins"}, openshiftAdminGroup)
 	if err != nil && !k8serr.IsNotFound(err) {
 		return nil, err
 	}

--- a/pkg/controller/installation/products/threescale/asserts_test.go
+++ b/pkg/controller/installation/products/threescale/asserts_test.go
@@ -123,7 +123,7 @@ func assertInstallationSuccessfull(scenario ThreeScaleTestScenario, configManage
 		return errors.New(fmt.Sprintf("Service discovery config is misconfigured"))
 	}
 
-	// rhsso users should be users in 3scale. If an rhsso user is also in dedicated-admins group that user should be an admin in 3scale.
+	// rhsso users should be users in 3scale. If an rhsso user is also in rhmi-admins group that user should be an admin in 3scale.
 	tsUsers, _ := fakeThreeScaleClient.GetUsers("accessToken")
 	if len(tsUsers.Users) != len(kcr.Spec.Users) {
 		return errors.New(fmt.Sprintf("Rhsso users should be mapped into 3scale users"))

--- a/pkg/controller/installation/products/threescale/objects_test.go
+++ b/pkg/controller/installation/products/threescale/objects_test.go
@@ -3,6 +3,7 @@ package threescale
 import (
 	"bytes"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 
@@ -127,7 +128,7 @@ var rhssoTest2 = &aerogearv1.KeycloakUser{
 
 var testDedicatedAdminsGroup = &usersv1.Group{
 	ObjectMeta: metav1.ObjectMeta{
-		Name: "dedicated-admins",
+		Name: "rhmi-admins",
 	},
 	Users: []string{
 		rhssoTest1.UserName,

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -578,7 +578,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient p
 	}
 
 	openshiftAdminGroup := &usersv1.Group{}
-	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: "dedicated-admins"}, openshiftAdminGroup)
+	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: "rhmi-admins"}, openshiftAdminGroup)
 	if err != nil && !k8serr.IsNotFound(err) {
 		return v1alpha1.PhaseFailed, err
 	}

--- a/pkg/resources/finalizers.go
+++ b/pkg/resources/finalizers.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,7 @@ import (
 // AddFinalizer adds a finalizer to the custom resource. This allows us to clean up oauth clients
 // and other cluster level objects owned by the installation before the cr is deleted
 func AddFinalizer(ctx context.Context, inst *v1alpha1.Installation, client pkgclient.Client, finalizer string) error {
-	if !contains(inst.GetFinalizers(), finalizer) && inst.GetDeletionTimestamp() == nil {
+	if !Contains(inst.GetFinalizers(), finalizer) && inst.GetDeletionTimestamp() == nil {
 		inst.SetFinalizers(append(inst.GetFinalizers(), finalizer))
 		err := client.Update(ctx, inst)
 		if err != nil {
@@ -69,15 +70,6 @@ func RemoveProductFinalizer(ctx context.Context, inst *v1alpha1.Installation, cl
 		return err
 	}
 	return nil
-}
-
-func contains(list []string, s string) bool {
-	for _, v := range list {
-		if v == s {
-			return true
-		}
-	}
-	return false
 }
 
 func remove(list []string, s string) []string {

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -109,7 +109,7 @@ func (r *Reconciler) ReconcileFinalizer(ctx context.Context, client pkgclient.Cl
 	// Run finalization logic. If it fails, don't remove the finalizer
 	// so that we can retry during the next reconciliation
 	if inst.GetDeletionTimestamp() != nil {
-		if contains(inst.GetFinalizers(), finalizer) {
+		if Contains(inst.GetFinalizers(), finalizer) {
 			phase, err := finalFunc()
 			if err != nil || phase != v1alpha1.PhaseCompleted {
 				return phase, err

--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -1,0 +1,12 @@
+package resources
+
+// Checks if value given is contained in a string array
+func Contains(list []string, value string) bool {
+	for _, v := range list {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## What
The following changes ensures that a group `rhmi-admins` is created during the bootstrap stage. This group should contain all users that are expected to be admins in the Integreatly product suite, which includes all users from the `dedicated-admins` group. 

Currently, the way users are set as admins to the Integreatly product suite is by reading users from the admin group. Instead of reading from `dedicated-admins`, the product should get users specified in the `rhmi-admins` group.

By doing this, we can set users as admins to the Integreatly product suite without having to give them `dedicated-admins` permissions.

## Verification Steps
1. Add a user to the `dedicated-admins` group.
2. Run the operator locally
3. Verify that the `rhmi-admins` group is created
   - Go to *Search* > *Groups*
   - The group `rhmi-admins` should be present
4. Verify that users added to `dedicated-admins` group is added to the `rhmi-admins` group
   - Go to the YAML definition of the `rhmi-admins` group
   - Any users included in the `dedicated-admins` group should also be included in the `rhmi-admins` group.
5. Verify that users are successfully reconciled between the `dedicated-admins` and `rhmi-admins` group.
   - Add another user to the `dedicated-admins` group.
   - This user should be added to the `rhmi-admins` group upon bootstrap reconcile.
6. Verify that users added to the `rhmi-admins` group are set as an admin user in the Integreatly product suite.
   - **Visible Namespaces**: 
      - `rhmi-admins` users should only be able to view the Fuse namespace and their own namespaces. 
          - Any users belonging to the `rhmi-admins` group should be added to the `rhmi-admins-view-fuse` role binding.
      - `dedicated-admins` users should be able to see all namespaces. 
      - A user that doesn't belong to any of these two groups should not be able to see any namespaces apart from their own.
   - **RHSSO**: 
      - Go to *Search* > *Keycloak Realm* > *openshift*
      - admin users should have the following extra permissions added to their `clientRoles`: 
         ```
          realm-management:
          - manage-users
          - manage-identity-providers
          - view-realm
         ```
   - **3Scale**:
      - Log in to the 3Scale admin console.
      - Any users belonging to the `rhmi-admins` group should have the role `admin`. 
      - Any users that doesn't belong to this group should have the role `member`