### PR TITLE
Fix struct field lint errors , change acronyms/abbreviations to capitals

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -392,8 +392,6 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/improbable-eng/thanos v0.3.2/go.mod h1:GZewVGILKuJVPNRn7L4Zw+7X96qzFOwj63b22xYGXBE=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
-github.com/integr8ly/cloud-resource-operator v0.0.0-20191125111132-250f22a81882 h1:56qTTlrtmW2V83ZY29p8O4U7WgQJ0ray4tYMcZqPHa8=
-github.com/integr8ly/cloud-resource-operator v0.0.0-20191125111132-250f22a81882/go.mod h1:/kzF/oFvvEJI8vUTNIyB8f0D+uR7YfsJZFRNnjtqdRo=
 github.com/integr8ly/cloud-resource-operator v0.6.0 h1:9p32tcT1TWy1jfxnwa38PqEmAi/GfdxEqywXDMn2jL8=
 github.com/integr8ly/cloud-resource-operator v0.6.0/go.mod h1:TnsQco5CRs5PF97XnEb3LpBhA6tkBfgc6JgBZG447xM=
 github.com/integr8ly/grafana-operator v1.3.1 h1:3fknUP3pI9/H0/HTxOOR5hzJVo1wPs5HMfBUlMYpzWk=
@@ -881,8 +879,6 @@ golang.org/x/sys v0.0.0-20190624142023-c5567b49c5d0/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190801041406-cbf593c0f2f3/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190922100055-0a153f010e69/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20190924154521-2837fb4f24fe/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwglRwMkXSBzwVbkOjLLA=
-golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1 h1:gZpLHxUX5BdYLA08Lj4YCJNN/jk7KtquiArPoeX0WvA=
 golang.org/x/sys v0.0.0-20200113162924-86b910548bc1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/pkg/apis/enmasse/enmasse/v1beta1/types.go
