### PR TITLE
✨ Enable 'ops' addon on Syndesis for monitoring

### DIFF
--- a/manifests/integreatly-rhsso/rhsso-8.0.1/keycloakoperator.8.0.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/rhsso-8.0.1/keycloakoperator.8.0.1.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: security
     certified: 'False'
-    containerImage: 'quay.io/keycloak/keycloak-operator:master'
+    containerImage: 'quay.io/wei_lee/keycloak-operator:intly'
     createdAt: 2019-11-08 00:00:00
     description: 'An Operator for installing and managing Keycloak'
     repository: 'https://github.com/keycloak/keycloak-operator'
@@ -185,7 +185,7 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: keycloak-operator
-                    image: quay.io/pb82/keycloak-operator:no-default-credentials
+                    image: quay.io/wei_lee/keycloak-operator:intly
                     imagePullPolicy: Always
                     name: keycloak-operator
                     resources: {}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-4671

Resources are created:
```bash
$ oc get servicemonitors,prometheusrules,grafanadashboards -n redhat-rhmi-fuse
NAME                                                         AGE
servicemonitor.monitoring.coreos.com/syndesis-infra          36m
servicemonitor.monitoring.coreos.com/syndesis-integrations   36m

NAME                                                                        AGE
prometheusrule.monitoring.coreos.com/ksm-fuse-online-alerts                 32m
prometheusrule.monitoring.coreos.com/syndesis-infra-db-alerting-rules       36m
prometheusrule.monitoring.coreos.com/syndesis-infra-meta-alerting-rules     36m
prometheusrule.monitoring.coreos.com/syndesis-infra-server-alerting-rules   36m
prometheusrule.monitoring.coreos.com/syndesis-integrations-alerting-rules   36m

NAME                                                                     AGE
grafanadashboard.integreatly.org/syndesis-infra-api-dashboard            36m
grafanadashboard.integreatly.org/syndesis-infra-db-dashboard             36m
grafanadashboard.integreatly.org/syndesis-infra-home-dashboard           36m
grafanadashboard.integreatly.org/syndesis-infra-jvm-dashboard            36m
grafanadashboard.integreatly.org/syndesis-integrations-camel-dashboard   36m
grafanadashboard.integreatly.org/syndesis-integrations-home-dashboard    36m
grafanadashboard.integreatly.org/syndesis-integrations-jvm-dashboard     36m
```

Bunch of Syndesis dashboards:
![image](https://user-images.githubusercontent.com/442386/73777930-393f6d00-4782-11ea-8e3e-6a3be5bf8141.png)

They get data successfully:
![image](https://user-images.githubusercontent.com/442386/73777877-2167e900-4782-11ea-8ac4-15178b00011c.png)

Bunch of prometheus rules, all green:
![image](https://user-images.githubusercontent.com/442386/73778161-a0f5b800-4782-11ea-90dc-6ab8048987fd.png)
