### PR TITLE
Update CI Dockerfile, fix make target for operator SDK

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -7,6 +7,6 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && cd $GOPATH/src/github.com/operator-framework \
     && git clone --depth 1 -b $OPERATOR_SDK_VERSION https://github.com/operator-framework/operator-sdk \
     && cd operator-sdk \
-    && make dep \
+    && make tidy \
     && make install \
     && rm -rf $GOPATH/.cache


### PR DESCRIPTION
Latest version of the SDK does not use dep, updates the Dockerfile accordingly.

```
$ docker build -t registry.svc.ci.openshift.org/openshift/release:intly-golang-1.13 - < Dockerfile.tools
$ IMAGE_NAME=registry.svc.ci.openshift.org/openshift/release:intly-golang-1.13 test/run 
operator-sdk version: "v0.12.0", commit: "2445fcda834ca4b7cf0d6c38fba6317fb219b469", go version: "go1.13.1 linux/amd64"
go version go1.13.1 linux/amd64
hello world
SUCCESS!

```