+++ b/pkg/apis/enmasse/enmasse/v1beta1/types.go
@@ -78,9 +78,9 @@ type CertificateSpec struct {
 }
 
 type ExposeSpec struct {
-	Type                string `json:"route"`
-	RouteServicePort    string `json:"routeServicePort"`
-	RouteTlsTermination string `json:"routeTlsTermination"`
+	Type               string `json:"route"`
+	RouteServicePort   string `json:"routeServicePort"`
+	RouteTLSermination string `json:"routeTlsTermination"`
 }
 
 type AddressSpaceStatus struct {

--- a/pkg/apis/monitoring/v1alpha1/blackboxtarget_types.go
+++ b/pkg/apis/monitoring/v1alpha1/blackboxtarget_types.go
@@ -10,7 +10,7 @@ import (
 // BlackboxtargetStructure contains:
 // A target (url, module and service name) to be probed by the
 type BlackboxtargetData struct {
-	Url     string `json:"url"`
+	URL     string `json:"url"`
 	Service string `json:"service"`
 	Module  string `json:"module"`
 }

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -331,7 +331,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-amqonline", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost() + r.Config.GetBlackboxTargetPath(),
+		URL:     r.Config.GetHost() + r.Config.GetBlackboxTargetPath(),
 		Service: "amq-service-broker",
 	}, ctx, cfg, installation, client)
 	if err != nil {

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -427,7 +427,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, client k8scli
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-codeready", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost(),
+		URL:     r.Config.GetHost(),
 		Service: "codeready-ui",
 	}, ctx, cfg, r.installation, client)
 	if err != nil {

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -393,7 +393,7 @@ func CreateBlackboxTarget(name string, target monitoring_v1alpha1.Blackboxtarget
 		return nil
 	}
 
-	if target.Url == "" {
+	if target.URL == "" {
 		// Retry later if the URL is not yet known
 		return nil
 	}
@@ -409,7 +409,7 @@ func CreateBlackboxTarget(name string, target monitoring_v1alpha1.Blackboxtarget
 		"Namespace":     cfg.GetNamespace(),
 		"MonitoringKey": cfg.GetLabelSelector(),
 		"name":          name,
-		"url":           target.Url,
+		"url":           target.URL,
 		"service":       target.Service,
 		"module":        module,
 	}

--- a/pkg/products/monitoring/templateHelper.go
+++ b/pkg/products/monitoring/templateHelper.go
@@ -55,7 +55,7 @@ func NewTemplateHelper(extraParams map[string]string) *TemplateHelper {
 func joinQuote(values []monitoring_v1alpha1.BlackboxtargetData) string {
 	var result []string
 	for _, s := range values {
-		result = append(result, fmt.Sprintf("\"%v@%v@%v\"", s.Module, s.Service, s.Url))
+		result = append(result, fmt.Sprintf("\"%v@%v@%v\"", s.Module, s.Service, s.URL))
 	}
 	return strings.Join(result, ", ")
 }

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -62,7 +62,7 @@ type Reconciler struct {
 	logger        *logrus.Entry
 	oauthv1Client oauthClient.OauthV1Interface
 	KeycloakHost  string
-	ApiUrl        string
+	APIURL        string
 	*resources.Reconciler
 	recorder record.EventRecorder
 }
@@ -87,7 +87,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		oauthv1Client: oauthv1Client,
 		Reconciler:    resources.NewReconciler(mpm),
 		recorder:      recorder,
-		ApiUrl:        apiUrl,
+		APIURL:        apiUrl,
 	}, nil
 }
 
@@ -614,7 +614,7 @@ func (r *Reconciler) setupOpenshiftIDP(ctx context.Context, installation *integr
 			FirstBrokerLoginFlowAlias: "first broker login",
 			Config: map[string]string{
 				"hideOnLoginPage": "",
-				"baseUrl":         r.ApiUrl,
+				"baseUrl":         r.APIURL,
 				"clientId":        r.getOAuthClientName(),
 				"disableUserInfo": "",
 				"clientSecret":    clientSecret,
@@ -637,7 +637,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-rhsso", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost(),
+		URL:     r.Config.GetHost(),
 		Service: "rhsso-ui",
 	}, ctx, cfg, installation, client)
 	if err != nil {

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -103,7 +103,7 @@ func TestReconciler_config(t *testing.T) {
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "test error on failed config",
@@ -120,7 +120,7 @@ func TestReconciler_config(t *testing.T) {
 			},
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
 			Recorder: setupRecorder(),
-			ApiUrl:   "https://serverurl",
+			APIURL:   "https://serverurl",
 		},
 	}
 
@@ -132,7 +132,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -197,7 +197,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		ExpectedStatus  integreatlyv1alpha1.StatusPhase
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
@@ -212,7 +212,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Recorder:       setupRecorder(),
-			ApiUrl:         "https://serverurl",
+			APIURL:         "https://serverurl",
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -235,7 +235,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			ExpectedError:  "failed to create/update keycloak custom resource: failed to create keycloak custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			Recorder:       setupRecorder(),
-			ApiUrl:         "https://serverurl",
+			APIURL:         "https://serverurl",
 		},
 	}
 	for _, tc := range cases {
@@ -246,7 +246,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -320,7 +320,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Installation    *integreatlyv1alpha1.Installation
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "test ready kcr returns phase complete",
@@ -330,7 +330,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test unready kcr cr returns phase in progress",
@@ -340,7 +340,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test missing kc cr returns phase failed",
@@ -351,7 +351,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test missing kcr cr returns phase failed",
@@ -362,7 +362,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test failed config write",
@@ -387,7 +387,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			},
 			Installation: &integreatlyv1alpha1.Installation{},
 			Recorder:     setupRecorder(),
-			ApiUrl:       "https://serverurl",
+			APIURL:       "https://serverurl",
 		},
 	}
 
@@ -399,7 +399,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -520,7 +520,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "test successful reconcile",
@@ -557,7 +557,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
 			Recorder:     setupRecorder(),
-			ApiUrl:       "https://serverurl",
+			APIURL:       "https://serverurl",
 		},
 	}
 
@@ -569,7 +569,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -51,12 +51,12 @@ type Reconciler struct {
 	installation  *integreatlyv1alpha1.Installation
 	logger        *logrus.Entry
 	oauthv1Client oauthClient.OauthV1Interface
-	ApiUrl        string
+	APIURL        string
 	*resources.Reconciler
 	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, apiUrl string) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.Installation, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, APIURL string) (*Reconciler, error) {
 	rhssoUserConfig, err := configManager.ReadRHSSOUser()
 	if err != nil {
 		return nil, err
@@ -76,7 +76,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		oauthv1Client: oauthv1Client,
 		Reconciler:    resources.NewReconciler(mpm),
 		recorder:      recorder,
-		ApiUrl:        apiUrl,
+		APIURL:        APIURL,
 	}, nil
 }
 
