### PR TITLE
INTLY-3037: Emit events on failed/successful installation

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/installation_types.go
+++ b/pkg/apis/integreatly/v1alpha1/installation_types.go
@@ -73,6 +73,10 @@ var (
 	OperatorVersion3Scale              OperatorVersion = "0.4.0"
 	OperatorVersionUPS                 OperatorVersion = "0.4.1"
 	OperatorVersionCloudResources      OperatorVersion = "0.4.0"
+
+	// Event reasons to be used when emitting events
+	EventProcessingError       string = "ProcessingError"
+	EventInstallationCompleted string = "InstallationCompleted"
 )
 
 // InstallationSpec defines the desired state of Installation

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -11,6 +11,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -52,17 +53,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err := r.reconcileOauthSecrets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)
 		return phase, err
 	}
 
 	phase, err = r.retrieveConsoleUrlAndSubdomain(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to retrieve console url and subdomain", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to retrieve console url and subdomain", err)
 		return phase, err
 	}
 
-	resources.EmitEventStageCompleted(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
+	events.HandleStageComplete(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
 
 	logrus.Infof("Bootstrap stage reconciled successfully")
 	return integreatlyv1alpha1.PhaseCompleted, nil

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -20,15 +20,17 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func NewBootstrapReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewBootstrapReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	return &Reconciler{
 		ConfigManager: configManager,
 		mpm:           mpm,
 		installation:  installation,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -38,6 +40,7 @@ type Reconciler struct {
 	mpm           marketplace.MarketplaceInterface
 	installation  *integreatlyv1alpha1.Installation
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
@@ -49,13 +52,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err := r.reconcileOauthSecrets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)
 		return phase, err
 	}
 
 	phase, err = r.retrieveConsoleUrlAndSubdomain(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to retrieve console url and subdomain", err)
 		return phase, err
 	}
+
+	resources.EmitEventStageCompleted(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
 
 	logrus.Infof("Bootstrap stage reconciled successfully")
 	return integreatlyv1alpha1.PhaseCompleted, nil

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -23,6 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -42,9 +43,10 @@ type Reconciler struct {
 	logger        *logrus.Entry
 	inst          *integreatlyv1alpha1.Installation
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	amqOnlineConfig, err := configManager.ReadAMQOnline()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve amq online config: %w", err)
@@ -65,6 +67,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		logger:        logger,
 		Reconciler:    resources.NewReconciler(mpm),
 		inst:          installation,
+		recorder:      recorder,
 	}, nil
 }
 
@@ -88,64 +91,76 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	ns := r.Config.GetNamespace()
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Namespace: ns, Channel: marketplace.IntegreatlyChannel, ManifestPackage: manifestPackage}, ns, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileAuthServices(ctx, serverClient, GetDefaultAuthServices(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile auth services", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBrokerConfigs(ctx, serverClient, GetDefaultBrokeredInfraConfigs(ns), GetDefaultStandardInfraConfigs(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile broker configs", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileAddressPlans(ctx, serverClient, GetDefaultAddressPlans(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile address plans", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileAddressSpacePlans(ctx, serverClient, GetDefaultAddressSpacePlans(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile address space plans", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileConfig(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile console service config", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBackup(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile backup", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, installation, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTargets(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
@@ -153,6 +168,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -155,7 +155,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -35,6 +35,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -113,6 +114,15 @@ func backupsSecretMock() *corev1.Secret {
 	}
 }
 
+func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
+	eventSource := corev1.EventSource{
+		Component: defaultNamespace,
+		Host:      "",
+	}
+	broadcaster := record.NewBroadcaster()
+	return broadcaster.NewRecorder(scheme, eventSource)
+}
+
 func TestReconcile_reconcileAuthServices(t *testing.T) {
 	scenarios := []struct {
 		Name           string
@@ -122,6 +132,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 		ExpectedStatus integreatlyv1alpha1.StatusPhase
 		AuthServices   []*enmassev1.AuthenticationService
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "Test returns none phase if successfully creating new auth services",
@@ -135,6 +146,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "Test returns none phase if trying to create existing auth services",
@@ -148,12 +160,13 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM)
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -178,6 +191,7 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 		BrokeredInfraConfigs []*v1beta1.BrokeredInfraConfig
 		StandardInfraConfigs []*v1beta1.StandardInfraConfig
 		FakeMPM              *marketplace.MarketplaceInterfaceMock
+		Recorder             record.EventRecorder
 	}{
 		{
 			Name:                 "Test returns none phase if successfully creating new address space plans",
@@ -187,6 +201,7 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			StandardInfraConfigs: GetDefaultStandardInfraConfigs(defaultNamespace),
 			ExpectedStatus:       integreatlyv1alpha1.PhaseCompleted,
 			Installation:         basicInstallation(),
+			Recorder:             setupRecorder(buildScheme()),
 		},
 		{
 			Name:                 "Test returns none phase if trying to create existing address space plans",
@@ -196,12 +211,13 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			FakeConfig:           basicConfigMock(),
 			ExpectedStatus:       integreatlyv1alpha1.PhaseCompleted,
 			Installation:         basicInstallation(),
+			Recorder:             setupRecorder(buildScheme()),
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM)
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -225,6 +241,7 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 		ExpectedStatus integreatlyv1alpha1.StatusPhase
 		AddressPlans   []*v1beta2.AddressPlan
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "Test returns none phase if successfully creating new address space plans",
@@ -233,6 +250,7 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 			AddressPlans:   GetDefaultAddressPlans(defaultNamespace),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation:   basicInstallation(),
+			Recorder:       setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "Test returns none phase if trying to create existing address space plans",
@@ -241,12 +259,13 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation:   basicInstallation(),
+			Recorder:       setupRecorder(buildScheme()),
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM)
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -270,6 +289,7 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 		ExpectedStatus    integreatlyv1alpha1.StatusPhase
 		AddressSpacePlans []*v1beta2.AddressSpacePlan
 		FakeMPM           *marketplace.MarketplaceInterfaceMock
+		Recorder          record.EventRecorder
 	}{
 		{
 			Name:              "Test returns none phase if successfully creating new address space plans",
@@ -278,6 +298,7 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 			AddressSpacePlans: GetDefaultAddressSpacePlans(defaultNamespace),
 			ExpectedStatus:    integreatlyv1alpha1.PhaseCompleted,
 			Installation:      basicInstallation(),
+			Recorder:          setupRecorder(buildScheme()),
 		},
 		{
 			Name:              "Test returns none phase if trying to create existing address space plans",
@@ -286,12 +307,13 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 			FakeConfig:        basicConfigMock(),
 			ExpectedStatus:    integreatlyv1alpha1.PhaseCompleted,
 			Installation:      basicInstallation(),
+			Recorder:          setupRecorder(buildScheme()),
 		},
 	}
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM)
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -315,6 +337,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 		FakeConfig         *config.ConfigReadWriterMock
 		ExpectError        bool
 		ValidateCallCounts func(t *testing.T, cfgMock *config.ConfigReadWriterMock)
+		Recorder           record.EventRecorder
 	}{
 		{
 			Name: "Test doesn't set host when the port is not 443",
@@ -335,6 +358,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config written once or more")
 				}
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name: "Test doesn't set host when the host is undefined or empty",
@@ -355,6 +379,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config written once or more")
 				}
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name: "Test successfully setting host when port and host are defined properly",
@@ -380,6 +405,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatalf("incorrect host, expected %s but got %s", expectedHost, cfg.GetHost())
 				}
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "Test continues when console it not found",
@@ -392,6 +418,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config called once or more")
 				}
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name: "Test fails with error when failing to write config",
@@ -424,11 +451,12 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 			ExpectedStatus:     integreatlyv1alpha1.PhaseFailed,
 			ExpectError:        true,
 			ValidateCallCounts: func(t *testing.T, cfgMock *config.ConfigReadWriterMock) {},
