### PR TITLE
adds operator version to installation cr

### DIFF
--- a/pkg/apis/aerogear/v1alpha1/types.go
+++ b/pkg/apis/aerogear/v1alpha1/types.go
@@ -246,8 +246,9 @@ type GenericStatus struct {
 	Message  string      `json:"message"`
 	Attempts int         `json:"attempts"`
 	// marked as true when all work is done on it
-	Ready   bool   `json:"ready"`
-	Version string `json:"version"`
+	Ready           bool   `json:"ready"`
+	Version         string `json:"version"`
+	OperatorVersion string `json:"operator"`
 }
 
 type KeycloakStatus struct {

--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -8,6 +8,7 @@ type StatusPhase string
 type InstallationType string
 type ProductName string
 type ProductVersion string
+type OperatorVersion string
 type PreflightStatus string
 type StageName string
 
@@ -67,21 +68,21 @@ var (
 	PreflightSuccess    PreflightStatus = "successful"
 	PreflightFail       PreflightStatus = "failed"
 
-	OperatorVersionAMQStreams            = "1.1.0"
-	OperatorVersionAMQOnline             = "1.2.2"
-	OperatorVersionMonitoring            = "0.0.28"
-	OperatorVersionSolutionExplorer      = "0.0.34"
-	OperatorVersionRHSSO                 = "1.9.5"
-	OperatorVersionRHSSOUser             = "1.9.5"
-	OperatorVersionCodeReadyWorkspaces   = "1.2.2"
-	OperatorVersionFuse                  = "1.4.0"
-	OperatorVersion3Scale                = "1.9.8"
-	OperatorVersionNexus                 = "0.9.0"
-	OperatorVersionLauncher              = "0.1.2"
-	OperatorVersionUPS                   = "0.3.0"
-	OperatorVersionMobileSecurityService = "0.4.1"
-	OperatorVersionMDC                   = "0.3.0"
-	OperatorVersionCloudResources        = "0.1.0"
+	OperatorVersionAMQStreams            OperatorVersion = "1.1.0"
+	OperatorVersionAMQOnline             OperatorVersion = "1.2.2"
+	OperatorVersionMonitoring            OperatorVersion = "0.0.28"
+	OperatorVersionSolutionExplorer      OperatorVersion = "0.0.34"
+	OperatorVersionRHSSO                 OperatorVersion = "1.9.5"
+	OperatorVersionRHSSOUser             OperatorVersion = "1.9.5"
+	OperatorVersionCodeReadyWorkspaces   OperatorVersion = "1.2.2"
+	OperatorVersionFuse                  OperatorVersion = "1.4.0"
+	OperatorVersion3Scale                OperatorVersion = "1.9.8"
+	OperatorVersionNexus                 OperatorVersion = "0.9.0"
+	OperatorVersionLauncher              OperatorVersion = "0.1.2"
+	OperatorVersionUPS                   OperatorVersion = "0.3.0"
+	OperatorVersionMobileSecurityService OperatorVersion = "0.4.1"
+	OperatorVersionMDC                   OperatorVersion = "0.3.0"
+	OperatorVersionCloudResources        OperatorVersion = "0.1.0"
 )
 
 // InstallationSpec defines the desired state of Installation
@@ -121,12 +122,13 @@ type InstallationStageStatus struct {
 }
 
 type InstallationProductStatus struct {
-	Name    ProductName    `json:"name"`
-	Version ProductVersion `json:"version"`
-	Host    string         `json:"host"`
-	Type    string         `json:"type,omitempty"`
-	Mobile  bool           `json:"mobile,omitempty"`
-	Status  StatusPhase    `json:"status"`
+	Name            ProductName     `json:"name"`
+	OperatorVersion OperatorVersion `json:"operator,omitempty"`
+	Version         ProductVersion  `json:"version"`
+	Host            string          `json:"host"`
+	Type            string          `json:"type,omitempty"`
+	Mobile          bool            `json:"mobile,omitempty"`
+	Status          StatusPhase     `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/controller/installation/products/amqonline/reconciler.go
+++ b/pkg/controller/installation/products/amqonline/reconciler.go
@@ -133,6 +133,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	return v1alpha1.PhaseCompleted, nil
 }

--- a/pkg/controller/installation/products/amqstreams/reconciler.go
+++ b/pkg/controller/installation/products/amqstreams/reconciler.go
@@ -109,6 +109,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/cloudresources/reconciler.go
+++ b/pkg/controller/installation/products/cloudresources/reconciler.go
@@ -81,6 +81,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -113,6 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/config/ConfigReadable_moq.go
+++ b/pkg/controller/installation/products/config/ConfigReadable_moq.go
@@ -9,10 +9,11 @@ import (
 )
 
 var (
-	lockConfigReadableMockGetHost           sync.RWMutex
-	lockConfigReadableMockGetProductName    sync.RWMutex
-	lockConfigReadableMockGetProductVersion sync.RWMutex
-	lockConfigReadableMockRead              sync.RWMutex
+	lockConfigReadableMockGetHost            sync.RWMutex
+	lockConfigReadableMockGetOperatorVersion sync.RWMutex
+	lockConfigReadableMockGetProductName     sync.RWMutex
+	lockConfigReadableMockGetProductVersion  sync.RWMutex
+	lockConfigReadableMockRead               sync.RWMutex
 )
 
 // Ensure, that ConfigReadableMock does implement ConfigReadable.
@@ -27,6 +28,9 @@ var _ ConfigReadable = &ConfigReadableMock{}
 //         mockedConfigReadable := &ConfigReadableMock{
 //             GetHostFunc: func() string {
 // 	               panic("mock out the GetHost method")
+//             },
+//             GetOperatorVersionFunc: func() v1alpha1.OperatorVersion {
+// 	               panic("mock out the GetOperatorVersion method")
 //             },
 //             GetProductNameFunc: func() v1alpha1.ProductName {
 // 	               panic("mock out the GetProductName method")
@@ -47,6 +51,9 @@ type ConfigReadableMock struct {
 	// GetHostFunc mocks the GetHost method.
 	GetHostFunc func() string
 
+	// GetOperatorVersionFunc mocks the GetOperatorVersion method.
+	GetOperatorVersionFunc func() v1alpha1.OperatorVersion
+
 	// GetProductNameFunc mocks the GetProductName method.
 	GetProductNameFunc func() v1alpha1.ProductName
 
@@ -60,6 +67,9 @@ type ConfigReadableMock struct {
 	calls struct {
 		// GetHost holds details about calls to the GetHost method.
 		GetHost []struct {
+		}
+		// GetOperatorVersion holds details about calls to the GetOperatorVersion method.
+		GetOperatorVersion []struct {
 		}
 		// GetProductName holds details about calls to the GetProductName method.
 		GetProductName []struct {
@@ -96,6 +106,32 @@ func (mock *ConfigReadableMock) GetHostCalls() []struct {
 	lockConfigReadableMockGetHost.RLock()
 	calls = mock.calls.GetHost
 	lockConfigReadableMockGetHost.RUnlock()
+	return calls
+}
+
+// GetOperatorVersion calls GetOperatorVersionFunc.
+func (mock *ConfigReadableMock) GetOperatorVersion() v1alpha1.OperatorVersion {
+	if mock.GetOperatorVersionFunc == nil {
+		panic("ConfigReadableMock.GetOperatorVersionFunc: method is nil but ConfigReadable.GetOperatorVersion was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockConfigReadableMockGetOperatorVersion.Lock()
+	mock.calls.GetOperatorVersion = append(mock.calls.GetOperatorVersion, callInfo)
+	lockConfigReadableMockGetOperatorVersion.Unlock()
+	return mock.GetOperatorVersionFunc()
+}
+
+// GetOperatorVersionCalls gets all the calls that were made to GetOperatorVersion.
+// Check the length with:
+//     len(mockedConfigReadable.GetOperatorVersionCalls())
+func (mock *ConfigReadableMock) GetOperatorVersionCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockConfigReadableMockGetOperatorVersion.RLock()
+	calls = mock.calls.GetOperatorVersion
+	lockConfigReadableMockGetOperatorVersion.RUnlock()
 	return calls
 }
 

--- a/pkg/controller/installation/products/config/amqStreams.go
+++ b/pkg/controller/installation/products/config/amqStreams.go
@@ -37,3 +37,7 @@ func (a *AMQStreams) GetProductName() v1alpha1.ProductName {
 func (a *AMQStreams) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionAMQStreams
 }
+
+func (a *AMQStreams) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionAMQStreams
+}

--- a/pkg/controller/installation/products/config/amqonline.go
+++ b/pkg/controller/installation/products/config/amqonline.go
@@ -42,6 +42,10 @@ func (a *AMQOnline) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionAMQOnline
 }
 
+func (a *AMQOnline) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionAMQOnline
+}
+
 func (c *AMQOnline) GetBackendSecretName() string {
 	return "s3-credentials"
 }

--- a/pkg/controller/installation/products/config/cloudresources.go
+++ b/pkg/controller/installation/products/config/cloudresources.go
@@ -39,3 +39,7 @@ func (c *CloudResources) GetProductName() v1alpha1.ProductName {
 func (c *CloudResources) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionCloudResources
 }
+
+func (c *CloudResources) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionCloudResources
+}

--- a/pkg/controller/installation/products/config/codeready.go
+++ b/pkg/controller/installation/products/config/codeready.go
@@ -35,8 +35,13 @@ func (c *CodeReady) Read() ProductConfig {
 func (c *CodeReady) GetProductName() v1alpha1.ProductName {
 	return v1alpha1.ProductCodeReadyWorkspaces
 }
+
 func (c *CodeReady) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionCodeReadyWorkspaces
+}
+
+func (c *CodeReady) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionCodeReadyWorkspaces
 }
 
 func (c *CodeReady) GetBackendSecretName() string {

--- a/pkg/controller/installation/products/config/fuse.go
+++ b/pkg/controller/installation/products/config/fuse.go
@@ -41,8 +41,16 @@ func (f *Fuse) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(f.config["VERSION"])
 }
 
+func (f *Fuse) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersion(f.config["VERSION"])
+}
+
 func (f *Fuse) SetProductVersion(newVersion string) {
 	f.config["VERSION"] = newVersion
+}
+
+func (f *Fuse) SetOperatorVersion(operator string) {
+	f.config["OPERATOR"] = operator
 }
 
 func (f *Fuse) Validate() error {

--- a/pkg/controller/installation/products/config/fuseonopenshift.go
+++ b/pkg/controller/installation/products/config/fuseonopenshift.go
@@ -37,6 +37,10 @@ func (f *FuseOnOpenshift) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionFuseOnOpenshift
 }
 
+func (f *FuseOnOpenshift) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionFuse
+}
+
 func (f *FuseOnOpenshift) Validate() error {
 	if f.GetProductName() == "" {
 		return errors.New("config product name is not defined")

--- a/pkg/controller/installation/products/config/launcher.go
+++ b/pkg/controller/installation/products/config/launcher.go
@@ -37,3 +37,7 @@ func (a *Launcher) GetProductName() v1alpha1.ProductName {
 func (c *Launcher) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionLauncher
 }
+
+func (c *Launcher) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionLauncher
+}

--- a/pkg/controller/installation/products/config/manager.go
+++ b/pkg/controller/installation/products/config/manager.go
@@ -59,6 +59,7 @@ type ConfigReadable interface {
 	Read() ProductConfig
 	GetProductName() v1alpha1.ProductName
 	GetProductVersion() v1alpha1.ProductVersion
+	GetOperatorVersion() v1alpha1.OperatorVersion
 	GetHost() string
 }
 

--- a/pkg/controller/installation/products/config/mobileDeveloperConsole.go
+++ b/pkg/controller/installation/products/config/mobileDeveloperConsole.go
@@ -38,6 +38,10 @@ func (mdc *MobileDeveloperConsole) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(mdc.config["VERSION"])
 }
 
+func (mdc *MobileDeveloperConsole) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionMDC
+}
+
 func (mdc *MobileDeveloperConsole) GetHost() string {
 	return mdc.config["HOST"]
 }

--- a/pkg/controller/installation/products/config/mobileSecurityService.go
+++ b/pkg/controller/installation/products/config/mobileSecurityService.go
@@ -37,3 +37,7 @@ func (a *MobileSecurityService) GetProductName() v1alpha1.ProductName {
 func (c *MobileSecurityService) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionMobileSecurityService
 }
+
+func (c *MobileSecurityService) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionMobileSecurityService
+}

--- a/pkg/controller/installation/products/config/monitoring.go
+++ b/pkg/controller/installation/products/config/monitoring.go
@@ -42,6 +42,10 @@ func (r *Monitoring) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionMonitoring
 }
 
+func (r *Monitoring) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionMonitoring
+}
+
 func (r *Monitoring) SetProductVersion(version string) {
 	r.Config["VERSION"] = version
 }

--- a/pkg/controller/installation/products/config/nexus.go
+++ b/pkg/controller/installation/products/config/nexus.go
@@ -42,6 +42,10 @@ func (n *Nexus) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionNexus
 }
 
+func (n *Nexus) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionNexus
+}
+
 func (n *Nexus) Validate() error {
 	if n.GetProductName() == "" {
 		return errors.New("config product name is not defined")

--- a/pkg/controller/installation/products/config/rhsso.go
+++ b/pkg/controller/installation/products/config/rhsso.go
@@ -49,8 +49,16 @@ func (r *RHSSO) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(r.Config["VERSION"])
 }
 
+func (r *RHSSO) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionRHSSO
+}
+
 func (r *RHSSO) SetProductVersion(version string) {
 	r.Config["VERSION"] = version
+}
+
+func (r *RHSSO) SetOperatorVersion(operator string) {
+	r.Config["OPERATOR"] = operator
 }
 
 func (r *RHSSO) Validate() error {

--- a/pkg/controller/installation/products/config/rhssouser.go
+++ b/pkg/controller/installation/products/config/rhssouser.go
@@ -49,9 +49,18 @@ func (r *RHSSOUser) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(r.Config["VERSION"])
 }
 
+func (r *RHSSOUser) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionRHSSOUser
+}
+
 func (r *RHSSOUser) SetProductVersion(version string) {
 	r.Config["VERSION"] = version
 }
+
+func (r *RHSSOUser) SetOperatorVersion(operator string) {
+	r.Config["OPERATOR"] = operator
+}
+
 func (r *RHSSOUser) Validate() error {
 	if r.GetProductName() == "" {
 		return errors.New("config product name is not defined")

--- a/pkg/controller/installation/products/config/solutionExplorer.go
+++ b/pkg/controller/installation/products/config/solutionExplorer.go
@@ -41,6 +41,10 @@ func (s *SolutionExplorer) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(s.config["VERSION"])
 }
 
+func (s *SolutionExplorer) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionSolutionExplorer
+}
+
 func (s *SolutionExplorer) SetProductVersion(newVersion string) {
 	s.config["VERSION"] = newVersion
 }

--- a/pkg/controller/installation/products/config/threescale.go
+++ b/pkg/controller/installation/products/config/threescale.go
@@ -41,6 +41,14 @@ func (t *ThreeScale) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.ProductVersion(t.config["VERSION"])
 }
 
+func (t *ThreeScale) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersion(t.config["OPERATOR"])
+}
+
+func (t *ThreeScale) SetOperatorVersion(operator string) {
+	t.config["OPERATOR"] = operator
+}
+
 func (t *ThreeScale) SetProductVersion(newVersion string) {
 	t.config["VERSION"] = newVersion
 }

--- a/pkg/controller/installation/products/config/ups.go
+++ b/pkg/controller/installation/products/config/ups.go
@@ -41,6 +41,10 @@ func (u *Ups) GetProductVersion() v1alpha1.ProductVersion {
 	return v1alpha1.VersionUps
 }
 
+func (u *Ups) GetOperatorVersion() v1alpha1.OperatorVersion {
+	return v1alpha1.OperatorVersionUPS
+}
+
 func (u *Ups) Validate() error {
 	if u.GetNamespace() == "" {
 		return errors.New("config namespace is not defined")

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -135,6 +135,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil
@@ -309,6 +310,10 @@ func (r *Reconciler) reconcileCustomResource(ctx context.Context, install *v1alp
 	err := client.Get(ctx, pkgclient.ObjectKey{Name: "syndesis-global-config", Namespace: r.Config.GetNamespace()}, st)
 	if err == nil && string(r.Config.GetProductVersion()) != string(st.Data["syndesis"]) {
 		r.Config.SetProductVersion(string(st.Data["syndesis"]))
+		r.ConfigManager.WriteConfig(r.Config)
+	}
+	if err == nil && string(r.Config.GetOperatorVersion()) != string(v1alpha1.OperatorVersionFuse) {
+		r.Config.SetOperatorVersion(string(v1alpha1.OperatorVersionFuse))
 		r.ConfigManager.WriteConfig(r.Config)
 	}
 

--- a/pkg/controller/installation/products/fuseonopenshift/reconciler.go
+++ b/pkg/controller/installation/products/fuseonopenshift/reconciler.go
@@ -121,6 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 	}
 
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s successfully reconciled", v1alpha1.ProductFuseOnOpenshift)
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/launcher/reconciler.go
+++ b/pkg/controller/installation/products/launcher/reconciler.go
@@ -118,6 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s is successfully reconciled", defaultLauncherName)
 	return phase, err

--- a/pkg/controller/installation/products/mobiledeveloperconsole/reconciler.go
+++ b/pkg/controller/installation/products/mobiledeveloperconsole/reconciler.go
@@ -112,6 +112,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/mobilesecurityservice/reconciler.go
+++ b/pkg/controller/installation/products/mobilesecurityservice/reconciler.go
@@ -107,6 +107,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/monitoring/reconciler.go
+++ b/pkg/controller/installation/products/monitoring/reconciler.go
@@ -154,6 +154,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s installation is reconciled successfully", packageName)
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/nexus/reconciler.go
+++ b/pkg/controller/installation/products/nexus/reconciler.go
@@ -106,6 +106,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/products/nexus/reconciler_test.go
+++ b/pkg/controller/installation/products/nexus/reconciler_test.go
@@ -385,7 +385,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 										Name: "nexus-install-plan",
 									},
 									Spec: operatorsv1alpha1.InstallPlanSpec{
-										ClusterServiceVersionNames: []string{"nexus.v" + integreatlyv1alpha1.OperatorVersionNexus},
+										ClusterServiceVersionNames: []string{"nexus.v" + string(integreatlyv1alpha1.OperatorVersionNexus)},
 										Approved:                   false,
 									},
 									Status: operatorsv1alpha1.InstallPlanStatus{

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -142,6 +142,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil
@@ -216,6 +217,10 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, inst *v1alpha1.Ins
 	err := serverClient.Get(ctx, pkgclient.ObjectKey{Name: keycloakName, Namespace: r.Config.GetNamespace()}, kc)
 	if err == nil && string(r.Config.GetProductVersion()) != kc.Status.Version {
 		r.Config.SetProductVersion(kc.Status.Version)
+		r.ConfigManager.WriteConfig(r.Config)
+	}
+	if err == nil && string(r.Config.GetOperatorVersion()) != kc.Status.OperatorVersion {
+		r.Config.SetOperatorVersion(kc.Status.OperatorVersion)
 		r.ConfigManager.WriteConfig(r.Config)
 	}
 

--- a/pkg/controller/installation/products/rhssouser/reconciler.go
+++ b/pkg/controller/installation/products/rhssouser/reconciler.go
@@ -121,6 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return v1alpha1.PhaseCompleted, nil
@@ -186,6 +187,10 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, inst *v1alpha1.Ins
 	err := serverClient.Get(ctx, pkgclient.ObjectKey{Name: keycloakName, Namespace: r.Config.GetNamespace()}, kc)
 	if err == nil && string(r.Config.GetProductVersion()) != kc.Status.Version {
 		r.Config.SetProductVersion(kc.Status.Version)
+		r.ConfigManager.WriteConfig(r.Config)
+	}
+	if err == nil && string(r.Config.GetOperatorVersion()) != kc.Status.OperatorVersion {
+		r.Config.SetOperatorVersion(kc.Status.OperatorVersion)
 		r.ConfigManager.WriteConfig(r.Config)
 	}
 

--- a/pkg/controller/installation/products/solutionexplorer/reconciler.go
+++ b/pkg/controller/installation/products/solutionexplorer/reconciler.go
@@ -161,6 +161,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	return v1alpha1.PhaseCompleted, nil
 }

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -179,6 +179,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, in *v1alpha1.Installation, p
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s installation is reconciled successfully", packageName)
 	return v1alpha1.PhaseCompleted, nil
@@ -677,6 +678,10 @@ func (r *Reconciler) reconcileServiceDiscovery(ctx context.Context, serverClient
 	err := serverClient.Get(ctx, pkgclient.ObjectKey{Name: "system-environment", Namespace: r.Config.GetNamespace()}, cm)
 	if err == nil && string(r.Config.GetProductVersion()) != cm.Data["AMP_RELEASE"] {
 		r.Config.SetProductVersion(cm.Data["AMP_RELEASE"])
+		r.ConfigManager.WriteConfig(r.Config)
+	}
+	if err == nil && string(r.Config.GetOperatorVersion()) != string(v1alpha1.OperatorVersion3Scale) {
+		r.Config.SetOperatorVersion(string(v1alpha1.OperatorVersion3Scale))
 		r.ConfigManager.WriteConfig(r.Config)
 	}
 

--- a/pkg/controller/installation/products/ups/reconciler.go
+++ b/pkg/controller/installation/products/ups/reconciler.go
@@ -113,6 +113,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
+	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	logrus.Infof("%s is successfully reconciled", defaultUpsName)
 

--- a/pkg/resources/installPlan.go
+++ b/pkg/resources/installPlan.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	v1alpha12 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -14,7 +15,7 @@ func upgradeApproval(ctx context.Context, client pkgclient.Client, ip *v1alpha1.
 		logrus.Infof("getting version for %s", ip.Spec.ClusterServiceVersionNames[0])
 		// convert "keycloak.1.8.2" into "1.8.2"
 		verStr := strings.SplitN(ip.Spec.ClusterServiceVersionNames[0], ".", 2)[1]
-		resourceVersion, err := NewVersion(verStr)
+		resourceVersion, err := NewVersion(v1alpha12.OperatorVersion(verStr))
 		if err != nil {
 			//bad version string, skip it
 			return errors.Wrap(err, "error determining installplan version")

--- a/pkg/resources/version.go
+++ b/pkg/resources/version.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/pkg/errors"
 	"regexp"
 	"strconv"
@@ -13,9 +14,9 @@ type Version struct {
 	Patch int
 }
 
-func NewVersion(version string) (*Version, error) {
+func NewVersion(version v1alpha1.OperatorVersion) (*Version, error) {
 	r, _ := regexp.Compile(`^[Vv]?([0-9]+)\.([0-9]+)(\.|\-)([0-9]+)$`)
-	matches := r.FindStringSubmatch(version)
+	matches := r.FindStringSubmatch(string(version))
 	if len(matches) < 5 {
 		return nil, errors.New("invalid version")
 	}

--- a/pkg/resources/version_test.go
+++ b/pkg/resources/version_test.go
@@ -1,6 +1,9 @@
 package resources
 
-import "testing"
+import (
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"testing"
+)
 
 func TestVersion(t *testing.T) {
 	scenarios := []struct {
@@ -85,7 +88,7 @@ func TestVersion(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			version, err := NewVersion(scenario.TestVersion)
+			version, err := NewVersion(v1alpha1.OperatorVersion(scenario.TestVersion))
 			scenario.Verifier(version, err, t)
 		})
 	}
@@ -291,8 +294,8 @@ func TestComparisons(t *testing.T) {
 	}
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			v1, _ := NewVersion(scenario.V1)
-			v2, _ := NewVersion(scenario.V2)
+			v1, _ := NewVersion(v1alpha1.OperatorVersion(scenario.V1))
+			v2, _ := NewVersion(v1alpha1.OperatorVersion(scenario.V2))
 			scenario.Verifier(v1, v2, t)
 		})
 	}


### PR DESCRIPTION
# What

https://issues.jboss.org/browse/INTLY-4214

Currently the version of the operator installed for each product is not stored within the cluster. It is perhaps possible to extract the operator version from the operator image, but this is not ideal.

In order to test that the correct version of each operator is installed, I am adding the operator version for each product to the Installation CR.

# Verification steps

## Manual verification

```shell
# prepare cluster (wait until complete)
make cluster/prepare/local

# deploy cr to cluster
oc create -f deploy/crds/examples/installation.cr.yaml

# run operator locally & wait until all products complete
operator-sdk up local

# check CR to make sure operator version is listed in each product status
oc get Installation example-installation -o yaml
```


## Automated verification

- check CI below that all tests pass