### PR TITLE
Fix replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)

### DIFF
--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -2,7 +2,6 @@ package threescale
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math/rand"
 	"net/http"
@@ -150,7 +149,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 				}
 			}
 
-			return nil, errors.New(fmt.Sprintf("user %s not found", userName))
+			return nil, fmt.Errorf("user %s not found", userName)
 		},
 		AddUserFunc: func(username string, email string, password string, accessToken string) (response *http.Response, e error) {
 			testUsers.Users = append(testUsers.Users, &User{


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-4982
Fixes
```sh
[hstefans@localhost integreatly-operator]$ golint `find . -type d -not -path "./vendor/*"` | grep  "should replace errors"
pkg/products/threescale/asserts_test.go:48:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:55:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:62:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:69:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:72:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:82:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:85:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:92:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:95:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:101:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:107:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:111:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:117:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:120:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:124:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/asserts_test.go:127:10: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)
pkg/products/threescale/clients_test.go:153:16: should replace errors.New(fmt.Sprintf(...)) with fmt.Errorf(...)

```