+			Recorder:           setupRecorder(buildScheme()),
 		},
 	}
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, nil, nil)
+			r, err := NewReconciler(s.FakeConfig, nil, nil, s.Recorder)
 			if err != nil {
 				t.Fatal("could not create reconciler", err)
 			}
@@ -490,6 +518,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
 		Installation   *integreatlyv1alpha1.Installation
 		Product        *integreatlyv1alpha1.InstallationProductStatus
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test successful reconcile",
@@ -524,6 +553,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder:     setupRecorder(buildScheme()),
 		},
 	}
 
@@ -533,6 +563,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeConfig,
 				tc.Installation,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -114,13 +114,8 @@ func backupsSecretMock() *corev1.Secret {
 	}
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconcile_reconcileAuthServices(t *testing.T) {
@@ -146,7 +141,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "Test returns none phase if trying to create existing auth services",
@@ -160,7 +155,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 					Namespace: "test-namespace",
 				},
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 	}
 
@@ -201,7 +196,7 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			StandardInfraConfigs: GetDefaultStandardInfraConfigs(defaultNamespace),
 			ExpectedStatus:       integreatlyv1alpha1.PhaseCompleted,
 			Installation:         basicInstallation(),
-			Recorder:             setupRecorder(buildScheme()),
+			Recorder:             setupRecorder(),
 		},
 		{
 			Name:                 "Test returns none phase if trying to create existing address space plans",
@@ -211,7 +206,7 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			FakeConfig:           basicConfigMock(),
 			ExpectedStatus:       integreatlyv1alpha1.PhaseCompleted,
 			Installation:         basicInstallation(),
-			Recorder:             setupRecorder(buildScheme()),
+			Recorder:             setupRecorder(),
 		},
 	}
 
@@ -250,7 +245,7 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 			AddressPlans:   GetDefaultAddressPlans(defaultNamespace),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation:   basicInstallation(),
-			Recorder:       setupRecorder(buildScheme()),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "Test returns none phase if trying to create existing address space plans",
@@ -259,7 +254,7 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation:   basicInstallation(),
-			Recorder:       setupRecorder(buildScheme()),
+			Recorder:       setupRecorder(),
 		},
 	}
 
@@ -298,7 +293,7 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 			AddressSpacePlans: GetDefaultAddressSpacePlans(defaultNamespace),
 			ExpectedStatus:    integreatlyv1alpha1.PhaseCompleted,
 			Installation:      basicInstallation(),
-			Recorder:          setupRecorder(buildScheme()),
+			Recorder:          setupRecorder(),
 		},
 		{
 			Name:              "Test returns none phase if trying to create existing address space plans",
@@ -307,7 +302,7 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 			FakeConfig:        basicConfigMock(),
 			ExpectedStatus:    integreatlyv1alpha1.PhaseCompleted,
 			Installation:      basicInstallation(),
-			Recorder:          setupRecorder(buildScheme()),
+			Recorder:          setupRecorder(),
 		},
 	}
 
@@ -358,7 +353,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config written once or more")
 				}
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name: "Test doesn't set host when the host is undefined or empty",
@@ -379,7 +374,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config written once or more")
 				}
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name: "Test successfully setting host when port and host are defined properly",
@@ -405,7 +400,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatalf("incorrect host, expected %s but got %s", expectedHost, cfg.GetHost())
 				}
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "Test continues when console it not found",
@@ -418,7 +413,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 					t.Fatal("config called once or more")
 				}
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name: "Test fails with error when failing to write config",
@@ -451,7 +446,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 			ExpectedStatus:     integreatlyv1alpha1.PhaseFailed,
 			ExpectError:        true,
 			ValidateCallCounts: func(t *testing.T, cfgMock *config.ConfigReadWriterMock) {},
