### PR TITLE
build api url based on apps url

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -599,7 +599,7 @@ func (r *Reconciler) setupOpenshiftIDP(ctx context.Context, installation *integr
 			FirstBrokerLoginFlowAlias: "first broker login",
 			Config: map[string]string{
 				"hideOnLoginPage": "",
-				"baseUrl":         r.APIURL,
+				"baseUrl":         "https://" + strings.Replace(r.installation.Spec.RoutingSubdomain, "apps", "api", 1) + ":6443",
 				"clientId":        r.getOAuthClientName(),
 				"disableUserInfo": "",
 				"clientSecret":    clientSecret,

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	"github.com/pkg/errors"
@@ -431,7 +432,7 @@ func (r *Reconciler) setupOpenshiftIDP(ctx context.Context, installation *integr
 			FirstBrokerLoginFlowAlias: "first broker login",
 			Config: map[string]string{
 				"hideOnLoginPage": "",
-				"baseUrl":         r.ApiUrl,
+				"baseUrl":         "https://" + strings.Replace(r.installation.Spec.RoutingSubdomain, "apps", "api", 1) + ":6443",
 				"clientId":        r.getOAuthClientName(),
 				"disableUserInfo": "",
 				"clientSecret":    clientSecret,


### PR DESCRIPTION
The URL for the API is being malformed, create it manually, based on the routing URL instead.

Made a technical debt issue to handle this more elegantly in the future:
https://issues.redhat.com/browse/INTLY-5134