### PR TITLE
Check to ensure extraparams are initialised correctly before use

### DIFF
--- a/pkg/controller/installation/products/amqonline/reconciler.go
+++ b/pkg/controller/installation/products/amqonline/reconciler.go
@@ -153,7 +153,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 // CreateResource Creates a generic kubernetes resource from a template
 func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
-	r.extraParams = map[string]string{}
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
 	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
 	r.extraParams["Namespace"] = r.Config.GetNamespace()
 

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -151,7 +151,9 @@ func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Inst
 }
 
 func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
-	r.extraParams = map[string]string{}
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
 	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
 	r.extraParams["Namespace"] = r.Config.GetNamespace()
 

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -152,7 +152,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 // CreateResource Creates a generic kubernetes resource from a template
 func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
-	r.extraParams = map[string]string{}
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
 	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
 	r.extraParams["Namespace"] = r.Config.GetNamespace()
 

--- a/pkg/controller/installation/products/solutionexplorer/reconciler.go
+++ b/pkg/controller/installation/products/solutionexplorer/reconciler.go
@@ -183,7 +183,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, inst *v1alpha1.Installation,
 
 // CreateResource Creates a generic kubernetes resource from a template
 func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
-	r.extraParams = map[string]string{}
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
 	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
 	r.extraParams["Namespace"] = r.Config.GetNamespace()
 

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -230,7 +230,9 @@ func (r *Reconciler) reconcileTemplates(ctx context.Context, inst *v1alpha1.Inst
 
 // CreateResource Creates a generic kubernetes resource from a template
 func (r *Reconciler) createResource(ctx context.Context, inst *v1alpha1.Installation, resourceName string, serverClient pkgclient.Client) (runtime.Object, error) {
-	r.extraParams = map[string]string{}
+	if r.extraParams == nil {
+		r.extraParams = map[string]string{}
+	}
 	r.extraParams["MonitoringKey"] = r.Config.GetLabelSelector()
 	r.extraParams["Namespace"] = r.Config.GetNamespace()
 


### PR DESCRIPTION
## Description
Check to ensure that extraparams are initialised before use.

## Verification:
- Install integreatly-operator and all RHMI products
- Should run to completion successfully
