### PR TITLE
created integreatly info custom metric

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -25,6 +25,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/metrics"
 	"github.com/operator-framework/operator-sdk/pkg/restmapper"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
+	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -32,6 +33,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/manager/signals"
+	customMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // Change below variables to serve metrics on different host or port.
@@ -41,7 +43,24 @@ var (
 	operatorMetricsPort int32 = 8686
 	products            []string
 )
+
+// Custom metrics
+var (
+	operatorVersion = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name:        "integreatly_version_info",
+			Help:        "Integreatly operator information",
+			ConstLabels: prometheus.Labels{"operator_version": version.Version},
+		},
+	)
+)
+
 var log = logf.Log.WithName("cmd")
+
+func init() {
+	// Register custom metrics with the global prometheus registry
+	customMetrics.Registry.MustRegister(operatorVersion)
+}
 
 func printVersion() {
 	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
@@ -67,7 +86,6 @@ func main() {
 	pflag.StringSliceVarP(&products, "products", "p", []string{"all"}, "--products=rhsso,fuse")
 
 	pflag.Parse()
-
 	// Use a zap logr.Logger implementation. If none of the zap
 	// flags are configured (or if the zap flag set is not being
 	// used), this defaults to a production zap logger.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20190605231540-b8a4faf68e36
 	github.com/operator-framework/operator-marketplace v0.0.0-20191105191618-530c85d41ce7
 	github.com/operator-framework/operator-sdk v0.12.1-0.20191112211508-82fc57de5e5b
+	github.com/prometheus/client_golang v1.1.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5
 	github.com/syndesisio/syndesis v0.0.0-20190717215458-2c30af7a7ab4


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/INTLY-3137

## Prerequisites

- Openshift 4.2 RHPDS cluster

## Verification

- Login into your cluster using `oc login`
- Prepare your cluster using the make file:
  `make cluster/prepare/local`
- The operator must be installed via OLM in order for custom metrics to work. A public image containing the code changes in this PR has been pre-built and resides in the `robrien` Quay registry. Create a new operator source file locally:
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: integreatly-operators
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: Integreatly Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: robrien
  type: appregistry
```
- Apply the above operator source to the `openshift-market` namespace:

     `oc apply -f <filename> -n openshift-marketplace`
- Install the `integreatly-operator` in the integreatly NS via Operator Hub - ensuring that the container image is correct: `quay.io/robrien/integreatly-operator:v1.14.0`
- Navigate to the  `integreatly-operator` pod in the UI, open the terminal, and run the following command: `curl <pod_ip_address>:8383/metrics`. A list of metrics should be displayed. Ensure that the newly added custom metric is included in this list: 

   ```
   # HELP integreatly_version_info Integreatly operator information
   # TYPE integreatly_version_info gauge
   integreatly_version_info{operator_version="1.14.0"} 0
   ```