### PR TITLE
INTLY-4908 exposed version number metric to prometheus for integreatl…

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,7 +50,7 @@ var (
 var (
 	operatorVersion = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "integreatly_version_info",
+			Name:        "version",
 			Help:        "Integreatly operator information",
 			ConstLabels: prometheus.Labels{
 				"operator_version": version.Version,

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -50,11 +50,11 @@ var (
 var (
 	operatorVersion = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name:        "version",
-			Help:        "Integreatly operator information",
+			Name: "integreatly_version_info",
+			Help: "Integreatly operator information",
 			ConstLabels: prometheus.Labels{
 				"operator_version": version.Version,
-				"integreatly_version" : version.IntegreatlyVersion,
+				"version":          version.IntegreatlyVersion,
 			},
 		},
 	)

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -52,7 +52,10 @@ var (
 		prometheus.GaugeOpts{
 			Name:        "integreatly_version_info",
 			Help:        "Integreatly operator information",
-			ConstLabels: prometheus.Labels{"operator_version": version.Version},
+			ConstLabels: prometheus.Labels{
+				"operator_version": version.Version,
+				"integreatly_version" : version.IntegreatlyVersion,
+			},
 		},
 	)
 )

--- a/version/version.go
+++ b/version/version.go
@@ -2,4 +2,5 @@ package version
 
 var (
 	Version = "1.15.0"
+	IntegreatlyVersion = "2.0.0"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,6 @@
 package version
 
 var (
-	Version = "1.15.0"
+	Version            = "1.15.0"
 	IntegreatlyVersion = "2.0.0"
 )


### PR DESCRIPTION
…y operator and integreatly product

### What
Create 2 metrics for prometheus: 
1 for the operator version
1 for the product (integreatly) version

### Verify
Run the operator
`curl 127.0.0.1:8383/metrics | grep oper`
Should produce 
`integreatly_version_info{integreatly_version="2.0.0",operator_version="1.15.0"} 0`

