### PR TITLE
feat: creates installation CR by the operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,6 @@ test/unit:
 	TEMPLATE_PATH=$(TEMPLATE_PATH) ./scripts/ci/unit_test.sh
 
 .PHONY: test/e2e
-test/e2e: export AWS_ACCESS_KEY_ID := 1234
-test/e2e: export AWS_SECRET_ACCESS_KEY := 1234
-test/e2e: export AWS_BUCKET := dummy
 test/e2e: export GH_CLIENT_ID := 1234
 test/e2e: export GH_CLIENT_SECRET := 1234
 test/e2e: cluster/cleanup cluster/prepare cluster/prepare/configmaps

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller"
 
 	"github.com/integr8ly/integreatly-operator/version"
+
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
 	"github.com/operator-framework/operator-sdk/pkg/leader"

--- a/go.mod
+++ b/go.mod
@@ -22,6 +22,7 @@ require (
 	github.com/operator-framework/operator-marketplace v0.0.0-20191105191618-530c85d41ce7
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
 	github.com/pkg/errors v0.8.1
+	github.com/prometheus/common v0.6.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	github.com/syndesisio/syndesis v0.0.0-20190717215458-2c30af7a7ab4

--- a/go.sum
+++ b/go.sum
@@ -41,7 +41,9 @@ github.com/aerogear/mobile-security-service-operator v0.0.0-20190927105148-a2ca3
 github.com/aerogear/mobile-security-service-operator v0.0.0-20190927105148-a2ca36e6de3c/go.mod h1:MECaSGMQcK7fwLfVBA6uKuezh1tTFSloYPdh6tRuUx0=
 github.com/aerogear/unifiedpush-operator v0.0.0-20190909105857-0efd293d3634 h1:w9eXZ6Vybn2iFUY7oXEiSl32dWdPE+TkUtKheB49ET8=
 github.com/aerogear/unifiedpush-operator v0.0.0-20190909105857-0efd293d3634/go.mod h1:XwokItBSp11dqdpaBix9+Viw4tMbuEowPedbuiKXYhc=
+github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
@@ -801,6 +803,7 @@ google.golang.org/grpc v1.19.1 h1:TrBcJ1yqAl1G++wO39nD/qtgpsW9/1+QGrluyMGEYgM=
 google.golang.org/grpc v1.19.1/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0 h1:G+97AoqBnmZIT91cLG/EkCoK9NSelj64P8bOHHNmGn0=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
+gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=


### PR DESCRIPTION
This PR allows the creation of the installation CR by the integreatly operator in case there is none installation CR created in the desired namespace

https://issues.jboss.org/browse/INTLY-4219

### Verification steps

1. Prepare the cluster for a local install
`make cluster/prepare/local`

2. Run the operator locally against a cluster
`operator-sdk up local --namespace=<namespace>`

3. Ensure a installation CR named `integreatly-operator` is being created and the install starts
`oc get installation integreatly-operator -o yaml`

4. Uninstall the operator with the operator-sdk running and wait until integreatly operator and the products have been removed
`make cluster/cleanup NAMESPACE=integreatly-operator`

5. Prepare the cluster for a local install again 
`make cluster/prepare/local`

6. Create an installation CR
`oc create -f deploy/crds/examples/installation.cr.yaml`

7. Run the operator locally against your cluster again
`operator-sdk up local --namespace=<namespace>`

8. Ensure that there is only one installation CR created in the namespace
`oc get installation`