-			Recorder:           setupRecorder(buildScheme()),
+			Recorder:           setupRecorder(),
 		},
 	}
 	for _, s := range scenarios {
@@ -553,7 +548,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(buildScheme()),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -19,6 +19,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -35,9 +36,10 @@ type Reconciler struct {
 	mpm           marketplace.MarketplaceInterface
 	logger        *logrus.Entry
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	config, err := configManager.ReadAMQStreams()
 	if err != nil {
 		return nil, fmt.Errorf("could not read amq streams config: %w", err)
@@ -55,6 +57,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		mpm:           mpm,
 		logger:        logger,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -78,32 +81,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	ns := r.Config.GetNamespace()
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Namespace: ns, Channel: marketplace.IntegreatlyChannel, Pkg: defaultSubscriptionName, ManifestPackage: manifestPackage}, ns, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.handleCreatingComponents(ctx, serverClient, installation)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to create components", err)
 		return phase, err
 	}
 
 	phase, err = r.handleProgressPhase(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to handle in progress phase", err)
 		return phase, err
 	}
 
@@ -111,6 +120,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/amqstreams/reconciler_test.go
+++ b/pkg/products/amqstreams/reconciler_test.go
@@ -53,13 +53,8 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
@@ -103,7 +98,7 @@ func TestReconciler_config(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -118,7 +113,7 @@ func TestReconciler_config(t *testing.T) {
 			FakeClient: moqclient.NewSigsClientMoqWithScheme(scheme, installation),
 			FakeConfig: basicConfigMock(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -185,7 +180,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -204,7 +199,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			ExpectError:    true,
 			ExpectedError:  "failed to get or create a kafka custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, tc := range cases {
@@ -304,7 +299,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			},
 			FakeConfig:   basicConfigMock(),
 			Installation: &integreatlyv1alpha1.Installation{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 		{
 			Name:           "test incomplete amount of pods returns phase in progress",
@@ -312,7 +307,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme),
 			FakeConfig:     basicConfigMock(),
 			Installation:   &integreatlyv1alpha1.Installation{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "test unready pods returns phase in progress",
@@ -320,7 +315,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, unreadyPods...),
 			FakeConfig:     basicConfigMock(),
 			Installation:   &integreatlyv1alpha1.Installation{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "test ready pods returns phase complete",
@@ -328,7 +323,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, append(readyPods, kafka)...),
 			FakeConfig:     basicConfigMock(),
 			Installation:   &integreatlyv1alpha1.Installation{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 
@@ -454,7 +449,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -69,7 +69,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err := r.ReconcileFinalizer(ctx, client, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {
 		// ensure resources are cleaned up before deleting the namespace
-		phase, err := r.doCloudResourcesExist(ctx, installation, client)
+		phase, err := r.cleanupResources(ctx, installation, client)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}
@@ -118,9 +118,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-// This only ensure that cloud resources no longer exists before proceeding to remove the cloud resource namespace.
-// The deletion of the resources below are handled by the cro operator
-func (r *Reconciler) doCloudResourcesExist(ctx context.Context, installation *integreatlyv1alpha1.Installation, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) cleanupResources(ctx context.Context, installation *integreatlyv1alpha1.Installation, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	r.logger.Info("ensuring cloud resources are cleaned up")
 
 	// ensure postgres instances are cleaned up

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	"github.com/sirupsen/logrus"
@@ -95,62 +96,62 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, r.Config.GetNamespace(), r.installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
 	if err != nil {
-		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
+		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileExternalDatasources(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile external data sources", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile external data sources", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileCheCluster(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile che cluster", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile che cluster", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileKeycloakClient(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile keycloak client", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile keycloak client", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTargets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBackups(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile backups", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile backups", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
 		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
@@ -159,7 +160,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
-	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
+	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -29,6 +29,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -50,9 +51,10 @@ type Reconciler struct {
 	mpm           marketplace.MarketplaceInterface
 	logger        *logrus.Entry
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	config, err := configManager.ReadCodeReady()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve che config: %w", err)
@@ -70,6 +72,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		mpm:           mpm,
 		logger:        logger,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -92,53 +95,63 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, r.Config.GetNamespace(), r.installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileExternalDatasources(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile external data sources", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileCheCluster(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile che cluster", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileKeycloakClient(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile keycloak client", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTargets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBackups(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile backups", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -146,6 +159,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -152,7 +152,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/codeready/reconciler_test.go
+++ b/pkg/products/codeready/reconciler_test.go
@@ -123,13 +123,8 @@ func buildScheme() *runtime.Scheme {
 	return scheme
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
@@ -159,7 +154,7 @@ func TestReconciler_config(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -175,7 +170,7 @@ func TestReconciler_config(t *testing.T) {
 			FakeClient: fakeclient.NewFakeClient(),
 			FakeConfig: basicConfigMock(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(buildScheme()),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -258,7 +253,7 @@ func TestCodeready_reconcileCluster(t *testing.T) {
 				},
 			}),
 			FakeConfig: basicConfigMock(),
-			Recorder:   setupRecorder(buildScheme()),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -336,7 +331,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test creating components returns in progress",
@@ -371,7 +366,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 	}
 
@@ -435,7 +430,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 			},
 			FakeClient: fakeclient.NewFakeClientWithScheme(buildScheme(), &testKeycloakRealm, &testCheCluster),
 			FakeConfig: basicConfigMock(),
-			Recorder:   setupRecorder(buildScheme()),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "test che cluster create error returns phase failed",
@@ -454,7 +449,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 			ExpectError:   true,
 			ExpectedError: "could not retrieve checluster for keycloak client update: get request failed",
 			FakeConfig:    basicConfigMock(),
-			Recorder:      setupRecorder(buildScheme()),
+			Recorder:      setupRecorder(),
 		},
 		{
 			Name:           "test che cluster available returns phase complete",
@@ -475,7 +470,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 				},
 			}),
 			FakeConfig: basicConfigMock(),
-			Recorder:   setupRecorder(buildScheme()),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -658,7 +653,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(buildScheme()),
+			Recorder: setupRecorder(),
 		},
 	}
 

--- a/pkg/products/codeready/reconciler_test.go
+++ b/pkg/products/codeready/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -122,6 +123,15 @@ func buildScheme() *runtime.Scheme {
 	return scheme
 }
 
+func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
+	eventSource := corev1.EventSource{
+		Component: defaultInstallationNamespace,
+		Host:      "",
+	}
+	broadcaster := record.NewBroadcaster()
+	return broadcaster.NewRecorder(scheme, eventSource)
+}
+
 func TestReconciler_config(t *testing.T) {
 
 	cases := []struct {
@@ -134,6 +144,7 @@ func TestReconciler_config(t *testing.T) {
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
 		Installation   *integreatlyv1alpha1.Installation
 		Product        *integreatlyv1alpha1.InstallationProductStatus
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test error on failed config",
@@ -147,7 +158,8 @@ func TestReconciler_config(t *testing.T) {
 					return nil, errors.New("could not read che config")
 				},
 			},
-			Product: &integreatlyv1alpha1.InstallationProductStatus{},
+			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -163,6 +175,7 @@ func TestReconciler_config(t *testing.T) {
 			FakeClient: fakeclient.NewFakeClient(),
 			FakeConfig: basicConfigMock(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder:   setupRecorder(buildScheme()),
 		},
 	}
 
@@ -172,6 +185,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeConfig,
 				tc.Installation,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -227,6 +241,7 @@ func TestCodeready_reconcileCluster(t *testing.T) {
 		FakeConfig     *config.ConfigReadWriterMock
 		FakeClient     k8sclient.Client
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test phase in progress when che cluster is missing",
@@ -243,6 +258,7 @@ func TestCodeready_reconcileCluster(t *testing.T) {
 				},
 			}),
 			FakeConfig: basicConfigMock(),
+			Recorder:   setupRecorder(buildScheme()),
 		},
 	}
 
@@ -252,6 +268,7 @@ func TestCodeready_reconcileCluster(t *testing.T) {
 				scenario.FakeConfig,
 				scenario.Installation,
 				scenario.FakeMPM,
+				scenario.Recorder,
 			)
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedError)
@@ -283,6 +300,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 		FakeConfig          *config.ConfigReadWriterMock
 		FakeClient          k8sclient.Client
 		FakeMPM             *marketplace.MarketplaceInterfaceMock
+		Recorder            record.EventRecorder
 	}{
 		{
 			Name:           "test creating components phase missing cluster expect p",
@@ -318,6 +336,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "test creating components returns in progress",
@@ -352,6 +371,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
+			Recorder: setupRecorder(buildScheme()),
 		},
 	}
 
@@ -361,6 +381,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 				scenario.FakeConfig,
 				scenario.Installation,
 				scenario.FakeMPM,
+				scenario.Recorder,
 			)
 			if err != nil && err.Error() != scenario.ExpectedCreateError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedCreateError)
@@ -401,6 +422,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 		FakeConfig     *config.ConfigReadWriterMock
 		FakeClient     k8sclient.Client
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test che cluster creating returns phase in progress",
@@ -413,6 +435,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 			},
 			FakeClient: fakeclient.NewFakeClientWithScheme(buildScheme(), &testKeycloakRealm, &testCheCluster),
 			FakeConfig: basicConfigMock(),
+			Recorder:   setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "test che cluster create error returns phase failed",
@@ -431,6 +454,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 			ExpectError:   true,
 			ExpectedError: "could not retrieve checluster for keycloak client update: get request failed",
 			FakeConfig:    basicConfigMock(),
+			Recorder:      setupRecorder(buildScheme()),
 		},
 		{
 			Name:           "test che cluster available returns phase complete",
@@ -451,6 +475,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 				},
 			}),
 			FakeConfig: basicConfigMock(),
+			Recorder:   setupRecorder(buildScheme()),
 		},
 	}
 
@@ -460,6 +485,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 				scenario.FakeConfig,
 				scenario.Installation,
 				scenario.FakeMPM,
+				scenario.Recorder,
 			)
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedError)
@@ -580,6 +606,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 		FakeMPM             *marketplace.MarketplaceInterfaceMock
 		ValidateCallCounts  func(mockConfig *config.ConfigReadWriterMock, mockMPM *marketplace.MarketplaceInterfaceMock, t *testing.T)
 		Product             *integreatlyv1alpha1.InstallationProductStatus
+		Recorder            record.EventRecorder
 	}{
 		{
 			Name:           "test successful installation without errors",
@@ -630,7 +657,8 @@ func TestCodeready_fullReconcile(t *testing.T) {
 						}, nil
 				},
 			},
