### PR TITLE
Add the monitoring label to all managed namespaces, including the nam…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,6 +133,7 @@ cluster/prepare: cluster/prepare/project cluster/prepare/secrets cluster/prepare
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
 	@oc new-project $(NAMESPACE)
+	@oc label namespace $(NAMESPACE) monitoring-key=middleware
 	@oc project $(NAMESPACE)
 
 .PHONY: cluster/prepare/secrets

--- a/deploy/integreatly.selectorsyncset.yml
+++ b/deploy/integreatly.selectorsyncset.yml
@@ -12,6 +12,8 @@ spec:
       kind: Namespace
       metadata:
         name: integreatly-operator
+        labels:
+          monitoring-key: middleware
     - apiVersion: operators.coreos.com/v1
       kind: OperatorSource
       metadata:

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -186,6 +186,7 @@ func PrepareObject(ns metav1.Object, install *v1alpha1.Installation) {
 		labels = map[string]string{}
 	}
 	labels["integreatly"] = "true"
+	labels["monitoring-key"] = "middleware"
 	labels[OwnerLabelKey] = string(install.GetUID())
 	ns.SetLabels(labels)
 }


### PR DESCRIPTION
…espace of the integreatly operator

This is to allow the application monitoring operator & it's components to watch all monitoring resources in all managed namespaces.