### PR TITLE
Always use corev1 & metav1; fix context imports

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -24,7 +24,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -134,9 +134,9 @@ func main() {
 	// }
 
 	// Add to the below struct any other metrics ports you want to expose.
-	servicePorts := []v1.ServicePort{
-		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
-		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: v1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
+	servicePorts := []corev1.ServicePort{
+		{Port: metricsPort, Name: metrics.OperatorPortName, Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: metricsPort}},
+		{Port: operatorMetricsPort, Name: metrics.CRPortName, Protocol: corev1.ProtocolTCP, TargetPort: intstr.IntOrString{Type: intstr.Int, IntVal: operatorMetricsPort}},
 	}
 	// Create Service object to expose the metrics port(s).
 	service, err := metrics.CreateMetricsService(ctx, cfg, servicePorts)
@@ -146,7 +146,7 @@ func main() {
 
 	// CreateServiceMonitors will automatically create the prometheus-operator ServiceMonitor resources
 	// necessary to configure Prometheus to scrape metrics from this operator.
-	services := []*v1.Service{service}
+	services := []*corev1.Service{service}
 	_, err = metrics.CreateServiceMonitors(cfg, namespace, services)
 	if err != nil {
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())

--- a/pkg/apis/3scale/v1alpha1/apimanager_types.go
+++ b/pkg/apis/3scale/v1alpha1/apimanager_types.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -61,7 +61,7 @@ const (
 
 type APIManagerCondition struct {
 	Type   APIManagerConditionType `json:"type" description:"type of APIManager condition"`
-	Status v1.ConditionStatus      `json:"status" description:"status of the condition, one of True, False, Unknown"` //TODO should be a custom ConditionStatus or the core v1 one?
+	Status corev1.ConditionStatus  `json:"status" description:"status of the condition, one of True, False, Unknown"` //TODO should be a custom ConditionStatus or the core v1 one?
 
 	// The Reason, Message, LastHeartbeatTime and LastTransitionTime fields are
 	// optional. Unless we really use them they should directly not be used even
@@ -161,9 +161,9 @@ type SystemPVCSpec struct {
 }
 
 type SystemS3Spec struct {
-	AWSBucket      string                  `json:"awsBucket"`
-	AWSRegion      string                  `json:"awsRegion"`
-	AWSCredentials v1.LocalObjectReference `json:"awsCredentialsSecret"`
+	AWSBucket      string                      `json:"awsBucket"`
+	AWSRegion      string                      `json:"awsRegion"`
+	AWSCredentials corev1.LocalObjectReference `json:"awsCredentialsSecret"`
 }
 
 type SystemDatabaseSpec struct {

--- a/pkg/controller/installation/products/amqonline/addressplans.go
+++ b/pkg/controller/installation/products/amqonline/addressplans.go
@@ -2,13 +2,13 @@ package amqonline
 
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 	return []*v1beta2.AddressPlan{
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "brokered-topic",
 				Namespace: ns,
 			},
@@ -24,7 +24,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "brokered-queue",
 				Namespace: ns,
 			},
@@ -40,7 +40,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-large-anycast",
 				Namespace: ns,
 			},
@@ -56,7 +56,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-large-multicast",
 				Namespace: ns,
 			},
@@ -72,7 +72,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-large-queue",
 				Namespace: ns,
 			},
@@ -89,7 +89,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-large-subscription",
 				Namespace: ns,
 			},
@@ -106,7 +106,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-large-topic",
 				Namespace: ns,
 			},
@@ -123,7 +123,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium-anycast",
 				Namespace: ns,
 			},
@@ -139,7 +139,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium-multicast",
 				Namespace: ns,
 			},
@@ -155,7 +155,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium-queue",
 				Namespace: ns,
 			},
@@ -172,7 +172,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium-subscription",
 				Namespace: ns,
 			},
@@ -189,7 +189,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium-topic",
 				Namespace: ns,
 			},
@@ -206,7 +206,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small-anycast",
 				Namespace: ns,
 			},
@@ -222,7 +222,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small-multicast",
 				Namespace: ns,
 			},
@@ -238,7 +238,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small-queue",
 				Namespace: ns,
 			},
@@ -255,7 +255,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small-subscription",
 				Namespace: ns,
 			},
@@ -272,7 +272,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small-topic",
 				Namespace: ns,
 			},
@@ -289,7 +289,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-xlarge-queue",
 				Namespace: ns,
 			},
@@ -306,7 +306,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-xlarge-topic",
 				Namespace: ns,
 			},

