### PR TITLE
add permission to create configmaps to the cluster role

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -239,6 +239,7 @@ rules:
     verbs:
       - get
       - update
+      - create
   - apiGroups:
       - apps.openshift.io
     resources:


### PR DESCRIPTION
## What
This is needed to create 3scale smtp configmap in the 3scale namespace which was added in this [PR](https://github.com/integr8ly/integreatly-operator/pull/197)

## Verification
1. Run the operator using the operator's service account
    - `make code/run/service_account NAMESPACE=<namespace>`
2. Ensure installation of all products has been completed successfully
