### PR TITLE
Change method parameter userId to userID

### DIFF
--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -16,10 +16,10 @@ type ThreeScaleInterface interface {
 	GetUser(username, accessToken string) (*User, error)
 	GetUsers(accessToken string) (*Users, error)
 	AddUser(username string, email string, password string, accessToken string) (*http.Response, error)
-	DeleteUser(userId int, accessToken string) (*http.Response, error)
-	SetUserAsAdmin(userId int, accessToken string) (*http.Response, error)
-	SetUserAsMember(userId int, accessToken string) (*http.Response, error)
-	UpdateUser(userId int, username string, email string, accessToken string) (*http.Response, error)
+	DeleteUser(userID int, accessToken string) (*http.Response, error)
+	SetUserAsAdmin(userID int, accessToken string) (*http.Response, error)
+	SetUserAsMember(userID int, accessToken string) (*http.Response, error)
+	UpdateUser(userID int, username string, email string, accessToken string) (*http.Response, error)
 }
 
 const (
@@ -146,7 +146,7 @@ func (tsc *threeScaleClient) AddUser(username string, email string, password str
 	return res, nil
 }
 
-func (tsc *threeScaleClient) DeleteUser(userId int, accessToken string) (*http.Response, error) {
+func (tsc *threeScaleClient) DeleteUser(userID int, accessToken string) (*http.Response, error) {
 	data := make(map[string]string)
 	data["access_token"] = accessToken
 	reqData, err := json.Marshal(data)
@@ -164,7 +164,7 @@ func (tsc *threeScaleClient) DeleteUser(userId int, accessToken string) (*http.R
 	return res, nil
 }
 
-func (tsc *threeScaleClient) SetUserAsAdmin(userId int, accessToken string) (*http.Response, error) {
+func (tsc *threeScaleClient) SetUserAsAdmin(userID int, accessToken string) (*http.Response, error) {
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
 	})
@@ -184,7 +184,7 @@ func (tsc *threeScaleClient) SetUserAsAdmin(userId int, accessToken string) (*ht
 	return res, err
 }
 
-func (tsc *threeScaleClient) SetUserAsMember(userId int, accessToken string) (*http.Response, error) {
+func (tsc *threeScaleClient) SetUserAsMember(userID int, accessToken string) (*http.Response, error) {
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
 	})
@@ -204,7 +204,7 @@ func (tsc *threeScaleClient) SetUserAsMember(userId int, accessToken string) (*h
 	return res, err
 }
 
-func (tsc *threeScaleClient) UpdateUser(userId int, username string, email string, accessToken string) (*http.Response, error) {
+func (tsc *threeScaleClient) UpdateUser(userID int, username string, email string, accessToken string) (*http.Response, error) {
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
 		"username":     username,

--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -153,7 +153,7 @@ func (tsc *threeScaleClient) DeleteUser(userID int, accessToken string) (*http.R
 
 	req, err := http.NewRequest(
 		http.MethodDelete,
-		fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d.json", tsc.wildCardDomain, userId),
+		fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d.json", tsc.wildCardDomain, userID),
 		bytes.NewBuffer(reqData))
 	req.Header.Add("Content-type", "application/json")
 	res, err := tsc.httpc.Do(req)
@@ -168,7 +168,7 @@ func (tsc *threeScaleClient) SetUserAsAdmin(userID int, accessToken string) (*ht
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
 	})
-	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d/admin.json", tsc.wildCardDomain, userId)
+	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d/admin.json", tsc.wildCardDomain, userID)
 	req, err := http.NewRequest(
 		"PUT",
 		url,
@@ -188,7 +188,7 @@ func (tsc *threeScaleClient) SetUserAsMember(userID int, accessToken string) (*h
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
 	})
-	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d/member.json", tsc.wildCardDomain, userId)
+	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d/member.json", tsc.wildCardDomain, userID)
 	req, err := http.NewRequest(
 		"PUT",
 		url,
@@ -210,7 +210,7 @@ func (tsc *threeScaleClient) UpdateUser(userID int, username string, email strin
 		"username":     username,
 		"email":        email,
 	})
-	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d.json", tsc.wildCardDomain, userId)
+	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d.json", tsc.wildCardDomain, userID)
 	req, err := http.NewRequest(
 		"PUT",
 		url,


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-4907 
- Before changes 
``` sh
golint $(find . -type d  -not -path "./vendor/*") | grep "method parameter"
pkg/products/threescale/three_scale_client.go:19:13: interface method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:20:17: interface method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:21:18: interface method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:22:13: interface method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:149:41: method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:167:45: method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:187:46: method parameter userId should be userID
pkg/products/threescale/three_scale_client.go:207:41: method parameter userId should be userID
```

