### PR TITLE
Intly 2932 remove customer admin

### DIFF
--- a/htpasswd
+++ b/htpasswd
@@ -1,0 +1,3 @@
+quay-builder-admin:$apr1$nSoKDg76$I1S86T79V6SctC9tuuqlH/
+test-user:$apr1$TXHbERZa$L2MUBPPaPfJXkBvsUTMrV.
+test-user-2:$apr1$E4YsfIBP$yoexybJc5U1H6aT60eTEL/

--- a/htpasswd
+++ b/htpasswd
@@ -1,3 +1,0 @@
-quay-builder-admin:$apr1$nSoKDg76$I1S86T79V6SctC9tuuqlH/
-test-user:$apr1$TXHbERZa$L2MUBPPaPfJXkBvsUTMrV.
-test-user-2:$apr1$E4YsfIBP$yoexybJc5U1H6aT60eTEL/

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -540,7 +540,6 @@ func getKcr(status aerogearv1.KeycloakRealmStatus) *aerogearv1.KeycloakRealm {
 					"metrics-listener",
 				},
 				Users: []*aerogearv1.KeycloakUser{
-					CustomerAdminUser,
 				},
 			},
 		},

--- a/pkg/products/threescale/asserts_test.go
+++ b/pkg/products/threescale/asserts_test.go
@@ -9,7 +9,6 @@ import (
 	aerogearv1 "github.com/integr8ly/integreatly-operator/pkg/apis/aerogear/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
-	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -93,19 +92,8 @@ func assertInstallationSuccessfull(scenario ThreeScaleTestScenario, configManage
 		return errors.New(fmt.Sprintf("SSO integration request to 3scale API was incorrect"))
 	}
 
-	// RHSSO CustomerAdmin admin user should be set as the default 3scale admin
-	defaultAdminUser, err := fakeThreeScaleClient.GetUser(rhsso.CustomerAdminUser.UserName, accessToken)
-	if err != nil {
-		return err
-	}
-	if defaultAdminUser.UserDetails.Email != rhsso.CustomerAdminUser.Email {
-		return errors.New(fmt.Sprintf("Request to 3scale API to update admin details was incorrect"))
-	}
 	adminSecret := &corev1.Secret{}
 	err = fakeSigsClient.Get(ctx, k8sclient.ObjectKey{Name: threeScaleAdminDetailsSecret.Name, Namespace: tsConfig.GetNamespace()}, adminSecret)
-	if string(adminSecret.Data["ADMIN_USER"]) != rhsso.CustomerAdminUser.UserName || string(adminSecret.Data["ADMIN_EMAIL"]) != rhsso.CustomerAdminUser.Email {
-		return errors.New(fmt.Sprintf("3scale admin secret details were not updated"))
-	}
 
 	// Service discovery should be configured
 	threeScaleOauth := &oauthv1.OAuthClient{}
@@ -119,9 +107,6 @@ func assertInstallationSuccessfull(scenario ThreeScaleTestScenario, configManage
 
 	serviceDiscoveryConfigMap := &corev1.ConfigMap{}
 	err = fakeSigsClient.Get(ctx, k8sclient.ObjectKey{Name: threeScaleServiceDiscoveryConfigMap.Name, Namespace: tsConfig.GetNamespace()}, serviceDiscoveryConfigMap)
-	if string(adminSecret.Data["ADMIN_USER"]) != rhsso.CustomerAdminUser.UserName || string(adminSecret.Data["ADMIN_EMAIL"]) != rhsso.CustomerAdminUser.Email {
-		return errors.New(fmt.Sprintf("3scale admin secret details were not updated"))
-	}
 	if string(serviceDiscoveryConfigMap.Data["service_discovery.yml"]) != sdConfig {
 		return errors.New(fmt.Sprintf("Service discovery config is misconfigured"))
 	}

--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -106,9 +106,7 @@ func getAppsV1Client(appsv1PreReqs map[string]*appsv1.DeploymentConfig) appsv1Cl
 
 func getThreeScaleClient() *ThreeScaleInterfaceMock {
 	testUsers := &Users{
-		Users: []*User{
-			threeScaleDefaultAdminUser,
-		},
+		Users: []*User{},
 	}
 	testAuthProviders := &AuthProviders{
 		AuthProviders: []*AuthProvider{},
@@ -153,19 +151,6 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 			}
 
 			return nil, errors.New(fmt.Sprintf("user %s not found", userName))
-		},
-		UpdateUserFunc: func(userId int, username string, email string, accessToken string) (response *http.Response, e error) {
-			if userId == threeScaleDefaultAdminUser.UserDetails.Id {
-				threeScaleDefaultAdminUser.UserDetails.Username = username
-				threeScaleDefaultAdminUser.UserDetails.Email = email
-				return &http.Response{
-					StatusCode: http.StatusOK,
-				}, nil
-			}
-
-			return &http.Response{
-				StatusCode: http.StatusBadRequest,
-			}, errors.New(fmt.Sprintf("Error updating 3scale admin user"))
 		},
 		AddUserFunc: func(username string, email string, password string, accessToken string) (response *http.Response, e error) {
 			testUsers.Users = append(testUsers.Users, &User{

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -11,8 +11,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 
-	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
-	appsv1 "github.com/openshift/api/apps/v1"
+ 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"
 
@@ -81,7 +80,6 @@ var keycloakrealm = &aerogearv1.KeycloakRealm{
 	Spec: aerogearv1.KeycloakRealmSpec{
 		KeycloakApiRealm: &aerogearv1.KeycloakApiRealm{
 			Users: []*aerogearv1.KeycloakUser{
-				rhsso.CustomerAdminUser,
 				rhssoTest1,
 				rhssoTest2,
 			},
@@ -94,10 +92,7 @@ var threeScaleAdminDetailsSecret = &corev1.Secret{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "system-seed",
 	},
-	Data: map[string][]byte{
-		"ADMIN_USER":  bytes.NewBufferString(threeScaleDefaultAdminUser.UserDetails.Username).Bytes(),
-		"ADMIN_EMAIL": bytes.NewBufferString(threeScaleDefaultAdminUser.UserDetails.Email).Bytes(),
-	},
+	Data: map[string][]byte{},
 }
 
 var threeScaleServiceDiscoveryConfigMap = &corev1.ConfigMap{
@@ -106,15 +101,6 @@ var threeScaleServiceDiscoveryConfigMap = &corev1.ConfigMap{
 	},
 	Data: map[string]string{
 		"service_discovery.yml": "",
-	},
-}
-
-var threeScaleDefaultAdminUser = &User{
-	UserDetails: UserDetails{
-		Id:       1,
-		Email:    "not" + rhsso.CustomerAdminUser.Email,
-		Username: "not" + rhsso.CustomerAdminUser.UserName,
-		Role:     adminRole,
 	},
 }
 

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -10,9 +10,6 @@ if [[ ! -f "htpasswd" ]]; then
   touch htpasswd
 fi
 
-htpasswd -b htpasswd customer-admin ${PASSWORD}
-echo user added customer-admin ${PASSWORD}
-
 htpasswd -b htpasswd test-user ${PASSWORD}
 echo user added test-user ${PASSWORD}
 
@@ -20,4 +17,4 @@ oc delete secret htpasswd-secret -n openshift-config
 oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
 oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "htpasswd_provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
 
-oc adm groups add-users dedicated-admins customer-admin
+oc adm groups add-users dedicated-admins test-user


### PR DESCRIPTION
**JIRAs:**
https://issues.redhat.com/browse/INTLY-2932

**What:**
Remove the creation of CustomerAdminUser in Keycloak
Remove "realm-management" permissions as managing users is now done via OSD configuration

**Verification:**
- Run basic install and verify success
- Run go test -v -coverprofile cover.out ./pkg/products/rhsso/...
- Run go test -v -coverprofile cover.out ./pkg/products/threescale/...
- run ./scripts/setup-htpass-idp.sh
- Verify customer-admin does not exist in OpenShift, Keycloak and ThreeScale


