### PR TITLE
INTLY-4256: Add target for running e2e tests with AWS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test/e2e/prow: test/e2e
 .PHONY: test/e2e
 test/e2e: export GH_CLIENT_ID := 1234
 test/e2e: export GH_CLIENT_SECRET := 1234
-test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/configmaps cluster/prepare/crd deploy/integreatly-installation-cr.yml
+test/e2e: cluster/cleanup cluster/cleanup/crds cluster/cleanup/roles cluster/prepare cluster/prepare/configmaps cluster/prepare/crd deploy/integreatly-installation-cr.yml
 	operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: test/e2e/aws
@@ -179,6 +179,11 @@ cluster/cleanup/crds:
 	@-oc delete crd grafanas.integreatly.org
 	@-oc delete crd installations.integreatly.org
 	@-oc delete crd webapps.integreatly.org
+
+.PHONY: cluster/cleanup/roles
+cluster/cleanup/roles:
+	@-oc delete -f deploy/role_binding.yaml -n $(NAMESPACE)
+	@-oc delete -f deploy/role.yaml -n $(NAMESPACE)
 
 .PHONY: deploy/integreatly-installation-cr.yml
 deploy/integreatly-installation-cr.yml: export SELF_SIGNED_CERTS := true

--- a/deploy/cro-configmaps.yaml
+++ b/deploy/cro-configmaps.yaml
@@ -10,9 +10,12 @@ objects:
       namespace: ${INSTALLATION_NAMESPACE}
     data:
       managed: >
-        {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
+        {"blobstorage":"${INSTALLATION_STORAGE_TYPE}", "smtpcredentials":"${INSTALLATION_STORAGE_TYPE}", "redis":"${INSTALLATION_STORAGE_TYPE}", "postgres":"${INSTALLATION_STORAGE_TYPE}"}
       workshop: >
-        {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
+        {"blobstorage":"${INSTALLATION_STORAGE_TYPE}", "smtpcredentials":"${INSTALLATION_STORAGE_TYPE}", "redis":"${INSTALLATION_STORAGE_TYPE}", "postgres":"${INSTALLATION_STORAGE_TYPE}"}
 parameters:
   - name: INSTALLATION_NAMESPACE
+    required: true
+  - name: INSTALLATION_STORAGE_TYPE
+    displayName: The storage type to be used by the Integreatly products (aws, openshift)
     required: true


### PR DESCRIPTION
## What
Now that we have the cloud service operator installed as part of RHMI, we should have our e2e test to be configurable to use either aws or in cluster storage.

- [x] Add a make target for `test/e2e/aws`. This should run the e2e test with AWS configured
- [x] Update the cro-configmap to use a parameter for the storage type to be used for the installation.
- [x] Update the e2e test to also test uninstallation

## Verification Steps
*NOTE*: Since the following test uses AWS, it needs to be ran on an OCP4 cluster with VPC peering connection configured. Follow this [guide](https://github.com/integr8ly/cloud-resource-operator#vpc-peering) on how to set this up
1. Run `make test/e2e/aws`
   - Ensure cro-configmap created points to `aws` as the storage type
   - Ensure test completes successfully
   - Ensure all resources created by the installation has been cleaned up.

2. Run `make test/e2e`
   - Ensure cro-configmap created points to `openshift` as the storage type
   - Ensure test completes successfully
   - Ensure all resources created by the installation has been cleaned up