### PR TITLE
feat: ocm fixes/updates, rhmi installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ If you want to test your changes on a cluster, the easiest solution would be to 
 3. Create cluster template: `make ocm/cluster.json`.
 
 This command will generate `ocm/cluster.json` file with generated cluster name. This file will be used as a template to create your cluster via OCM CLI.
+By default, it will set the expiration timestamp for a cluster for 4 hours, meaning your cluster will be automatically deleted after 4 hours after you generated this template. If you want to change the default timestamp, you can update it in `ocm/cluster.json` or delete the whole line from the file if you don't want your cluster to be deleted automatically at all.
 
 4. Create the cluster: `make ocm/cluster/create`.
 

--- a/README.md
+++ b/README.md
@@ -139,10 +139,31 @@ To setup your cluster to have dedicated admins run the `./scripts/setup-htpass-i
 
 ## Tests
 
+### Unit tests
+
 Running unit tests:
 ```sh
 make test/unit
 ```
+
+### E2E testing
+
+If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using [OCM CLI](https://github.com/openshift-online/ocm-cli/releases):
+
+1. Download the CLI tool and add it to your PATH
+2. Export [OCM_TOKEN](https://github.com/openshift-online/ocm-cli#log-in): `export OCM_TOKEN="<TOKEN_VALUE>"`
+3. Create cluster template: `make ocm/cluster.json`.
+
+This command will generate `ocm/cluster.json` file with generated cluster name. This file will be used as a template to create your cluster via OCM CLI.
+
+4. Create the cluster: `make ocm/cluster/create`.
+
+This command will send a request to [Red Hat OpenShift Cluster Manager](https://cloud.redhat.com/) to spin up your cluster and waits until it's ready. You can see the details of your cluster in `ocm/cluster-details.json` file
+
+5. Once your cluster is ready, you can login via `oc` and install integreatly-operator by following instructions above.
+
+**Note**: it is possible to install the latest released version of integreatly-operator as an addon.
+Run `make ocm/install/rhmi-addon` to trigger the installation
 
 ## Release
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Running unit tests:
 make test/unit
 ```
 
