### PR TITLE
Intly 3770 monitoring e2e

### DIFF
--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -49,36 +49,6 @@ spec:
         for: 5m
         labels:
           severity: critical
-      - alert: ThreeScaleBackendRedisPod
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: >-
-            3Scale backend-redis has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-redis.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemRedisPod
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: >-
-            3Scale system-redis has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-redis.*"})
-        for: 5m
-        labels:
-          severity: critical
-      - alert: ThreeScaleSystemMySQLPod
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: >-
-            3Scale system-mysql has no pods in a ready state.
-        expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-mysql.*"})
-        for: 5m
-        labels:
-          severity: critical
       - alert: ThreeScaleSystemAppPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md

--- a/templates/monitoring/kube_state_metrics_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_alerts.yaml
@@ -18,24 +18,6 @@ spec:
         for: 15m
         labels:
           severity: critical
-      - alert: ESPodCount
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: Expected at least Elastic Search 1 pods in namespace {{ "{{" }} $labels.namespace {{ "}}" }}.
-        expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="openshift-logging", pod=~"logging-es-data-master-.*"})) 
-        for: 5m
-        labels:
-          severity: warning
-      - alert: ESNotReady
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: Not all Elastic Search replication controllers are in a ready state.
-        expr: |
-          count(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"}) != sum(kube_replicationcontroller_status_ready_replicas{namespace="openshift-logging", replicationcontroller=~"logging-es-data-master-.*"})
-        for: 5m
-        labels:
-          severity: warning
       - alert: KubePodNotReady
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md

--- a/templates/monitoring/kube_state_metrics_launcher_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_launcher_alerts.yaml
@@ -12,9 +12,9 @@ spec:
         - alert: LauncherPodCount
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 6 pods.
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 3 pods.
           expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 6
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 3
           for: 5m
           labels:
             severity: critical

--- a/templates/monitoring/kube_state_metrics_monitoring_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_monitoring_alerts.yaml
@@ -7,14 +7,14 @@ metadata:
   namespace: {{ index .Params "Namespace" }}
 spec:
   groups:
-    - name: mointoring.rules
+    - name: monitoring.rules
       rules:
         - alert: MiddlewareMonitoringPodCount
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 6 pods.
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 7 pods.
           expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 6
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 7
           for: 5m
           labels:
             severity: critical

--- a/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
@@ -12,9 +12,9 @@ spec:
         - alert: RHSSOPodCount
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 3 pods.
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 4 pods.
           expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 3
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 4
           for: 5m
           labels:
             severity: critical

--- a/templates/monitoring/kube_state_metrics_solution_explorer_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_solution_explorer_alerts.yaml
@@ -12,9 +12,9 @@ spec:
         - alert: SolutionExplorerPodCount
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 2 pods.
+            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 3 pods.
           expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 2
+            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 3
           for: 5m
           labels:
             severity: critical

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -85,7 +85,7 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 	// Define the json output of the prometheus api call
 	type Labels struct {
 		Alertname string `json:"alertname,omitempty"`
-		Severity string  `json:"severity,omitempty"`
+		Severity  string `json:"severity,omitempty"`
 	}
 
 	type Annotations struct {
@@ -93,34 +93,33 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 	}
 
 	type Alerts struct {
-		Labels Labels `json:"labels,omitempty"`
-		State string `json:"state,omitempty"`
+		Labels      Labels      `json:"labels,omitempty"`
+		State       string      `json:"state,omitempty"`
 		Annotations Annotations `json:"annotations,omitempty"`
-		ActiveAt string `json:"activeAt,omitempty"`
-		Value string `json:"value,omitempty"`
+		ActiveAt    string      `json:"activeAt,omitempty"`
+		Value       string      `json:"value,omitempty"`
 	}
 
-	type Data struct{
+	type Data struct {
 		Alerts []Alerts `json:"alerts,omitempty"`
 	}
 
-	type Output struct{
+	type Output struct {
 		Status string `json:"status"`
-		Data Data `json:"data"`
-
+		Data   Data   `json:"data"`
 	}
 
 	output, err := execToPod("curl localhost:9090/api/v1/alerts",
-							"prometheus-application-monitoring-0",
-							intlyNamespacePrefix +"middleware-monitoring",
-							"prometheus", f )
+		"prometheus-application-monitoring-0",
+		intlyNamespacePrefix+"middleware-monitoring",
+		"prometheus", f)
 	if err != nil {
-		return fmt.Errorf("failed to exec to pod: %s" , err)
+		return fmt.Errorf("failed to exec to pod: %s", err)
 	}
 
 	var promApiCallOutput Output
 	err = json.Unmarshal([]byte(output), &promApiCallOutput)
-	if err != nil{
+	if err != nil {
 		t.Logf("Failed to unmarshall json: %s", err)
 	}
 
@@ -128,8 +127,8 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 	var firingalerts []string
 	var pendingalerts []string
 	var deadmanswitchfiring = false
-	for a := 0; a < len(promApiCallOutput.Data.Alerts) ; a++{
-		if promApiCallOutput.Data.Alerts[a].Labels.Alertname == "DeadMansSwitch" && promApiCallOutput.Data.Alerts[a].State == "firing"{
+	for a := 0; a < len(promApiCallOutput.Data.Alerts); a++ {
+		if promApiCallOutput.Data.Alerts[a].Labels.Alertname == "DeadMansSwitch" && promApiCallOutput.Data.Alerts[a].State == "firing" {
 			deadmanswitchfiring = true
 		}
 		if promApiCallOutput.Data.Alerts[a].Labels.Alertname != "DeadMansSwitch" {
@@ -141,7 +140,7 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 			if promApiCallOutput.Data.Alerts[a].State == "firing" {
 				firingalerts = append(firingalerts, promApiCallOutput.Data.Alerts[a].Labels.Alertname)
 			}
-			if promApiCallOutput.Data.Alerts[a].State == "pending"{
+			if promApiCallOutput.Data.Alerts[a].State == "pending" {
 				pendingalerts = append(pendingalerts, promApiCallOutput.Data.Alerts[a].Labels.Alertname)
 			}
 		}
@@ -149,14 +148,14 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 
 	var status []string
 	if len(firingalerts) > 0 {
-		falert := fmt.Sprint(string(len(firingalerts))+ "Firing alerts: ", firingalerts)
+		falert := fmt.Sprint(string(len(firingalerts))+"Firing alerts: ", firingalerts)
 		status = append(status, falert)
 	}
 	if len(pendingalerts) > 0 {
-		palert := fmt.Sprint(string(len(pendingalerts))+ "Pending alerts: ", pendingalerts)
+		palert := fmt.Sprint(string(len(pendingalerts))+"Pending alerts: ", pendingalerts)
 		status = append(status, palert)
 	}
-	if deadmanswitchfiring == false{
+	if deadmanswitchfiring == false {
 		dms := fmt.Sprint("DeadMansSwitch is not firing")
 		status = append(status, dms)
 	}
@@ -169,7 +168,7 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 	return nil
 }
 
-func execToPod(command string, podname string, namespace string, container string, f *framework.Framework ) (string, error){
+func execToPod(command string, podname string, namespace string, container string, f *framework.Framework) (string, error) {
 	req := f.KubeClient.CoreV1().RESTClient().Post().
 		Resource("pods").
 		Name(podname).
@@ -182,12 +181,12 @@ func execToPod(command string, podname string, namespace string, container strin
 	}
 	parameterCodec := runtime.NewParameterCodec(scheme)
 	req.VersionedParams(&v1.PodExecOptions{
-		Container: 	container,
-		Command:	strings.Fields(command),
-		Stdin:		false,
-		Stdout:     true,
-		Stderr:		true,
-		TTY:		false,
+		Container: container,
+		Command:   strings.Fields(command),
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
 	}, parameterCodec)
 
 	exec, err := remotecommand.NewSPDYExecutor(f.KubeConfig, "POST", req.URL())
@@ -195,7 +194,7 @@ func execToPod(command string, podname string, namespace string, container strin
 		return "", fmt.Errorf("error while creating Executor: %v", err)
 	}
 
-	var stdout, stderr  bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	err = exec.Stream(remotecommand.StreamOptions{
 		Stdin:  nil,
 		Stdout: &stdout,
@@ -209,8 +208,7 @@ func execToPod(command string, podname string, namespace string, container strin
 	return stdout.String(), nil
 }
 
-
-func getConfigMap (name string, namespace string, f *framework.Framework) (map[string]string, error) {
+func getConfigMap(name string, namespace string, f *framework.Framework) (map[string]string, error) {
 	configmap := &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -5,7 +5,6 @@ import (
 	goctx "context"
 	"encoding/json"
 	"fmt"
-
 	"strconv"
 
 	v1 "k8s.io/api/core/v1"

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -1,14 +1,20 @@
 package e2e
 
 import (
+	"bytes"
 	goctx "context"
+	"encoding/json"
 	"fmt"
+
 	"strconv"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	//"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 
@@ -21,7 +27,6 @@ import (
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -75,6 +80,154 @@ func waitForProductDeployment(t *testing.T, f *framework.Framework, ctx *framewo
 
 	t.Logf("%s:%s up, waited %d", namespace, deploymentName, elapsed)
 	return nil
+}
+
+func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
+	// Define the json output of the prometheus api call
+	type Labels struct {
+		Alertname string `json:"alertname,omitempty"`
+		Severity string  `json:"severity,omitempty"`
+	}
+
+	type Annotations struct {
+		Message string `json:"message,omitempty"`
+	}
+
+	type Alerts struct {
+		Labels Labels `json:"labels,omitempty"`
+		State string `json:"state,omitempty"`
+		Annotations Annotations `json:"annotations,omitempty"`
+		ActiveAt string `json:"activeAt,omitempty"`
+		Value string `json:"value,omitempty"`
+	}
+
+	type Data struct{
+		Alerts []Alerts `json:"alerts,omitempty"`
+	}
+
+	type Output struct{
+		Status string `json:"status"`
+		Data Data `json:"data"`
+
+	}
+
+	output, err := execToPod("curl localhost:9090/api/v1/alerts",
+							"prometheus-application-monitoring-0",
+							intlyNamespacePrefix +"middleware-monitoring",
+							"prometheus", f )
+	if err != nil {
+		return fmt.Errorf("failed to exec to pod: %s" , err)
+	}
+
+	var promApiCallOutput Output
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil{
+		t.Logf("Failed to unmarshall json: %s", err)
+	}
+
+	// Check if any alerts other than DeadMansSwitch are firing or pending
+	var firingalerts []string
+	var pendingalerts []string
+	var deadmanswitchfiring = false
+	for a := 0; a < len(promApiCallOutput.Data.Alerts) ; a++{
+		if promApiCallOutput.Data.Alerts[a].Labels.Alertname == "DeadMansSwitch" && promApiCallOutput.Data.Alerts[a].State == "firing"{
+			deadmanswitchfiring = true
+		}
+		if promApiCallOutput.Data.Alerts[a].Labels.Alertname != "DeadMansSwitch" {
+			// ESPodCount will always fail since that alert is for OSD
+			// so it shouldn't cause our test to fail
+			if promApiCallOutput.Data.Alerts[a].Labels.Alertname == "ESPodCount" {
+				continue
+			}
+			if promApiCallOutput.Data.Alerts[a].State == "firing" {
+				firingalerts = append(firingalerts, promApiCallOutput.Data.Alerts[a].Labels.Alertname)
+			}
+			if promApiCallOutput.Data.Alerts[a].State == "pending"{
+				pendingalerts = append(pendingalerts, promApiCallOutput.Data.Alerts[a].Labels.Alertname)
+			}
+		}
+	}
+
+	var status []string
+	if len(firingalerts) > 0 {
+		falert := fmt.Sprint(string(len(firingalerts))+ "Firing alerts: ", firingalerts)
+		status = append(status, falert)
+	}
+	if len(pendingalerts) > 0 {
+		palert := fmt.Sprint(string(len(pendingalerts))+ "Pending alerts: ", pendingalerts)
+		status = append(status, palert)
+	}
+	if deadmanswitchfiring == false{
+		dms := fmt.Sprint("DeadMansSwitch is not firing")
+		status = append(status, dms)
+	}
+
+	if len(status) > 0 {
+		return fmt.Errorf("alert tests failed: %s", status)
+	}
+
+	t.Logf("No unexpected alerts found")
+	return nil
+}
+
+func execToPod(command string, podname string, namespace string, container string, f *framework.Framework ) (string, error){
+	req := f.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podname).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container)
+	scheme := runtime.NewScheme()
+	if err := v1.AddToScheme(scheme); err != nil {
+		return "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&v1.PodExecOptions{
+		Container: 	container,
+		Command:	strings.Fields(command),
+		Stdin:		false,
+		Stdout:     true,
+		Stderr:		true,
+		TTY:		false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(f.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr  bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error in Stream: %v", err)
+	}
+
+	return stdout.String(), nil
+}
+
+
+func getConfigMap (name string, namespace string, f *framework.Framework) (map[string]string, error) {
+	configmap := &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	key := client.ObjectKey{
+		Name:      configmap.GetName(),
+		Namespace: configmap.GetNamespace(),
+	}
+	err := f.Client.Get(goctx.TODO(), key, configmap)
+	if err != nil {
+		return map[string]string{}, fmt.Errorf("could not get configmap: %configmapname", err)
+	}
+
+	return configmap.Data, nil
 }
 
 func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
@@ -442,6 +595,13 @@ func IntegreatlyCluster(t *testing.T) {
 	}
 	// check that all of the operators deploy and all of the installation phases complete
 	if err = integreatlyManagedTest(t, f, ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Waiting for alerts to normalise")
+	time.Sleep(5 * time.Minute)
+
+	if err = integreatlyMonitoringTest(t, f, ctx); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Adds a check for alerts which are firing to the e2e test by exec'ing into the prometheus pod to curl the alerts endpoint.

To Verify:

Check out this branch
Run make test/e2e