### PR TITLE
Update configmap clusterrole permissions

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -239,6 +239,7 @@ rules:
     verbs:
       - get
       - update
+      - create
   - apiGroups:
       - apps.openshift.io
     resources:


### PR DESCRIPTION
Allows the integreatly operator to create configmaps in other namespaces