-			Product: &integreatlyv1alpha1.InstallationProductStatus{},
+			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder: setupRecorder(buildScheme()),
 		},
 	}
 
@@ -640,6 +668,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 				scenario.FakeConfig,
 				scenario.Installation,
 				scenario.FakeMPM,
+				scenario.Recorder,
 			)
 			if err != nil && err.Error() != scenario.ExpectedCreateError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedCreateError)

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -141,7 +141,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	"github.com/sirupsen/logrus"
@@ -96,50 +97,50 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, r.Config.GetNamespace(), installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), defaultFusePullSecret, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s pull secret", defaultFusePullSecret), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s pull secret", defaultFusePullSecret), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileViewFusePerms(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile view fuse permissions", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile view fuse permissions", err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
 	if err != nil {
-		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
+		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileCustomResource(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile custom resource", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile custom resource", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, installation, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
 		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
@@ -148,7 +149,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
-	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
+	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	logrus.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -47,9 +48,10 @@ type Reconciler struct {
 	extraParams   map[string]string
 	mpm           marketplace.MarketplaceInterface
 	logger        *logrus.Entry
+	recorder      record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	fuseConfig, err := configManager.ReadFuse()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve fuse config: %w", err)
@@ -70,6 +72,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		mpm:           mpm,
 		logger:        logger,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -93,43 +96,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, r.Config.GetNamespace(), installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcilePullSecret(ctx, r.Config.GetNamespace(), defaultFusePullSecret, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s pull secret", defaultFusePullSecret), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileViewFusePerms(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile view fuse permissions", err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileCustomResource(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile custom resource", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, installation, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -137,6 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	logrus.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -73,13 +73,8 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
@@ -113,7 +108,7 @@ func TestReconciler_config(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -138,7 +133,7 @@ func TestReconciler_config(t *testing.T) {
 			}),
 			FakeConfig: basicConfigMock(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -220,7 +215,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseInProgress,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:       "Test reconcile custom resource returns failed when cr status is failed",
@@ -234,7 +229,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			ExpectError:    true,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:       "Test reconcile custom resource returns phase complete when cr status is installed",
@@ -247,7 +242,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:       "Test reconcile custom resource returns phase in progress when cr status is installing",
@@ -260,7 +255,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseInProgress,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -281,7 +276,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			ExpectError:    true,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, tc := range cases {
@@ -422,7 +417,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -29,6 +29,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -72,6 +73,15 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
+func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
+	eventSource := corev1.EventSource{
+		Component: defaultInstallationNamespace,
+		Host:      "",
+	}
+	broadcaster := record.NewBroadcaster()
+	return broadcaster.NewRecorder(scheme, eventSource)
+}
+
 func TestReconciler_config(t *testing.T) {
 	scheme, err := getBuildScheme()
 	if err != nil {
@@ -88,6 +98,7 @@ func TestReconciler_config(t *testing.T) {
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
 		Installation   *integreatlyv1alpha1.Installation
 		Product        *integreatlyv1alpha1.InstallationProductStatus
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test error on failed config",
@@ -101,7 +112,8 @@ func TestReconciler_config(t *testing.T) {
 					return nil, errors.New("could not read fuse config")
 				},
 			},
-			Product: &integreatlyv1alpha1.InstallationProductStatus{},
+			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder: setupRecorder(scheme),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -126,6 +138,7 @@ func TestReconciler_config(t *testing.T) {
 			}),
 			FakeConfig: basicConfigMock(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder:   setupRecorder(scheme),
 		},
 	}
 
@@ -135,6 +148,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeConfig,
 				tc.Installation,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -193,6 +207,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 		ExpectError    bool
 		ExpectedStatus integreatlyv1alpha1.StatusPhase
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:       "Test reconcile custom resource returns in progress when successful created",
@@ -205,6 +220,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseInProgress,
+			Recorder:       setupRecorder(scheme),
 		},
 		{
 			Name:       "Test reconcile custom resource returns failed when cr status is failed",
@@ -218,6 +234,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			ExpectError:    true,
+			Recorder:       setupRecorder(scheme),
 		},
 		{
 			Name:       "Test reconcile custom resource returns phase complete when cr status is installed",
@@ -230,6 +247,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			Recorder:       setupRecorder(scheme),
 		},
 		{
 			Name:       "Test reconcile custom resource returns phase in progress when cr status is installing",
@@ -242,6 +260,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseInProgress,
+			Recorder:       setupRecorder(scheme),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -262,6 +281,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			ExpectError:    true,
+			Recorder:       setupRecorder(scheme),
 		},
 	}
 	for _, tc := range cases {
@@ -270,6 +290,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				tc.FakeConfig,
 				tc.Installation,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -366,6 +387,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
 		Installation   *integreatlyv1alpha1.Installation
 		Product        *integreatlyv1alpha1.InstallationProductStatus
+		Recorder       record.EventRecorder
 	}{
 		{
 			Name:           "test successful reconcile",
@@ -400,6 +422,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder:     setupRecorder(scheme),
 		},
 	}
 
@@ -409,6 +432,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeConfig,
 				tc.Installation,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/fuseonopenshift/reconciler.go
+++ b/pkg/products/fuseonopenshift/reconciler.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -74,13 +75,14 @@ type Reconciler struct {
 	ConfigManager config.ConfigReadWriter
 	httpClient    http.Client
 	logger        *logrus.Entry
+	recorder      record.EventRecorder
 }
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	config, err := configManager.ReadFuseOnOpenshift()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve %s config: %w", integreatlyv1alpha1.ProductFuseOnOpenshift, err)
@@ -103,28 +105,33 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		logger:        logger,
 		httpClient:    httpClient,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.Installation, product *integreatlyv1alpha1.InstallationProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	phase, err := r.reconcileConfigMap(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile configmap", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileImageStreams(ctx, serverClient, installation)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile image streams", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, serverClient, installation)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
 		return phase, err
 	}
 
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	logrus.Infof("%s successfully reconciled", integreatlyv1alpha1.ProductFuseOnOpenshift)
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/fuseonopenshift/reconciler_test.go
+++ b/pkg/products/fuseonopenshift/reconciler_test.go
@@ -15,7 +15,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -50,13 +49,8 @@ func getFakeConfig() *config.ConfigReadWriterMock {
 	}
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: "fuse-on-openshift",
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestFuseOnOpenShift(t *testing.T) {
@@ -120,7 +114,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test error on invalid image stream file content",
@@ -136,7 +130,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			}),
 			FakeConfig: getFakeConfig(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "test error on invalid image stream",
@@ -156,7 +150,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			}),
 			FakeConfig: getFakeConfig(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "test error on invalid template file content",
@@ -175,7 +169,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			}),
 			FakeConfig: getFakeConfig(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "test error on invalid template object",
@@ -196,7 +190,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			}),
 			FakeConfig: getFakeConfig(),
 			Product:    &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "test successful reconcile when resource already exists",
