### PR TITLE
☸ Run e2e tests with image deployed on cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test/e2e/prow: test/e2e
 test/e2e: export GH_CLIENT_ID := 1234
 test/e2e: export GH_CLIENT_SECRET := 1234
 test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/configmaps cluster/prepare/crd deploy/integreatly-installation-cr.yml
-	INTEGREATLY_OPERATOR_DISABLE_ELECTION=true operator-sdk --verbose test local ./test/e2e --namespace $(NAMESPACE) --up-local --go-test-flags "-timeout=60m" --debug
+	INTEGREATLY_OPERATOR_DISABLE_ELECTION=true operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: test/e2e/olm
 test/e2e/olm: export GH_CLIENT_ID := 1234

--- a/Makefile
+++ b/Makefile
@@ -95,7 +95,7 @@ test/e2e/prow: test/e2e
 test/e2e: export GH_CLIENT_ID := 1234
 test/e2e: export GH_CLIENT_SECRET := 1234
 test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/configmaps cluster/prepare/crd deploy/integreatly-installation-cr.yml
-	INTEGREATLY_OPERATOR_DISABLE_ELECTION=true operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
+	operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: test/e2e/olm
 test/e2e/olm: export GH_CLIENT_ID := 1234

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,11 +50,6 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))
 }
 
-// isLeaderElectionEnabled based on environment variable INTEGREATLY_OPERATOR_DISABLE_ELECTION.
-func isLeaderElectionEnabled() bool {
-	return os.Getenv("INTEGREATLY_OPERATOR_DISABLE_ELECTION") == ""
-}
-
 func main() {
 	// Add the zap logger flag set to the CLI. The flag set must
 	// be added before calling pflag.Parse().
@@ -95,15 +90,11 @@ func main() {
 
 	ctx := context.TODO()
 
-	if isLeaderElectionEnabled() {
-		// Become the leader before proceeding
-		err = leader.Become(ctx, "integreatly-operator-lock")
-		if err != nil {
-			log.Error(err, "")
-			os.Exit(1)
-		}
-	} else {
-		log.Info("Warning: Leader election is disabled")
+	// Become the leader before proceeding
+	err = leader.Become(ctx, "integreatly-operator-lock")
+	if err != nil {
+		log.Error(err, "")
+		os.Exit(1)
 	}
 
 	// Create a new Cmd to provide shared dependencies and start components

--- a/pkg/resources/oauthResolver.go
+++ b/pkg/resources/oauthResolver.go
@@ -10,6 +10,8 @@ import (
 	"os"
 
 	"github.com/sirupsen/logrus"
+
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 )
 
 const oauthServerDetails = "%s/.well-known/oauth-authorization-server"
@@ -33,7 +35,7 @@ func (or *OauthResolver) GetOauthEndPoint() (*OauthServerConfig, error) {
 
 	caCert, err := ioutil.ReadFile(rootCAFile)
 	// if running locally, CA certificate isn't available in expected path
-	if os.IsNotExist(err) || os.Getenv("INTEGREATLY_OPERATOR_DISABLE_ELECTION") != "" {
+	if os.IsNotExist(err) && os.Getenv(k8sutil.ForceRunModeEnv) == string(k8sutil.LocalRunMode) {
 		logrus.Warn("GetOauthEndPoint() will skip certificate verification - this is acceptable only if operator is running locally")
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},


### PR DESCRIPTION
I've also removed the manual leader election toggle. Leader election
will be skipped if running locally anyway now:

```
{"level":"info","ts":1578480384.2597575,"logger":"leader","msg":"Trying to become the leader."}
{"level":"info","ts":1578480384.2597752,"logger":"leader","msg":"Skipping leader election; not running in a cluster."}
```

There was one other reference to it, which didn't seem like a great
usage of it (it looks like we wanted to check if we were running
locally, rather than if leader election should be disabled).