### PR TITLE
added to query to fix error

### DIFF
--- a/templates/monitoring/backup-monitoring-alerts.yaml
+++ b/templates/monitoring/backup-monitoring-alerts.yaml
@@ -23,7 +23,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job {{ "}}" }} has been running for longer than 600 seconds
         expr: |
-          time() - (max(kube_job_status_active * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job) * ON(job) GROUP_RIGHT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job, namespace, label_cronjob_name) > 0) > 600
+          time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job_name, namespace, label_cronjob_name) > 0) > 600
         labels:
           severity: critical
       - alert: CronJobSuspended

--- a/templates/monitoring/backup-monitoring-alerts.yaml
+++ b/templates/monitoring/backup-monitoring-alerts.yaml
@@ -15,7 +15,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job {{ "}}" }} has been running for longer than 300 seconds
         expr: |
-          time() - (max(kube_job_status_active * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job) * ON(job) GROUP_RIGHT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job, namespace, label_cronjob_name) > 0) > {{ 300 }}
+          time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (job_name, namespace, label_cronjob_name) > 0) > {{ 300 }}
         labels:
           severity: warning
       - alert: JobRunningTimeExceeded


### PR DESCRIPTION
The following pr is to verify the following [Jira](https://issues.redhat.com/browse/INTLY-4351)
### Prerequisites:
OSD4 cluster with integreatly based of the pr branch 
### Verification steps
1.Create 2 jobs using the ui (example job works fine)
2.Modify the yaml to include the label `monitoring_key=middleware` as well as include sleep(400) like the following:
```
command:
            - perl
            - '-Mbignum=bpi'
            - '-wle'
            - sleep(400)
            - print bpi(2000)
```
3. Navigate to prometheus alert JobRunningTimeExceeded (300 seconds and 600 seconds)
4. When the job has been running for 5 mins execute the query and the two jobs show be returned.