### PR TITLE
INTLY-4327 - Update 3scale operator to use 2.7 3scale

### DIFF
--- a/manifests/integreatly-3scale/3scale-0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml
@@ -1,95 +1,95 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
-  name: 3scale-operator.v1.9-7
+  name: 3scale-operator.v0.4.0
   namespace: placeholder
   annotations:
     repository: https://github.com/3scale/3scale-operator
-    capabilities: Basic Install
+    capabilities: Full Lifecycle
     categories: "Integration & Delivery"
     certified: "false"
     description: 3scale Operator to provision 3scale and publish/manage API
-    containerImage: registry.redhat.io/3scale-amp26/3scale-operator:1.9-7
+    containerImage: registry.redhat.io/3scale-amp2/3scale-rhel7-operator:1.10-4
     createdAt: 2019-05-30T22:40:00Z
     support: Red Hat, Inc.
     tectonic-visibility: ocs
     alm-examples: >-
-      [{"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager"},"spec":{"wildcardDomain":"example.com"}},
-      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-ha"},"spec":{"highAvailability":{"enabled":true},"wildcardDomain":"example.com"}},
-      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-s3"},"spec":{"system":{"fileStorage":{"amazonSimpleStorageService":{"awsBucket":"\u003cbucket-name\u003e","awsCredentialsSecret":{"name":"\u003ccredentials-secret-name\u003e"},"awsRegion":"\u003cregion\u003e"}}},"wildcardDomain":"\u003cdesired-domain\u003e"}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"API","metadata":{"labels":{"environment":"testing"},"name":"example-api"},"spec":{"description":"api01","integrationMethod":{"apicastHosted":{"apiTestGetRequest":"/","authenticationSettings":{"credentials":{"apiKey":{"authParameterName":"user-key","credentialsLocation":"headers"}},"errors":{"authenticationFailed":{"contentType":"text/plain; charset=us-ascii","responseBody":"Authentication failed","responseCode":403},"authenticationMissing":{"contentType":"text/plain; charset=us-ascii","responseBody":"Authentication Missing","responseCode":403}},"hostHeader":"","secretToken":"MySecretTokenBetweenApicastAndMyBackend_1237120312"},"mappingRulesSelector":{"matchLabels":{"api":"api01"}},"privateBaseURL":"https://echo-api.3scale.net:443"}}}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Binding","metadata":{"name":"example-binding"},"spec":{"APISelector":{"matchLabels":{"environment":"testing"}},"credentialsRef":{"name":"ecorp-tenant-secret"}}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Limit","metadata":{"labels":{"api":"api01"},"name":"plan01-metric01-day-10"},"spec":{"description":"Limit for metric01 in plan01","maxValue":10,"metricRef":{"name":"metric01"},"period":"day"}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"MappingRule","metadata":{"labels":{"api":"api01"},"name":"metric01-get-path01"},"spec":{"increment":1,"method":"GET","metricRef":{"name":"metric01"},"path":"/path01"}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Metric","metadata":{"labels":{"api":"api01"},"name":"metric01"},"spec":{"description":"metric01","incrementHits":false,"unit":"hit"}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Plan","metadata":{"labels":{"api":"api01"},"name":"example-plan"},"spec":{"approvalRequired":false,"costs":{"costMonth":0,"setupFee":0},"default":true,"limitSelector":{"matchLabels":{"plan":"plan01"}},"trialPeriod":0}},
-      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Tenant","metadata":{"name":"example-tenant"},"spec":{"email":"admin@example.com","masterCredentialsRef":{"name":"system-seed"},"organizationName":"Example.com","passwordCredentialsRef":{"name":"ecorp-admin-secret"},"systemMasterUrl":"https://master.example.com","tenantSecretRef":{"name":"ecorp-tenant-secret","namespace":"operator-test"},"username":"admin"}}]
+       [{"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager"},"spec":{"wildcardDomain":"example.com"}},
+       {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-ha"},"spec":{"highAvailability":{"enabled":true},"wildcardDomain":"example.com"}},
+       {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-s3"},"spec":{"system":{"fileStorage":{"amazonSimpleStorageService":{"awsBucket":"\u003cbucket-name\u003e","awsCredentialsSecret":{"name":"\u003ccredentials-secret-name\u003e"},"awsRegion":"\u003cregion\u003e"}}},"wildcardDomain":"\u003cdesired-domain\u003e"}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"API","metadata":{"labels":{"environment":"testing"},"name":"example-api"},"spec":{"description":"api01","integrationMethod":{"apicastHosted":{"apiTestGetRequest":"/","authenticationSettings":{"credentials":{"apiKey":{"authParameterName":"user-key","credentialsLocation":"headers"}},"errors":{"authenticationFailed":{"contentType":"text/plain; charset=us-ascii","responseBody":"Authentication failed","responseCode":403},"authenticationMissing":{"contentType":"text/plain; charset=us-ascii","responseBody":"Authentication Missing","responseCode":403}},"hostHeader":"","secretToken":"MySecretTokenBetweenApicastAndMyBackend_1237120312"},"mappingRulesSelector":{"matchLabels":{"api":"api01"}},"privateBaseURL":"https://echo-api.3scale.net:443"}}}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Binding","metadata":{"name":"example-binding"},"spec":{"APISelector":{"matchLabels":{"environment":"testing"}},"credentialsRef":{"name":"ecorp-tenant-secret"}}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Limit","metadata":{"labels":{"api":"api01"},"name":"plan01-metric01-day-10"},"spec":{"description":"Limit for metric01 in plan01","maxValue":10,"metricRef":{"name":"metric01"},"period":"day"}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"MappingRule","metadata":{"labels":{"api":"api01"},"name":"metric01-get-path01"},"spec":{"increment":1,"method":"GET","metricRef":{"name":"metric01"},"path":"/path01"}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Metric","metadata":{"labels":{"api":"api01"},"name":"metric01"},"spec":{"description":"metric01","incrementHits":false,"unit":"hit"}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Plan","metadata":{"labels":{"api":"api01"},"name":"example-plan"},"spec":{"approvalRequired":false,"costs":{"costMonth":0,"setupFee":0},"default":true,"limitSelector":{"matchLabels":{"plan":"plan01"}},"trialPeriod":0}},
+       {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Tenant","metadata":{"name":"example-tenant"},"spec":{"email":"admin@example.com","masterCredentialsRef":{"name":"system-seed"},"organizationName":"Example.com","passwordCredentialsRef":{"name":"ecorp-admin-secret"},"systemMasterUrl":"https://master.example.com","tenantSecretRef":{"name":"ecorp-tenant-secret","namespace":"operator-test"},"username":"admin"}}]
 spec:
   customresourcedefinitions:
     owned:
-      - kind: APIManager
-        name: apimanagers.apps.3scale.net
-        version: v1alpha1
-        description: API Manager
-        displayName: API Manager
-        resources:
-          - kind: DeploymentConfig
-            version: apps.openshift.io/v1
-          - kind: PersistentVolumeClaim
-            version: v1
-          - kind: Service
-            version: v1
-          - kind: Route
-            version: route.openshift.io/v1
-          - kind: ImageStream
-            version: image.openshift.io/v1
-        specDescriptors:
-          - displayName: Wildcard Domain
-            description: Wildcard domain as configured in the API Manager object
-            path: wildcardDomain
-            x-descriptors:
-              - "urn:alm:descriptor:com.tectonic.ui:label"
-        statusDescriptors:
-          - displayName: Deployments
-            description: API Manager Deployment Configs
-            path: deployments
-            x-descriptors:
-              - "urn:alm:descriptor:com.tectonic.ui:podStatuses"
-      - kind: API
-        name: apis.capabilities.3scale.net
-        version: v1alpha1
-        description: API
-        displayName: API
-      - kind: Binding
-        name: bindings.capabilities.3scale.net
-        version: v1alpha1
-        description: Binding
-        displayName: Binding
-      - kind: Limit
-        name: limits.capabilities.3scale.net
-        version: v1alpha1
-        description: Limit
-        displayName: Limit
-      - kind: MappingRule
-        name: mappingrules.capabilities.3scale.net
-        version: v1alpha1
-        description: MappingRule
-        displayName: MappingRule
-      - kind: Metric
-        name: metrics.capabilities.3scale.net
-        version: v1alpha1
-        description: Metric
-        displayName: Metric
-      - kind: Plan
-        name: plans.capabilities.3scale.net
-        version: v1alpha1
-        description: Plan
-        displayName: Plan
-      - kind: Tenant
-        name: tenants.capabilities.3scale.net
-        version: v1alpha1
-        description: Tenant
-        displayName: Tenant
+    - kind: APIManager
+      name: apimanagers.apps.3scale.net
+      version: v1alpha1
+      description: API Manager
+      displayName: API Manager
+      resources:
+        - kind: DeploymentConfig
+          version: apps.openshift.io/v1
+        - kind: PersistentVolumeClaim
+          version: v1
+        - kind: Service
+          version: v1
+        - kind: Route
+          version: route.openshift.io/v1
+        - kind: ImageStream
+          version: image.openshift.io/v1
+      specDescriptors:
+        - displayName: Wildcard Domain
+          description: Wildcard domain as configured in the API Manager object
+          path: wildcardDomain
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:label"
+      statusDescriptors:
+        - displayName: Deployments
+          description: API Manager Deployment Configs
+          path: deployments
+          x-descriptors:
+            - "urn:alm:descriptor:com.tectonic.ui:podStatuses"
+    - kind: API
+      name: apis.capabilities.3scale.net
+      version: v1alpha1
+      description: API
+      displayName: API
+    - kind: Binding
+      name: bindings.capabilities.3scale.net
+      version: v1alpha1
+      description: Binding
+      displayName: Binding
+    - kind: Limit
+      name: limits.capabilities.3scale.net
+      version: v1alpha1
+      description: Limit
+      displayName: Limit
+    - kind: MappingRule
+      name: mappingrules.capabilities.3scale.net
+      version: v1alpha1
+      description: MappingRule
+      displayName: MappingRule
+    - kind: Metric
+      name: metrics.capabilities.3scale.net
+      version: v1alpha1
+      description: Metric
+      displayName: Metric
+    - kind: Plan
+      name: plans.capabilities.3scale.net
+      version: v1alpha1
+      description: Plan
+      displayName: Plan
+    - kind: Tenant
+      name: tenants.capabilities.3scale.net
+      version: v1alpha1
+      description: Tenant
+      displayName: Tenant
   description: |
     The 3scale Operator creates and maintains the Red Hat 3scale API Management on [OpenShift](https://www.openshift.com/) in various deployment configurations.
 
@@ -98,23 +98,23 @@ spec:
 
     ### Supported Features
     * **Installer** A way to install a 3scale API Management solution, providing configurability options at the time of installation
+    * **Upgrade** Upgrade from previously installed 3scale API Management solution
+    * **Reconcilliation** Tunable CRD parameters after 3scale API Management solution is installed
     * **Capabilities** Ability to define 3scale API definitions and set them into a 3scale API Management solution
 
-    ### Upgrading your installation
-    Currently upgrading feature is not available.
-
     ### Documentation
-    Documentation can be found on our [website](https://github.com/3scale/3scale-operator/blob/v0.3.0/doc/user-guide.md).
+    [3scale api management](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management)
+    [Deploying 3scale using the operator](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.7/html/installing_3scale/onpremises-installation#deploying-threescale-using-the-operator)
 
     ### Getting help
-    If you encounter any issues while using 3scale operator, you can create an issue on our [website](https://github.com/3scale/3scale-operator) for bugs, enhancements, or other requests.
+    If you encounter any issues while using 3scale operator, you can create an issue on our [Github repo](https://github.com/3scale/3scale-operator) for bugs, enhancements, or other requests.
 
     ### Contributing
     You can contribute by:
 
     * Raising any issues you find using 3scale Operator
     * Fixing issues by opening [Pull Requests](https://github.com/3scale/3scale-operator/pulls)
-    * Improving [documentation](https://github.com/3scale/3scale-operator/blob/v0.3.0/doc/user-guide.md)
+    * Improving [documentation](https://github.com/3scale/3scale-operator/blob/v0.4.0/doc/user-guide.md)
     * Talking about 3scale Operator
 
     All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale/3scale-operator/issues).
@@ -125,149 +125,159 @@ spec:
   keywords:
     - 3scale
     - API
-  displayName: 3scale Operator
+  displayName: 3scale
   install:
     spec:
       deployments:
-        - name: 3scale-operator
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - name: 3scale-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: threescale-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
                 name: threescale-operator
-            strategy: {}
-            template:
-              metadata:
-                labels:
-                  name: threescale-operator
-              spec:
-                containers:
-                  - command:
-                      - 3scale-operator
-                    env:
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.namespace
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: threescale-operator
-                    image: registry.redhat.io/3scale-amp26/3scale-operator:1.9-7
-                    imagePullPolicy: Always
-                    name: 3scale-operator
-                    resources: {}
-                serviceAccountName: 3scale-operator
-      permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-                - replicationcontrollers
-                - services
-                - endpoints
-                - persistentvolumeclaims
-                - events
-                - configmaps
-                - secrets
-                - serviceaccounts
-                - bindings/finalizers
-              verbs:
-                - '*'
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - daemonsets
-                - replicasets
-                - statefulsets
-              verbs:
-                - '*'
-            - apiGroups:
-                - apps
-              resourceNames:
+            spec:
+              containers:
+              - command:
                 - 3scale-operator
-              resources:
-                - deployments/finalizers
-              verbs:
-                - update
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - roles
-                - rolebindings
-              verbs:
-                - '*'
-            - apiGroups:
-                - image.openshift.io
-              resources:
-                - imagestreams
-                - imagestreams/layers
-              verbs:
-                - '*'
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes
-              verbs:
-                - '*'
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes/custom-host
-              verbs:
-                - create
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes/status
-              verbs:
-                - get
-            - apiGroups:
-                - apps.openshift.io
-              resources:
-                - deploymentconfigs
-              verbs:
-                - '*'
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - get
-                - create
-            - apiGroups:
-                - apps.3scale.net
-              resources:
-                - '*'
-              verbs:
-                - '*'
-            - apiGroups:
-                - capabilities.3scale.net
-              resources:
-                - '*'
-                - bindings
-                - metrics
-                - plans
-                - limits
-                - mappingrules
-                - tenants
-              verbs:
-                - '*'
-          serviceAccountName: 3scale-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: threescale-operator
+                - name: BACKEND_IMAGE
+                  value: registry.redhat.io/3scale-amp2/backend-rhel7:3scale2.7
+                - name: APICAST_IMAGE
+                  value: registry.redhat.io/3scale-amp2/apicast-gateway-rhel7:3scale2.7
+                - name: SYSTEM_IMAGE
+                  value: registry.redhat.io/3scale-amp2/system-rhel7:3scale2.7
+                - name: ZYNC_IMAGE
+                  value: registry.redhat.io/3scale-amp2/zync-rhel7:3scale2.7
+                - name: SYSTEM_MEMCACHED_IMAGE
+                  value: registry.redhat.io/3scale-amp2/memcached-rhel7:3scale2.7
+                image: registry.redhat.io/3scale-amp2/3scale-rhel7-operator:1.10-4
+                imagePullPolicy: Always
+                name: 3scale-operator
+                resources: {}
+              serviceAccountName: 3scale-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - replicationcontrollers
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - bindings/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - 3scale-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreams/layers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps.3scale.net
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - '*'
+          - bindings
+          - metrics
+          - plans
+          - limits
+          - mappingrules
+          - tenants
+          verbs:
+          - '*'
+        serviceAccountName: 3scale-operator
     strategy: deployment
   installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: true
-      type: SingleNamespace
-    - supported: false
-      type: MultiNamespace
-    - supported: false
-      type: AllNamespaces
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
   maturity: alpha
   provider:
     name: Red Hat
@@ -275,11 +285,11 @@ spec:
     - name: GitHub
       url: https://github.com/3scale/3scale-operator
     - name: Documentation
-      url: https://www.redhat.com/en/technologies/jboss-middleware/3scale
+      url: https://github.com/3scale/3scale-operator/blob/v0.4.0/doc/user-guide.md
   maintainers:
     - email: openshift-operators@redhat.com
       name: Red Hat
-  version: 1.9.7
+  version: 0.4.0
   icon:
     - base64data: iVBORw0KGgoAAAANSUhEUgAAAOsAAADoCAYAAAAOnhN7AAAABGdBTUEAALGPC/xhBQAAACBjSFJNAAB6JgAAgIQAAPoAAACA6AAAdTAAAOpgAAA6mAAAF3CculE8AAACC2lUWHRYTUw6Y29tLmFkb2JlLnhtcAAAAAAAPHg6eG1wbWV0YSB4bWxuczp4PSJhZG9iZTpuczptZXRhLyIgeDp4bXB0az0iWE1QIENvcmUgNS40LjAiPgogICA8cmRmOlJERiB4bWxuczpyZGY9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkvMDIvMjItcmRmLXN5bnRheC1ucyMiPgogICAgICA8cmRmOkRlc2NyaXB0aW9uIHJkZjphYm91dD0iIgogICAgICAgICAgICB4bWxuczp0aWZmPSJodHRwOi8vbnMuYWRvYmUuY29tL3RpZmYvMS4wLyI+CiAgICAgICAgIDx0aWZmOlJlc29sdXRpb25Vbml0PjI8L3RpZmY6UmVzb2x1dGlvblVuaXQ+CiAgICAgICAgIDx0aWZmOkNvbXByZXNzaW9uPjE8L3RpZmY6Q29tcHJlc3Npb24+CiAgICAgICAgIDx0aWZmOk9yaWVudGF0aW9uPjE8L3RpZmY6T3JpZW50YXRpb24+CiAgICAgICAgIDx0aWZmOlBob3RvbWV0cmljSW50ZXJwcmV0YXRpb24+MjwvdGlmZjpQaG90b21ldHJpY0ludGVycHJldGF0aW9uPgogICAgICA8L3JkZjpEZXNjcmlwdGlvbj4KICAgPC9yZGY6UkRGPgo8L3g6eG1wbWV0YT4KD0UqkwAAPCdJREFUeAHtfc1y20i2JinZVa7pDSumerYNPUB3UU9gajezMr3r7uoIk09gaTdd90aIjJiovjtLTyA4+ndWop9A9BOIFf0Awt12dYfZi7ltV9nifB+dUIEQkDj5AxAkkREggcxzTp48mSfPyR8k2q0m1FoCv/nNb3q3t7fPwGQPV4ArGaLFYjHBdf6Xv/wlSiY099sngfb2FWk7SvTLX/4yaLfbF7h6whKFn3zyyUkYhnMhfAO2YRJolLWGFfarX/2qT0UFax1D9qioR3/6059mhngN+AZIoFHWmlWScnuvHNgSK6zKq4e8vsT1LdztsHGnHSRfMmqjrCUL2IQ8Xd+9vb1r4Jha1HQ2EVziQ51L/Otf/5qWe5BGxPMYlnmUEd9ErVkCe2vOv8k+IQEo6ikeXRWVFIN3796RVmaAoo6QMMhMbLVO6YbnpDXRa5RAY1kdhI9G3wX6XcPGrOzsz3/+88SGpLKqNza4eTiwrp9nWVfw/QY4nTw8xM9gXQ816U3SGiTwYA15bnyW8UwtCtJLFgaTQi0oQoS4p6aTPLCqgyQtH/c//PADaZ4laalxqk5RCd5N4jT39ZBA4wYb1kM8rtQsqQQgeaWsrpg6rPJjMbAQsAyawqwbsBIk0FhWQ6EKl1RouS5xHUjJg24Z1uwezT/84Q9TdCRz8EUe88IsL8Emnh3c/v5+H53Hl7i4fsz8v8U1MfVAbPLfFpzGshrUpHJ/e0KUwHCiRqc8wizvgQX3Yj5GnOfEL6OhUGNdujRtMBh0IIMXcPFvQPMF8AbKI+njnhNg10i/olxx34QCCTTKWiCgZDKtQ/K56L4ka1mUbWG6WpoJcwDHtpNkSXpU1O+///4KMjhOxqfvqbxcrjIdNqTp7MJzo6wGtQzrYGT9AG8yDo0MWJGCzvIAobBDKMkR0sfgc8p/bIo4UIqchyaKjxUVwF0RwkeXvLGwBcJqxqwFAkomwwrM0bCTUdp7wL/WAqwmUrGC1Sjnp0hHgeNXpPPyGmBRj0FQqqhx3h3I6wIP7ECakCGBxrJmCCUvSlmgvOSs+CgrMivOULGzSGTFvcqKrCDuuU0ekEGvcYfzJbcTllU1gH4sBijd7NNPP51mbRiIYbL+OXOJCZEpG1VWeiouAnyYist9fPjwYQiLxEkYX2GOTRETX8SkdITruDpyrKeZDmBX07ZaWVXDoWsVJCsYytaCYsyhxOdo0GcmSgtFHwL/GvQ6SZqp+zmen6bitI/kAfyMAXSqBZQnnpuUS05WD4lxb08PUZj6ZSHEjgJsrRuMhj9Cw7lCvQY5dUtlO+WMJSdEcmDuRau3Ujiumt1L/BgR4c/qNTV2HMAlvmvgdsGRK5F14KMzFNfFOvhbZ55baVmhqAMIVWqhulRYwB9KK4LuMOETr5gtUeleuyx7KOtKi0x+bBvtDErPzmQjA7yW+UYyXgHT7QryqDSLeDsgMjVt7LV5NQydTRf8X+IKcJmEpaKuw/2NmVQdGDsb21CberAtQFl4W2dZ1YZ4U0WlfJ/jGvFm3YGWG675IV9zg6U5FvAzB8x5HVxf4XbG3CLxBfjcxESC2k3GOmPH1lIW+RVkEPJ5G8PWWVZYpWtU1LICTSuMmwTU2qMpamnwHE/z7Rm42I85nkOj7CEzHpQW4T7C/esyG2ja1adSfPjwYaI7UYLzBeBLOgwB6F3gXuHCibkC+jNQG4IO/7cqbKOyLhxqiJUcOuBvDSr3NUMxX6BAQU6hJrCCJ3lKa9FpcqnpoMiF/+qrr47RUZEvXRDR0hGoY9rWzgbbCBuNs2ODt204UDSeqniJcgWasvV1e3rVJJfUus2Rz1GRotLLgKJKLDb3JRcptKZo9UzaRmVlxVsFNFBp47KivwlIfEsGfA6EvHYAl/nuLhUPXgpn2Me4dHXCI1QPJG4rFLAPWsxTEgi7VWHrJphQO1NcVhX14MGD2VbVrmFh1Pj02BCtA/gLXJlLX1DCESziGSbLeugMuwnaPNRtUmRNE/C8DVLPukfytVVh65QVrtk5xlJ9i1pCu9ntA7Iht+cWciNKF67zIG+8r+Q6ARyvJlhKYOvcYM7mYlwzNZTHHA2V7tquB5tOLpbZk/imrH9Y5rkBbRNYA7LrA62tZeU6GtzSgKKhe2pi9bBJ/6naldSViBbKPcyb1ZTgbwOMcoFdiiKStUsGXDKC5ySdOJq45FVH3HadmFLLBc/AUw9XJ8VbhOcpKuulZC2UM4cYJ12iN+6l6CQfI9AbSuglkepyr3ZrLddgY55QnldF66AxbPLfw86jFtzg0tsTJ8BQp8dJ3jPu6SkdblsHXLpwMwR5LwrjnS7XzgoU6w6Pbq7UGqpGyA6APT+vCNcM10bvdhE02jEnd1BOUfCgrHwl8ECUmSMQl5ZAYpBDZo74I/DCOt6qsHZl5cQEJErhm4atrZQiQRQ01iR6iEY7TEbk3dMTwdDhTV66IF60+0hARwSiOhdOiPVwdXBROV9hhtnolUfgbExYq7I6KGos4J1TWMhshMKfxgIo+ocH8lT6JhCsNQ846xXRzElvdn/lCMZX9Npmg9HouiiEdLIgr7zsUS9pFfIAtilelZPWRBygfCYyPhcTXgXk9r7JalTz5FsCa1NWjlFRGB9KFsB9O/YtmDrSM9zBExchUB1j/Jz7ryxwmAuQk8D5A5PZ+hwyTXSBBNairBxvOLhbWUV6viPWNcgqfFEcZojFnSIs5AmUb1pEM5E+lLrZCZzm1kICa1lnxbQ6Z2d9Bk6O9EEw9ElUQktNzDDvJ7i6uAJcy6Aa/Qwd08tNmZ1UFvJIjY3pcucpuvdlL+UBUJbLAPk5nbwR09mW/7UoK4TXK0GAj0EzLIFuLkk2aHQSuQ1aeQ89EDjG5M0UzyeborTgc4SO6IydIJTmS5SBHVELZXgNSz31uTbNDo9r4iDfYx5xQF7WX+WLaWzT/1pmg9HIF76FSCsGd+zIN90sesqaXiFt2YCzYDRx1rOmyvJca2hnJsG1zfxOayZwxZFCWc7B1launZqIe12W1YTHWsEKG5eO5wsoHXf7hDqgrDRaZeBGSAuy0nPiTN9sySFTTjQs9wtQLur0+B4r4UrtjFm3PJUDw7QnsOrkqYNrhivCtfZNNGuZYELBNzYod62ocRWV7wJucb8IKCe98NiTBB633Z0knut4O5AwBeUp9bR+dIIc0tywU2Be4ImKysC6Zl2xk73h5Cju1xIaZTUQO48UURVpgJUNCjov2JNnp+bHqjHvEBDzfKhlCtNzj10pwK0k2bTh+5J9unBQwgvEneIqqo8AnR9fth+kaVTxvBZl5fjSd+FQka9900zTA9+sUF8hoMtlQ0y50HQJJ1n4Sr4c44VZ6Zsah3IVKZNx0bjHGkgDQ0QXz8gwqx/B16KsfDPkRxa83WU2XF/UldvqtbGg8T235Y8WFtdT9PQHoEPXeIxryGdOtDHdlnZVeO/fv48M8zKF15JX6/3HWqCcRBiHCxvPKIecKHotE0yG7yVKCsI3PkptnKicJxJGDGECvubm8iqXwo2Q78Qw77WDk3e4lKy3roQZ31sa0Q55LrMk6yyY5WQUEs6yEsuIW4tlVQ2MlsBLgGUpfRIFeQRemE0RiV+wT0XvzCO8LFHdQf5e36ahVYSi9lwEDS+mjA48l6W1KCu5QS/JHom9qmuYVLHdDRUr6v1NC4MK75nibBO82lwx1JUJiso1dJFS6+gk0+CCO9enq7In+ZHcr01Zua0NDZVjrbmE0RwYfttFW9E5eDbRHRukBqdYAhjChLCwR1TKFHQEhTiparNLKu/aPa5lzBpLge4w3JEDrG/Z7AaaUFErfNtjBr6de+O47In/KHG/s7fKwk4pAE78mJ67tQuCW6uyUsBK2Q7VZxEka138zgt720nFFRQhP+/KCotCuk1ISMDnvuME2TJu52UQzaNpPRWWR9A1Xi2RPAadFcWAO/QacTw6ZOaahw2+8BsrpqR5av3nJkiYPaVc+rh+pvD+E/9rk4viYSP/IMs3YLzjwDzlzqFcJWHtljVdSmUxJ+n4dT+XsNzEIonLydlLDBcugENFTYdTdHJTHsFa4bAgzcMmPlP+A1vG4RWd2+La4K1tgsmG2XXiqOWm0CcPmGAbS+gpRb0CbJaiLklwZpJ7W7luK6HZwLRaSv5zG1lwMqxqd712ltVUcGqfJte7erg6uCJcU1aEUjA8+gmkid6UCsN8nAIq+0zKnzr/uCvIsAP+LgF3KIDdaBB2YJALTxxZkQvKL1Yiyh8eyRA0KDOTMKcXY4LgA7Z2Y1ZpoVRlXdKi5OEg7eSPf/zjWV66TTzH1BaVm86KS06FnzgkkmV+1u/Mphnlc/IwcZSdytFhPK0Lnjnh96qqCT/FyymyH5CHnDBH/DnX8iXDAtXhvwDOslw5NOPoGW4oX/5XGkpRViXQHkoSqNJ4nwCBgK9Bu6vo6/68NlxmpCqX40ebIFZUEkdezGfAe4PgZeKD9Qhl5Ldae4K8S5+lhyxG4IOKKg1zdCSiM6IEZZ0jU3EHIGXQBM67ssIS8H3A4wwm2BN56ZEMlaWUTymAB3YUdJ8CXKJA1xfu01jS28cEIU+bs3ydT8dXMpZam5hd/osPFk8iFd2DH5tOKyYr7rAzDA09iBnqbWpSb3HGPv+9KqtAoOydjlxdCORzAzqBVBDoPLy7w3HeqlE/xzOVNyuwzBPbMbSlss5Nl4SSjKsyUTmsAhq31yN2BO1KwqdYYSXE1gHjbTaYYysUYFBQiPh4jgKwwuSgECIBAEV5knj0eguloCU5RB4HmNw4YseADMZosE/5TKXBVelX6mgJbAsJxWCnY62ozBcy6NHDsuUhiSdsV0mUvPsLWs28xE2I9zYbjAp6JikwK5JCk86EpmlyKxoUIx299mdVngiMTH0yA4V/BeXrGdK0Vlbk46SoMZ+o52PU1SvX5Q3Q8cIP+YIs2YGUNourXOgB6utxLAf+owyv8ec8b+PNsoKZHi5RcHktjHtGRZlsCRA3Y6Aoc5PioLGcm8DHsMr97cbPrv98X9SFhuKn40Ijhdsvw7qSJocr6AxukB/fke0lL8bhuiYMjQ3urYJPZfUp1NzCqEF+lAuQkaB6toyU+kfRYoP/sQGnLuvLXocLbLCOyuGVH8pwf3+/byDLQlB2KFDSa5a1CJgw8Aqtz3DypqzozadFzHpMf2lCCwIKTeDrBqvWigsVFnVwhvHxyIF/rw2ZfKAh9/hvGXqWeLloaRc1F1CQoMbTFwA1NVQ8KXEgyGIFxJuyoteQKlDkOo5RDXK2UpKcB/BV6xP+cti+F80yo+EfIWFyLxFxTMPGBE5uWQUX96wgw6AgXZdsqgQ6Wss0KKsXmvQY0LaoqLbhwlTm3iaY0JhC9BbPwXlXxz2EZd2gknS5A0jwHuzY9w6mJA9V36tObsp8IesuFLTj2vFVUIYvK8ij8iwge45DnRRfjemnUua9WVZmSAWCMuoyF+0mkTDPsSs6iEPADlN5zhEX0tIoCywht3EwKNtsAxSVGwqcGnQdK4ZbXcHXwJU3jmHZ6UrpeLOszFBN/hzRlwcjzxIVNcP9ue1yja4wtOjMWgfjI+3N/34UvH/QCmJaDx48mn0+mrNjaIJGAmgHrzXJRUmULxXDWwA/znUGj67vjaGPb1LNJPS8KmucYV3fSY35k/z/7eufdNuL98/arXa31W71PgCpnVje/fD929bfv36E3eyt6aLder1o7U/+xzf/TyR0Sf5Vw9BKo5f3nq2jckzBkE/FiNc8XcsZuBKI8WHEHsf3Rf9e3eCizDYhHQo4wHWz1/rA6fhjKqqWb6S3sY5G+H98/ek18bXw9U703tmodWLbUr+yRczDc+QnJruWcXijrEr8tKRUNjxyhi9Q0UZ/C1ph4P/9t4+uSM8IuR7A5z7ZgNWYugx91BAn8shT6MKPRz6sSDXKCrH9498+O6ZlVMpmJcgVJFhb0ts0K4sJwgnKMV8pi8MDNiCMHdCXqFB4L6sHIMa3r5z5UeX51rVcNvg7r6xQqAs0iBc2whPgXJC+AK4WIJwghCyGnpiZ+JitVvMfoStPLJdHqxq58hPjm0zAtWOkuvxzWjx5XAeWYMTHdJiWQSnSwBTPFB4N5eynv3vny0KYZm8Mj9n8vHeSpbSMXrCXEMXkFzu9gQQ2A8br63Fso5gRfpORj03UIZfhJIi1UlbN2cERCvNUWihJwen6lmhRs1gYfvHN2zAroY5xtgoLmZZ2yiIUdgRZnRrIK0JnP/Rh4dN5OnYeS3KUFTyHozTtvOfauMGsCKU8nQxmA8RxA3Q3I804ipM/FSsqeFy84FqtMbNrQuDWRcjoKbKPhCxwrDtm41Pr7UI0ORg66xHGnQfACHExv7zAlx9OMAY/LENRmSlo01PS8ZDH2108ebx7ENxYW1bua0RlstHP0Xs57fflPkvQuBHw63xcCfPgrK+3ySQB03cgWJP94ndvxT3pHR5uKG8sOzzB7V2HhcqO8PxazZritpyATnIAysy7h6uDKw4c485Qd68ePnwIHQ2dGm9MVPpPmUB5A8Dz4m6pGS+PY1OSzQ3KeFwBICmTXPhUgrFrbqSsajzJ9/UGGQyyos7Z++HfKJi4XGgYRy69pZqhvTBi0CPwYq919NP/83YqJckGgQbIMWRPgxMBZh2fFNGwtBtJlgprrKiUptgNVoNqHt51DLysnoRxp2D+mrAkbhC6Ulj0pD0pbA7caU58JdHtD/IxF2Q5AFOSA9P4BsglO71KCtFkcicBzqPAJT5ARHgXmXODDnWKJE4ohTkg2mixsgrecIkz6vJQ6vihTv9qo0KwVp6wBisZu6oem8on7vjYkSoFX2sRdy1zuv9QwCHH06gDjkNDKqZSzgnjmMbxPJXbVj6ivcGqAYitH5jj2wQDaQ8C+LlBASID2BVQ7vXF5tCVuHU83O63+8j3rCBvuuqdApis5BeYA3DaOZRF1Gfc8qWIvdagvWg9brcXHc4ftFscb7bn3Gf94LYVfv4fbyOfeVZBS42Vi+rVmhWpZX1ukcMTA5xXUli1y0YKvgK3B6u2ErGmh8XtQisbuLNU5q4lex2M6weWuKWiUUm5FfPDXusGXeYp913HE33LfzwznukbvGWzNBlKldWm4bDBiYKywDMBsNEB2Wl6ccNIx1f+3F5o5QlPQ6vMAn5d8QVZmIFwYu/D3uKaCirCBNwmbtkUlc0SqNANVmMnS/JyNFjMopMfeD7vSE5xFZK9Ol9zq0dodwr40CpzAS6TXfEFWchBfpyBtxqCcMtmy8eGErXp5llCPnPcT+GJnLusMMgl4QZZaFmhRJFbFjJsNUg/BPTy5IfEAD0+9WEoo5QNlXxxPBui2tjv/v1RT5NjrZRNw2dhkionx98uAW8y/be+LQEaHFzXaFMvQCMp2w6e+5j84YabC4tVDFuWrPAKLSuVCAWZgzoLZhJmJsAxrHKJw/h5R/9t5F07Ub0ZdTp4Sd9VUT+Wq/3hAvSmpqdzxEuOIFLUfgdY8WBeTkbhI7Pl/BZaVpXtxCJ78aSRBe2tRoEFsOroEkKhsq89vP/+7TGYCPww0u4oekbkoIC0ph0h0gCGaSCErRxMpKxwE8aGnM3hPp8Z4pQKvrjdr0UDjgup28XE7XsxnOX/1BLPK1q71eL40FswpacOGB8YMvDcEL4ycJGyqvWjoZQrWIZh1ftEi3jbpPORXI8e4YRJkTzKTlcbPwLP+QQmJ3BYnr7fVUrumXV3coVj1jgLjiWx/jfHsgLHIHluRWmvJMV8uPwvF95b7a4LDS+42NCvo8POEe4YvZlTHVxWGifm6jCz+aG9BzknTpjLYtYiDss5rL+ZBBWy6Ejg0jDqW0xROt70Wb1oQEvdwxXzMsf9BB3qS9N6EllWEF8GbJeawL09gMKeIGLChsGL97iGSCvtlSTQdw63BUrinIGQAHfpFIFymUrJtgg0mT7HR3+fJiPWdb9o33bLyHvhbQxcBnc/0uQ+bc4yI6aPq/NjyvJ+wDTTvdxiyxpnptzbMzzz2qjQbu1DSW6P1800jy2V8MC9pFxSAOxAAO/9dAZBnnUHiWwYNLV46TyohDBohe2MMKjff0r3Dxgra5qxTXr+4nf/NcECewSeg3XxTVfcZPyMihzCnXqJnpjuVD+D7xni+GpimJEmiuIYjeM7WPLHuDoxEhoTPQCr74q25S+tx9mJ/vcM9pHD05tgNpidnUmYmACnYZXre5yO1zzzTTWRjHdKWZXAxvg3rUCNrM2SsOXRePJH9fRTrhm+f/++G+fIb9W6TOSRnlraGEBJl2ShoDF5/vdwncJSTBF/gg5hxkhJwHu7UfJQdAmOBOa2LV/WomzA+xktmIQ2YVwn51SnKs0uhmNHPIwf8v5XaiYPaNviYV1vUKag6nLRqv73b94dVp1vVn7ozan0V7g6WekZcXPEUWHDjLTMqL9//ekbfMdASj+TxmrkYv7FN+8+X43TP6kOieVkebWBHZLrh8wg14+9njane4l8xa6wXEYTTPey2NAI9PqFvVgZRbvdMztzpwweSNNCUYlGpbuAperzQRbaExmcFMqcHq0r3OEj5KDjZY70oauiSkuRAdfJiLsXtZPKyg0JcPvO7kmjxAh0t2PdRogSs84ifYFIUQNJI8P6iPfQ7t+2xml8l2dbelRYWK6nyPuQ9Y7rbhWD1pQrHCYeg0sZXHB3ccy6lBfP8YWbFsBN67sIUIgb/vSbtyMhbKlgsKoDZNB1yITj3GPgj4po8AXy7377qdGYMY8mOzvXF9KhkDPQ51W3MJcwtJOWNRbM/iefwR1eTOLnkv5DvN61Frc7pzxPcuJNojkhIgrsFDlWFwHnA9Wms8tn8S7Fpj2JcGptWbmkwN0kmGHrQRTcHeV05OmdONWNeoPjKXp/0bpYGr/omS5XDU/i7xfxLUjvcIlCuh6598lnRx++/xdcbysvpm6dnVY8nE1GezWSMXczaYmqxLYEKIZJLh1IKyrGNflnQ8D+2FOMJ3oZeHPEnWOcceaybJGmu3xfsn37AvFBOs3iOeIkVo3GqMsiqDXAK4vyZKEYH6f58SsIt6fCGeKotdg74dp4VuZ1jsNQAx2TaCNLix06Nr+cSMqjVVYq5w8//MCtUU80ijNFRq98DdANChoh36dqHIJb98D3L/kaFtw2uHlWSw7RotV6WZfxaVoinpV1DNmP0nkUPVPGtz+8GyzPobp3xMuCHfEUsn/l42SIIl7KSlfLRVRYrYU1UVTymqmszAzHidKyHRsUiJv8xy7T3waKGrPFz/gdlnECuzqK5DHGtBC4VnEjMDOFFXhVdyvgU1lR185rknElbuu/mszj+L6bKiM38hsfJXNPWZEBCV/iClIZiB45Lc7N5KYuKtfv0ACYr1FgftxDa4RkCLw8OvPBfXk8ePBoZnpygWHW3sFRvzD+7gGNzenLCO4cbBYFdpTYfRa5GJYVZVU9wQuIoeMoijnwjQ40Rt43wAls8oXCPuUbQTa4u4YDOV+jzOyQnQJc4JW240SsQRZJ4G7pBpXICvShqMy4g0u8eM5eB/ABLqsAi/zMCnE3kc49FDv0QKMhYSiBpbJyjAo8uqD89xW60jce1NKMS749F+RdwlUTgZFDmTlPMHbAb1AtJbBUVrUjJbCkoUPrK6upg/GR5rOT8cFP3Wlw651tOHEZd9lm2uDhjSBlVZ+XJQyul5ZFu6FrJwG13DUE9tyQgvHaqiH9BlwjgT2uoyK9NMuE8SQ/UtXV8OAjKfJBZJdoKHf4iLPpgnJz9xgnDEMBbANSkgQeoLIel0Q7SbaPh1kyInU/wbOLBZ6m6G3lY7z9koXDuJFvkuhkWigDhX+k1l+foS3wO689hUjavF5XqaTs2NExdMiD68v1oDUAmSe4urgCXBEulsnbJh7QygzKQC1P34BMAwDx4o4lvsgf4fY1T7IwWeJsg+gbIC6Fg/+yAo+t0I6TwMcNMg9sGNj2NT+lTC8gGza6ZJjj4RyyHSUjN/FeNe5L8B6k+A/RqE9MGrWS10UGrSTpCA9ed8CROPPWbJUlSDIs60+6dZYTTGUrKnuTwjygcMNkKQzuJ2XuUzbgoxRQNOIRrOgViHczMqBcbb82n0FuPVFs4Mj5GleAKx34WYsrNbeSTrv3DHlxeyzlFdxLXI1gOr9xkyXXVUjBE/nDxp7liYYJ76QIc1l/KN+NkoEWfjkbrIXwkAjmCwVChYNSnxlmxxP9bJW8RQFTSLzqeLAzGx7kcSqQSW2/Ni/gnS49raAucBnwWAfANFWH9ECkgcoi7gjyiLIdsUNBOy/kMYdGhx2Mqu8cEMwG56b4TZhLyKm3D8YSWMBYH71J5UQveAUBv6GQeMGy30BYvEYUvpCH0sAUD+KGx968qLJLY9aBsLIogYDEsyIY1CE7NtO6o6KJ5ZzFA/bRXyK+m5VmGKc9NqcSZYXFjKRMc/wF5TkAfJiDM0M8lxAOTcYxMS006AsqZ46rEgDuFJV3DTgfwo+zNf4HD30gdUwQIefCBm1CrwpY1EVPmE+gg1Od20AHo0mjrK0CO/ectmRFD7Qu8rw8KmtkRdUACQzMDcBbXHSHMlIh25w8ii+4vJ9TSXGFJvRiWCoq7gfxs+Y/QJq38YwmH13SY11iVprPRpNFv4w407aRx0PyiNY8GE38cjikSc9MUkpFa+4zdJSHcI8mT4qY4hrgKi2gQl7bEvc1eQRFHYAHXtJAq0blPpQi+ISDleQyik+StaSFck6FjEU6OAMLrSNjlJanVEZEsoEH6AjG6Z1itKzWipSdz/1Y16+i3adoFWPTA/KL2QOr3ByRfFkcRzZKR4eXNEMmvIrCyyKANaT3y8oT9f88TfsBXUo0SDbkIJ3o6XmS7iE80RWTQfm6AA7ECKuAT/AYrkaV/0RvBFbHtDFIGr0x83yf93a/jQX+28dtyBFfFaA8swKOYmlFyw9v7bWmBsfaDEHsClcniyitLyYfR1lpcRys3BTW1aZDjkkY/XNiDPll8mtEKAcY9d9LJ8UTTON0gsfnMmmL2MwquAjxI1BgAOsN1MYbQTlf+mKAx6/wzKR/fP3p9Ye91g0UBjOmUNh8RWXWQQtHtbQxSYdPZ1zxRH4eRqe+1ZrLGq0rGj6HG5MU0BzPY8nhAtztlMI1eZybDrcqcLu76QIslZXWlb1XOtHD81i5OR5I2ZNA2Tr22F6m5I2zV96ISUc3czlSJ2aQSvrd149GOI1wqaAFyhmj5fy3O+hAjqnsOCbnQqe0alLxKScROaEIgpxI5ITiKIf4SrRaGQhXIuUPEzlodZDpWeG7o0h5FAuWC27AikvDvisJlb/IdbkDLvkGDWYOfmxzmdkixnjKZerFz/xXPE11nRkbKlz4nwF8QBxNmCNtqEkXJfGERx4Z2m610QZgH/2GAZR2wEO/H3z62TjvOByldFObrGHtxlD0PnDBvzjw8xonYugKAXkML7KL4izvlJVCQsNgj8YF3iAGsPmnotblo77kn/zYlEPhRDa47BXVbGE/a2wTdx6QOem/RIPJPFoVCjv86quvvgU8x2NZjdB472y6PLSmH8/15Xm33pV0JTta2tvv/9X729c/GZp8+nKFSM4DrTM2uwyRB9uwJMwBdGSzXi8h7grDM5uSNO7VDBeXuSMDBe4lAaX3aFTic1ClNH3AQSnoNQSmtFAe4/OdoFzHGuXKY4GvoQ11Y6eUhY7QCUxdJ++Wk0d7i0s3dzevSLp4HDu62B+WcSIk6rqLnIuMTgSYpzrPRsc98hghnR1oaQG8rejnykMyV3XaICYVZA0cjXOKD/KOdY0tSb/qe1UeaY+7ZI9lkkxuJMuCSrzA8yAZZ3jPzSChIY4VOKxbd6/1/grWNMtiW9G0QBqWdUYw6mIAfp7govIGuCJcM1yvXGWsOk7IrrQwA48ra/y5yhqzwF4KjfYZnruwtgH+eTFEiKc1eMWZS9ce/iPJcn8NFYlnDRmdSWxIX1fY0hWWFvXD3uJ6zYoay6A0hY0zKOMf9f0GdEvp6KBb9zzUQmUto5DrpAkLK/muTQQejVwkG8utkYNxR6GhdS9peSr+9/+6qt71vceKiljMb1sPjnyPYfNy8xXvsXO+xxIMxUHaAMbrrPeAtzUCbu0JvIEjlG+SUcYIcWNM9hzCBaG7JAoc58ProPvrK/imt8IXJ5Pqo6hkrd3Za324ZCeywmjNH6BQ45JYDNOKynx2zrKmhcuxB+NcTktXE0ov0rRdn9mp+J4DUB/gunTlrST8jfpiHGUA6zrC3ynvPYVcr6r2ysolEFit5xBEl8LAPcfJL303YhdBo8KuY/5c6GTghrDww4x4qyi1RHNTk3FqZhnw9b0jg22KmTSqjvRZ/xir5q4+1NoNhhAGUMxrKOgxrh4vVMQA7scVx55VV0pWfnSBEb/sSLLSHeN6jvgr6PxCXp0Vlcy2P3i1UivlL+sBw6Yj0J55oD/EMG2SR6e2yqq2WlEhO1nMU4GpzFlpVcY5vkdZxGqgOoMiuMJ0WtWPn7IsBF0vAPYWf/fvj3rrZcIsd26qUAobmmHeQXOHHSc0tfi1VVZYVI4DMhX1roh+xwoJsvW59dUZ8JuodbeqsdTbt/w+7mYFKiyHLJxngOJNDbjnDrQDnUWNadVWWcFgN2ZS8x+kNztrYHc7aXH7bHME0O7rNv3XuRycS1EbaQ65VqoUd57geYb7Ca4hlPRzKrh0u+Pd3uAEsbrcBhJG0pudJTibBJPeH2rD+3IDhKzzsyFfCg42/fdAOPRJnDP/UB5u8umQLv5nvLKWSVzzhRJSKXl5C7VVVgpRTShpC7vuWWFMds21DDom+mhIquE7clI1+uIJcgxdc9W9UIH2xdUFLr9Qafne7MQ1vzLxa+sGQ4gvBQUPBTClgqgetBSFRQOaemL+sSc6VZLpuWYWryaAzgBXR0Ovi/Z2iRUG5zOENXk4J3lRVroXvHyOH6EEIUqn6+nq9B6ijk/rSsJkxStr5CTiohUkHzfjvt1x2dGkVgouUFadkq6IAgrbwzvdtVVYKzeYSomCPcfVR2kDuILLQqNx0aWY42GK+3NXFxUK+zRrLy8tDi7xwHylRkp4QFlfQgYDz6TnDx8+DL3QxHKIFzoVE3n//m0XWU5Ns00oqikq4Xn6/xX+V954sSHkG6dtShCCGAHnVIIXK5XruItrjfESBidcXOmR95ima4cSywFyucQ9Oy8vAR3hiY9jWsgMjlRZeGGqYiI2u5lYr55OPOGRRKOKi6zNzkhZ0SDpVgy0FO8n0tIeqbHd/dQKY5KTDci2k8g6wn3uaQ0JuNxbj42Es5Tx9H9ufiYJu6SsJsakQIYcZh1Il1UKaHlJFo9ZLRWVTFIprnyOZ21KDv6XWxeBO8CVVFSSC3A5fTZDVeoR6LBzcgmzOh2J41KQNeH62lBBC91fUxkysxUpKxs6sHnZhlJf+SpiSvFPryCtpGnUABHWn81Q3gMVNsJlHGhRuW2tTr25cSHWiIB67iL7ojo24ZDLR7UJImUFty9cOeZMm1IaV1JG+KoCqajSwMq+pFsrRUjCUWGhcJycGOOaJ9M09xHSuIm7UVSNkIqS0NkFRTAm6aBn1QZM8jCBLZwNVgrmhWkU/hmYC00Y9AB7akEj+OGHHwbAO7PAbSnLOILCn5EOyv0YdHq4knKM8DzF9RoKHuK/zBCBeFBmBmXQXtzuz03owiB0TeCLYH3TK8qvKL1QWUHAmytA64oG3KnKzWNetuMO1bFYKWssdFVO0nCiE9Oz/scnLXDMQGCNvyZE02Ne0L7mqDdv3ILWzJSYOt6HBqKrcEnj3EeHLHGDA5Wpl794CcYLsQIijnnFwi7Ipf7Jy2/P1J/NVQ4X5uurUFZj5VrN1O1J7Qm4BJVk2+H9BTzUCzfqsi+fJzN2za/BX4cE8JGodWTrkueiZW7VHL93c49dKP/re5E5EdzBB/jjnGRGD6CwI016YZLEshYSaQDqLYGPx6TgUO0NCov2g5em7Kphx8QUTwMvpoUdbM81dOKkZ/GNzb9EWWc2hOuA49jTRnUogz8e2uKG5y9Pa0qR6Xg1zonbXON7l3+MV7XfIcqg3c+IS0cF6QiTZ4myRiYEi2AdFaiI/Eo6e1oKfSVS/mDcs8tJVw+JrXsbUx5MEVnzqraPunZMbDfD6mtJn6NEWf28+QE+qDjKVdFz5TGVn/SwIMetZmcWeLVFWbrCFpM21RdoMX/wySMn2aPuqGgzB95PTPefC43C3IGnVqGyqilnp0xiBjEAt+4xYxqm/+xpIUijymevWnWnYlouG/jF/nKjhg1qZTg4fPw873OQUiZYd9wJBnhThWU7t/10icT9lsDkFrNQWRXmSS4FYQJ7Hh9rTcLsVsCwM+hEqLDLyqr7iQErhTN4UBNNEwOUqkEjV6saM0yFRXs7xDM9K9arNrB9AoAvnIRawJxE1WZ0uPzQ1CgHXRTdFkEBSK0TDaTwKbjcU8ZTcKU+cnodH9E6hYXvZWQUYkZvbOr+ZNCpdVSdD/q2eSVOIuzE5pgnUEruU+8CL8L9HPevcT+BIs0ktIpg1I4/booIFGyE/5euikpaYmUlsKXCsldjj+VFGOTDNbDykhsmfL3T6spXVfh1/IQGJpXGP/3m7agqGWxiPkbKygKqhV2uKXWKCkzXgq97beP4r6jsdU//x799doz6eVETPjfuGzfrkJuxspJJ5VYc4/YJri7jEmGO+wmPOtk1i5WQgbdbdI48zKtH9w1EI0ycTHx1fngp/QI0B96YtSCErwTM9j757Mh1Uski641DsVLWdCnZoKCcHa6h+mpI6Tx27Vl1iFSmfqrs7AxPMKwIU/FWj9/99lPJ92qtaBcjLSb7n3w2bBS1WFKE8KKssqwaKBMJoAO8BHxaUe9IwNLmfm3sDkh4Aws7ACg7hsoC+D/76e/eOa8yVMZwDTJqlLUGlZBmgbPWmJm+Ssennrk08Xkqzvrxb1//pLvfel/BR5axR3mxP/zid/81sWa2BoixN4l66pEdeJZT3LNOZmWx1yhrWZJ1oIuGIBpLooF4/9jyd18/Gn382ly741CETFRa0weffjbeVLdXc+BesrxcEprgOve9DCjdFJFkprkvWQKo6KDkLHLJc/kE48iDxcfNBFEuoDhh+bZPuH/bOqDbu4mKyvkDvquKzvEGxR7g0nVkPFP7mLDodEeA9RYay+pNlP4IFY1X45zKsKwx7fhfrcly1r+HK8AlCEsFnWJK5NX+J48mZSgoZDQAI4/jjg0KEuH5tc/ZctBrqYk+Dkm6fLYIPJPLy9laa1FWuhOYOQ7igvs6uDumt+n/qiHSFdYFr2NWXUZxGnc/8ZT8vUW7e5t1mBhecn/wvhV9/h9voxjH9786NoWyybNu3JU09nFAugdFjYvvRWErU1ZV8GNw/wxXEJci8R/h3umg7QStjb+Fwl6jELm9ORqktxP7N0VYkMkIvJ4K+Q0x2TMUwmaCoWO4gpx7mYnmkdzS+NQc7UeMSsastBTqkwYUdPBj9it3jOdB2/T1ByspO/hQ8NaIF8uxSWJVbUKqqCya0zEqzM+jopKfPr0C3tiG0i0rCn0B5gYWDDr3jEV50trzqFBMuT9JVwzGQlPEvUZa6HtWr4ivZLpy++4s7Lr5SfJW1b3yym6QX8c0T8jrwKb+0G7f2ORXwF8E63pQAJObXKqyosAj5GzSG64wCmUpzdVTvD1HhoUNAIp7hj3O42Z31kr1VPaAuhogM3b6xoF1x1ckTRBd8ivKx2VSsDQ3GAWmNbBWVBYagn7h+xs57KXBG8eD5K1QUckHOo1juOfWn9UgjSY4SeCJAzbboWl4bIoghccrmtZlkRzyLeVjBY6Khka+EmfzgJ7oBfCcBuZxvsqdusKzTQUShx/aPdgUC6ssxGPURRDLoA6ufcyL9B/88x1UKfgKHPB6KxGyBxscGWW7trekXYqy0hpaCimrwH3Ssxl3pIm9e/eOL57bKGpMiif8U9kP44g6/qeXN1INvYcO8BQwUyjB0Idc6ygDR54CR/xcdJf2V4qyojH0crm1SFD0QgvUOxS13/b4LsL+pkuLhYmC0JSE4uE58Hq4Ogn8Oe6pPC9dj5QBbxegNUjQzrxlZ4rrGvC1Ohggk1m3yMgN3Tt2st6NiJc1Zg2MuCgGdqaHWUEqia9wakKIngEs2RV4oFXu40pXGJ/7UJ5LwkGBuib0Y1jgcsgwiJ8F/8zXOj8BfV8gMwdCUwfcWqGWoqywEI89l/JnLvQ4VgV+34VGCjeQKhTh4Blc05KlaGQ+KjhjBaLVBu5xJlF9ZAf1RSWvbQB/57bMQfYvLXDnFjgiFJRlKgLMACpFWdFovBYWBXSilzxvKUMGtlH9IkQ1k01r2imCTaUT3khheRBciob4kR0ElV2MUDGgGleHptlSMSxPK5ma5iWFh6wjKWwarhRlRSbfpjNyeUYB/+mCD/ez54Jviwu+L4BrqqhxdsQjfmHwMaEHGT0rzGiNANjRdYLsZwYszHj+lwH8HSjq7fXdg+cbdCCvbEmWpayRLUNZeCigSSVlkfAeB54e64gqt7SngxGkLSeziuDQuLpFMIL0ngBmbSBcLivYgpnkzWnj/MOHD0MQmycJerqfu0wglqKsEOrEU+FIZo4ecuqRni9S2g7Eo6UqnBjzpKyBL8GURYcKi1n4Q9Af4sqSP9vdkDAua+EK97yEcjjRLGXphoXFxEqIwg5cCwwLBnLh3IUOJhl45MapC400LhTkn+m41HMv9Wz72LVFrApPbTbpI78nuAJcMc8R7md0KzGmnvha01XLZiFolxZgcM6wps6hQeApkxn4HrnQKsWykiEoxxh/TkpGfO7JJT2XUMaX69gBFPAUFKSLk4smfzwNEyIxQwqQSopOecQ3pRB1gYsKGysqoQJcffC3PGUBsBdqZp5ptQ7KQDwFk65tmOUkjSFvXEJpyqp60RMn5vb2vBwQrgQ/ceElhRtZzjKmyPh59KSsUxNuuCSldnPRY+kIcZevShJXCL9WMFjCGRg4wjV3YIS4XjaelKasLJxyV2x6FBZw6FMhYAmdxgssTyK8TNyXfgsvRdtY2DFCYacujJisRyplu0J+XYs8O8AxWpayyMMbSkJhZ6ZEWSdwpw8UDVP0e/DtezElRKjKpZtUWLksIMY4PMTaWDhFrIMP8jAogitI59jjsACGnxm5AUxQBCdJR36F9URXGUpNBTIOlDlmKY8kiGp8ynwK67KAXi0+VlbA40oy6nSAiFNcAS5dYNs9R72FOiDTtFImmNJMKMU7xHY4bqnjJEQPV4ArDhFupuzdfVrTmHj8j17uBK4bG5ltQ5sDdxjTK/ifIn1QACNJnkiAKDfI9wzyPZbAJ2DmUFZpmVoeXoaIs+6A1ws8HMURdf9XyhfS+ID3HuTG3V+Pcc928S2uCB3m1NdEWloe7XTEtj87WAZWiHjs4WLpUnXApYgwFZf7aOg9GJWJmy/Qod7kZm6RAHrezz62YGMjUEods9ZRApxsQuOnGzvGxcYqCRPTsQctHd1LCXENDF3uUJN+LwnwQ+T7FAnRvcTViNC0TPv7+/1VEu5PsETP3KnsBoVK3OA6ihKNegQre5Z3BhN4jnBNcXHsMcO/cYDSDOEiXQOxY4zsMN2vdslMOOxAvo9xdZk/3TVc1mueUCyeVUVSPgN5HPokuK20vEt+kwUF5eXL5YGtcmaVneMbxF/h6mSl58TNES92uXNoeI9GWRbeiYIgOgGrQ83K4KXONHfODdZVhnKRZzoY0zSl+EfAk9IlXO0U1bTcJvDJA99N8HYNdmfd4CorWinsISzTAPlyNryfkf8Eca8AG2akNVGNBFqNslbYCJQihswyuYWwzOWqCovXZFWyBDZuzMrlA7pN3O+rthGWLKKGfCwBeAY3uA/iZ1//6MQ2rh36KrsJnY2xrGgoIxTsGa4AExItTARxlxC32Z24vCNoIqwGdjnuDjzLQTqWt8427uA33YOpfY+mZmg5m9rV1FaI3nmoSd+ZJLUZg50a5RXLLML9jMs2fLHa1iNRO9AuQctbAE+lfXVB8fsCzAYJhrm+fGIrgwSdym9rr6wQOA8LPy6SDDcC7LKFhZfRhQwoq16BrOZI59rxqAAuM9mzK8zTH0o5NF15YqeZhcAaNryzw7K2Bebk6Rxd66UbdbZQoaJSCmik7EF3MqjND9LPE3YgJB7yza8L8N4oYHugNw8GdVbK94PU5F2eorK88b5ko7KvG7jWyoqG0TMQUEDlNoDfClBaVDT6CxTGSPFogbEp39ilVdsozzwIL/TxweMsPmA1OQzQBpZ/09pLrZUV0g60Ek8l7triurKMVDgjRY3Fxgar3MU4SvSP4cYJAEMRcDYQ91qTRikBw4FAQnjT2kutlRWNaS4R+q7CcF8zyh44lv+5jTvMCT3UDxXOtI7GwPVyAohjuTcOvdZLN+ghpwYSnfuYmqdrxLdL4Epx03ovkX+E+xmu2uwygnyeJ/izvV1+UBrIZ6YE6MZC0UP1jusA+J0cGlToCWQ6rmhSh/XUy+HlLppr9XcPG3CzCbPBookTNFzjj+Ym64fWRTW642R8zn3EiRYfnUMO/cJodirg4aYQUADAThGu7ZEAVAvC8TMAeAUEpGeEa1a1nJRsrsFCh3xkBdf2kkWz7LhaW1YWXrlaV7jNFTzSePr6mPA2gYrKw7+QFxuaJHBjBs8Roks3kiD4huF4Czx4IWtQbm1+kMUMALysg1obTdZDhPHtxGRdlNYbdUMX/QWuTgYzTu0lg14lUbW3rJSC6rE545msxKWAaBX4mQSTylwiqp9YUbNoJ+E092tRWI8nUSyLBkVbW1tQdXAMRujWZykXeQxN3WhlYU+B28MV4OLGkJdlzUKDfqlhbRVkU6qMXneienMbckscdASXuOlbEwAi3NHKjybZFmXVdcQZdbI8L2pXN7/U3g1OVpiqpEkyzuVeNXgnRWX+6PFp9Q9ceDHFRZ5zU5w8eHoneWllxie8mo4wH25m4Ddsd3K3Wq2XboQVaA2GBk+3y0fgx5Kdld6EEeVRRCY4GtiZJq20JLUpQ6qod3xAYTfmZP87pj3c7LSyQn7eFAwN6ImH+jAiAYs4MULIAeY4LieptGh6Nci3Z5kBJwSPLXE3Fm1nlZWNxWetQXECn/QktJDnOeDmEtg8GLrAruP+PNq6eA9ejS+vSMdmrdJ2Vll914KDlbBmhUsUyHdsTQCKDmUdOuC7oPZckIHLj2J1HWlsFHqjrBtVXfeZVcsQ4f2Uwhha5KOKdhRlMdPJijSJwyy8Mw2T/NYN2yirvxqY+SNlRglu7BAW1mRjfIQcduoERTOJ1hN6o5ZufIrw/fv33DLok2TkQiyxhvwlXFMuUdDyfYtLtJZMC4tNABOUiZsABriyAt3m803dFJBVoF2Ka+9SYdNlxZjnBnFBOt7yeQgLF5rigocBcKhgAa68YHzWFCfQ8LXxDpQ3gILO2Dmt0eW9Vy6U+xqR3XsJBhHYhvi57c41g2xqA7qzlpU1QCsDK/bCQ23weJKJCR21IYCbKfoCPCrcJRq4+KypqjfPC8qwAoLyvITsXZTVaL/wSuYb+uDVD9w0GfDwMPAc4XIN56Y9PF8cQKYSRU3yNoDCUsErCbTOvNix+M5QyX5uSxceA5etdirstBvMmkbjZ+9Ol8w28EtvhybIGJ+KDoHT0Czt5QEqp1oDTXckEfhhvqGGL6MkNU6/NEICMCyy0+uQpvnVBX7nlZUVAYUd4M/GYs3g/h6ZWFVf76FCobx/zAlyGEEOp7h0wbjMOmIWshcPBXT5bmLaTrvBcYXRWsCtOsJzFMcJ/nmOkJGikibGas8FtAtBfNGJMxIqKsG7yoWPUZ3+KXtYyqcgEgkI0bIPBXBbCdIoq6pWTshA+Q6hBCeIijS1zeWRIzQaq3doQT/tXmqyyk/yRYc5QFE5FCiyqElmukq5k3HW93ybirIHASriBFeEaxmgyFPWCT0JyHykonfyr3GDc6qd7mr69DsfM6xo5IucLI2j0Xi91B944hBgYMjAHPl/bojTgDtIwEtlO+S/c6g+lRXCO4TCzFyFCJ7egEbHlA49DB8dmGm+uwrfuMEbXPNwDeee2DdWVOaL/Hue8m/ICCTQKKtASHUFqdOOpLrKaJv4apS1+tp0dlsVy77oWEsAkz9r58Ga+Q1EbJS14krDzOZLH1n6oqN4mdjwhFMlpzZ4DY6dBBpltZObNZbrNjuV8VzRseYjiQgLadOBYC9IOE/Sae7LlUCjrOXK9x511cC5lusSTnwqisWpkXOsi7qWwaX8O4nbKOsaqh3LLSGy5WUTuN0utEHU4UD5hkiXuMO0psY7t3R5N2kyCezLwBoo3xL461//+uoXv/jFP0H3f0ppcycPFPW3UngTuNls9hY8/d+f//zn/wm8Lq5OBn4Ipf5fv//976OMtCaqZAm0S6bfkC+QQOITD4McUFqyKr/AtmQDGyWosLz4Aawpv7jm0/VeZtL8GEmgUVYjcZUHPMA7ozjNoYvJHl7LY11gSSv/Alt5JWwou0rg/wNp6JZe9MHFaAAAAABJRU5ErkJggg==
       mediatype: image/png

--- a/manifests/integreatly-3scale/3scale-0.4.0/apps_v1alpha1_apimanager_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/apps_v1alpha1_apimanager_crd.yaml
@@ -37,19 +37,49 @@ spec:
                   type: string
                 openSSLVerify:
                   type: boolean
+                productionSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
                 registryURL:
                   type: string
                 responseCodes:
                   type: boolean
+                stagingSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
               type: object
             appLabel:
               type: string
             backend:
               properties:
+                cronSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
                 image:
                   type: string
+                listenerSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
                 redisImage:
                   type: string
+                workerSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
               type: object
             highAvailability:
               properties:
@@ -62,6 +92,12 @@ spec:
               type: boolean
             system:
               properties:
+                appSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
                 database:
                   properties:
                     mysql:
@@ -90,9 +126,9 @@ spec:
                         awsRegion:
                           type: string
                       required:
-                        - awsBucket
-                        - awsRegion
-                        - awsCredentialsSecret
+                      - awsBucket
+                      - awsRegion
+                      - awsCredentialsSecret
                       type: object
                     persistentVolumeClaim:
                       description: Union type. Only one of the fields can be set.
@@ -107,6 +143,12 @@ spec:
                   type: string
                 redisImage:
                   type: string
+                sidekiqSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
               type: object
             tenantName:
               type: string
@@ -114,13 +156,25 @@ spec:
               type: string
             zync:
               properties:
+                appSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
                 image:
                   type: string
                 postgreSQLImage:
                   type: string
+                queSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
               type: object
           required:
-            - wildcardDomain
+          - wildcardDomain
           type: object
         status:
           properties:
@@ -132,8 +186,8 @@ spec:
                   type:
                     type: string
                 required:
-                  - type
-                  - status
+                - type
+                - status
                 type: object
               type: array
             deployments:
@@ -156,10 +210,10 @@ spec:
                   type: array
               type: object
           required:
-            - deployments
+          - deployments
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_api_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_api_crd.yaml
@@ -36,8 +36,8 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - authParameterName
-                                - credentialsLocation
+                              - authParameterName
+                              - credentialsLocation
                               type: object
                             appID:
                               properties:
@@ -48,9 +48,9 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - appIDParameterName
-                                - appKeyParameterName
-                                - credentialsLocation
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
                               type: object
                             openIDConnector:
                               properties:
@@ -59,8 +59,8 @@ spec:
                                 issuer:
                                   type: string
                               required:
-                                - issuer
-                                - credentialsLocation
+                              - issuer
+                              - credentialsLocation
                               type: object
                           type: object
                         errors:
@@ -75,9 +75,9 @@ spec:
                                   format: int64
                                   type: integer
                               required:
-                                - responseCode
-                                - contentType
-                                - responseBody
+                              - responseCode
+                              - contentType
+                              - responseBody
                               type: object
                             authenticationMissing:
                               properties:
@@ -89,23 +89,23 @@ spec:
                                   format: int64
                                   type: integer
                               required:
-                                - responseCode
-                                - contentType
-                                - responseBody
+                              - responseCode
+                              - contentType
+                              - responseBody
                               type: object
                           required:
-                            - authenticationFailed
-                            - authenticationMissing
+                          - authenticationFailed
+                          - authenticationMissing
                           type: object
                         hostHeader:
                           type: string
                         secretToken:
                           type: string
                       required:
-                        - hostHeader
-                        - secretToken
-                        - credentials
-                        - errors
+                      - hostHeader
+                      - secretToken
+                      - credentials
+                      - errors
                       type: object
                     mappingRulesSelector:
                       type: object
@@ -140,9 +140,9 @@ spec:
                     privateBaseURL:
                       type: string
                   required:
-                    - privateBaseURL
-                    - apiTestGetRequest
-                    - authenticationSettings
+                  - privateBaseURL
+                  - apiTestGetRequest
+                  - authenticationSettings
                   type: object
                 apicastOnPrem:
                   properties:
@@ -159,8 +159,8 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - authParameterName
-                                - credentialsLocation
+                              - authParameterName
+                              - credentialsLocation
                               type: object
                             appID:
                               properties:
@@ -171,9 +171,9 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - appIDParameterName
-                                - appKeyParameterName
-                                - credentialsLocation
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
                               type: object
                             openIDConnector:
                               properties:
@@ -182,8 +182,8 @@ spec:
                                 issuer:
                                   type: string
                               required:
-                                - issuer
-                                - credentialsLocation
+                              - issuer
+                              - credentialsLocation
                               type: object
                           type: object
                         errors:
@@ -198,9 +198,9 @@ spec:
                                   format: int64
                                   type: integer
                               required:
-                                - responseCode
-                                - contentType
-                                - responseBody
+                              - responseCode
+                              - contentType
+                              - responseBody
                               type: object
                             authenticationMissing:
                               properties:
@@ -212,23 +212,23 @@ spec:
                                   format: int64
                                   type: integer
                               required:
-                                - responseCode
-                                - contentType
-                                - responseBody
+                              - responseCode
+                              - contentType
+                              - responseBody
                               type: object
                           required:
-                            - authenticationFailed
-                            - authenticationMissing
+                          - authenticationFailed
+                          - authenticationMissing
                           type: object
                         hostHeader:
                           type: string
                         secretToken:
                           type: string
                       required:
-                        - hostHeader
-                        - secretToken
-                        - credentials
-                        - errors
+                      - hostHeader
+                      - secretToken
+                      - credentials
+                      - errors
                       type: object
                     mappingRulesSelector:
                       type: object
@@ -267,11 +267,11 @@ spec:
                     stagingPublicBaseURL:
                       type: string
                   required:
-                    - privateBaseURL
-                    - apiTestGetRequest
-                    - authenticationSettings
-                    - stagingPublicBaseURL
-                    - productionPublicBaseURL
+                  - privateBaseURL
+                  - apiTestGetRequest
+                  - authenticationSettings
+                  - stagingPublicBaseURL
+                  - productionPublicBaseURL
                   type: object
                 codePlugin:
                   properties:
@@ -286,8 +286,8 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - authParameterName
-                                - credentialsLocation
+                              - authParameterName
+                              - credentialsLocation
                               type: object
                             appID:
                               properties:
@@ -298,9 +298,9 @@ spec:
                                 credentialsLocation:
                                   type: string
                               required:
-                                - appIDParameterName
-                                - appKeyParameterName
-                                - credentialsLocation
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
                               type: object
                             openIDConnector:
                               properties:
@@ -309,15 +309,15 @@ spec:
                                 issuer:
                                   type: string
                               required:
-                                - issuer
-                                - credentialsLocation
+                              - issuer
+                              - credentialsLocation
                               type: object
                           type: object
                       required:
-                        - credentials
+                      - credentials
                       type: object
                   required:
-                    - authenticationSettings
+                  - authenticationSettings
                   type: object
               type: object
             metricSelector:
@@ -351,13 +351,13 @@ spec:
                       values:
                         type: array
           required:
-            - description
-            - integrationMethod
+          - description
+          - integrationMethod
           type: object
         status:
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_binding_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_binding_crd.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: plans.capabilities.3scale.net
+  name: bindings.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net
   names:
-    kind: Plan
-    listKind: PlanList
-    plural: plans
-    singular: plan
+    kind: Binding
+    listKind: BindingList
+    plural: bindings
+    singular: binding
   scope: Namespaced
   subresources:
     status: {}
@@ -17,20 +17,7 @@ spec:
       properties:
         spec:
           properties:
-            approvalRequired:
-              type: boolean
-            costs:
-              properties:
-                costMonth:
-                  format: double
-                  type: number
-                setupFee:
-                  format: double
-                  type: number
-              type: object
-            default:
-              type: boolean
-            limitSelector:
+            apiSelector:
               type: object
               properties:
                 matchLabels:
@@ -45,19 +32,34 @@ spec:
                         type: string
                       values:
                         type: array
-            trialPeriod:
-              format: int64
-              type: integer
+            credentialsRef:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
           required:
-            - default
-            - trialPeriod
-            - approvalRequired
-            - limitSelector
+          - credentialsRef
           type: object
         status:
+          properties:
+            currentState:
+              type: string
+            desiredState:
+              type: string
+            lastSync:
+              type: object
+              properties:
+                seconds:
+                  type: integer
+                nanos:
+                  type: integer
+            previousState:
+              type: string
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_limit_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_limit_crd.yaml
@@ -41,13 +41,13 @@ spec:
             period:
               type: string
           required:
-            - period
-            - maxValue
-            - metricRef
+          - period
+          - maxValue
+          - metricRef
         status:
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_mappingrule_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_mappingrule_crd.yaml
@@ -42,15 +42,15 @@ spec:
             path:
               type: string
           required:
-            - path
-            - method
-            - increment
-            - metricRef
+          - path
+          - method
+          - increment
+          - metricRef
           type: object
         status:
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_metric_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_metric_crd.yaml
@@ -24,14 +24,14 @@ spec:
             unit:
               type: string
           required:
-            - unit
-            - description
-            - incrementHits
+          - unit
+          - description
+          - incrementHits
           type: object
         status:
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_plan_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_plan_crd.yaml
@@ -1,14 +1,14 @@
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
 metadata:
-  name: bindings.capabilities.3scale.net
+  name: plans.capabilities.3scale.net
 spec:
   group: capabilities.3scale.net
   names:
-    kind: Binding
-    listKind: BindingList
-    plural: bindings
-    singular: binding
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
   scope: Namespaced
   subresources:
     status: {}
@@ -17,7 +17,20 @@ spec:
       properties:
         spec:
           properties:
-            apiSelector:
+            approvalRequired:
+              type: boolean
+            costs:
+              properties:
+                costMonth:
+                  format: double
+                  type: number
+                setupFee:
+                  format: double
+                  type: number
+              type: object
+            default:
+              type: boolean
+            limitSelector:
               type: object
               properties:
                 matchLabels:
@@ -32,34 +45,19 @@ spec:
                         type: string
                       values:
                         type: array
-            credentialsRef:
-              type: object
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
+            trialPeriod:
+              format: int64
+              type: integer
           required:
-            - credentialsRef
+          - default
+          - trialPeriod
+          - approvalRequired
+          - limitSelector
           type: object
         status:
-          properties:
-            currentState:
-              type: string
-            desiredState:
-              type: string
-            lastSync:
-              type: object
-              properties:
-                seconds:
-                  type: integer
-                nanos:
-                  type: integer
-            previousState:
-              type: string
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_tenant_crd.yaml
+++ b/manifests/integreatly-3scale/3scale-0.4.0/capabilities_v1alpha1_tenant_crd.yaml
@@ -47,13 +47,13 @@ spec:
             username:
               type: string
           required:
-            - username
-            - email
-            - organizationName
-            - systemMasterUrl
-            - tenantSecretRef
-            - passwordCredentialsRef
-            - masterCredentialsRef
+          - username
+          - email
+          - organizationName
+          - systemMasterUrl
+          - tenantSecretRef
+          - passwordCredentialsRef
+          - masterCredentialsRef
           type: object
         status:
           properties:
@@ -64,11 +64,11 @@ spec:
               format: int64
               type: integer
           required:
-            - tenantId
-            - adminId
+          - tenantId
+          - adminId
           type: object
   version: v1alpha1
   versions:
-    - name: v1alpha1
-      served: true
-      storage: true
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale.package.yaml
+++ b/manifests/integreatly-3scale/3scale.package.yaml
@@ -1,4 +1,4 @@
 packageName: integreatly-3scale
 channels:
   - name: integreatly
-    currentCSV: 3scale-operator.v1.9-7
+    currentCSV: 3scale-operator.v0.4.0

--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -54,7 +54,7 @@ var (
 	VersionCodeReadyWorkspaces ProductVersion = "1.2.0.GA"
 	VersionFuseOnOpenshift     ProductVersion = "master"
 	VersionMonitoring          ProductVersion = "1.0.0"
-	Version3Scale              ProductVersion = "2.6"
+	Version3Scale              ProductVersion = "2.7"
 	VersionUps                 ProductVersion = "2.3.2"
 	VersionCloudResources      ProductVersion = "0.4.0"
 
@@ -63,14 +63,14 @@ var (
 	PreflightFail       PreflightStatus = "failed"
 
 	OperatorVersionAMQStreams          OperatorVersion = "1.1.0"
-	OperatorVersionAMQOnline           OperatorVersion = "1.2.2"
+	OperatorVersionAMQOnline           OperatorVersion = "1.3.1"
 	OperatorVersionMonitoring          OperatorVersion = "1.0.0"
 	OperatorVersionSolutionExplorer    OperatorVersion = "0.0.34"
 	OperatorVersionRHSSO               OperatorVersion = "1.9.5"
 	OperatorVersionRHSSOUser           OperatorVersion = "1.9.5"
 	OperatorVersionCodeReadyWorkspaces OperatorVersion = "1.2.2"
 	OperatorVersionFuse                OperatorVersion = "1.4.0"
-	OperatorVersion3Scale              OperatorVersion = "1.9.8"
+	OperatorVersion3Scale              OperatorVersion = "0.4.0"
 	OperatorVersionUPS                 OperatorVersion = "0.4.1"
 	OperatorVersionCloudResources      OperatorVersion = "0.4.0"
 )

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -101,7 +101,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 15 pods.
         expr: |
-          absent(sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) >= 15)
+          absent(sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) >= 14)
         for: 5m
         labels:
           severity: warning


### PR DESCRIPTION
## Description
Updates the 3scale operator to use 3scale 2.7. 

CSV files were copied from https://github.com/3scale/3scale-operator/tree/3scale-2.7.0/deploy/olm-catalog/3scale-operator with edits to point to the `registry.redhat.io` instead of `registry.stage.redhat.io` and removing the old `0.3.0` csv and the `replaces` label

Jira:
 * https://issues.redhat.com/browse/INTLY-4327

## Verification
* Clone this branch
* Run the operator locally against cluster with at least these products installed:
```
operator-sdk up local --namespace=integreatly --operator-flags=--products=rhsso,rhssouser,cloud-resources,3scale
```
* Ensure 3scale gets installed correctly
* Run the `setup-htpass-idp.sh` script and note the outputed password for `customer-admin`
```
./scripts/setup-htpass-idp.sh
```
* Login in to 3scale using the Single Sign On option using the `htpasswd` provider using the `customer-admin` credentials as noted above
* Input account information while keeping username as `customer-admin`
* Link to existing `customer-admin` accont, using the password: `Password1`
* Ensure user signed it correctly and can complete the tutorial for creating an example endpoint after initial login