### PR TITLE
INTLY-4131: Ensure rhmi-developers group has view access to Fuse namespace

### DIFF
--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -23,3 +23,17 @@ roleRef:
   kind: ClusterRole
   name: integreatly-operator
   apiGroup: rbac.authorization.k8s.io
+---
+# This is required for granting view access permission to the Fuse namespace for rhmi-developer users.
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: integreatly-operator-cluster-view
+subjects:
+  - kind: ServiceAccount
+    name: integreatly-operator
+    namespace: integreatly
+roleRef:
+  kind: ClusterRole
+  name: view
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -3,8 +3,9 @@ package fuse
 import (
 	"context"
 	"fmt"
-	v13 "github.com/openshift/api/image/v1"
 	"strings"
+
+	v13 "github.com/openshift/api/image/v1"
 
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "github.com/openshift/api/route/v1"
@@ -30,8 +31,9 @@ import (
 const (
 	defaultInstallationNamespace = "fuse"
 	defaultSubscriptionName      = "integreatly-syndesis"
-	adminGroupName               = "dedicated-admins"
 	defaultFusePullSecret        = "syndesis-pull-secret"
+	developersGroupName          = "rhmi-developers"
+	clusterViewRoleName          = "view"
 )
 
 type Reconciler struct {
@@ -99,7 +101,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 		return phase, err
 	}
 
-	phase, err = r.reconcileAdminPerms(ctx, serverClient)
+	phase, err = r.reconcileViewFusePerms(ctx, serverClient)
 	if err != nil || phase != v1alpha1.PhaseCompleted {
 		return phase, err
 	}
@@ -191,69 +193,39 @@ func (r *Reconciler) reconcileImageVersion(ctx context.Context, install *v1alpha
 	return v1alpha1.PhaseFailed, errors.New("Could not find trigger for postgres:9.5 in deploymentconfig")
 }
 
-func (r *Reconciler) reconcileAdminPerms(ctx context.Context, client pkgclient.Client) (v1alpha1.StatusPhase, error) {
-	r.logger.Infof("Reconciling permissions for %s group on %s namespace", adminGroupName, r.Config.GetNamespace())
-
-	roleName := adminGroupName + "-view-fuse"
-	adminViewFuseRole := &rbacv1.ClusterRole{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: roleName,
-		},
-	}
-	or, err := controllerutil.CreateOrUpdate(ctx, client, adminViewFuseRole, func(existing runtime.Object) error {
-		cr := existing.(*rbacv1.ClusterRole)
-
-		cr.Rules = []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"namespaces"},
-				Verbs:     []string{"get"},
-			},
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"pods"},
-				Verbs:     []string{"get", "list"},
-			},
-			{
-				APIGroups: []string{"*"},
-				Resources: []string{"pods/log"},
-				Verbs:     []string{"get"},
-			},
-		}
-
-		return nil
-	})
-	r.logger.Infof("The %s role perms were: %s", adminViewFuseRole.Name, or)
+// Ensures all users in rhmi-developers group have view Fuse permissions
+func (r *Reconciler) reconcileViewFusePerms(ctx context.Context, client pkgclient.Client) (v1alpha1.StatusPhase, error) {
+	r.logger.Infof("Reconciling view Fuse permissions for %s group on %s namespace", developersGroupName, r.Config.GetNamespace())
 
 	openshiftUsers := &usersv1.UserList{}
-	err = client.List(ctx, &pkgclient.ListOptions{}, openshiftUsers)
+	err := client.List(ctx, &pkgclient.ListOptions{}, openshiftUsers)
 	if err != nil {
 		return v1alpha1.PhaseFailed, err
 	}
 
-	openshiftAdminGroup := &usersv1.Group{}
-	err = client.Get(ctx, pkgclient.ObjectKey{Name: adminGroupName}, openshiftAdminGroup)
+	rhmiDevelopersGroup := &usersv1.Group{}
+	err = client.Get(ctx, pkgclient.ObjectKey{Name: developersGroupName}, rhmiDevelopersGroup)
 	if err != nil && !k8serr.IsNotFound(err) {
 		return v1alpha1.PhaseFailed, err
 	}
 
-	adminViewFuseRoleBinding := &rbacv1.RoleBinding{
+	viewFuseRoleBinding := &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleName,
+			Name:      developersGroupName + "-fuse-view",
 			Namespace: r.Config.GetNamespace(),
 		},
 		RoleRef: rbacv1.RoleRef{
 			APIGroup: "rbac.authorization.k8s.io",
 			Kind:     "ClusterRole",
-			Name:     roleName,
+			Name:     clusterViewRoleName,
 		},
 	}