-### E2E testing
+## Using `ocm` for installation of RHMI
 
 If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using [OCM CLI](https://github.com/openshift-online/ocm-cli/releases):
 
@@ -160,10 +160,16 @@ This command will generate `ocm/cluster.json` file with generated cluster name. 
 
 This command will send a request to [Red Hat OpenShift Cluster Manager](https://cloud.redhat.com/) to spin up your cluster and waits until it's ready. You can see the details of your cluster in `ocm/cluster-details.json` file
 
-5. Once your cluster is ready, you can login via `oc` and install integreatly-operator by following instructions above.
+5. Once your cluster is ready, OpenShift Console URL will be printed out together with the `kubeadmin` user & password. These are also saved to `ocm/cluster-credentials.json` file. Also there will be `ocm/cluster.kubeconfig` file created that you can use for running `oc` commands right away, for example, for listing all projects on your OpenShift cluster:
 
-**Note**: it is possible to install the latest released version of integreatly-operator as an addon.
-Run `make ocm/install/rhmi-addon` to trigger the installation
+```
+oc --config ocm/cluster.kubeconfig projects
+```
+
+6. If you want to install the latest released RHMI, you can trigger it by applying an RHMI addon.
+Run `make ocm/install/rhmi-addon` to trigger the installation. Once the installation is completed, the installation CR with RHMI components info will be printed to the console.
+
+7. If you want to delete your cluster, run `make ocm/cluster/delete`
 
 ## Release
 

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -70,6 +70,7 @@ ocm/install/rhmi-addon:
 	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
+	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o yaml | jq -r '.status.stages'
 
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -1,14 +1,35 @@
 #OCM_IMAGE=registry.svc.ci.openshift.org/openshift/release:intly-golang-1.12
 #OCM=docker run --rm -it -u 1000 -v "/home/mnairn/go/src/github.com/integr8ly/integreatly-operator:/integreatly-operator/" -w "/integreatly-operator" -v "${HOME}/tmp-home:/myhome:z" -e "HOME=/myhome" --entrypoint=/usr/local/bin/ocm ${OCM_IMAGE}
+UNAME=$(shell uname)
 OCM=ocm
-OCM_CLUSTER_NAME=rhmi-$(date +"%y%m%d_%H%M")
+OCM_CLUSTER_NAME=rhmi-$(shell date +"%y%m%d-%H%M")
+# Lifespan in hours from the time the cluster.json was created
+OCM_CLUSTER_LIFESPAN=4
+
+define get_cluster_id
+	@$(eval OCM_CLUSTER_ID=$(shell mkdir -p ocm && touch ocm/cluster-details.json && jq -r .id < ocm/cluster-details.json ))
+endef
+
+define get_kubeadmin_password
+	@$(eval KUBEADMIN_PASSWORD=$(shell $(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin.password ))
+endef
+
+define save_cluster_credentials
+	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .kubeconfig > ocm/cluster.kubeconfig
+	$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin | tee ocm/cluster-credentials.json
+endef
+
+ifeq ($(UNAME), Linux)
+	OCM_CLUSTER_EXPIRATION_TIMESTAMP=$(shell date --date="${OCM_CLUSTER_LIFESPAN} hour" "+%FT%TZ")
+else ifeq ($(UNAME), Darwin)
+	OCM_CLUSTER_EXPIRATION_TIMESTAMP=$(shell date -v+${OCM_CLUSTER_LIFESPAN}H "+%FT%TZ")
+endif
 
 .PHONY: ocm/version
 ocm/version:
 	@${OCM} version
 
 ocm/login: export OCM_URL := https://api.stage.openshift.com/
-ocm/login: export OCM_TOKEN := ""
 .PHONY: ocm/login
 ocm/login:
 	@${OCM} login --url=$(OCM_URL) --token=$(OCM_TOKEN)
@@ -30,19 +51,34 @@ ocm/cluster/list:
 	@${OCM} cluster list
 
 .PHONY: ocm/cluster/create
-ocm/cluster/create:
-	@$(eval OCM_CLUSTER_ID=$(shell ${OCM} post /api/clusters_mgmt/v1/clusters --body=ocm/cluster.json | jq -r .id ))
-	@echo "Cluster creation started. Cluster id: ${OCM_CLUSTER_ID}"
+ocm/cluster/create: ocm/cluster/send_create_request
+	@$(call get_cluster_id)
 	$(call wait_command, $(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/status | jq -r .state | grep -q ready, cluster creation, 120m, 300)
+	$(call wait_command, $(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin | grep -q admin, fetching cluster credentials, 10m, 30)
+	echo "Console URL:"
+	$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID} | jq -r .console.url
+	echo "Login credentials:"
+	@$(call save_cluster_credentials)
+
+.PHONY: ocm/cluster/send_create_request
+ocm/cluster/send_create_request:
+	@${OCM} post /api/clusters_mgmt/v1/clusters --body=ocm/cluster.json | jq -r > ocm/cluster-details.json
+
+.PHONY: ocm/install/rhmi-addon
+ocm/install/rhmi-addon:
+	@$(call get_cluster_id)
+	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
+	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly-operator -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 30)
 
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:
+	@$(call get_cluster_id)
 	${OCM} delete /api/clusters_mgmt/v1/clusters/$(OCM_CLUSTER_ID)
 
 .PHONY: ocm/cluster.json
-ocm/cluster.json: export OCM_CLUSTER_NAME := ""
 ocm/cluster.json: export OCM_CLUSTER_REGION := "eu-west-1"
 ocm/cluster.json:
 	@mkdir -p ocm
 	sed "s/OCM_CLUSTER_NAME/$(OCM_CLUSTER_NAME)/g" templates/ocm-cluster/cluster-template.json | \
-	sed "s/OCM_CLUSTER_REGION/$(OCM_CLUSTER_REGION)/g" > ocm/cluster.json
+	sed "s/OCM_CLUSTER_REGION/$(OCM_CLUSTER_REGION)/g" | \
+	sed "s/OCM_CLUSTER_EXPIRATION_TIMESTAMP/$(OCM_CLUSTER_EXPIRATION_TIMESTAMP)/g" > ocm/cluster.json

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -67,7 +67,7 @@ ocm/cluster/send_create_request:
 .PHONY: ocm/install/rhmi-addon
 ocm/install/rhmi-addon:
 	@$(call get_cluster_id)
-	#@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
+	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
 	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r '.status.stages'

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -67,10 +67,10 @@ ocm/cluster/send_create_request:
 .PHONY: ocm/install/rhmi-addon
 ocm/install/rhmi-addon:
 	@$(call get_cluster_id)
-	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
+	#@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
-	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o yaml | jq -r '.status.stages'
+	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r '.status.stages'
 
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:

--- a/templates/ocm-cluster/cluster-template.json
+++ b/templates/ocm-cluster/cluster-template.json
@@ -3,6 +3,7 @@
   "region": {
     "id": "OCM_CLUSTER_REGION"
   },
+  "expiration_timestamp": "OCM_CLUSTER_EXPIRATION_TIMESTAMP",
   "nodes" : {
     "compute" : 4,
     "compute_machine_type" : {"id" : "m5.xlarge" }


### PR DESCRIPTION
See [readme](https://github.com/integr8ly/integreatly-operator/pull/327/files#diff-04c6e90faac2675aa89e2176d2eec7d8) for more details

JIRA ticket: https://issues.redhat.com/browse/INTLY-5046

Changes were tested locally (cluster template generation -> cluster creation -> RHMI addon installation -> cluster deletion)

The only step that had to be done separately was creation of smtp secret (`make cluster/prepare/smtp`), which operator requires to be present in the namespace, but afaik that should be automated as a part of RHMI addon installation too.
Hi @philbrookes, is my assumption correct? ^