### PR TITLE
metrics error workaround added

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"os"
 	"runtime"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis"
 	"github.com/integr8ly/integreatly-operator/pkg/controller"
 	"github.com/integr8ly/integreatly-operator/version"
+    "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -129,9 +131,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	// if err = serveCRMetrics(cfg); err != nil {
-	// 	log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
-	// }
+	if err = serveCRMetrics(cfg); err != nil {
+		log.Info("Could not generate and serve custom resource metrics", "error", err.Error())
+	}
 
 	// Add to the below struct any other metrics ports you want to expose.
 	servicePorts := []corev1.ServicePort{
@@ -169,21 +171,18 @@ func main() {
 // serveCRMetrics gets the Operator/CustomResource GVKs and generates metrics based on those types.
 // It serves those metrics on "http://metricsHost:operatorMetricsPort".
 func serveCRMetrics(cfg *rest.Config) error {
-	// Below function returns filtered operator/CustomResource specific GVKs.
-	// For more control override the below GVK list with your own custom logic.
-	filteredGVK, err := k8sutil.GetGVKsFromAddToScheme(apis.AddToScheme)
-	if err != nil {
-		return err
-	}
 	// Get the namespace the operator is currently deployed in.
 	operatorNs, err := k8sutil.GetOperatorNamespace()
 	if err != nil {
 		return err
 	}
+
+	installationGVK := [] schema.GroupVersionKind{v1alpha1.SchemaGroupVersionKind}
+
 	// To generate metrics in other namespaces, add the values below.
 	ns := []string{operatorNs}
 	// Generate and serve custom resource specific metrics.
-	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, filteredGVK, metricsHost, operatorMetricsPort)
+	err = kubemetrics.GenerateAndServeCRMetrics(cfg, ns, installationGVK, metricsHost, operatorMetricsPort)
 	if err != nil {
 		return err
 	}

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -15,9 +15,9 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/integr8ly/integreatly-operator/pkg/apis"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller"
 	"github.com/integr8ly/integreatly-operator/version"
-    "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	kubemetrics "github.com/operator-framework/operator-sdk/pkg/kube-metrics"
@@ -177,7 +177,7 @@ func serveCRMetrics(cfg *rest.Config) error {
 		return err
 	}
 
-	installationGVK := [] schema.GroupVersionKind{v1alpha1.SchemaGroupVersionKind}
+	installationGVK := []schema.GroupVersionKind{v1alpha1.SchemaGroupVersionKind}
 
 	// To generate metrics in other namespaces, add the values below.
 	ns := []string{operatorNs}

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -10,6 +10,7 @@ rules:
   resources:
     - pods
     - services
+    - services/finalizers
     - endpoints
     - persistentvolumeclaims
     - events


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/INTLY-4276

Example of errors that were occurring constantly in the logs: https://gist.github.com/obrienrobert/8fd9fc755f808ce52b0a2e6b6d88837b

## Prerequisites

- Openshift 4.2 RHPDS cluster

## Verification

- Login into your cluster using `oc login`
- Prepare your cluster using the make file:
  `make cluster/prepare/local`
- A public image containing the code changes in this PR has been pre-built and resides in the `robrien` Quay registry. Create a new operator source file locally:
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: integreatly-operators
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: Integreatly Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: robrien
  type: appregistry
```
- Apply the above operator source to the `openshift-market` namespace:

     `oc apply -f <filename> -n openshift-marketplace`
- Install the `integreatly-operator` in the integreatly NS via Operator Hub - ensuring that the container image is correct: `quay.io/robrien/integreatly-operator:v1.14.0-dev`
- Check the logs of the `integreatly-operator` pod. Ensure that no `Failed to list *unstructured.Unstructured: the server could not find the requested resource` errors are present.
- To ensure that the metrics are being correctly served, navigate to the pod in the UI, open the terminal, and run the following command: `curl <pod_ip_address>:8383/metrics`. A list of metrics should be displayed.