@@ -205,7 +199,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			FakeClient:     fakeclient.NewFakeClient(integreatlyImgStream),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "test successful reconcile without sample cluster operator installed",
@@ -215,7 +209,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			FakeClient:     fakeclient.NewFakeClient(),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "test successful reconcile with sample cluster operator installed",
@@ -225,7 +219,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			FakeClient:     fakeclient.NewFakeClient(sampleClusterConfig, sampleClusterImgStream),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -177,7 +177,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s populateParams", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to populate parameters", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -185,7 +184,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -193,7 +191,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileScrapeConfigs", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile scrape configs", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -23,6 +23,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -48,13 +49,14 @@ type Reconciler struct {
 	installation  *integreatlyv1alpha1.Installation
 	monitoring    *monitoring_v1alpha1.ApplicationMonitoring
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	logger := logrus.NewEntry(logrus.StandardLogger())
 	monitoringConfig, err := configManager.ReadMonitoring()
 
@@ -73,6 +75,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		installation:  installation,
 		mpm:           mpm,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -87,7 +90,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		err := serverClient.List(ctx, blackboxtargets, blackboxtargetsListOpts...)
 		if err != nil {
 			logrus.Infof("Phase: Monitoring ReconcileFinalizer blackboxtargets error")
-			return integreatlyv1alpha1.PhaseFailed, err
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to list blackbox targets: %w", err)
 		}
 		if len(blackboxtargets.Items) > 0 {
 			logrus.Infof("Phase: Monitoring ReconcileFinalizer blackboxtargets list > 0")
@@ -100,12 +103,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 					continue
 				}
 				if err != nil {
-					return integreatlyv1alpha1.PhaseFailed, err
+					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to get %s blackbox target: %w", bbt.Name, err)
 				}
 
 				err = serverClient.Delete(ctx, b)
 				if err != nil && !kerrors.IsNotFound(err) {
-					return integreatlyv1alpha1.PhaseFailed, err
+					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete %s blackbox target: %w", b.Name, err)
 				}
 			}
 			return integreatlyv1alpha1.PhaseInProgress, nil
@@ -115,14 +118,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: defaultMonitoringName, Namespace: r.Config.GetNamespace()}, m)
 		if err != nil && !kerrors.IsNotFound(err) {
 			logrus.Infof("Phase: Monitoring ReconcileFinalizer error fetch ApplicationMonitoring CR")
-			return integreatlyv1alpha1.PhaseFailed, err
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to get %s application monitoring custom resource: %w", defaultMonitoringName, err)
 		}
 		if !kerrors.IsNotFound(err) {
 			if m.DeletionTimestamp == nil {
 				logrus.Infof("Phase: Monitoring ReconcileFinalizer delete ApplicationMonitoring CR")
 				err = serverClient.Delete(ctx, m)
 				if err != nil && !kerrors.IsNotFound(err) {
-					return integreatlyv1alpha1.PhaseFailed, err
+					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete %s application monitoring custom resource: %w", defaultMonitoringName, err)
 				}
 			}
 			return integreatlyv1alpha1.PhaseInProgress, nil
@@ -136,6 +139,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
@@ -144,44 +148,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	logrus.Infof("Phase: %s ReconcileNamespace", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: ns, ManifestPackage: manifestPackagae}, ns, serverClient)
 	logrus.Infof("Phase: %s ReconcileSubscription", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileComponents(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcileComponents", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile components", err)
 		return phase, err
 	}
 
 	phase, err = r.populateParams(ctx, serverClient)
 	logrus.Infof("Phase: %s populateParams", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to populate parameters", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, serverClient)
-	logrus.Infof("Phase: %s reconcileComponents", phase)
+	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
 	phase, err = r.reconcileScrapeConfigs(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcileScrapeConfigs", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile scrape configs", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -191,9 +202,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	err = r.ConfigManager.WriteConfig(r.Config)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to update monitoring config", err)
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not update monitoring config: %w", err)
 	}
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.MonitoringStage, r.Config.GetProductName())
 	logrus.Infof("%s installation is reconciled successfully", packageName)
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -68,21 +68,11 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
-	scheme, err := getBuildScheme()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		Name           string
 		ExpectError    bool
@@ -106,7 +96,7 @@ func TestReconciler_config(t *testing.T) {
 					return nil, errors.New("could not read monitoring config")
 				},
 			},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:         "test namespace is set without fail",
@@ -119,7 +109,7 @@ func TestReconciler_config(t *testing.T) {
 					}), nil
 				},
 			},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test subscription phase with error from mpm",
@@ -133,7 +123,7 @@ func TestReconciler_config(t *testing.T) {
 			},
 			FakeClient: fakeclient.NewFakeClient(),
 			FakeConfig: basicConfigMock(),
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -174,7 +164,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			FakeConfig:     basicConfigMock(),
 			Installation:   &integreatlyv1alpha1.Installation{},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -194,7 +184,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			ExpectError:    true,
 			ExpectedError:  "failed to create/update applicationmonitoring custom resource",
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, tc := range cases {
@@ -308,7 +298,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: basicInstallation(),
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 
@@ -371,7 +361,7 @@ func TestReconciler_testPhases(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test subscription creating returns phase in progress",
@@ -388,7 +378,7 @@ func TestReconciler_testPhases(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 		{
 			Name:           "test components creating returns phase in progress",
@@ -417,7 +407,7 @@ func TestReconciler_testPhases(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 	}
 

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -28,6 +28,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -66,9 +67,10 @@ type Reconciler struct {
 	logger        *logrus.Entry
 	oauthv1Client oauthClient.OauthV1Interface
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	rhssoConfig, err := configManager.ReadRHSSO()
 	if err != nil {
 		return nil, err
@@ -87,6 +89,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		logger:        logger,
 		oauthv1Client: oauthv1Client,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -117,42 +120,50 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileComponents(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile components", err)
 		return phase, err
 	}
 
 	phase, err = r.handleProgressPhase(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to handle in progress phase", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, installation, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTargets(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
@@ -160,6 +171,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.AuthenticationStage, r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -83,21 +83,11 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultRhssoNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
-	scheme, err := getBuildScheme()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		Name            string
 		ExpectError     bool
@@ -125,7 +115,7 @@ func TestReconciler_config(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 	}
 
@@ -197,7 +187,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -219,7 +209,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			ExpectError:    true,
 			ExpectedError:  "failed to create/update keycloak custom resource: failed to create keycloak custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, tc := range cases {
@@ -311,7 +301,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test unready kcr cr returns phase in progress",
@@ -320,7 +310,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test missing kc cr returns phase failed",
@@ -330,7 +320,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test missing kcr cr returns phase failed",
@@ -340,7 +330,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test failed config write",
@@ -364,7 +354,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				},
 			},
 			Installation: &integreatlyv1alpha1.Installation{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 
@@ -521,7 +511,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -42,9 +43,10 @@ type Reconciler struct {
 	logger        *logrus.Entry
 	oauthv1Client oauthClient.OauthV1Interface
 	*resources.Reconciler
+	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
 	rhssoUserConfig, err := configManager.ReadRHSSOUser()
 	if err != nil {
 		return nil, err
@@ -63,6 +65,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		logger:        logger,
 		oauthv1Client: oauthv1Client,
 		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
 	}, nil
 }
 
@@ -93,31 +96,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileComponents(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile components", err)
 		return phase, err
 	}
 
 	phase, err = r.handleProgressPhase(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to handle in progress phase", err)
 		return phase, err
 	}
 
@@ -125,6 +134,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	aerogearv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
@@ -96,37 +97,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
-		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
+		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileComponents(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile components", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile components", err)
 		return phase, err
 	}
 
 	phase, err = r.handleProgressPhase(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to handle in progress phase", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to handle in progress phase", err)
 		return phase, err
 	}
 
@@ -134,7 +135,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
-	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
+	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -76,7 +77,21 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
+func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
+	eventSource := corev1.EventSource{
+		Component: defaultRhssoNamespace,
+		Host:      "",
+	}
+	broadcaster := record.NewBroadcaster()
+	return broadcaster.NewRecorder(scheme, eventSource)
+}
+
 func TestReconciler_config(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		Name            string
 		ExpectError     bool
@@ -88,6 +103,7 @@ func TestReconciler_config(t *testing.T) {
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
+		Recorder        record.EventRecorder
 	}{
 		{
 			Name:            "test error on failed config",
@@ -102,7 +118,8 @@ func TestReconciler_config(t *testing.T) {
 					return nil, errors.New("could not read rhsso config")
 				},
 			},
-			Product: &integreatlyv1alpha1.InstallationProductStatus{},
+			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder: setupRecorder(scheme),
 		},
 	}
 
@@ -113,6 +130,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.Installation,
 				tc.FakeOauthClient,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -159,6 +177,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		ExpectedError   string
 		ExpectedStatus  integreatlyv1alpha1.StatusPhase
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
+		Recorder        record.EventRecorder
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
@@ -172,6 +191,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			Recorder:       setupRecorder(scheme),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -193,6 +213,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			ExpectError:    true,
 			ExpectedError:  "failed to create/update keycloak custom resource: failed to create keycloak custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
+			Recorder:       setupRecorder(scheme),
 		},
 	}
 	for _, tc := range cases {
@@ -202,6 +223,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				tc.Installation,
 				tc.FakeOauthClient,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -274,6 +296,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 		FakeOauthClient oauthClient.OauthV1Interface
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Installation    *integreatlyv1alpha1.Installation
+		Recorder        record.EventRecorder
 	}{
 		{
 			Name:            "test ready kcr returns phase complete",
@@ -282,6 +305,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
+			Recorder:        setupRecorder(scheme),
 		},
 		{
 			Name:            "test unready kcr cr returns phase in progress",
@@ -290,6 +314,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
+			Recorder:        setupRecorder(scheme),
 		},
 		{
 			Name:            "test missing kc cr returns phase failed",
@@ -299,6 +324,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
+			Recorder:        setupRecorder(scheme),
 		},
 		{
 			Name:            "test missing kcr cr returns phase failed",
@@ -308,6 +334,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
+			Recorder:        setupRecorder(scheme),
 		},
 		{
 			Name:            "test failed config write",
@@ -328,6 +355,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				},
 			},
 			Installation: &integreatlyv1alpha1.Installation{},
+			Recorder:     setupRecorder(scheme),
 		},
 	}
 
