### PR TITLE
fix: generate smtp secret after addon installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ OPERATOR_SDK_VERSION=0.12.0
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "${QUAY_PASSWORD}"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
-KUBECONFIG="${HOME}/.kube/config"
 
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
@@ -163,7 +162,7 @@ cluster/prepare/olm: cluster/prepare/project cluster/prepare/osrc
 
 .PHONY: cluster/prepare/smtp
 cluster/prepare/smtp:
-	@-oc --config $(KUBECONFIG) create secret generic rhmi-smtp -n $(NAMESPACE) \
+	@-oc create secret generic rhmi-smtp -n $(NAMESPACE) \
 		--from-literal=host=smtp.example.com \
 		--from-literal=username=dummy \
 		--from-literal=password=dummy \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ OPERATOR_SDK_VERSION=0.12.0
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "${QUAY_PASSWORD}"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
+KUBECONFIG="${HOME}/.kube/config"
 
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
@@ -162,7 +163,7 @@ cluster/prepare/olm: cluster/prepare/project cluster/prepare/osrc
 
 .PHONY: cluster/prepare/smtp
 cluster/prepare/smtp:
-	@-oc create secret generic rhmi-smtp -n $(NAMESPACE) \
+	@-oc --config $(KUBECONFIG) create secret generic rhmi-smtp -n $(NAMESPACE) \
 		--from-literal=host=smtp.example.com \
 		--from-literal=username=dummy \
 		--from-literal=password=dummy \

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -69,6 +69,7 @@ ocm/install/rhmi-addon:
 	@$(call get_cluster_id)
 	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
+	@make KUBECONFIG="ocm/cluster.kubeconfig" cluster/prepare/smtp
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
 	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r '.status.stages'
 

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -5,6 +5,10 @@ OCM=ocm
 OCM_CLUSTER_NAME=rhmi-$(shell date +"%y%m%d-%H%M")
 # Lifespan in hours from the time the cluster.json was created
 OCM_CLUSTER_LIFESPAN=4
+# Namespace the RHMI operator is expected to be running in after addon installation
+RHMI_OPERATOR_NS=redhat-rhmi-operator
+# Path to the new cluster's kubeconfig
+CLUSTER_KUBECONFIG="ocm/cluster.kubeconfig"
 
 define get_cluster_id
 	@$(eval OCM_CLUSTER_ID=$(shell mkdir -p ocm && touch ocm/cluster-details.json && jq -r .id < ocm/cluster-details.json ))
@@ -15,7 +19,7 @@ define get_kubeadmin_password
 endef
 
 define save_cluster_credentials
-	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .kubeconfig > ocm/cluster.kubeconfig
+	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .kubeconfig > $(CLUSTER_KUBECONFIG)
 	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin | tee ocm/cluster-credentials.json
 endef
 
@@ -68,10 +72,15 @@ ocm/cluster/send_create_request:
 ocm/install/rhmi-addon:
 	@$(call get_cluster_id)
 	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
-	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
-	@$(MAKE) KUBECONFIG="ocm/cluster.kubeconfig" cluster/prepare/smtp
-	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
-	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r '.status.stages'
+	$(call wait_command, oc --config=$(CLUSTER_KUBECONFIG) get installation -n $(RHMI_OPERATOR_NS) | grep -q integreatly, installation CR created, 10m, 30)
+	@-oc --config=$(CLUSTER_KUBECONFIG) create secret generic rhmi-smtp -n $(RHMI_OPERATOR_NS) \
+		--from-literal=host=smtp.example.com \
+		--from-literal=username=dummy \
+		--from-literal=password=dummy \
+		--from-literal=port=587 \
+		--from-literal=tls=true
+	$(call wait_command, oc --config=$(CLUSTER_KUBECONFIG) get installation integreatly -n $(RHMI_OPERATOR_NS) -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
+	@oc --config=$(CLUSTER_KUBECONFIG) get installation integreatly -n $(RHMI_OPERATOR_NS) -o json | jq -r '.status.stages'
 
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -69,7 +69,7 @@ ocm/install/rhmi-addon:
 	@$(call get_cluster_id)
 	@echo '{"addon":{"id":"rhmi"}}' | ${OCM} post /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/addons
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation -n redhat-rhmi-operator | grep -q integreatly, installation CR created, 10m, 30)
-	@make KUBECONFIG="ocm/cluster.kubeconfig" cluster/prepare/smtp
+	@$(MAKE) KUBECONFIG="ocm/cluster.kubeconfig" cluster/prepare/smtp
 	$(call wait_command, oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r .status.stages.\\\"solution-explorer\\\".phase | grep -q completed, rhmi installation, 60m, 300)
 	@oc --config=ocm/cluster.kubeconfig get installation integreatly -n redhat-rhmi-operator -o json | jq -r '.status.stages'
 


### PR DESCRIPTION
This change is based on discussion with @philbrookes yesterday.
We would need to generate a dummy smtp secret after integreatly-operator's namespace is created, so the operator is able to start with installation.