@@ -414,7 +414,7 @@ func (r *Reconciler) setupOpenshiftIDP(ctx context.Context, installation *integr
 			FirstBrokerLoginFlowAlias: "first broker login",
 			Config: map[string]string{
 				"hideOnLoginPage": "",
-				"baseUrl":         r.ApiUrl,
+				"baseUrl":         r.APIURL,
 				"clientId":        r.getOAuthClientName(),
 				"disableUserInfo": "",
 				"clientSecret":    clientSecret,

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -94,7 +94,7 @@ func TestReconciler_config(t *testing.T) {
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
 		Recorder        record.EventRecorder
-		APIURL string
+		APIURL          string
 	}{
 		{
 			Name:            "test error on failed config",

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -94,7 +94,7 @@ func TestReconciler_config(t *testing.T) {
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL string
 	}{
 		{
 			Name:            "test error on failed config",
@@ -111,7 +111,7 @@ func TestReconciler_config(t *testing.T) {
 			},
 			Recorder: setupRecorder(),
 			Product:  &integreatlyv1alpha1.InstallationProductStatus{},
-			ApiUrl:   "https://serverurl",
+			APIURL:   "https://serverurl",
 		},
 	}
 
@@ -123,7 +123,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -192,7 +192,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		ExpectedStatus  integreatlyv1alpha1.StatusPhase
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
@@ -207,7 +207,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			},
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Recorder:       setupRecorder(),
-			ApiUrl:         "https://serverurl",
+			APIURL:         "https://serverurl",
 		},
 		{
 			Name: "Test reconcile custom resource returns failed on unsuccessful create",
@@ -230,7 +230,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			ExpectedError:  "failed to create/update keycloak custom resource: failed to create keycloak custom resource",
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			Recorder:       setupRecorder(),
-			ApiUrl:         "https://serverurl",
+			APIURL:         "https://serverurl",
 		},
 	}
 	for _, tc := range cases {
@@ -241,7 +241,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -315,7 +315,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 		FakeMPM         *marketplace.MarketplaceInterfaceMock
 		Installation    *integreatlyv1alpha1.Installation
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "test ready kcr returns phase complete",
@@ -325,7 +325,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test unready kcr cr returns phase in progress",
@@ -335,7 +335,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test missing kc cr returns phase failed",
@@ -346,7 +346,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test missing kcr cr returns phase failed",
@@ -357,7 +357,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			FakeConfig:      basicConfigMock(),
 			Installation:    &integreatlyv1alpha1.Installation{},
 			Recorder:        setupRecorder(),
-			ApiUrl:          "https://serverurl",
+			APIURL:          "https://serverurl",
 		},
 		{
 			Name:            "test failed config write",
@@ -379,7 +379,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 			},
 			Installation: &integreatlyv1alpha1.Installation{},
 			Recorder:     setupRecorder(),
-			ApiUrl:       "https://serverurl",
+			APIURL:       "https://serverurl",
 		},
 	}
 
@@ -391,7 +391,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -501,7 +501,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		Installation    *integreatlyv1alpha1.Installation
 		Product         *integreatlyv1alpha1.InstallationProductStatus
 		Recorder        record.EventRecorder
-		ApiUrl          string
+		APIURL          string
 	}{
 		{
 			Name:            "test successful reconcile",
@@ -538,7 +538,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			Installation: installation,
 			Product:      &integreatlyv1alpha1.InstallationProductStatus{},
 			Recorder:     setupRecorder(),
-			ApiUrl:       "https://serverurl",
+			APIURL:       "https://serverurl",
 		},
 	}
 
@@ -550,7 +550,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeOauthClient,
 				tc.FakeMPM,
 				tc.Recorder,
-				tc.ApiUrl,
+				tc.APIURL,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -242,7 +242,7 @@ func (r *Reconciler) reconcileBlackboxTarget(ctx context.Context, installation *
 	}
 
 	target := monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost(),
+		URL:     r.Config.GetHost(),
 		Service: "webapp-ui",
 	}
 

