### PR TITLE
Fix swapped unit test names

### DIFF
--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -60,7 +60,7 @@ func TestSubscriptionReconciler(t *testing.T) {
 			},
 		},
 		{
-			Name: "subscription controller doesn't change other subscription in the same namespace",
+			Name: "subscription controller doesn't change subscription in different namespace",
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: "other-ns",
@@ -88,7 +88,7 @@ func TestSubscriptionReconciler(t *testing.T) {
 			},
 		},
 		{
-			Name: "subscription controller doesn't change subscription in different namespace",
+			Name: "subscription controller doesn't change other subscription in the same namespace",
 			Request: reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Namespace: operatorNamespace,


### PR DESCRIPTION
I made a small mistake in my previous PR (https://github.com/integr8ly/integreatly-operator/pull/293) - the names of the new test cases were swapped. Fixing that here.

@philbrookes can you approve please? :)