@@ -338,6 +366,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.Installation,
 				tc.FakeOauthClient,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -446,6 +475,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
+		Recorder        record.EventRecorder
 	}{
 		{
 			Name:            "test successful reconcile",
@@ -481,6 +511,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
+			Recorder:     setupRecorder(scheme),
 		},
 	}
 
@@ -491,6 +522,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.Installation,
 				tc.FakeOauthClient,
 				tc.FakeMPM,
+				tc.Recorder,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -77,21 +77,11 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultRhssoNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_config(t *testing.T) {
-	scheme, err := getBuildScheme()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	cases := []struct {
 		Name            string
 		ExpectError     bool
@@ -119,7 +109,7 @@ func TestReconciler_config(t *testing.T) {
 				},
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 	}
 
@@ -191,7 +181,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				},
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -213,7 +203,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			ExpectError:    true,
 			ExpectedError:  "failed to create/update keycloak custom resource: failed to create keycloak custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, tc := range cases {
@@ -305,7 +295,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test unready kcr cr returns phase in progress",
@@ -314,7 +304,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test missing kc cr returns phase failed",
@@ -324,7 +314,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test missing kcr cr returns phase failed",
@@ -334,7 +324,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
-			Recorder:        setupRecorder(scheme),
+			Recorder:        setupRecorder(),
 		},
 		{
 			Name:            "test failed config write",
@@ -355,7 +345,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				},
 			},
 			Installation: &integreatlyv1alpha1.Installation{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 
@@ -511,7 +501,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			},
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -28,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -57,6 +58,7 @@ type Reconciler struct {
 	logger        *logrus.Entry
 	OauthResolver OauthResolver
 	installation  *integreatlyv1alpha1.Installation
+	recorder      record.EventRecorder
 }
 
 //go:generate moq -out OauthResolver_moq.go . OauthResolver
@@ -69,7 +71,7 @@ type productInfo struct {
 	Version integreatlyv1alpha1.ProductVersion
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, resolver OauthResolver) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, resolver OauthResolver, recorder record.EventRecorder) (*Reconciler, error) {
 	seConfig, err := configManager.ReadSolutionExplorer()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve solution explorer config: %w", err)
@@ -93,6 +95,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		OauthResolver: resolver,
 		oauthv1Client: oauthv1Client,
 		installation:  installation,
+		recorder:      recorder,
 	}, nil
 }
 
@@ -121,31 +124,37 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileNamespace(ctx, r.Config.GetNamespace(), installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", r.Config.GetNamespace()), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", r.Config.GetNamespace()), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubNameAndPkg, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetNamespace(), ManifestPackage: manifestPackage}, r.Config.GetNamespace(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubNameAndPkg), err)
 		return phase, err
 	}
 
 	phase, err = r.ReconcileCustomResource(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile custom resource", err)
 		return phase, err
 	}
 
 	route, err := r.ensureAppUrl(ctx, serverClient)
 	if err != nil {
+		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, "Route for solution explorer is not available", err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
@@ -162,18 +171,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		},
 	}, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile oauth client", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTarget(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileTemplates(ctx, installation, serverClient)
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Infof("Error: %s", err)
+		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile templates", err)
+		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 
@@ -181,6 +193,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
+	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.SolutionExplorerStage, r.Config.GetProductName())
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -186,7 +186,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/solutionexplorer/reconciler_test.go
+++ b/pkg/products/solutionexplorer/reconciler_test.go
@@ -16,7 +16,6 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 
-	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -63,13 +62,8 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 	}
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultName,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 var oauthResolver = func() OauthResolver {
@@ -103,7 +97,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 					t.Fatal("expected 1 call to GetOauthEndPointCalls but got  ", len(m.GetOauthEndPointCalls()))
 				}
 			},
-			Recorder: setupRecorder(scheme),
+			Recorder: setupRecorder(),
 		},
 	}
 
