### PR TITLE
Add permissions for granting fuse only view

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -107,6 +107,7 @@ rules:
     verbs:
       - get
       - list
+      - watch
   - apiGroups:
       - ""
     resources:
@@ -361,3 +362,11 @@ rules:
       - update
       - create
   # remove to here
+  # Needed for granting fuse only view
+  - apiGroups:
+      - build.openshift.io
+    resources:
+      - jenkins
+    verbs:
+      - "*"
+  # end permissions for granting fuse only view

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -23,17 +23,3 @@ roleRef:
   kind: ClusterRole
   name: integreatly-operator
   apiGroup: rbac.authorization.k8s.io
----
-# This is required for granting view access permission to the Fuse namespace for rhmi-developer users.
-kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1
-metadata:
-  name: integreatly-operator-cluster-view
-subjects:
-  - kind: ServiceAccount
-    name: integreatly-operator
-    namespace: integreatly
-roleRef:
-  kind: ClusterRole
-  name: view
-  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
## Description
When installing operator via OperatorSource, the operator does not have the necessary permissions for granting the fuse only view from https://github.com/integr8ly/integreatly-operator/pull/204 

## Verification
* Install OperatorSource pointed to my registry
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: integreatly-operators
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: Integreatly Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: kevfan
  type: appregistry
```
* Install integreatly
* Login as a non-admin user
  * User should get added to the rhmi-developers group
  * Verify that this user gets added as a subject to the rhmi-developers-view-fuse role binding located in the Fuse namespace. (This may take a couple of seconds to reconcile)
  * Verify that the role binding references the cluster role view
  * User should only be able to see Fuse and their own namespaces.
* Verify that the user only has view access to the Fuse namespace
  * Click on the Fuse namespace
  * Ensure that the user can view the Overview, YAML and Workload pages.
  * Ensure that the user is not able to update any resources within the namespace