### PR TITLE
fix: correct BlackboxTargetPath for monitoring in amq-online

### DIFF
--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -315,7 +315,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-amqonline", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost() + "/" + r.Config.GetBlackboxTargetPath(),
+		Url:     r.Config.GetHost() + r.Config.GetBlackboxTargetPath(),
 		Service: "amq-service-broker",
 	}, ctx, cfg, installation, client)
 	if err != nil {


### PR DESCRIPTION
### Issue

`//` are being added to the blackbox target url 

### Verification steps

1) Install the operator
2) Go to middleware-monitoring namespace, route and acess grafana
3) Verify if all components are up 