@@ -173,7 +167,7 @@ func TestSolutionExplorer(t *testing.T) {
 			FakeConfig:   basicConfigMock(),
 			client:       fake.NewFakeClient(webappNs, webappCR, installation, webappRoute),
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:     setupRecorder(scheme),
+			Recorder:     setupRecorder(),
 		},
 	}
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -235,7 +235,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	logrus.Infof("Phase: %s reconcileTemplates", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile templates", err)
-		logrus.Infof("Error: %s", err.Error())
 		return phase, err
 	}
 

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -55,13 +55,8 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	return scheme, err
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 type ThreeScaleTestScenario struct {
@@ -148,7 +143,7 @@ func TestThreeScale(t *testing.T) {
 			MPM:            marketplace.NewManager(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Product:        &integreatlyv1alpha1.InstallationProductStatus{},
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 	for _, scenario := range scenarios {

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
@@ -95,7 +96,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
 		return phase, err
 	}
 
@@ -103,38 +104,38 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err = r.ReconcileNamespace(ctx, ns, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", ns), err)
 		return phase, err
 	}
 
 	namespace, err := resources.GetNS(ctx, ns, serverClient)
 	if err != nil {
-		resources.EmitEventProcessingError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
+		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, fmt.Sprintf("Failed to retrieve %s namespace", ns), err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: defaultSubscriptionName, Namespace: ns, Channel: marketplace.IntegreatlyChannel, ManifestPackage: manifestPackage}, ns, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", defaultSubscriptionName), err)
 
 		return phase, err
 	}
 
 	phase, err = r.reconcileComponents(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile components", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile components", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileHost(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile host", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile host", err)
 		return phase, err
 	}
 
 	phase, err = r.reconcileBlackboxTargets(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		resources.EmitEventProcessingError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile blackbox targets", err)
 		return phase, err
 	}
 
@@ -142,7 +143,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
-	resources.EmitEventProductCompleted(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
+	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	logrus.Infof("%s is successfully reconciled", defaultUpsName)
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/ups/reconciler_test.go
+++ b/pkg/products/ups/reconciler_test.go
@@ -115,13 +115,8 @@ func getTestPostgresSec() *corev1.Secret {
 	}
 }
 
-func setupRecorder(scheme *runtime.Scheme) record.EventRecorder {
-	eventSource := corev1.EventSource{
-		Component: defaultInstallationNamespace,
-		Host:      "",
-	}
-	broadcaster := record.NewBroadcaster()
-	return broadcaster.NewRecorder(scheme, eventSource)
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 func TestReconciler_ReconcileCustomResource(t *testing.T) {
@@ -152,7 +147,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 			},
 			FakeConfig: basicConfigMock(),
 			FakeClient: fake.NewFakeClientWithScheme(scheme, getTestPostgres(), getTestPostgresSec(), mockUpsCRWithStatus(upsv1alpha1.PhaseReconciling)),
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 		{
 			Name:           "UPS Test: Phase failed when error in creating custom resource",
@@ -169,7 +164,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectErr: true,
-			Recorder:  setupRecorder(scheme),
+			Recorder:  setupRecorder(),
 		},
 		{
 			Name:           "UPS Test: Phase failed when general error in finding custom resource",
@@ -183,7 +178,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 				},
 			},
 			ExpectErr: true,
-			Recorder:  setupRecorder(scheme),
+			Recorder:  setupRecorder(),
 		},
 		{
 			Name:           "UPS Test: Phase in progress when custom resource is not in phase complete",
@@ -197,7 +192,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 			},
 			FakeConfig: basicConfigMock(),
 			FakeClient: fake.NewFakeClientWithScheme(scheme, getTestPostgres(), getTestPostgresSec(), mockUpsCRWithStatus(upsv1alpha1.PhaseInitializing)),
-			Recorder:   setupRecorder(scheme),
+			Recorder:   setupRecorder(),
 		},
 	}
 
