### PR TITLE
Include all packages in coverprofile, but omit generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ anaconda-mode/
 *.test
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+*.out.tmp
 ### Vim ###
 # swap
 .sw[a-p]

--- a/scripts/ci/unit_test.sh
+++ b/scripts/ci/unit_test.sh
@@ -26,7 +26,8 @@ report_coverage_travis() {
 }
 
 echo Running tests:
-go test -v -covermode=count -coverprofile=$COVER_PROFILE ./pkg/...
+go test -v -covermode=count -coverpkg=./pkg/... -coverprofile=$COVER_PROFILE.tmp ./pkg/...
+cat $COVER_PROFILE.tmp | grep -v "zz_generated" > $COVER_PROFILE
 
 if [[ ! -z "${REPORT_COVERAGE}" ]]; then
 


### PR DESCRIPTION
A recent PR that added new unit tests caused the coverage % to go down.
https://github.com/integr8ly/integreatly-operator/pull/205
It looks like any package that doesn't have a test file in it is omitted from the coverage report. In that PR, a  test file was added, which caused all files in the monitoring package to be included int he coverage report, and take the overall % of coverage down.

This PR changes the coverprofile so it include all packages (omitting generated files) in an attempt to get a better gauge on where coverage is missing. (It should show any 0% covered packages, which were omitted from results before)

See https://github.com/golang/go/issues/24570 for some discussion on this topic.