### PR TITLE
INTLY-4237 - use Roles for backups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,9 +93,6 @@ test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/c
 	INTEGREATLY_OPERATOR_DISABLE_ELECTION=true operator-sdk --verbose test local ./test/e2e --namespace $(NAMESPACE) --up-local --go-test-flags "-timeout=60m" --debug
 
 .PHONY: test/e2e/olm
-test/e2e/olm: export AWS_ACCESS_KEY_ID := 1234
-test/e2e/olm: export AWS_SECRET_ACCESS_KEY := 1234
-test/e2e/olm: export AWS_BUCKET := dummy
 test/e2e/olm: export GH_CLIENT_ID := 1234
 test/e2e/olm: export GH_CLIENT_SECRET := 1234
 test/e2e/olm: cluster/cleanup/olm cluster/prepare/olm cluster/prepare/configmaps cluster/deploy/integreatly-installation-cr.yml

--- a/README.md
+++ b/README.md
@@ -62,14 +62,27 @@ make cluster/prepare/local
 ```
 
 
-* 3scale requires AWS credentials for backups to an S3 bucket. The bucket should have all public access turned off.
+* 3scale requires AWS S3 bucket credentials for storage. The bucket should have all public access turned off.
 Currently this secret (`threescale-blobstorage-<installation-name>`) is created with dummy credentials by the [cloud resource operator](https://github.com/integr8ly/cloud-resource-operator), in the namespace the integreatly operator is deployed into. In order for this feature to work, these credentials should be replaced:
     * _bucketName_: The name of the AWS bucket
     * _bucketRegion_: The AWS region where the bucket has been created
     * _credentialKeyID_: The AWS access key
     * _credentialSecretKey_: The AWS secret key
-   
 
+You can use this command to replace S3 credentials in 3Scale secret:
+```sh
+oc process -f deploy/s3-secret.yaml -p AWS_ACCESS_KEY_ID=<YOURID> -p AWS_SECRET_ACCESS_KEY=<YOURKEY> -p AWS_BUCKET=<YOURBUCKET> -p AWS_REGION=eu-west-1 -p NAMESPACE=<integreatly-operator-namespace> -p NAME=threescale-blobstorage-<installation-name> | oc replace -f -
+```
+
+* Backup jobs require AWS S3 bucket credentials for storage. A `backups-s3-credentials` Secret is created the same way as a 3Scale secret described above.
+
+You can use this command to replace S3 credentials in backup secret:
+```sh
+oc process -f deploy/s3-secret.yaml -p AWS_ACCESS_KEY_ID=<YOURID> -p AWS_SECRET_ACCESS_KEY=<YOURKEY> -p AWS_BUCKET=<YOURBUCKET> -p AWS_REGION=eu-west-1 -p NAMESPACE=<integreatly-operator-namespace> | oc replace -f -
+```
+
+
+### Installation custom resource
 An `Installation` custom resource can now be created which will kick of the installation of the integreatly products, once the operator is running:
 ```sh
 # Create the installation custom resource definition