--- a/pkg/controller/installation/products/amqonline/addressspaceplans.go
+++ b/pkg/controller/installation/products/amqonline/addressspaceplans.go
@@ -3,13 +3,13 @@ package amqonline
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 	return []*v1beta2.AddressSpacePlan{
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "brokered-single-broker",
 				Namespace: ns,
 			},
@@ -30,7 +30,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-medium",
 				Namespace: ns,
 			},
@@ -68,7 +68,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-small",
 				Namespace: ns,
 			},
@@ -104,7 +104,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-unlimited-with-mqtt",
 				Namespace: ns,
 			},
@@ -142,7 +142,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-unlimited",
 				Namespace: ns,
 			},

--- a/pkg/controller/installation/products/amqonline/authservices.go
+++ b/pkg/controller/installation/products/amqonline/authservices.go
@@ -3,13 +3,13 @@ package amqonline
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/admin/v1beta1"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetDefaultAuthServices(ns string) []*v1beta1.AuthenticationService {
 	return []*v1beta1.AuthenticationService{
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "standard-authservice",
 				Namespace: ns,
 			},
@@ -18,7 +18,7 @@ func GetDefaultAuthServices(ns string) []*v1beta1.AuthenticationService {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "none-authservice",
 				Namespace: ns,
 			},

