### PR TITLE
fix: fixes olm pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/c
 	operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: install/olm
-install/olm: cluster/cleanup/olm cluster/prepare/olm cluster/prepare/configmaps cluster/deploy/integreatly-installation-cr.yml
+install/olm: cluster/cleanup/olm cluster/prepare/olm cluster/prepare/configmaps cluster/prepare/smtp cluster/deploy/integreatly-installation-cr.yml
 
 .PHONY: test/e2e/olm
 test/e2e/olm: install/olm
@@ -162,7 +162,7 @@ cluster/prepare/olm: cluster/prepare/project cluster/prepare/osrc
 
 .PHONY: cluster/prepare/smtp
 cluster/prepare/smtp:
-	@-oc create secret generic rhmi-smtp -n $(NAMESPACE) \
+	@-oc create secret generic $(INSTALLATION_PREFIX)-smtp -n $(NAMESPACE) \
 		--from-literal=host=smtp.example.com \
 		--from-literal=username=dummy \
 		--from-literal=password=dummy \

--- a/deploy/crds/examples/installation.cr.yaml
+++ b/deploy/crds/examples/installation.cr.yaml
@@ -7,4 +7,4 @@ spec:
   namespacePrefix: redhat-rhmi-
   selfSignedCerts: true
   useClusterStorage: true
-  smtpSecret: rhmi-smtp
+  smtpSecret: redhat-rhmi-smtp

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -140,7 +140,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 				Type:            string(integreatlyv1alpha1.InstallationTypeManaged),
 				NamespacePrefix: DefaultInstallationPrefix,
 				SelfSignedCerts: false,
-				SMTPSecret:      "rhmi-smtp",
+				SMTPSecret:      DefaultInstallationPrefix + "smtp",
 			},
 		}
 

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -23,6 +23,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -665,7 +666,7 @@ func IntegreatlyCluster(t *testing.T) {
 		},
 	}
 	err = f.Client.Create(context.TODO(), smtpSec, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
+	if err != nil && !apierrors.IsAlreadyExists(err) {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
### What:

OLM nightly pipeline is failing with `preflightMessage: Could not find redhat-rhmi-smtp secret in redhat-rhmi-operator namespace` 

It's missing to create the stmp secret and also the installation CR [integreatly-installation-cr.yaml](https://github.com/integr8ly/integreatly-operator/blob/1.16.0/deploy/crds/examples/integreatly-installation-cr.yaml#L10) uses `INSTALLATION_PREFIX` to name the secret 


### Verification step 

1) Run `make test/e2e/olm`
2) Ensure `redhat-rhmi-smtp` secret is created
3) Ensure installation completes successfully 