@@ -244,7 +239,7 @@ func TestReconciler_ReconcileHost(t *testing.T) {
 			Installation:   &integreatlyv1alpha1.Installation{},
 			FakeConfig:     basicConfigMock(),
 			FakeClient:     fake.NewFakeClientWithScheme(scheme, basicRouteMock()),
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "UPS Test: Cannot retrieve route - phase failed",
@@ -254,7 +249,7 @@ func TestReconciler_ReconcileHost(t *testing.T) {
 			Installation:   &integreatlyv1alpha1.Installation{},
 			FakeConfig:     errorConfigMock(),
 			FakeClient:     fake.NewFakeClientWithScheme(scheme),
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 		{
 			Name:           "UPS Test: Cannot update config with route url - phase failed",
@@ -264,7 +259,7 @@ func TestReconciler_ReconcileHost(t *testing.T) {
 			Installation:   &integreatlyv1alpha1.Installation{},
 			FakeConfig:     errorConfigMock(),
 			FakeClient:     fake.NewFakeClientWithScheme(scheme, basicRouteMock()),
-			Recorder:       setupRecorder(scheme),
+			Recorder:       setupRecorder(),
 		},
 	}
 

--- a/pkg/resources/events.go
+++ b/pkg/resources/events.go
@@ -1,0 +1,32 @@
+package resources
+
+import (
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+
+	"k8s.io/client-go/tools/record"
+)
+
+// Emits a normal event upon successful completion of stage reconcile
+func EmitEventStageCompleted(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName) {
+	stageStatus := installation.Status.Stages[stageName]
+	if stageStatus == nil || stageStatus.Phase != integreatlyv1alpha1.PhaseCompleted {
+		recorder.Event(installation, "Normal", integreatlyv1alpha1.EventInstallationCompleted, fmt.Sprintf("%s stage has reconciled successfully", stageName))
+	}
+}
+
+// Emits a normal event upon successful completion of product installation
+func EmitEventProductCompleted(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName, productName integreatlyv1alpha1.ProductName) {
+	stage := installation.Status.Stages[stageName]
+	if stage == nil || stage.Products[productName] == nil || stage.Products[productName].Status != integreatlyv1alpha1.PhaseCompleted {
+		recorder.Event(installation, "Normal", integreatlyv1alpha1.EventInstallationCompleted, fmt.Sprintf("%s was installed successfully", productName))
+	}
+}
+
+// Emits a warning event when a processing error occurs during reconcile. It is only emitted on phase failed
+func EmitEventProcessingError(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, phase integreatlyv1alpha1.StatusPhase, errorMessage string, err error) {
+	if err != nil && phase == integreatlyv1alpha1.PhaseFailed {
+		recorder.Event(installation, "Warning", integreatlyv1alpha1.EventProcessingError, fmt.Sprintf("%s:\n%s", errorMessage, err.Error()))
+	}
+}

--- a/pkg/resources/events/events.go
+++ b/pkg/resources/events/events.go
@@ -1,4 +1,4 @@
-package resources
+package events
 
 import (
 	"fmt"
@@ -9,7 +9,7 @@ import (
 )
 
 // Emits a normal event upon successful completion of stage reconcile
-func EmitEventStageCompleted(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName) {
+func HandleStageComplete(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName) {
 	stageStatus := installation.Status.Stages[stageName]
 	if stageStatus == nil || stageStatus.Phase != integreatlyv1alpha1.PhaseCompleted {
 		recorder.Event(installation, "Normal", integreatlyv1alpha1.EventInstallationCompleted, fmt.Sprintf("%s stage has reconciled successfully", stageName))
@@ -17,7 +17,7 @@ func EmitEventStageCompleted(recorder record.EventRecorder, installation *integr
 }
 
 // Emits a normal event upon successful completion of product installation
-func EmitEventProductCompleted(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName, productName integreatlyv1alpha1.ProductName) {
+func HandleProductComplete(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, stageName integreatlyv1alpha1.StageName, productName integreatlyv1alpha1.ProductName) {
 	stage := installation.Status.Stages[stageName]
 	if stage == nil || stage.Products[productName] == nil || stage.Products[productName].Status != integreatlyv1alpha1.PhaseCompleted {
 		recorder.Event(installation, "Normal", integreatlyv1alpha1.EventInstallationCompleted, fmt.Sprintf("%s was installed successfully", productName))
@@ -25,7 +25,7 @@ func EmitEventProductCompleted(recorder record.EventRecorder, installation *inte
 }
 
 // Emits a warning event when a processing error occurs during reconcile. It is only emitted on phase failed
-func EmitEventProcessingError(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, phase integreatlyv1alpha1.StatusPhase, errorMessage string, err error) {
+func HandleError(recorder record.EventRecorder, installation *integreatlyv1alpha1.Installation, phase integreatlyv1alpha1.StatusPhase, errorMessage string, err error) {
 	if err != nil && phase == integreatlyv1alpha1.PhaseFailed {
 		recorder.Event(installation, "Warning", integreatlyv1alpha1.EventProcessingError, fmt.Sprintf("%s:\n%s", errorMessage, err.Error()))
 	}

--- a/pkg/resources/events/events_test.go
+++ b/pkg/resources/events/events_test.go
@@ -1,0 +1,192 @@
+package events
+
+import (
+	"errors"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"k8s.io/client-go/tools/record"
+)
+
+const (
+	stageName   = "stageName"
+	productName = "testProduct"
+)
+
+type EventsScenario struct {
+	Name               string
+	Installation       *integreatlyv1alpha1.Installation
+	ExpectedEventCount int
+	Error              error
+	ErrorMessage       string
+	StatusPhase        integreatlyv1alpha1.StatusPhase
+}
+
+func TestHandleStageComplete(t *testing.T) {
+	cases := []EventsScenario{
+		{
+			Name:               "test stage complete event handler on a stage thats unavailable",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ExpectedEventCount: 1,
+		},
+		{
+			Name: "test stage complete event handler on a stage thats not completed",
+			Installation: &integreatlyv1alpha1.Installation{
+				Status: integreatlyv1alpha1.InstallationStatus{
+					Stages: map[integreatlyv1alpha1.StageName]*integreatlyv1alpha1.InstallationStageStatus{
+						stageName: &integreatlyv1alpha1.InstallationStageStatus{
+							Name:  stageName,
+							Phase: integreatlyv1alpha1.PhaseInProgress,
+						},
+					},
+				},
+			},
+			ExpectedEventCount: 1,
+		},
+		{
+			Name: "test stage complete event handler on a stage thats completed",
+			Installation: &integreatlyv1alpha1.Installation{
+				Status: integreatlyv1alpha1.InstallationStatus{
+					Stages: map[integreatlyv1alpha1.StageName]*integreatlyv1alpha1.InstallationStageStatus{
+						stageName: &integreatlyv1alpha1.InstallationStageStatus{
+							Name:  stageName,
+							Phase: integreatlyv1alpha1.PhaseCompleted,
+						},
+					},
+				},
+			},
+			ExpectedEventCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(1)
+			HandleStageComplete(recorder, tc.Installation, stageName)
+
+			if len(recorder.Events) != tc.ExpectedEventCount {
+				t.Fatalf("Expected event count %d but got %d", tc.ExpectedEventCount, len(recorder.Events))
+			}
+		})
+	}
+}
+
+func TestHandleProductComplete(t *testing.T) {
+	cases := []EventsScenario{
+		{
+			Name:               "test product complete event handler on a stage thats unavailable",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ExpectedEventCount: 1,
+		},
+		{
+			Name: "test product complete event handler on a product thats unavailable",
+			Installation: &integreatlyv1alpha1.Installation{
+				Status: integreatlyv1alpha1.InstallationStatus{
+					Stages: map[integreatlyv1alpha1.StageName]*integreatlyv1alpha1.InstallationStageStatus{
+						stageName: &integreatlyv1alpha1.InstallationStageStatus{
+							Name:     stageName,
+							Phase:    integreatlyv1alpha1.PhaseInProgress,
+							Products: map[integreatlyv1alpha1.ProductName]*integreatlyv1alpha1.InstallationProductStatus{},
+						},
+					},
+				},
+			},
+			ExpectedEventCount: 1,
+		},
+		{
+			Name: "test product complete event handler on a product thats in progress",
+			Installation: &integreatlyv1alpha1.Installation{
+				Status: integreatlyv1alpha1.InstallationStatus{
+					Stages: map[integreatlyv1alpha1.StageName]*integreatlyv1alpha1.InstallationStageStatus{
+						stageName: &integreatlyv1alpha1.InstallationStageStatus{
+							Name:  stageName,
+							Phase: integreatlyv1alpha1.PhaseInProgress,
+							Products: map[integreatlyv1alpha1.ProductName]*integreatlyv1alpha1.InstallationProductStatus{
+								productName: &integreatlyv1alpha1.InstallationProductStatus{
+									Name:   productName,
+									Status: integreatlyv1alpha1.PhaseInProgress,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedEventCount: 1,
+		},
+		{
+			Name: "test product complete event handler on a product thats completed",
+			Installation: &integreatlyv1alpha1.Installation{
+				Status: integreatlyv1alpha1.InstallationStatus{
+					Stages: map[integreatlyv1alpha1.StageName]*integreatlyv1alpha1.InstallationStageStatus{
+						stageName: &integreatlyv1alpha1.InstallationStageStatus{
+							Name:  stageName,
+							Phase: integreatlyv1alpha1.PhaseInProgress,
+							Products: map[integreatlyv1alpha1.ProductName]*integreatlyv1alpha1.InstallationProductStatus{
+								productName: &integreatlyv1alpha1.InstallationProductStatus{
+									Name:   productName,
+									Status: integreatlyv1alpha1.PhaseCompleted,
+								},
+							},
+						},
+					},
+				},
+			},
+			ExpectedEventCount: 0,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(1)
+			HandleProductComplete(recorder, tc.Installation, stageName, productName)
+
+			if len(recorder.Events) != tc.ExpectedEventCount {
+				t.Fatalf("Expected event count %d but got %d", tc.ExpectedEventCount, len(recorder.Events))
+			}
+		})
+	}
+}
+
+func TestHandleError(t *testing.T) {
+	cases := []EventsScenario{
+		{
+			Name:               "test error event handler with no errors and phase not failed",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ErrorMessage:       "failed installation",
+			ExpectedEventCount: 0,
+		},
+		{
+			Name:               "test error event handler with an error and phase not failed",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ExpectedEventCount: 0,
+			Error:              errors.New("an error occurred"),
+			ErrorMessage:       "failed installation",
+		},
+		{
+			Name:               "test error event handler with no errors and phase failed",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ExpectedEventCount: 0,
+			StatusPhase:        integreatlyv1alpha1.PhaseFailed,
+			ErrorMessage:       "failed installation",
+		},
+		{
+			Name:               "test error event handler with an error and phase failed",
+			Installation:       &integreatlyv1alpha1.Installation{},
+			ExpectedEventCount: 1,
+			Error:              errors.New("an error occurred"),
+			ErrorMessage:       "failed installation",
+			StatusPhase:        integreatlyv1alpha1.PhaseFailed,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			recorder := record.NewFakeRecorder(1)
+			HandleError(recorder, tc.Installation, tc.StatusPhase, tc.ErrorMessage, tc.Error)
+
+			if len(recorder.Events) != tc.ExpectedEventCount {
+				t.Fatalf("Expected event count %d but got %d", tc.ExpectedEventCount, len(recorder.Events))
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What
Add an event recorder to the bootstrap and product reconcilers to emit events on failed and successful installations. 

[INTLY-3037](https://issues.redhat.com/browse/INTLY-3037)

## Verificaton
1. Install integreatly using this branch
2. Check for integreatly operator events on your cluster. This can be seen in the `Events` page.
   - Events should be emitted for each product's successful installation
   - Events should be emitted when an error occurs resulting to a failed installation