--- a/pkg/controller/installation/products/amqonline/infraconfigs.go
+++ b/pkg/controller/installation/products/amqonline/infraconfigs.go
@@ -3,13 +3,13 @@ package amqonline
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func GetDefaultBrokeredInfraConfigs(ns string) []*v1beta1.BrokeredInfraConfig {
 	return []*v1beta1.BrokeredInfraConfig{
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      "default",
 				Namespace: ns,
 			},
@@ -34,7 +34,7 @@ func GetDefaultBrokeredInfraConfigs(ns string) []*v1beta1.BrokeredInfraConfig {
 func GetDefaultStandardInfraConfigs(ns string) []*v1beta1.StandardInfraConfig {
 	return []*v1beta1.StandardInfraConfig{
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "default-minimal",
 			},
 			Spec: v1beta1.StandardInfraConfigSpec{
@@ -60,7 +60,7 @@ func GetDefaultStandardInfraConfigs(ns string) []*v1beta1.StandardInfraConfig {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "default-with-mqtt",
 				Annotations: map[string]string{
 					"enmasse.io/with-mqtt": "true",
@@ -89,7 +89,7 @@ func GetDefaultStandardInfraConfigs(ns string) []*v1beta1.StandardInfraConfig {
 			},
 		},
 		{
-			ObjectMeta: v1.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name: "default",
 			},
 			Spec: v1beta1.StandardInfraConfigSpec{

--- a/pkg/controller/installation/products/amqonline/reconciler_test.go
+++ b/pkg/controller/installation/products/amqonline/reconciler_test.go
@@ -32,7 +32,7 @@ import (
 	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -278,7 +278,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 		{
 			Name: "Test doesn't set host when the port is not 443",
 			Client: fake.NewFakeClientWithScheme(buildScheme(), &enmassev1.ConsoleService{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      defaultConsoleSvcName,
 					Namespace: defaultNamespace,
 				},
@@ -298,7 +298,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 		{
 			Name: "Test doesn't set host when the host is undefined or empty",
 			Client: fake.NewFakeClientWithScheme(buildScheme(), &enmassev1.ConsoleService{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      defaultConsoleSvcName,
 					Namespace: defaultNamespace,
 				},
@@ -318,7 +318,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 		{
 			Name: "Test successfully setting host when port and host are defined properly",
 			Client: fake.NewFakeClientWithScheme(buildScheme(), &enmassev1.ConsoleService{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      defaultConsoleSvcName,
 					Namespace: defaultNamespace,
 				},
@@ -355,7 +355,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 		{
 			Name: "Test fails with error when failing to write config",
 			Client: fake.NewFakeClientWithScheme(buildScheme(), &enmassev1.ConsoleService{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      defaultConsoleSvcName,
 					Namespace: defaultNamespace,
 				},
@@ -409,26 +409,26 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 
 func TestReconciler_fullReconcile(t *testing.T) {
 	consoleSvc := &enmassev1.ConsoleService{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultConsoleSvcName,
 			Namespace: defaultInstallationNamespace,
 		},
 	}
 
 	installation := &v1alpha1.Installation{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      "installation",
 			Namespace: defaultInstallationNamespace,
 			UID:       types.UID("xyz"),
 		},
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       "installation",
 			APIVersion: v1alpha1.SchemeGroupVersion.String(),
 		},
 	}
 
 	ns := &corev1.Namespace{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name: defaultInstallationNamespace,
 			Labels: map[string]string{
 				resources.OwnerLabelKey: string(installation.GetUID()),
@@ -464,7 +464,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{
 							Items: []operatorsv1alpha1.InstallPlan{
 								{
-									ObjectMeta: v1.ObjectMeta{
+									ObjectMeta: metav1.ObjectMeta{
 										Name: "amqonline-install-plan",
 									},
 									Status: operatorsv1alpha1.InstallPlanStatus{

--- a/pkg/controller/installation/products/amqstreams/reconciler.go
+++ b/pkg/controller/installation/products/amqstreams/reconciler.go
@@ -14,7 +14,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -176,7 +176,7 @@ func (r *Reconciler) handleCreatingComponents(ctx context.Context, client pkgcli
 func (r *Reconciler) handleProgressPhase(ctx context.Context, client pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	r.logger.Debug("checking amq streams pods are running")
 
-	pods := &v1.PodList{}
+	pods := &corev1.PodList{}
 	listOpts := []pkgclient.ListOption{
 		pkgclient.InNamespace(r.Config.GetNamespace()),
 	}
@@ -194,8 +194,8 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, client pkgclient.C
 checkPodStatus:
 	for _, pod := range pods.Items {
 		for _, cnd := range pod.Status.Conditions {
-			if cnd.Type == v1.ContainersReady {
-				if cnd.Status != v1.ConditionStatus("True") {
+			if cnd.Type == corev1.ContainersReady {
+				if cnd.Status != corev1.ConditionStatus("True") {
 					return v1alpha1.PhaseInProgress, nil
 				}
 				break checkPodStatus

--- a/pkg/controller/installation/products/codeready/reconciler.go
+++ b/pkg/controller/installation/products/codeready/reconciler.go
@@ -24,7 +24,7 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -168,7 +168,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	}
 
 	// get the secret created by the cloud resources operator
-	croSec := &v1.Secret{}
+	croSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: postgres.Status.SecretRef.Name, Namespace: postgres.Status.SecretRef.Namespace}, croSec)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to get postgres credential secret")
@@ -176,7 +176,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 
 	// create backup secret
 	logrus.Info("Reconciling codeready backup secret")
-	cheBackUpSecret := &v1.Secret{
+	cheBackUpSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Config.GetPostgresBackupSecretName(),
 			Namespace: r.Config.GetNamespace(),
@@ -539,7 +539,7 @@ func (r *Reconciler) createCheCluster(ctx context.Context, kcCfg *config.RHSSO, 
 	}
 
 	// get the postgres cloud resources operator cr
-	croSec := &v1.Secret{}
+	croSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: pcr.Status.SecretRef.Name, Namespace: pcr.Status.SecretRef.Namespace}, croSec)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get postgres credential secret")

--- a/pkg/controller/installation/products/config/manager.go
+++ b/pkg/controller/installation/products/config/manager.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -20,7 +20,7 @@ import (
 type ProductConfig map[string]string
 
 func NewManager(ctx context.Context, client pkgclient.Client, namespace string, configMapName string, inst *v1alpha1.Installation) (*Manager, error) {
-	cfgmap := &v1.ConfigMap{
+	cfgmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: namespace,
 			Name:      configMapName,
@@ -66,7 +66,7 @@ type ConfigReadable interface {
 type Manager struct {
 	Client       pkgclient.Client
 	Namespace    string
-	cfgmap       *v1.ConfigMap
+	cfgmap       *corev1.ConfigMap
 	context      context.Context
 	installation *v1alpha1.Installation
 }

--- a/pkg/controller/installation/products/config/manager_test.go
+++ b/pkg/controller/installation/products/config/manager_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +44,7 @@ func TestWriteConfig(t *testing.T) {
 		// Test basic adding config
 		{
 			productName: mockProductName,
-			existingResources: []runtime.Object{&v1.ConfigMap{
+			existingResources: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,
@@ -56,7 +56,7 @@ func TestWriteConfig(t *testing.T) {
 		// Test overwrite config
 		{
 			productName: mockProductName,
-			existingResources: []runtime.Object{&v1.ConfigMap{
+			existingResources: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,
@@ -87,7 +87,7 @@ func TestWriteConfig(t *testing.T) {
 		if err = mgr.WriteConfig(test.toWrite); err != nil {
 			t.Fatalf("could not write config %v", err)
 		}
-		readCfgMap := &v1.ConfigMap{
+		readCfgMap := &corev1.ConfigMap{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      mockConfigMapName,
 				Namespace: mockNamespaceName,
@@ -117,7 +117,7 @@ func TestReadConfigForProduct(t *testing.T) {
 	}{
 		{
 			productName: mockProductName,
-			existingResources: []runtime.Object{&v1.ConfigMap{
+			existingResources: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,

--- a/pkg/controller/installation/products/config/manager_test.go
+++ b/pkg/controller/installation/products/config/manager_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	v1 "k8s.io/api/core/v1"
-	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -45,7 +45,7 @@ func TestWriteConfig(t *testing.T) {
 		{
 			productName: mockProductName,
 			existingResources: []runtime.Object{&v1.ConfigMap{
-				ObjectMeta: v12.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,
 				},
@@ -57,7 +57,7 @@ func TestWriteConfig(t *testing.T) {
 		{
 			productName: mockProductName,
 			existingResources: []runtime.Object{&v1.ConfigMap{
-				ObjectMeta: v12.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,
 				},
@@ -88,7 +88,7 @@ func TestWriteConfig(t *testing.T) {
 			t.Fatalf("could not write config %v", err)
 		}
 		readCfgMap := &v1.ConfigMap{
-			ObjectMeta: v12.ObjectMeta{
+			ObjectMeta: metav1.ObjectMeta{
 				Name:      mockConfigMapName,
 				Namespace: mockNamespaceName,
 			},
@@ -118,7 +118,7 @@ func TestReadConfigForProduct(t *testing.T) {
 		{
 			productName: mockProductName,
 			existingResources: []runtime.Object{&v1.ConfigMap{
-				ObjectMeta: v12.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Name:      mockConfigMapName,
 					Namespace: mockNamespaceName,
 				},

--- a/pkg/controller/installation/products/fuse/reconciler.go
+++ b/pkg/controller/installation/products/fuse/reconciler.go
@@ -21,7 +21,7 @@ import (
 	v1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"
 
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -321,7 +321,7 @@ func (r *Reconciler) reconcileOauthProxy(ctx context.Context, client pkgclient.C
 
 // reconcileCustomResource ensures that the fuse custom resource exists
 func (r *Reconciler) reconcileCustomResource(ctx context.Context, install *v1alpha1.Installation, client pkgclient.Client) (v1alpha1.StatusPhase, error) {
-	st := &v12.Secret{}
+	st := &corev1.Secret{}
 	// if this errors, it can be ignored
 	err := client.Get(ctx, pkgclient.ObjectKey{Name: "syndesis-global-config", Namespace: r.Config.GetNamespace()}, st)
 	if err == nil && string(r.Config.GetProductVersion()) != string(st.Data["syndesis"]) {

--- a/pkg/controller/installation/products/monitoring/reconciler.go
+++ b/pkg/controller/installation/products/monitoring/reconciler.go
@@ -15,7 +15,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/controller/installation/products/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 
-	v12 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -217,7 +217,7 @@ func (r *Reconciler) reconcileScrapeConfigs(ctx context.Context, serverClient pk
 		jobs.WriteByte('\n')
 	}
 
-	scrapeConfigSecret := &v12.Secret{
+	scrapeConfigSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Config.GetAdditionalScrapeConfigSecretName(),
 			Namespace: r.Config.GetNamespace(),
@@ -314,7 +314,7 @@ func (r *Reconciler) createResource(ctx context.Context, resourceName string, se
 // Read the credentials of the Prometheus instance in the openshift-monitoring
 // namespace from the grafana datasource secret
 func (r *Reconciler) readFederatedPrometheusCredentials(ctx context.Context, serverClient pkgclient.Client) (*monitoring_v1alpha1.GrafanaDataSourceSecret, error) {
-	secret := &v12.Secret{}
+	secret := &corev1.Secret{}
 
 	selector := pkgclient.ObjectKey{
 		Namespace: openshiftMonitoringNamespace,

--- a/pkg/controller/installation/products/monitoring/reconciler.go
+++ b/pkg/controller/installation/products/monitoring/reconciler.go
@@ -17,7 +17,7 @@ import (
 
 	v12 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -218,7 +218,7 @@ func (r *Reconciler) reconcileScrapeConfigs(ctx context.Context, serverClient pk
 	}
 
 	scrapeConfigSecret := &v12.Secret{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      r.Config.GetAdditionalScrapeConfigSecretName(),
 			Namespace: r.Config.GetNamespace(),
 		},
@@ -260,7 +260,7 @@ func (r *Reconciler) reconcileTemplates(ctx context.Context, serverClient pkgcli
 func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient pkgclient.Client) (v1alpha1.StatusPhase, error) {
 	r.Logger.Info("Reconciling Monitoring Components")
 	m := &monitoring_v1alpha1.ApplicationMonitoring{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      defaultMonitoringName,
 			Namespace: r.Config.GetNamespace(),
 		},

--- a/pkg/controller/installation/products/rhsso/reconciler.go
+++ b/pkg/controller/installation/products/rhsso/reconciler.go
@@ -23,7 +23,6 @@ import (
 	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -322,7 +321,7 @@ func (r *Reconciler) exportConfig(ctx context.Context, serverClient pkgclient.Cl
 	}
 	kcAdminCredSecretName := kc.Spec.AdminCredentials
 
-	kcAdminCredSecret := &v1.Secret{
+	kcAdminCredSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kcAdminCredSecretName,
 			Namespace: r.Config.GetNamespace(),
@@ -425,7 +424,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, inst *v1alpha
 }
 
 func (r *Reconciler) setupGithubIDP(ctx context.Context, kcr *aerogearv1.KeycloakRealm, serverClient pkgclient.Client) error {
-	githubCreds := &v1.Secret{}
+	githubCreds := &corev1.Secret{}
 	err := serverClient.Get(ctx, pkgclient.ObjectKey{Name: githubOauthAppCredentialsSecretName, Namespace: r.ConfigManager.GetOperatorNamespace()}, githubCreds)
 	if err != nil {
 		logrus.Errorf("Unable to find Github oauth credentials secret in namespace %s", r.ConfigManager.GetOperatorNamespace())

--- a/pkg/controller/installation/products/rhsso/reconciler_test.go
+++ b/pkg/controller/installation/products/rhsso/reconciler_test.go
@@ -29,7 +29,6 @@ import (
 	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -250,21 +249,21 @@ func TestReconciler_handleProgress(t *testing.T) {
 		Phase: aerogearv1.PhaseReconcile,
 	})
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: defaultRhssoNamespace,
 		},
 	}
 
-	githubOauthSecret := &v1.Secret{
+	githubOauthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-oauth-secret",
 			Namespace: defaultOperatorNamespace,
 		},
 	}
 
-	oauthClientSecrets := &v1.Secret{
+	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
 			Namespace: defaultOperatorNamespace,
@@ -424,21 +423,21 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: defaultRhssoNamespace,
 		},
 	}
 
-	githubOauthSecret := &v1.Secret{
+	githubOauthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-oauth-secret",
 			Namespace: defaultOperatorNamespace,
 		},
 	}
 
-	oauthClientSecrets := &v1.Secret{
+	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
 			Namespace: defaultOperatorNamespace,

--- a/pkg/controller/installation/products/rhssouser/reconciler.go
+++ b/pkg/controller/installation/products/rhssouser/reconciler.go
@@ -17,7 +17,7 @@ import (
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -233,7 +233,7 @@ func (r *Reconciler) exportConfig(ctx context.Context, serverClient pkgclient.Cl
 	}
 	kcAdminCredSecretName := kc.Spec.AdminCredentials
 
-	kcAdminCredSecret := &v1.Secret{
+	kcAdminCredSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      kcAdminCredSecretName,
 			Namespace: r.Config.GetNamespace(),
@@ -254,7 +254,7 @@ func (r *Reconciler) exportConfig(ctx context.Context, serverClient pkgclient.Cl
 }
 
 func (r *Reconciler) setupOpenshiftIDP(ctx context.Context, inst *v1alpha1.Installation, kcr *aerogearv1.KeycloakRealm, serverClient pkgclient.Client) error {
-	oauthClientSecrets := &v1.Secret{
+	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: r.ConfigManager.GetOauthClientsSecretName(),
 		},

--- a/pkg/controller/installation/products/rhssouser/reconciler_test.go
+++ b/pkg/controller/installation/products/rhssouser/reconciler_test.go
@@ -28,7 +28,6 @@ import (
 	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -244,21 +243,21 @@ func TestReconciler_handleProgress(t *testing.T) {
 		Phase: aerogearv1.PhaseReconcile,
 	})
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: defaultRhssoNamespace,
 		},
 	}
 
-	githubOauthSecret := &v1.Secret{
+	githubOauthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-oauth-secret",
 			Namespace: defaultOperatorNamespace,
 		},
 	}
 
-	oauthClientSecrets := &v1.Secret{
+	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
 			Namespace: defaultOperatorNamespace,
@@ -415,21 +414,21 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
-	secret := &v1.Secret{
+	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-secret",
 			Namespace: defaultRhssoNamespace,
 		},
 	}
 
-	githubOauthSecret := &v1.Secret{
+	githubOauthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "github-oauth-secret",
 			Namespace: defaultOperatorNamespace,
 		},
 	}
 
-	oauthClientSecrets := &v1.Secret{
+	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
 			Namespace: defaultOperatorNamespace,

--- a/pkg/controller/installation/products/solutionexplorer/object_test.go
+++ b/pkg/controller/installation/products/solutionexplorer/object_test.go
@@ -8,12 +8,12 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
 var webappCR = &webappv1alpha1.WebApp{
-	ObjectMeta: v1.ObjectMeta{
+	ObjectMeta: metav1.ObjectMeta{
 		Namespace: "solution-explorer",
 		Name:      "solution-explorer",
 	},
@@ -23,18 +23,18 @@ var webappCR = &webappv1alpha1.WebApp{
 }
 
 var webappRoute = &routev1.Route{
-	ObjectMeta: v1.ObjectMeta{
+	ObjectMeta: metav1.ObjectMeta{
 		Name:      defaultRouteName,
 		Namespace: defaultName,
 	},
 }
 
 var installation = &v1alpha1.Installation{
-	TypeMeta: v1.TypeMeta{
+	TypeMeta: metav1.TypeMeta{
 		Kind:       "Installation",
 		APIVersion: v1alpha1.SchemeGroupVersion.String(),
 	},
-	ObjectMeta: v1.ObjectMeta{
+	ObjectMeta: metav1.ObjectMeta{
 		Name:      "example-installation",
 		Namespace: "integreatly-operator",
 		UID:       types.UID("xyz"),
@@ -82,7 +82,7 @@ var installation = &v1alpha1.Installation{
 }
 
 var webappNs = &corev1.Namespace{
-	ObjectMeta: v1.ObjectMeta{
+	ObjectMeta: metav1.ObjectMeta{
 		Name: defaultName,
 		Labels: map[string]string{
 			resources.OwnerLabelKey: string(installation.GetUID()),

--- a/pkg/controller/installation/products/solutionexplorer/reconciler_test.go
+++ b/pkg/controller/installation/products/solutionexplorer/reconciler_test.go
@@ -16,7 +16,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -139,7 +139,7 @@ func TestSolutionExplorer(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{
 							Items: []operatorsv1alpha1.InstallPlan{
 								{
-									ObjectMeta: v1.ObjectMeta{
+									ObjectMeta: metav1.ObjectMeta{
 										Name: "solutionexplorer-install-plan",
 									},
 									Status: operatorsv1alpha1.InstallPlanStatus{

--- a/pkg/controller/installation/products/threescale/reconciler.go
+++ b/pkg/controller/installation/products/threescale/reconciler.go
@@ -33,7 +33,6 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -300,12 +299,12 @@ func (r *Reconciler) reconcileSMTPCredentials(ctx context.Context, serverClient 
 	}
 
 	// get the secret containing smtp credentials
-	credSec := &v1.Secret{}
+	credSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: smtpCred.Status.SecretRef.Name, Namespace: smtpCred.Status.SecretRef.Namespace}, credSec)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to get smtp credential secret")
 	}
-	smtpCfgMap := &v1.ConfigMap{
+	smtpCfgMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "smtp",
 			Namespace: r.Config.GetNamespace(),
@@ -436,14 +435,14 @@ func (r *Reconciler) getBlobStorageFileStorageSpec(ctx context.Context, serverCl
 	}
 
 	// get blob storage connection secret
-	blobStorageSec := &v1.Secret{}
+	blobStorageSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: blobStorage.Status.SecretRef.Name, Namespace: blobStorage.Status.SecretRef.Namespace}, blobStorageSec)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get blob storage connection secret")
 	}
 
 	// create s3 credentials secret
-	credSec := &v1.Secret{
+	credSec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      s3CredentialsSecretName,
 			Namespace: r.Config.GetNamespace(),
@@ -464,7 +463,7 @@ func (r *Reconciler) getBlobStorageFileStorageSpec(ctx context.Context, serverCl
 		S3: &threescalev1.SystemS3Spec{
 			AWSBucket: string(blobStorageSec.Data["bucketName"]),
 			AWSRegion: string(blobStorageSec.Data["bucketRegion"]),
-			AWSCredentials: v1.LocalObjectReference{
+			AWSCredentials: corev1.LocalObjectReference{
 				Name: s3CredentialsSecretName,
 			},
 		},
@@ -520,14 +519,14 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 
 	// get the secret created by the cloud resources operator
 	// containing backend redis connection details
-	credSec := &v1.Secret{}
+	credSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: backendRedis.Status.SecretRef.Name, Namespace: backendRedis.Status.SecretRef.Namespace}, credSec)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to get backend redis credential secret")
 	}
 
 	// create backend redis external connection secret needed for the 3scale apimanager
-	backendRedisSecret := &v1.Secret{
+	backendRedisSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalBackendRedisSecretName,
 			Namespace: r.Config.GetNamespace(),
@@ -552,14 +551,14 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 
 	// get the secret created by the cloud resources operator
 	// containing system redis connection details
-	systemCredSec := &v1.Secret{}
+	systemCredSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: systemRedis.Status.SecretRef.Name, Namespace: systemRedis.Status.SecretRef.Namespace}, systemCredSec)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to get system redis credential secret")
 	}
 
 	// create system redis external connection secret needed for the 3scale apimanager
-	redisSecret := &v1.Secret{
+	redisSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalRedisSecretName,
 			Namespace: r.Config.GetNamespace(),
@@ -584,14 +583,14 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	}
 
 	// get the secret containing redis credentials
-	postgresCredSec := &v1.Secret{}
+	postgresCredSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, pkgclient.ObjectKey{Name: postgres.Status.SecretRef.Name, Namespace: postgres.Status.SecretRef.Namespace}, postgresCredSec)
 	if err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to get postgres credential secret")
 	}
 
 	// create postgres external connection secret
-	postgresSecret := &v1.Secret{
+	postgresSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      externalPostgresSecretName,
 			Namespace: r.Config.GetNamespace(),

--- a/pkg/controller/installation/products/ups/reconciler_test.go
+++ b/pkg/controller/installation/products/ups/reconciler_test.go
@@ -16,7 +16,7 @@ import (
 	routev1 "github.com/openshift/api/route/v1"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -56,11 +56,11 @@ func errorConfigMock() *config.ConfigReadWriterMock {
 
 func basicRouteMock() *routev1.Route {
 	return &routev1.Route{
-		TypeMeta: v1.TypeMeta{
+		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
 			APIVersion: "v1",
 		},
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ups",
 			Name:      defaultRoutename,
 		},
@@ -69,7 +69,7 @@ func basicRouteMock() *routev1.Route {
 
 func mockUpsCRWithStatus(phase upsv1alpha1.StatusPhase) *upsv1alpha1.UnifiedPushServer {
 	return &upsv1alpha1.UnifiedPushServer{
-		ObjectMeta: v1.ObjectMeta{
+		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "ups",
 			Name:      "ups",
 		},

--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,7 +36,7 @@ func TestSubscriptionReconciler(t *testing.T) {
 				},
 			},
 			APISubscription: &v1alpha1.Subscription{
-				ObjectMeta: v1.ObjectMeta{
+				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "test-namespace",
 					Name:      "test-subscription",
 				},

--- a/pkg/resources/creators.go
+++ b/pkg/resources/creators.go
@@ -3,7 +3,7 @@ package resources
 import (
 	pkgerr "github.com/pkg/errors"
 
-	"golang.org/x/net/context"
+	"context"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/resources/finalizers.go
+++ b/pkg/resources/finalizers.go
@@ -9,7 +9,7 @@ import (
 
 	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,7 +50,7 @@ func RemoveNamespace(ctx context.Context, inst *v1alpha1.Installation, client pk
 		return v1alpha1.PhaseFailed, err
 	}
 
-	if ns.Status.Phase == v1.NamespaceTerminating {
+	if ns.Status.Phase == corev1.NamespaceTerminating {
 		return v1alpha1.PhaseInProgress, nil
 	}
 

--- a/pkg/resources/pullSecret.go
+++ b/pkg/resources/pullSecret.go
@@ -3,7 +3,7 @@ package resources
 import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
-	"golang.org/x/net/context"
+	"context"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -16,7 +16,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -56,8 +56,8 @@ func (r *Reconciler) ReconcileOauthClient(ctx context.Context, inst *v1alpha1.In
 	return v1alpha1.PhaseCompleted, nil
 }
 
-func GetNS(ctx context.Context, namespace string, client pkgclient.Client) (*v1.Namespace, error) {
-	ns := &v1.Namespace{
+func GetNS(ctx context.Context, namespace string, client pkgclient.Client) (*corev1.Namespace, error) {
+	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: namespace,
 		},
@@ -65,7 +65,7 @@ func GetNS(ctx context.Context, namespace string, client pkgclient.Client) (*v1.
 	err := client.Get(ctx, pkgclient.ObjectKey{Name: ns.Name}, ns)
 	if err == nil {
 		// workaround for https://github.com/kubernetes/client-go/issues/541
-		ns.TypeMeta = metav1.TypeMeta{Kind: "Namespace", APIVersion: v1.SchemeGroupVersion.Version}
+		ns.TypeMeta = metav1.TypeMeta{Kind: "Namespace", APIVersion: corev1.SchemeGroupVersion.Version}
 	}
 	return ns, err
 }
@@ -83,10 +83,10 @@ func (r *Reconciler) ReconcileNamespace(ctx context.Context, namespace string, i
 		return v1alpha1.PhaseCompleted, nil
 	}
 	// ns exists so check it is our namespace
-	if !IsOwnedBy(ns, inst) && ns.Status.Phase != v1.NamespaceTerminating {
+	if !IsOwnedBy(ns, inst) && ns.Status.Phase != corev1.NamespaceTerminating {
 		return v1alpha1.PhaseFailed, errors.New("existing namespace found with name " + ns.Name + " but it is not owned by the integreatly installation and it isn't being deleted")
 	}
-	if ns.Status.Phase == v1.NamespaceTerminating {
+	if ns.Status.Phase == corev1.NamespaceTerminating {
 		logrus.Debugf("namespace %s is terminating, maintaining phase to try again on next reconcile", namespace)
 		return v1alpha1.PhaseInProgress, nil
 	}
@@ -94,7 +94,7 @@ func (r *Reconciler) ReconcileNamespace(ctx context.Context, namespace string, i
 	if err := client.Update(ctx, ns); err != nil {
 		return v1alpha1.PhaseFailed, errors.Wrap(err, "failed to update the ns definition ")
 	}
-	if ns.Status.Phase != v1.NamespaceActive {
+	if ns.Status.Phase != corev1.NamespaceActive {
 		return v1alpha1.PhaseInProgress, nil
 	}
 	return v1alpha1.PhaseCompleted, nil

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -56,6 +56,7 @@ func (r *Reconciler) ReconcileOauthClient(ctx context.Context, inst *v1alpha1.In
 	return v1alpha1.PhaseCompleted, nil
 }
 
+// GetNS gets the specified corev1.Namespace from the k8s API server
 func GetNS(ctx context.Context, namespace string, client pkgclient.Client) (*corev1.Namespace, error) {
 	ns := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -20,7 +20,7 @@ import (
 
 	routev1 "github.com/openshift/api/route/v1"
 
-	v1 "k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -174,11 +174,11 @@ func execToPod(command string, podname string, namespace string, container strin
 		SubResource("exec").
 		Param("container", container)
 	scheme := runtime.NewScheme()
-	if err := v1.AddToScheme(scheme); err != nil {
+	if err := corev1.AddToScheme(scheme); err != nil {
 		return "", fmt.Errorf("error adding to scheme: %v", err)
 	}
 	parameterCodec := runtime.NewParameterCodec(scheme)
-	req.VersionedParams(&v1.PodExecOptions{
+	req.VersionedParams(&corev1.PodExecOptions{
 		Container: container,
 		Command:   strings.Fields(command),
 		Stdin:     false,
@@ -207,7 +207,7 @@ func execToPod(command string, podname string, namespace string, container strin
 }
 
 func getConfigMap(name string, namespace string, f *framework.Framework) (map[string]string, error) {
-	configmap := &v1.ConfigMap{
+	configmap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
@@ -442,7 +442,7 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 
 func checkIntegreatlyNamespaceLabels(t *testing.T, f *framework.Framework, namespaces []string, label string) error {
 	for _, namespaceName := range namespaces {
-		namespace := &v1.Namespace{}
+		namespace := &corev1.Namespace{}
 		err := f.Client.Get(goctx.TODO(), client.ObjectKey{Name: intlyNamespacePrefix + namespaceName}, namespace)
 		if err != nil {
 			return errors.Wrap(err, "Error getting namespace: "+namespaceName+" from cluster")
@@ -505,7 +505,7 @@ func checkRoutes(t *testing.T, f *framework.Framework, product string, numberRou
 
 func checkPvcs(t *testing.T, f *framework.Framework, s string, pvcNamespaces []string) error {
 	for _, pvcNamespace := range pvcNamespaces {
-		pvcs := &v1.PersistentVolumeClaimList{}
+		pvcs := &corev1.PersistentVolumeClaimList{}
 		err := f.Client.List(goctx.TODO(), pvcs, &client.ListOptions{Namespace: intlyNamespacePrefix + pvcNamespace})
 		if err != nil {
 			return errors.Wrap(err, "Error getting PVCs for namespace: "+pvcNamespace)


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-4187

Like #268, this doesn't solve everything. It just does the following:

- [x] Sets `metav1` and `corev1` import aliases consistently
- [x] Fixes a couple of `context` imports with `go tool fix -r context cmd/ pkg/`
- [x] Adds a comment to an exported function to satisfy a warning highlighted by openshift-ci-robot in response to the `/lint` prow command