### PR TITLE
Update SSO replicas to 3

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -420,7 +420,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
 		}
 		kc.Labels = GetInstanceLabels()
-		kc.Spec.Instances = 1
+		kc.Spec.Instances = 3
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{
 			Enabled: true,
 		}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -179,7 +179,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
 		}
 		kc.Labels = getInstanceLabels()
-		kc.Spec.Instances = 1
+		kc.Spec.Instances = 3
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{Enabled: true}
 		kc.Spec.Profile = rhsso.RHSSOProfile
 		return nil

--- a/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_rhsso_alerts.yaml
@@ -7,15 +7,6 @@ spec:
   groups:
     - name: rhsso.rules
       rules:
-        - alert: RHSSOPodCount
-          annotations:
-            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected exactly 4 pods.
-          expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) != 4
-          for: 5m
-          labels:
-            severity: critical
         - alert: RHSSOPodHighMemory
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md


### PR DESCRIPTION
## What
Deploying RHSSO in a HA fashion by deploying with 3 replicas for both the cluster SSO and Application SSO

Removed the alert for number of pods running in the namespace as this is actually taken care of by an alert included in Keycloak now anyway - https://github.com/keycloak/keycloak-operator/blob/master/pkg/model/prometheus_rule.go#L86-L94