-	or, err = controllerutil.CreateOrUpdate(ctx, client, adminViewFuseRoleBinding, func(existing runtime.Object) error {
+	or, err := controllerutil.CreateOrUpdate(ctx, client, viewFuseRoleBinding, func(existing runtime.Object) error {
 		rb := existing.(*rbacv1.RoleBinding)
 
 		subjects := []rbacv1.Subject{}
 		for _, osUser := range openshiftUsers.Items {
-			if userIsOpenshiftAdmin(osUser, openshiftAdminGroup) {
+			if groupContainsUser(osUser, rhmiDevelopersGroup) {
 				subjects = append(subjects, rbacv1.Subject{
 					APIGroup: "rbac.authorization.k8s.io",
 					Name:     osUser.Name,
@@ -268,7 +240,7 @@ func (r *Reconciler) reconcileAdminPerms(ctx context.Context, client pkgclient.C
 	if err != nil {
 		return v1alpha1.PhaseFailed, err
 	}
-	r.logger.Infof("The %s subjects were: %s", adminViewFuseRoleBinding.Name, or)
+	r.logger.Infof("The %s subjects were: %s", viewFuseRoleBinding.Name, or)
 	return v1alpha1.PhaseCompleted, nil
 }
 
@@ -382,8 +354,8 @@ func (r *Reconciler) reconcileCustomResource(ctx context.Context, install *v1alp
 	return v1alpha1.PhaseCompleted, nil
 }
 
-func userIsOpenshiftAdmin(user usersv1.User, adminGroup *usersv1.Group) bool {
-	for _, userName := range adminGroup.Users {
+func groupContainsUser(user usersv1.User, group *usersv1.Group) bool {
+	for _, userName := range group.Users {
 		if user.Name == userName {
 			return true
 		}

--- a/pkg/controller/installation/products/fuse/reconciler_test.go
+++ b/pkg/controller/installation/products/fuse/reconciler_test.go
@@ -346,9 +346,9 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			Name: "test1",
 		},
 	}
-	openshiftAdminGroup := &usersv1.Group{
+	rhmiDevelopersGroup := &usersv1.Group{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "dedicated-admins",
+			Name: "rhmi-developers",
 		},
 		Users: []string{
 			test1User.Name,
@@ -369,7 +369,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:           "test successful reconcile",
 			ExpectedStatus: v1alpha1.PhaseCompleted,
-			FakeClient:     fakeclient.NewFakeClientWithScheme(scheme, getFuseCr(syn.SyndesisPhaseInstalled), getFuseDC(ns.Name), ns, route, secret, test1User, openshiftAdminGroup, pullSecret, installation),
+			FakeClient:     fakeclient.NewFakeClientWithScheme(scheme, getFuseCr(syn.SyndesisPhaseInstalled), getFuseDC(ns.Name), ns, route, secret, test1User, rhmiDevelopersGroup, pullSecret, installation),
 			FakeConfig:     basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient pkgclient.Client, owner ownerutil.Owner, os operatorsv1.OperatorSource, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval) error {


### PR DESCRIPTION
## What
The following changes ensures that all users belonging to the group `rhmi-developers` can access and view the Fuse namespace. 

## Verification Steps
1. Run the operator locally
2. Login as a non-admin user
    - User should get added to the `rhmi-developers` group
    - Verify that this user gets added as a subject to the `rhmi-developers-view-fuse` role binding located in the Fuse namespace. (This may take a couple of seconds to reconcile)
    - Verify that the role binding references the cluster role `view`
    - User should only be able to see Fuse and their own namespaces.
3. Verify that the user only has view access to the Fuse namespace
    - Click on the Fuse namespace
    - Ensure that the user can view the *Overview*, *YAML* and *Workload* pages.
    - Ensure that the user is not able to update any resources within the namespace