@@ -81,6 +94,7 @@ oc create -f deploy/crds/examples/installation.cr.yaml
 # The operator can now be run locally
 make code/run
 ```
+*Note:* if an operator doesn't find Installation resource, it will create one (Name: `integreatly-operator`).
 
 ### Logging in to SSO 
 

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -90,17 +90,19 @@ rules:
       - update
   - apiGroups:
       - "rbac.authorization.k8s.io"
-    # these are required so the operator can create a clusterrole to assign to the backup jobs serviceaccount
+    # these are required so the operator can create a role to assign to the backup jobs serviceaccount
     # and enable the backup to see the items it needs to backup
     resources:
-      - "clusterroles" # may be able to do this with roles instead
-      - "clusterrolebindings" # may be able to do this with rolebindings instead
+      - "roles"
+      - "rolebindings"
     verbs:
+      - get
       - create
       - update
       - delete
   # integreatly-operator doesn't require these permissions, but must have them to be able to grant them to the back
   # service accounts it creates and assigns.
+  # Keeping this before we can leverage admin permissions in product namespaces
   - apiGroups:
       - "*"
     resources:

--- a/deploy/s3-secret.yaml
+++ b/deploy/s3-secret.yaml
@@ -1,0 +1,28 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: integreatly-s3-bucket
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: ${NAME}
+      namespace: ${NAMESPACE}
+    stringData:
+      credentialKeyID: ${AWS_ACCESS_KEY_ID}
+      credentialSecretKey: ${AWS_SECRET_ACCESS_KEY}
+      bucketName: ${AWS_BUCKET}
+      bucketRegion: ${AWS_REGION}
+parameters:
+  - name: NAME
+    value: "backups-s3-credentials"
+  - name: NAMESPACE
+    required: true
+  - name: AWS_ACCESS_KEY_ID
+    required: true
+  - name: AWS_SECRET_ACCESS_KEY
+    required: true
+  - name: AWS_BUCKET
+    required: true
+  - name: AWS_REGION
+    required: true

--- a/pkg/client/sigs_client_moq.go
+++ b/pkg/client/sigs_client_moq.go
@@ -5,11 +5,10 @@ package client
 
 import (
 	"context"
-	"sync"
-
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sync"
 )
 
 var (
@@ -69,31 +68,31 @@ var _ SigsClientInterface = &SigsClientInterfaceMock{}
 //     }
 type SigsClientInterfaceMock struct {
 	// CreateFunc mocks the Create method.
-	CreateFunc func(ctx context.Context, obj runtime.Object, opts ...k8sclient.CreateOption) error
+	CreateFunc func(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error
 
 	// DeleteFunc mocks the Delete method.
-	DeleteFunc func(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteOption) error
+	DeleteFunc func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error
 
 	// DeleteAllOfFunc mocks the DeleteAllOf method.
-	DeleteAllOfFunc func(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteAllOfOption) error
+	DeleteAllOfFunc func(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error
 
 	// GetFunc mocks the Get method.
 	GetFunc func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error
 
 	// GetSigsClientFunc mocks the GetSigsClient method.
-	GetSigsClientFunc func() k8sclient.Client
+	GetSigsClientFunc func() client.Client
 
 	// ListFunc mocks the List method.
-	ListFunc func(ctx context.Context, list runtime.Object, opts ...k8sclient.ListOption) error
+	ListFunc func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error
 
 	// PatchFunc mocks the Patch method.
-	PatchFunc func(ctx context.Context, obj runtime.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error
+	PatchFunc func(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error
 
 	// StatusFunc mocks the Status method.
-	StatusFunc func() k8sclient.StatusWriter
+	StatusFunc func() client.StatusWriter
 
 	// UpdateFunc mocks the Update method.
-	UpdateFunc func(ctx context.Context, obj runtime.Object, opts ...k8sclient.UpdateOption) error
+	UpdateFunc func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -104,7 +103,7 @@ type SigsClientInterfaceMock struct {
 			// Obj is the obj argument value.
 			Obj runtime.Object
 			// Opts is the opts argument value.
-			Opts []k8sclient.CreateOption
+			Opts []client.CreateOption
 		}
 		// Delete holds details about calls to the Delete method.
 		Delete []struct {
@@ -113,7 +112,7 @@ type SigsClientInterfaceMock struct {
 			// Obj is the obj argument value.
 			Obj runtime.Object
 			// Opts is the opts argument value.
-			Opts []k8sclient.DeleteOption
+			Opts []client.DeleteOption
 		}
 		// DeleteAllOf holds details about calls to the DeleteAllOf method.
 		DeleteAllOf []struct {
@@ -122,7 +121,7 @@ type SigsClientInterfaceMock struct {
 			// Obj is the obj argument value.
 			Obj runtime.Object
 			// Opts is the opts argument value.
-			Opts []k8sclient.DeleteAllOfOption
+			Opts []client.DeleteAllOfOption
 		}
 		// Get holds details about calls to the Get method.
 		Get []struct {
@@ -143,7 +142,7 @@ type SigsClientInterfaceMock struct {
 			// List is the list argument value.
 			List runtime.Object
 			// Opts is the opts argument value.
-			Opts []k8sclient.ListOption
+			Opts []client.ListOption
 		}
 		// Patch holds details about calls to the Patch method.
 		Patch []struct {
@@ -152,9 +151,9 @@ type SigsClientInterfaceMock struct {
 			// Obj is the obj argument value.
 			Obj runtime.Object
 			// Patch is the patch argument value.
-			Patch k8sclient.Patch
+			Patch client.Patch
 			// Opts is the opts argument value.
-			Opts []k8sclient.PatchOption
+			Opts []client.PatchOption
 		}
 		// Status holds details about calls to the Status method.
 		Status []struct {
@@ -166,20 +165,20 @@ type SigsClientInterfaceMock struct {
 			// Obj is the obj argument value.
 			Obj runtime.Object
 			// Opts is the opts argument value.
-			Opts []k8sclient.UpdateOption
+			Opts []client.UpdateOption
 		}
 	}
 }
 
 // Create calls CreateFunc.
-func (mock *SigsClientInterfaceMock) Create(ctx context.Context, obj runtime.Object, opts ...k8sclient.CreateOption) error {
+func (mock *SigsClientInterfaceMock) Create(ctx context.Context, obj runtime.Object, opts ...client.CreateOption) error {
 	if mock.CreateFunc == nil {
 		panic("SigsClientInterfaceMock.CreateFunc: method is nil but SigsClientInterface.Create was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.CreateOption
+		Opts []client.CreateOption
 	}{
 		Ctx:  ctx,
 		Obj:  obj,
@@ -197,12 +196,12 @@ func (mock *SigsClientInterfaceMock) Create(ctx context.Context, obj runtime.Obj
 func (mock *SigsClientInterfaceMock) CreateCalls() []struct {
 	Ctx  context.Context
 	Obj  runtime.Object
-	Opts []k8sclient.CreateOption
+	Opts []client.CreateOption
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.CreateOption
+		Opts []client.CreateOption
 	}
 	lockSigsClientInterfaceMockCreate.RLock()
 	calls = mock.calls.Create
@@ -211,14 +210,14 @@ func (mock *SigsClientInterfaceMock) CreateCalls() []struct {
 }
 
 // Delete calls DeleteFunc.
-func (mock *SigsClientInterfaceMock) Delete(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteOption) error {
+func (mock *SigsClientInterfaceMock) Delete(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
 	if mock.DeleteFunc == nil {
 		panic("SigsClientInterfaceMock.DeleteFunc: method is nil but SigsClientInterface.Delete was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.DeleteOption
+		Opts []client.DeleteOption
 	}{
 		Ctx:  ctx,
 		Obj:  obj,
@@ -236,12 +235,12 @@ func (mock *SigsClientInterfaceMock) Delete(ctx context.Context, obj runtime.Obj
 func (mock *SigsClientInterfaceMock) DeleteCalls() []struct {
 	Ctx  context.Context
 	Obj  runtime.Object
-	Opts []k8sclient.DeleteOption
+	Opts []client.DeleteOption
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.DeleteOption
+		Opts []client.DeleteOption
 	}
 	lockSigsClientInterfaceMockDelete.RLock()
 	calls = mock.calls.Delete
@@ -250,14 +249,14 @@ func (mock *SigsClientInterfaceMock) DeleteCalls() []struct {
 }
 
 // DeleteAllOf calls DeleteAllOfFunc.
-func (mock *SigsClientInterfaceMock) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteAllOfOption) error {
+func (mock *SigsClientInterfaceMock) DeleteAllOf(ctx context.Context, obj runtime.Object, opts ...client.DeleteAllOfOption) error {
 	if mock.DeleteAllOfFunc == nil {
 		panic("SigsClientInterfaceMock.DeleteAllOfFunc: method is nil but SigsClientInterface.DeleteAllOf was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.DeleteAllOfOption
+		Opts []client.DeleteAllOfOption
 	}{
 		Ctx:  ctx,
 		Obj:  obj,
@@ -275,12 +274,12 @@ func (mock *SigsClientInterfaceMock) DeleteAllOf(ctx context.Context, obj runtim
 func (mock *SigsClientInterfaceMock) DeleteAllOfCalls() []struct {
 	Ctx  context.Context
 	Obj  runtime.Object
-	Opts []k8sclient.DeleteAllOfOption
+	Opts []client.DeleteAllOfOption
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.DeleteAllOfOption
+		Opts []client.DeleteAllOfOption
 	}
 	lockSigsClientInterfaceMockDeleteAllOf.RLock()
 	calls = mock.calls.DeleteAllOf
@@ -328,7 +327,7 @@ func (mock *SigsClientInterfaceMock) GetCalls() []struct {
 }
 
 // GetSigsClient calls GetSigsClientFunc.
-func (mock *SigsClientInterfaceMock) GetSigsClient() k8sclient.Client {
+func (mock *SigsClientInterfaceMock) GetSigsClient() client.Client {
 	if mock.GetSigsClientFunc == nil {
 		panic("SigsClientInterfaceMock.GetSigsClientFunc: method is nil but SigsClientInterface.GetSigsClient was just called")
 	}
@@ -354,14 +353,14 @@ func (mock *SigsClientInterfaceMock) GetSigsClientCalls() []struct {
 }
 
 // List calls ListFunc.
-func (mock *SigsClientInterfaceMock) List(ctx context.Context, list runtime.Object, opts ...k8sclient.ListOption) error {
+func (mock *SigsClientInterfaceMock) List(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
 	if mock.ListFunc == nil {
 		panic("SigsClientInterfaceMock.ListFunc: method is nil but SigsClientInterface.List was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		List runtime.Object
-		Opts []k8sclient.ListOption
+		Opts []client.ListOption
 	}{
 		Ctx:  ctx,
 		List: list,
@@ -379,12 +378,12 @@ func (mock *SigsClientInterfaceMock) List(ctx context.Context, list runtime.Obje
 func (mock *SigsClientInterfaceMock) ListCalls() []struct {
 	Ctx  context.Context
 	List runtime.Object
-	Opts []k8sclient.ListOption
+	Opts []client.ListOption
 } {
 	var calls []struct {
 		Ctx  context.Context
 		List runtime.Object
-		Opts []k8sclient.ListOption
+		Opts []client.ListOption
 	}
 	lockSigsClientInterfaceMockList.RLock()
 	calls = mock.calls.List
@@ -393,15 +392,15 @@ func (mock *SigsClientInterfaceMock) ListCalls() []struct {
 }
 
 // Patch calls PatchFunc.
-func (mock *SigsClientInterfaceMock) Patch(ctx context.Context, obj runtime.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+func (mock *SigsClientInterfaceMock) Patch(ctx context.Context, obj runtime.Object, patch client.Patch, opts ...client.PatchOption) error {
 	if mock.PatchFunc == nil {
 		panic("SigsClientInterfaceMock.PatchFunc: method is nil but SigsClientInterface.Patch was just called")
 	}
 	callInfo := struct {
 		Ctx   context.Context
 		Obj   runtime.Object
-		Patch k8sclient.Patch
-		Opts  []k8sclient.PatchOption
+		Patch client.Patch
+		Opts  []client.PatchOption
 	}{
 		Ctx:   ctx,
 		Obj:   obj,
@@ -420,14 +419,14 @@ func (mock *SigsClientInterfaceMock) Patch(ctx context.Context, obj runtime.Obje
 func (mock *SigsClientInterfaceMock) PatchCalls() []struct {
 	Ctx   context.Context
 	Obj   runtime.Object
-	Patch k8sclient.Patch
-	Opts  []k8sclient.PatchOption
+	Patch client.Patch
+	Opts  []client.PatchOption
 } {
 	var calls []struct {
 		Ctx   context.Context
 		Obj   runtime.Object
-		Patch k8sclient.Patch
-		Opts  []k8sclient.PatchOption
+		Patch client.Patch
+		Opts  []client.PatchOption
 	}
 	lockSigsClientInterfaceMockPatch.RLock()
 	calls = mock.calls.Patch
@@ -436,7 +435,7 @@ func (mock *SigsClientInterfaceMock) PatchCalls() []struct {
 }
 
 // Status calls StatusFunc.
-func (mock *SigsClientInterfaceMock) Status() k8sclient.StatusWriter {
+func (mock *SigsClientInterfaceMock) Status() client.StatusWriter {
 	if mock.StatusFunc == nil {
 		panic("SigsClientInterfaceMock.StatusFunc: method is nil but SigsClientInterface.Status was just called")
 	}
@@ -462,14 +461,14 @@ func (mock *SigsClientInterfaceMock) StatusCalls() []struct {
 }
 
 // Update calls UpdateFunc.
-func (mock *SigsClientInterfaceMock) Update(ctx context.Context, obj runtime.Object, opts ...k8sclient.UpdateOption) error {
+func (mock *SigsClientInterfaceMock) Update(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
 	if mock.UpdateFunc == nil {
 		panic("SigsClientInterfaceMock.UpdateFunc: method is nil but SigsClientInterface.Update was just called")
 	}
 	callInfo := struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.UpdateOption
+		Opts []client.UpdateOption
 	}{
 		Ctx:  ctx,
 		Obj:  obj,
@@ -487,12 +486,12 @@ func (mock *SigsClientInterfaceMock) Update(ctx context.Context, obj runtime.Obj
 func (mock *SigsClientInterfaceMock) UpdateCalls() []struct {
 	Ctx  context.Context
 	Obj  runtime.Object
-	Opts []k8sclient.UpdateOption
+	Opts []client.UpdateOption
 } {
 	var calls []struct {
 		Ctx  context.Context
 		Obj  runtime.Object
-		Opts []k8sclient.UpdateOption
+		Opts []client.UpdateOption
 	}
 	lockSigsClientInterfaceMockUpdate.RLock()
 	calls = mock.calls.Update

--- a/pkg/controller/installation/marketplace/MarketplaceManager_moq.go
+++ b/pkg/controller/installation/marketplace/MarketplaceManager_moq.go
@@ -5,12 +5,10 @@ package marketplace
 
 import (
 	"context"
-	"sync"
-
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
-
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sync"
 )
 
 var (
@@ -42,10 +40,10 @@ var _ MarketplaceInterface = &MarketplaceInterfaceMock{}
 //     }
 type MarketplaceInterfaceMock struct {
 	// GetSubscriptionInstallPlansFunc mocks the GetSubscriptionInstallPlans method.
-	GetSubscriptionInstallPlansFunc func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*v1alpha1.InstallPlanList, *v1alpha1.Subscription, error)
+	GetSubscriptionInstallPlansFunc func(ctx context.Context, serverClient client.Client, subName string, ns string) (*v1alpha1.InstallPlanList, *v1alpha1.Subscription, error)
 
 	// InstallOperatorFunc mocks the InstallOperator method.
-	InstallOperatorFunc func(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t Target, operatorGroupNamespaces []string, approvalStrategy v1alpha1.Approval) error
+	InstallOperatorFunc func(ctx context.Context, serverClient client.Client, owner ownerutil.Owner, t Target, operatorGroupNamespaces []string, approvalStrategy v1alpha1.Approval) error
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -54,7 +52,7 @@ type MarketplaceInterfaceMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ServerClient is the serverClient argument value.
-			ServerClient k8sclient.Client
+			ServerClient client.Client
 			// SubName is the subName argument value.
 			SubName string
 			// Ns is the ns argument value.
@@ -65,7 +63,7 @@ type MarketplaceInterfaceMock struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ServerClient is the serverClient argument value.
-			ServerClient k8sclient.Client
+			ServerClient client.Client
 			// Owner is the owner argument value.
 			Owner ownerutil.Owner
 			// T is the t argument value.
@@ -79,13 +77,13 @@ type MarketplaceInterfaceMock struct {
 }
 
 // GetSubscriptionInstallPlans calls GetSubscriptionInstallPlansFunc.
-func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlans(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*v1alpha1.InstallPlanList, *v1alpha1.Subscription, error) {
+func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlans(ctx context.Context, serverClient client.Client, subName string, ns string) (*v1alpha1.InstallPlanList, *v1alpha1.Subscription, error) {
 	if mock.GetSubscriptionInstallPlansFunc == nil {
 		panic("MarketplaceInterfaceMock.GetSubscriptionInstallPlansFunc: method is nil but MarketplaceInterface.GetSubscriptionInstallPlans was just called")
 	}
 	callInfo := struct {
 		Ctx          context.Context
-		ServerClient k8sclient.Client
+		ServerClient client.Client
 		SubName      string
 		Ns           string
 	}{
@@ -105,13 +103,13 @@ func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlans(ctx context.Co
 //     len(mockedMarketplaceInterface.GetSubscriptionInstallPlansCalls())
 func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlansCalls() []struct {
 	Ctx          context.Context
-	ServerClient k8sclient.Client
+	ServerClient client.Client
 	SubName      string
 	Ns           string
 } {
 	var calls []struct {
 		Ctx          context.Context
-		ServerClient k8sclient.Client
+		ServerClient client.Client
 		SubName      string
 		Ns           string
 	}
@@ -122,13 +120,13 @@ func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlansCalls() []struc
 }
 
 // InstallOperator calls InstallOperatorFunc.
-func (mock *MarketplaceInterfaceMock) InstallOperator(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t Target, operatorGroupNamespaces []string, approvalStrategy v1alpha1.Approval) error {
+func (mock *MarketplaceInterfaceMock) InstallOperator(ctx context.Context, serverClient client.Client, owner ownerutil.Owner, t Target, operatorGroupNamespaces []string, approvalStrategy v1alpha1.Approval) error {
 	if mock.InstallOperatorFunc == nil {
 		panic("MarketplaceInterfaceMock.InstallOperatorFunc: method is nil but MarketplaceInterface.InstallOperator was just called")
 	}
 	callInfo := struct {
 		Ctx                     context.Context
-		ServerClient            k8sclient.Client
+		ServerClient            client.Client
 		Owner                   ownerutil.Owner
 		T                       Target
 		OperatorGroupNamespaces []string
@@ -152,7 +150,7 @@ func (mock *MarketplaceInterfaceMock) InstallOperator(ctx context.Context, serve
 //     len(mockedMarketplaceInterface.InstallOperatorCalls())
 func (mock *MarketplaceInterfaceMock) InstallOperatorCalls() []struct {
 	Ctx                     context.Context
-	ServerClient            k8sclient.Client
+	ServerClient            client.Client
 	Owner                   ownerutil.Owner
 	T                       Target
 	OperatorGroupNamespaces []string
@@ -160,7 +158,7 @@ func (mock *MarketplaceInterfaceMock) InstallOperatorCalls() []struct {
 } {
 	var calls []struct {
 		Ctx                     context.Context
-		ServerClient            k8sclient.Client
+		ServerClient            client.Client
 		Owner                   ownerutil.Owner
 		T                       Target
 		OperatorGroupNamespaces []string

--- a/pkg/controller/installation/products/Reconciler_moq.go
+++ b/pkg/controller/installation/products/Reconciler_moq.go
@@ -5,12 +5,10 @@ package products
 
 import (
 	"context"
-	"sync"
-
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sync"
 )
 
 var (
@@ -31,7 +29,7 @@ var _ Interface = &InterfaceMock{}
 //             GetPreflightObjectFunc: func(ns string) runtime.Object {
 // 	               panic("mock out the GetPreflightObject method")
 //             },
-//             ReconcileFunc: func(ctx context.Context, inst *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient client.Client) (v1alpha1.StatusPhase, error) {
+//             ReconcileFunc: func(ctx context.Context, installation *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient client.Client) (v1alpha1.StatusPhase, error) {
 // 	               panic("mock out the Reconcile method")
 //             },
 //         }
@@ -45,7 +43,7 @@ type InterfaceMock struct {
 	GetPreflightObjectFunc func(ns string) runtime.Object
 
 	// ReconcileFunc mocks the Reconcile method.
-	ReconcileFunc func(ctx context.Context, installation *integreatlyv1alpha1.Installation, product *integreatlyv1alpha1.InstallationProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error)
+	ReconcileFunc func(ctx context.Context, installation *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient client.Client) (v1alpha1.StatusPhase, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -58,12 +56,12 @@ type InterfaceMock struct {
 		Reconcile []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
-			// Inst is the inst argument value.
-			Inst *integreatlyv1alpha1.Installation
+			// Installation is the installation argument value.
+			Installation *v1alpha1.Installation
 			// Product is the product argument value.
-			Product *integreatlyv1alpha1.InstallationProductStatus
+			Product *v1alpha1.InstallationProductStatus
 			// ServerClient is the serverClient argument value.
-			ServerClient k8sclient.Client
+			ServerClient client.Client
 		}
 	}
 }
@@ -100,18 +98,18 @@ func (mock *InterfaceMock) GetPreflightObjectCalls() []struct {
 }
 
 // Reconcile calls ReconcileFunc.
-func (mock *InterfaceMock) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.Installation, product *integreatlyv1alpha1.InstallationProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (mock *InterfaceMock) Reconcile(ctx context.Context, installation *v1alpha1.Installation, product *v1alpha1.InstallationProductStatus, serverClient client.Client) (v1alpha1.StatusPhase, error) {
 	if mock.ReconcileFunc == nil {
 		panic("InterfaceMock.ReconcileFunc: method is nil but Interface.Reconcile was just called")
 	}
 	callInfo := struct {
 		Ctx          context.Context
-		Inst         *integreatlyv1alpha1.Installation
-		Product      *integreatlyv1alpha1.InstallationProductStatus
-		ServerClient k8sclient.Client
+		Installation *v1alpha1.Installation
+		Product      *v1alpha1.InstallationProductStatus
+		ServerClient client.Client
 	}{
 		Ctx:          ctx,
-		Inst:         installation,
+		Installation: installation,
 		Product:      product,
 		ServerClient: serverClient,
 	}
@@ -126,15 +124,15 @@ func (mock *InterfaceMock) Reconcile(ctx context.Context, installation *integrea
 //     len(mockedInterface.ReconcileCalls())
 func (mock *InterfaceMock) ReconcileCalls() []struct {
 	Ctx          context.Context
-	Inst         *integreatlyv1alpha1.Installation
-	Product      *integreatlyv1alpha1.InstallationProductStatus
-	ServerClient k8sclient.Client
+	Installation *v1alpha1.Installation
+	Product      *v1alpha1.InstallationProductStatus
+	ServerClient client.Client
 } {
 	var calls []struct {
 		Ctx          context.Context
-		Inst         *integreatlyv1alpha1.Installation
-		Product      *integreatlyv1alpha1.InstallationProductStatus
-		ServerClient k8sclient.Client
+		Installation *v1alpha1.Installation
+		Product      *v1alpha1.InstallationProductStatus
+		ServerClient client.Client
 	}
 	lockInterfaceMockReconcile.RLock()
 	calls = mock.calls.Reconcile

--- a/pkg/controller/installation/products/amqonline/reconciler_test.go
+++ b/pkg/controller/installation/products/amqonline/reconciler_test.go
@@ -87,6 +87,20 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 				"NAMESPACE": "middleware-monitoring",
 			}), nil
 		},
+		GetBackupsSecretNameFunc: func() string {
+			return "backups-s3-credentials"
+		},
+	}
+}
+
+func backupsSecretMock() *corev1.Secret {
+	config := basicConfigMock()
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.GetBackupsSecretNameFunc(),
+			Namespace: config.GetOperatorNamespace(),
+		},
+		Data: map[string][]byte{},
 	}
 }
 
@@ -453,7 +467,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:           "test successful reconcile",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(buildScheme(), ns, consoleSvc, installation),
+			FakeClient:     moqclient.NewSigsClientMoqWithScheme(buildScheme(), ns, consoleSvc, installation, backupsSecretMock()),
 			FakeConfig:     basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval) error {

--- a/pkg/controller/installation/products/codeready/reconciler_test.go
+++ b/pkg/controller/installation/products/codeready/reconciler_test.go
@@ -85,6 +85,20 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 		WriteConfigFunc: func(config config.ConfigReadable) error {
 			return nil
 		},
+		GetBackupsSecretNameFunc: func() string {
+			return "backups-s3-credentials"
+		},
+	}
+}
+
+func backupsSecretMock() *corev1.Secret {
+	config := basicConfigMock()
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.GetBackupsSecretNameFunc(),
+			Namespace: config.GetOperatorNamespace(),
+		},
+		Data: map[string][]byte{},
 	}
 }
 
@@ -570,7 +584,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 			Name:           "test successful installation without errors",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation:   installation,
-			FakeClient:     fakeclient.NewFakeClientWithScheme(buildScheme(), &testKeycloakRealm, dep, ns, cluster, installation, pg, sec),
+			FakeClient:     fakeclient.NewFakeClientWithScheme(buildScheme(), &testKeycloakRealm, dep, ns, cluster, installation, pg, sec, backupsSecretMock()),
 			FakeConfig:     basicConfigMock(),
 			ValidateCallCounts: func(mockConfig *config.ConfigReadWriterMock, mockMPM *marketplace.MarketplaceInterfaceMock, t *testing.T) {
 				if len(mockConfig.ReadCodeReadyCalls()) != 1 {

--- a/pkg/controller/installation/products/config/ConfigReadWriter_moq.go
+++ b/pkg/controller/installation/products/config/ConfigReadWriter_moq.go
@@ -4,12 +4,12 @@
 package config
 
 import (
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"sync"
-
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
 var (
+	lockConfigReadWriterMockGetBackupsSecretName      sync.RWMutex
 	lockConfigReadWriterMockGetOauthClientsSecretName sync.RWMutex
 	lockConfigReadWriterMockGetOperatorNamespace      sync.RWMutex
 	lockConfigReadWriterMockReadAMQOnline             sync.RWMutex
@@ -39,6 +39,9 @@ var _ ConfigReadWriter = &ConfigReadWriterMock{}
 //
 //         // make and configure a mocked ConfigReadWriter
 //         mockedConfigReadWriter := &ConfigReadWriterMock{
+//             GetBackupsSecretNameFunc: func() string {
+// 	               panic("mock out the GetBackupsSecretName method")
+//             },
 //             GetOauthClientsSecretNameFunc: func() string {
 // 	               panic("mock out the GetOauthClientsSecretName method")
 //             },
@@ -97,6 +100,9 @@ var _ ConfigReadWriter = &ConfigReadWriterMock{}
 //
 //     }
 type ConfigReadWriterMock struct {
+	// GetBackupsSecretNameFunc mocks the GetBackupsSecretName method.
+	GetBackupsSecretNameFunc func() string
+
 	// GetOauthClientsSecretNameFunc mocks the GetOauthClientsSecretName method.
 	GetOauthClientsSecretNameFunc func() string
 
@@ -125,7 +131,7 @@ type ConfigReadWriterMock struct {
 	ReadMonitoringFunc func() (*Monitoring, error)
 
 	// ReadProductFunc mocks the ReadProduct method.
-	ReadProductFunc func(product integreatlyv1alpha1.ProductName) (ConfigReadable, error)
+	ReadProductFunc func(product v1alpha1.ProductName) (ConfigReadable, error)
 
 	// ReadRHSSOFunc mocks the ReadRHSSO method.
 	ReadRHSSOFunc func() (*RHSSO, error)
@@ -146,10 +152,13 @@ type ConfigReadWriterMock struct {
 	WriteConfigFunc func(config ConfigReadable) error
 
 	// readConfigForProductFunc mocks the readConfigForProduct method.
-	readConfigForProductFunc func(product integreatlyv1alpha1.ProductName) (ProductConfig, error)
+	readConfigForProductFunc func(product v1alpha1.ProductName) (ProductConfig, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
+		// GetBackupsSecretName holds details about calls to the GetBackupsSecretName method.
+		GetBackupsSecretName []struct {
+		}
 		// GetOauthClientsSecretName holds details about calls to the GetOauthClientsSecretName method.
 		GetOauthClientsSecretName []struct {
 		}
@@ -180,7 +189,7 @@ type ConfigReadWriterMock struct {
 		// ReadProduct holds details about calls to the ReadProduct method.
 		ReadProduct []struct {
 			// Product is the product argument value.
-			Product integreatlyv1alpha1.ProductName
+			Product v1alpha1.ProductName
 		}
 		// ReadRHSSO holds details about calls to the ReadRHSSO method.
 		ReadRHSSO []struct {
@@ -205,9 +214,35 @@ type ConfigReadWriterMock struct {
 		// readConfigForProduct holds details about calls to the readConfigForProduct method.
 		readConfigForProduct []struct {
 			// Product is the product argument value.
-			Product integreatlyv1alpha1.ProductName
+			Product v1alpha1.ProductName
 		}
 	}
+}
+
+// GetBackupsSecretName calls GetBackupsSecretNameFunc.
+func (mock *ConfigReadWriterMock) GetBackupsSecretName() string {
+	if mock.GetBackupsSecretNameFunc == nil {
+		panic("ConfigReadWriterMock.GetBackupsSecretNameFunc: method is nil but ConfigReadWriter.GetBackupsSecretName was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockConfigReadWriterMockGetBackupsSecretName.Lock()
+	mock.calls.GetBackupsSecretName = append(mock.calls.GetBackupsSecretName, callInfo)
+	lockConfigReadWriterMockGetBackupsSecretName.Unlock()
+	return mock.GetBackupsSecretNameFunc()
+}
+
+// GetBackupsSecretNameCalls gets all the calls that were made to GetBackupsSecretName.
+// Check the length with:
+//     len(mockedConfigReadWriter.GetBackupsSecretNameCalls())
+func (mock *ConfigReadWriterMock) GetBackupsSecretNameCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockConfigReadWriterMockGetBackupsSecretName.RLock()
+	calls = mock.calls.GetBackupsSecretName
+	lockConfigReadWriterMockGetBackupsSecretName.RUnlock()
+	return calls
 }
 
 // GetOauthClientsSecretName calls GetOauthClientsSecretNameFunc.
@@ -445,12 +480,12 @@ func (mock *ConfigReadWriterMock) ReadMonitoringCalls() []struct {
 }
 
 // ReadProduct calls ReadProductFunc.
-func (mock *ConfigReadWriterMock) ReadProduct(product integreatlyv1alpha1.ProductName) (ConfigReadable, error) {
+func (mock *ConfigReadWriterMock) ReadProduct(product v1alpha1.ProductName) (ConfigReadable, error) {
 	if mock.ReadProductFunc == nil {
 		panic("ConfigReadWriterMock.ReadProductFunc: method is nil but ConfigReadWriter.ReadProduct was just called")
 	}
 	callInfo := struct {
-		Product integreatlyv1alpha1.ProductName
+		Product v1alpha1.ProductName
 	}{
 		Product: product,
 	}
@@ -464,10 +499,10 @@ func (mock *ConfigReadWriterMock) ReadProduct(product integreatlyv1alpha1.Produc
 // Check the length with:
 //     len(mockedConfigReadWriter.ReadProductCalls())
 func (mock *ConfigReadWriterMock) ReadProductCalls() []struct {
-	Product integreatlyv1alpha1.ProductName
+	Product v1alpha1.ProductName
 } {
 	var calls []struct {
-		Product integreatlyv1alpha1.ProductName
+		Product v1alpha1.ProductName
 	}
 	lockConfigReadWriterMockReadProduct.RLock()
 	calls = mock.calls.ReadProduct
@@ -637,12 +672,12 @@ func (mock *ConfigReadWriterMock) WriteConfigCalls() []struct {
 }
 
 // readConfigForProduct calls readConfigForProductFunc.
-func (mock *ConfigReadWriterMock) readConfigForProduct(product integreatlyv1alpha1.ProductName) (ProductConfig, error) {
+func (mock *ConfigReadWriterMock) readConfigForProduct(product v1alpha1.ProductName) (ProductConfig, error) {
 	if mock.readConfigForProductFunc == nil {
 		panic("ConfigReadWriterMock.readConfigForProductFunc: method is nil but ConfigReadWriter.readConfigForProduct was just called")
 	}
 	callInfo := struct {
-		Product integreatlyv1alpha1.ProductName
+		Product v1alpha1.ProductName
 	}{
 		Product: product,
 	}
@@ -656,10 +691,10 @@ func (mock *ConfigReadWriterMock) readConfigForProduct(product integreatlyv1alph
 // Check the length with:
 //     len(mockedConfigReadWriter.readConfigForProductCalls())
 func (mock *ConfigReadWriterMock) readConfigForProductCalls() []struct {
-	Product integreatlyv1alpha1.ProductName
+	Product v1alpha1.ProductName
 } {
 	var calls []struct {
-		Product integreatlyv1alpha1.ProductName
+		Product v1alpha1.ProductName
 	}
 	lockConfigReadWriterMockreadConfigForProduct.RLock()
 	calls = mock.calls.readConfigForProduct

--- a/pkg/controller/installation/products/config/ConfigReadable_moq.go
+++ b/pkg/controller/installation/products/config/ConfigReadable_moq.go
@@ -4,9 +4,8 @@
 package config
 
 import (
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"sync"
-
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
 var (
@@ -53,13 +52,13 @@ type ConfigReadableMock struct {
 	GetHostFunc func() string
 
 	// GetOperatorVersionFunc mocks the GetOperatorVersion method.
-	GetOperatorVersionFunc func() integreatlyv1alpha1.OperatorVersion
+	GetOperatorVersionFunc func() v1alpha1.OperatorVersion
 
 	// GetProductNameFunc mocks the GetProductName method.
-	GetProductNameFunc func() integreatlyv1alpha1.ProductName
+	GetProductNameFunc func() v1alpha1.ProductName
 
 	// GetProductVersionFunc mocks the GetProductVersion method.
-	GetProductVersionFunc func() integreatlyv1alpha1.ProductVersion
+	GetProductVersionFunc func() v1alpha1.ProductVersion
 
 	// ReadFunc mocks the Read method.
 	ReadFunc func() ProductConfig
@@ -111,7 +110,7 @@ func (mock *ConfigReadableMock) GetHostCalls() []struct {
 }
 
 // GetOperatorVersion calls GetOperatorVersionFunc.
-func (mock *ConfigReadableMock) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
+func (mock *ConfigReadableMock) GetOperatorVersion() v1alpha1.OperatorVersion {
 	if mock.GetOperatorVersionFunc == nil {
 		panic("ConfigReadableMock.GetOperatorVersionFunc: method is nil but ConfigReadable.GetOperatorVersion was just called")
 	}
@@ -137,7 +136,7 @@ func (mock *ConfigReadableMock) GetOperatorVersionCalls() []struct {
 }
 
 // GetProductName calls GetProductNameFunc.
-func (mock *ConfigReadableMock) GetProductName() integreatlyv1alpha1.ProductName {
+func (mock *ConfigReadableMock) GetProductName() v1alpha1.ProductName {
 	if mock.GetProductNameFunc == nil {
 		panic("ConfigReadableMock.GetProductNameFunc: method is nil but ConfigReadable.GetProductName was just called")
 	}
@@ -163,7 +162,7 @@ func (mock *ConfigReadableMock) GetProductNameCalls() []struct {
 }
 
 // GetProductVersion calls GetProductVersionFunc.
-func (mock *ConfigReadableMock) GetProductVersion() integreatlyv1alpha1.ProductVersion {
+func (mock *ConfigReadableMock) GetProductVersion() v1alpha1.ProductVersion {
 	if mock.GetProductVersionFunc == nil {
 		panic("ConfigReadableMock.GetProductVersionFunc: method is nil but ConfigReadable.GetProductVersion was just called")
 	}

--- a/pkg/controller/installation/products/config/amqonline.go
+++ b/pkg/controller/installation/products/config/amqonline.go
@@ -65,8 +65,8 @@ func (a *AMQOnline) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
 	return integreatlyv1alpha1.OperatorVersionAMQOnline
 }
 
-func (c *AMQOnline) GetBackendSecretName() string {
-	return "s3-credentials"
+func (c *AMQOnline) GetBackupsSecretName() string {
+	return "backups-s3-credentials"
 }
 
 func (c *AMQOnline) GetBackupSchedule() string {

--- a/pkg/controller/installation/products/config/codeready.go
+++ b/pkg/controller/installation/products/config/codeready.go
@@ -55,8 +55,8 @@ func (c *CodeReady) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
 	return integreatlyv1alpha1.OperatorVersionCodeReadyWorkspaces
 }
 
-func (c *CodeReady) GetBackendSecretName() string {
-	return "s3-credentials"
+func (c *CodeReady) GetBackupsSecretName() string {
+	return "backups-s3-credentials"
 }
 
 func (c *CodeReady) GetPostgresBackupSecretName() string {

--- a/pkg/controller/installation/products/config/manager.go
+++ b/pkg/controller/installation/products/config/manager.go
@@ -37,6 +37,7 @@ func NewManager(ctx context.Context, client k8sclient.Client, namespace string, 
 type ConfigReadWriter interface {
 	readConfigForProduct(product integreatlyv1alpha1.ProductName) (ProductConfig, error)
 	GetOauthClientsSecretName() string
+	GetBackupsSecretName() string
 	WriteConfig(config ConfigReadable) error
 	ReadAMQStreams() (*AMQStreams, error)
 	ReadRHSSO() (*RHSSO, error)
@@ -114,6 +115,10 @@ func (m *Manager) GetOperatorNamespace() string {
 
 func (m *Manager) GetOauthClientsSecretName() string {
 	return "oauth-client-secrets"
+}
+
+func (m *Manager) GetBackupsSecretName() string {
+	return "backups-s3-credentials"
 }
 
 func (m *Manager) ReadAMQStreams() (*AMQStreams, error) {

--- a/pkg/controller/installation/products/monitoring/reconciler.go
+++ b/pkg/controller/installation/products/monitoring/reconciler.go
@@ -92,12 +92,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 				logrus.Infof("Phase: Monitoring ReconcileFinalizer try delete blackboxtarget %s", bbt.Name)
 				b := &monitoring_v1alpha1.BlackboxTarget{}
 				err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: bbt.Name, Namespace: r.Config.GetNamespace()}, b)
+				if kerrors.IsNotFound(err) {
+					continue
+				}
 				if err != nil {
 					return integreatlyv1alpha1.PhaseFailed, err
 				}
 
 				err = serverClient.Delete(ctx, b)
-				if err != nil {
+				if err != nil && !kerrors.IsNotFound(err) {
 					return integreatlyv1alpha1.PhaseFailed, err
 				}
 			}
@@ -114,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			if m.DeletionTimestamp == nil {
 				logrus.Infof("Phase: Monitoring ReconcileFinalizer delete ApplicationMonitoring CR")
 				err = serverClient.Delete(ctx, m)
-				if err != nil {
+				if err != nil && !kerrors.IsNotFound(err) {
 					return integreatlyv1alpha1.PhaseFailed, err
 				}
 			}

--- a/pkg/controller/installation/products/solutionexplorer/OauthResolver_moq.go
+++ b/pkg/controller/installation/products/solutionexplorer/OauthResolver_moq.go
@@ -4,9 +4,8 @@
 package solutionexplorer
 
 import (
-	"sync"
-
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"sync"
 )
 
 var (

--- a/pkg/resources/backup_test.go
+++ b/pkg/resources/backup_test.go
@@ -7,6 +7,7 @@ import (
 	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 
 	batchv1 "k8s.io/api/batch/v1"
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
@@ -30,27 +31,20 @@ func basicClient(objects ...runtime.Object) k8sclient.Client {
 }
 
 func TestBackups(t *testing.T) {
-	ownerNS := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "product",
-		},
-		Status: corev1.NamespaceStatus{
-			Phase: corev1.NamespaceActive,
-		},
-	}
-
 	scenarios := []struct {
-		Name         string
-		BackupConfig BackupConfig
-		Context      context.Context
-		Instance     *integreatlyv1alpha1.Installation
-		Client       k8sclient.Client
-		Validation   func(e error, t *testing.T)
+		Name          string
+		BackupConfig  BackupConfig
+		Context       context.Context
+		ConfigManager *config.ConfigReadWriterMock
+		Instance      *integreatlyv1alpha1.Installation
+		Client        k8sclient.Client
+		Validation    func(e error, t *testing.T)
 	}{
 		{
-			Name:    "test backups reconcile without errors",
-			Context: context.TODO(),
-			Client:  basicClient(ownerNS),
+			Name:          "test backups reconcile without errors",
+			Context:       context.TODO(),
+			Client:        basicClient(backupsSecretMock()),
+			ConfigManager: getMockConfigManager(),
 			BackupConfig: BackupConfig{
 				Name:      "test-backups",
 				Namespace: "backups",
@@ -74,13 +68,15 @@ func TestBackups(t *testing.T) {
 		{
 			Name:    "test backups reconcile without errors when objects already exist",
 			Context: context.TODO(),
-			Client: basicClient(ownerNS,
+			Client: basicClient(
 				&rbacv1.ClusterRole{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "backupjob",
 					},
 				},
+				backupsSecretMock(),
 			),
+			ConfigManager: getMockConfigManager(),
 			BackupConfig: BackupConfig{
 				Name:      "test-backups",
 				Namespace: "backups",
@@ -105,11 +101,33 @@ func TestBackups(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			err := ReconcileBackup(scenario.Context, scenario.Client, scenario.BackupConfig, ownerNS)
+			err := ReconcileBackup(scenario.Context, scenario.Client, scenario.BackupConfig, scenario.ConfigManager)
 
 			if scenario.Validation != nil {
 				scenario.Validation(err, t)
 			}
 		})
+	}
+}
+
+func getMockConfigManager() *config.ConfigReadWriterMock {
+	return &config.ConfigReadWriterMock{
+		GetOperatorNamespaceFunc: func() string {
+			return "integreatly-operator"
+		},
+		GetBackupsSecretNameFunc: func() string {
+			return "backups-s3-credentials"
+		},
+	}
+}
+
+func backupsSecretMock() *corev1.Secret {
+	config := getMockConfigManager()
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.GetBackupsSecretNameFunc(),
+			Namespace: config.GetOperatorNamespace(),
+		},
+		Data: map[string][]byte{},
 	}
 }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-4237

Changes made in this PR:
- switching to Roles instead of ClusterRoles for backup ServiceAccount.
- syncing S3 backups secret from integreatly ns -> product namespaces that have backup jobs
- fixing postgres credentials secret for the backups
- addintg template and steps for providing S3 credentials into clusters that can't create S3 bucket automatically
- fixing a small issue in monitoring finalizer (a bit of offtopic, but it might give false negative result on e2e tests, so better fix it sooner rather than later). I've put it in a separate commit for easier review.

**Verification steps:**
Install Integreatly using this PR. Make sure to use ServiceAccount if running locally (`make code/run/service_account`).
Following newly added Readme steps, update the S3 credentials Secret with valid credentials.
Verify that existing backup jobs work correctly:
a) AMQ Online PV backups job:
- create a queue and some some data (you can follow WT1, ignoring integration part, just skip to Nodejs app and send some pineapples :) )
- trigger a Job from CronJob definition:
```
oc create job enmasse-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-pv-backup -n rhmi-amq-online
```
- open `Workloads -> Jobs` in OCP console
- new Job will appear in the list, open it and navigatte to `Pods` tab
- open a Pod spawned by this job and watch the `Logs`
- there should be no errors in the logs, and the job should finish by uploading a backup artifact to S3 successfully
- Verify that a backup was successfully uploaded to your S3 bucket

b) CodeReady workspace PV backup job:
- login as test-user into CodeReady (if you see a Keycloak dialog asking you for email/name/etc., make sure integreatly operator is running, and go to CodeReady URL again)
- create a workspace and make sure workspace pod starts in codeready namespace (there is a bug with PVCs, you can try stopping the workspace in CRW UI and starting it again)
- Trigger a backup Job:
```
oc create job codeready-pv-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/codeready-pv-backup -n rhmi-codeready-workspaces
```
- Verify the backup worked (see last 5 steps of the `a) AMQ Online PV backups job` steps)

c) CodeReady Postgres backup job:
- Trigger a backup Job:
```
oc create job codeready-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/codeready-postgres-backup -n rhmi-codeready-workspaces
```
- Verify the backup worked (see last 5 steps of the `a) AMQ Online PV backups job` steps)