--- a/pkg/products/threescale/asserts_test.go
+++ b/pkg/products/threescale/asserts_test.go
@@ -81,7 +81,7 @@ func assertInstallationSuccessfull(scenario ThreeScaleTestScenario, configManage
 	if tsIsNotFoundError(err) {
 		return errors.New(fmt.Sprintf("SSO integration was not created"))
 	}
-	if authProvider.ProviderDetails.ClientId != clientId || authProvider.ProviderDetails.Site != rhssoConfig.GetHost()+"/auth/realms/"+rhssoConfig.GetRealm() {
+	if authProvider.ProviderDetails.ClientID != clientId || authProvider.ProviderDetails.Site != rhssoConfig.GetHost()+"/auth/realms/"+rhssoConfig.GetRealm() {
 		return errors.New(fmt.Sprintf("SSO integration request to 3scale API was incorrect"))
 	}
 

--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -117,7 +117,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 				ProviderDetails: AuthProviderDetails{
 					Kind:                           data["kind"],
 					Name:                           data["name"],
-					ClientId:                       data["client_id"],
+					ClientID:                       data["client_id"],
 					ClientSecret:                   data["client_secret"],
 					Site:                           data["site"],
 					SkipSSLCertificateVerification: data["skip_ssl_certificate_verification"] == "true",
@@ -156,7 +156,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 			testUsers.Users = append(testUsers.Users, &User{
 				UserDetails: UserDetails{
 					Role:     memberRole,
-					Id:       rand.Int(),
+					ID:       rand.Int(),
 					Username: username,
 					Email:    email,
 				},
@@ -167,7 +167,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 		},
 		SetUserAsAdminFunc: func(userId int, accessToken string) (response *http.Response, e error) {
 			for _, user := range testUsers.Users {
-				if user.UserDetails.Id == userId {
+				if user.UserDetails.ID == userId {
 					user.UserDetails.Role = adminRole
 				}
 			}
@@ -177,7 +177,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 		},
 		SetUserAsMemberFunc: func(userId int, accessToken string) (response *http.Response, e error) {
 			for _, user := range testUsers.Users {
-				if user.UserDetails.Id == userId {
+				if user.UserDetails.ID == userId {
 					user.UserDetails.Role = memberRole
 				}
 			}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -726,7 +726,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient k
 	}
 	for _, tsUser := range deleted {
 		if tsUser.UserDetails.Username != *systemAdminUsername {
-			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
+			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.ID, *accessToken)
 			if err != nil || res.StatusCode != http.StatusOK {
 				return integreatlyv1alpha1.PhaseInProgress, err
 			}
@@ -750,12 +750,12 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, serverClient k
 		}
 
 		if userIsOpenshiftAdmin(tsUser, openshiftAdminGroup) && tsUser.UserDetails.Role != adminRole {
-			res, err := r.tsClient.SetUserAsAdmin(tsUser.UserDetails.Id, *accessToken)
+			res, err := r.tsClient.SetUserAsAdmin(tsUser.UserDetails.ID, *accessToken)
 			if err != nil || res.StatusCode != http.StatusOK {
 				return integreatlyv1alpha1.PhaseInProgress, err
 			}
 		} else if !userIsOpenshiftAdmin(tsUser, openshiftAdminGroup) && tsUser.UserDetails.Role != memberRole {
-			res, err := r.tsClient.SetUserAsMember(tsUser.UserDetails.Id, *accessToken)
+			res, err := r.tsClient.SetUserAsMember(tsUser.UserDetails.ID, *accessToken)
 			if err != nil || res.StatusCode != http.StatusOK {
 				return integreatlyv1alpha1.PhaseInProgress, err
 			}
@@ -822,7 +822,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-3scale-admin-ui", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost() + "/" + r.Config.GetBlackboxTargetPathForAdminUI(),
+		URL:     r.Config.GetHost() + "/" + r.Config.GetBlackboxTargetPathForAdminUI(),
 		Service: "3scale-admin-ui",
 	}, ctx, cfg, installation, client)
 	if err != nil {
@@ -835,7 +835,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 		return integreatlyv1alpha1.PhaseInProgress, fmt.Errorf("error getting threescale system-developer route: %w", err)
 	}
 	err = monitoring.CreateBlackboxTarget("integreatly-3scale-system-developer", monitoringv1alpha1.BlackboxtargetData{
-		Url:     "https://" + route.Spec.Host,
+		URL:     "https://" + route.Spec.Host,
 		Service: "3scale-developer-console-ui",
 	}, ctx, cfg, installation, client)
 	if err != nil {
@@ -848,7 +848,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 		return integreatlyv1alpha1.PhaseInProgress, fmt.Errorf("error getting threescale system-master route: %w", err)
 	}
 	err = monitoring.CreateBlackboxTarget("integreatly-3scale-system-master", monitoringv1alpha1.BlackboxtargetData{
-		Url:     "https://" + route.Spec.Host,
+		URL:     "https://" + route.Spec.Host,
 		Service: "3scale-system-admin-ui",
 	}, ctx, cfg, installation, client)
 	if err != nil {

--- a/pkg/products/threescale/types.go
+++ b/pkg/products/threescale/types.go
@@ -11,7 +11,7 @@ type User struct {
 }
 
 type UserDetails struct {
-	Id       int    `json:"id"`
+	ID       int    `json:"id"`
 	State    string `json:"state"`
 	Role     string `json:"role"`
 	Username string `json:"username"`
@@ -27,25 +27,25 @@ type AuthProvider struct {
 }
 
 type AuthProviderDetails struct {
-	Id                             int    `json:"id"`
+	ID                             int    `json:"id"`
 	Kind                           string `json:"kind"`
 	AccountType                    string `json:"account_type"`
 	Name                           string `json:"name"`
 	SystemName                     string `json:"system_name"`
-	ClientId                       string `json:"client_id"`
+	ClientID                       string `json:"client_id"`
 	ClientSecret                   string `json:"client_secret"`
 	Site                           string `json:"site"`
 	AuthorizeURL                   string `json:"authorize_url"`
 	SkipSSLCertificateVerification bool   `json:"skip_ssl_certificate_verification"`
 	AutomaticallyApproveAccounts   bool   `json:"automatically_approve_accounts"`
-	AccountId                      int    `json:"account_id"`
+	AccountID                      int    `json:"account_id"`
 	UsernameKey                    string `json:"username_key"`
 	IdentifierKey                  string `json:"identifier_key"`
 	TrustEmail                     bool   `json:"trust_email"`
 	Published                      bool   `json:"published"`
 	CreatedAt                      string `json:"created_at"`
 	UpdatedAt                      string `json:"updated_at"`
-	CallbackUrl                    string `json:"callback_url"`
+	CallbackURL                    string `json:"callback_url"`
 }
 
 type tsError struct {

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -247,7 +247,7 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	err = monitoring.CreateBlackboxTarget("integreatly-ups", monitoringv1alpha1.BlackboxtargetData{
-		Url:     r.Config.GetHost() + "/" + r.Config.GetBlackboxTargetPath(),
+		URL:     r.Config.GetHost() + "/" + r.Config.GetBlackboxTargetPath(),
 		Service: "ups-ui",
 	}, ctx, cfg, installation, client)
 	if err != nil {


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-4979
Issues found before fixes
``` sh
golint `find . -type d -not -path "./vendor/*"` | grep "struct field"
pkg/apis/enmasse/enmasse/v1beta1/types.go:83:2: struct field RouteTlsTermination should be RouteTLSTermination
pkg/apis/monitoring/v1alpha1/blackboxtarget_types.go:13:2: struct field Url should be URL
pkg/products/rhssouser/reconciler.go:54:2: struct field ApiUrl should be APIURL
pkg/products/rhssouser/reconciler_test.go:97:3: struct field ApiUrl should be APIURL
pkg/products/rhssouser/reconciler_test.go:195:3: struct field ApiUrl should be APIURL
pkg/products/rhssouser/reconciler_test.go:318:3: struct field ApiUrl should be APIURL
pkg/products/rhssouser/reconciler_test.go:504:3: struct field ApiUrl should be APIURL
pkg/products/threescale/types.go:14:2: struct field Id should be ID
pkg/products/threescale/types.go:30:2: struct field Id should be ID
pkg/products/threescale/types.go:35:2: struct field ClientId should be ClientID
pkg/products/threescale/types.go:41:2: struct field AccountId should be AccountID
pkg/products/threescale/types.go:48:2: struct field CallbackUrl should be CallbackURL
pkg/products/rhsso/reconciler.go:65:2: struct field ApiUrl should be APIURL
pkg/products/rhsso/reconciler_test.go:106:3: struct field ApiUrl should be APIURL
pkg/products/rhsso/reconciler_test.go:200:3: struct field ApiUrl should be APIURL
pkg/products/rhsso/reconciler_test.go:323:3: struct field ApiUrl should be APIURL
pkg/products/rhsso/reconciler_test.go:523:3: struct field ApiUrl should be APIURL

```
`go vet ./...` and `make/compile` pass locally, `golint` also returns no errors of the same type