### PR TITLE
feat: remove customer admin

### DIFF
--- a/htpasswd
+++ b/htpasswd
@@ -1,0 +1,3 @@
+quay-builder-admin:$apr1$nSoKDg76$I1S86T79V6SctC9tuuqlH/
+test-user:$apr1$TXHbERZa$L2MUBPPaPfJXkBvsUTMrV.
+test-user-2:$apr1$E4YsfIBP$yoexybJc5U1H6aT60eTEL/

--- a/htpasswd
+++ b/htpasswd
@@ -1,3 +1,0 @@
-quay-builder-admin:$apr1$nSoKDg76$I1S86T79V6SctC9tuuqlH/
-test-user:$apr1$TXHbERZa$L2MUBPPaPfJXkBvsUTMrV.
-test-user-2:$apr1$E4YsfIBP$yoexybJc5U1H6aT60eTEL/

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -8,10 +8,10 @@ import (
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 
-	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	appsv1 "github.com/openshift/api/apps/v1"
 	v1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -765,7 +765,6 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient k
 			}
 		}
 	}
-
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -3,9 +3,10 @@ package threescale
 import (
 	"context"
 	"fmt"
+	"net/http"
+
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/pkg/errors"
-	"net/http"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
@@ -13,6 +14,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoring"
+	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
@@ -24,7 +26,6 @@ import (
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
-	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 
@@ -724,6 +725,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient k
 			return integreatlyv1alpha1.PhaseInProgress, err
 		}
 	}
+
 	for _, tsUser := range deleted {
 		if tsUser.UserDetails.Username != *systemAdminUsername {
 			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
@@ -738,10 +740,12 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient k
 	if err != nil && !k8serr.IsNotFound(err) {
 		return integreatlyv1alpha1.PhaseInProgress, err
 	}
+
 	newTsUsers, err := r.tsClient.GetUsers(*accessToken)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseInProgress, err
 	}
+
 	for _, tsUser := range newTsUsers.Users {
 
 		// skip if ts user is the system user admin

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -10,9 +10,6 @@ if [[ ! -f "htpasswd" ]]; then
   touch htpasswd
 fi
 
-htpasswd -b htpasswd customer-admin ${PASSWORD}
-echo user added customer-admin ${PASSWORD}
-
 htpasswd -b htpasswd test-user ${PASSWORD}
 echo user added test-user ${PASSWORD}
 
@@ -20,4 +17,4 @@ oc delete secret htpasswd-secret -n openshift-config
 oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
 oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "htpasswd_provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
 
-oc adm groups add-users dedicated-admins customer-admin
+oc adm groups add-users dedicated-admins test-user

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -10,6 +10,9 @@ if [[ ! -f "htpasswd" ]]; then
   touch htpasswd
 fi
 
+htpasswd -b htpasswd customer-admin ${PASSWORD}
+echo user added customer-admin ${PASSWORD}
+
 htpasswd -b htpasswd test-user ${PASSWORD}
 echo user added test-user ${PASSWORD}
 
@@ -17,4 +20,4 @@ oc delete secret htpasswd-secret -n openshift-config
 oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
 oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "htpasswd_provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
 
-oc adm groups add-users dedicated-admins test-user
+oc adm groups add-users dedicated-admins customer-admin


### PR DESCRIPTION
Follow up on https://github.com/integr8ly/integreatly-operator/pull/297 review

### JIRAs:
https://issues.redhat.com/browse/INTLY-2932

### What:
Remove the creation of CustomerAdminUser in Keycloak
Remove "realm-management" permissions as managing users is now done via OSD configuration

### Verification:

Run basic install and verify success
Run go test -v -coverprofile cover.out ./pkg/products/rhsso/...
Run go test -v -coverprofile cover.out ./pkg/products/threescale/...
run ./scripts/setup-htpass-idp.sh
Verify customer-admin does not exist in OpenShift, Keycloak and ThreeScale