### PR TITLE
Filter integreatly in subscription controller

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -6,6 +6,7 @@ import (
 	"github.com/RHsyseng/operator-utils/pkg/resource/detector"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -17,6 +18,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
+const (
+	// IntegreatlyPackage - package name is used for Subsription name
+	IntegreatlyPackage = "integreatly"
+)
+
 // Add creates a new Subscription Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, _ []string, _ *detector.Detector) error {
@@ -24,7 +30,8 @@ func Add(mgr manager.Manager, _ []string, _ *detector.Detector) error {
 }
 
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileSubscription{client: mgr.GetClient(), scheme: mgr.GetScheme()}
+	operatorNs, _ := k8sutil.GetOperatorNamespace()
+	return &ReconcileSubscription{client: mgr.GetClient(), scheme: mgr.GetScheme(), operatorNamespace: operatorNs}
 }
 
 func add(mgr manager.Manager, r reconcile.Reconciler) error {
@@ -44,13 +51,19 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 var _ reconcile.Reconciler = &ReconcileSubscription{}
 
 type ReconcileSubscription struct {
-	client k8sclient.Client
-	scheme *runtime.Scheme
+	client            k8sclient.Client
+	scheme            *runtime.Scheme
+	operatorNamespace string
 }
 
 // Reconcile will ensure that that Subscription object(s) have Manual approval for the upgrades
 // In a namespaced installation of integreatly operator it will only reconcile Subscription of the integreatly operator itself
 func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	// skip any Subscriptions that are not integreatly operator
+	if request.Namespace != r.operatorNamespace || request.Name != IntegreatlyPackage {
+		return reconcile.Result{}, nil
+	}
+
 	instance := &v1alpha1.Subscription{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {


### PR DESCRIPTION
Now, that the integreatly operator will only be installed in cluster mode, it will automatically watch all Subsriptions on the cluster.
This PR should ensure that it will only change it's own subscription to Manual.