### PR TITLE
INTLY-5138 - Create flag to switch namespace installation mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .idea
 scripts/htpasswd
+htpasswd
 .DS_Store
 # Temporary Build Files
 tmp/_output/bin/integreatly-operator

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ export INSTALLATION_TYPE   ?= managed
 export INSTALLATION_NAME   ?= integreatly
 export INSTALLATION_PREFIX ?= redhat-rhmi
 export USE_CLUSTER_STORAGE ?= true
+export OPERATORS_IN_PRODUCT_NAMESPACE ?= false # e2e tests and createInstallationCR() need to be updated when default is changed
 
 define wait_command
 	@echo Waiting for $(2) for $(3)...
@@ -199,6 +200,7 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/INSTALLATION_TYPE/$(INSTALLATION_TYPE)/g" | \
 	sed "s/INSTALLATION_PREFIX/$(INSTALLATION_PREFIX)/g" | \
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
+	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > deploy/integreatly-rhmi-cr.yml
 	@-oc create -f deploy/integreatly-rhmi-cr.yml
 

--- a/deploy/crds/examples/integreatly-rhmi-cr.yaml
+++ b/deploy/crds/examples/integreatly-rhmi-cr.yaml
@@ -7,4 +7,5 @@ spec:
   namespacePrefix: INSTALLATION_PREFIX-
   selfSignedCerts: SELF_SIGNED_CERTS
   useClusterStorage: USE_CLUSTER_STORAGE
+  operatorsInProductNamespace: OPERATORS_IN_PRODUCT_NAMESPACE
   smtpSecret: INSTALLATION_PREFIX-smtp

--- a/deploy/integreatly-installation-cr.yml
+++ b/deploy/integreatly-installation-cr.yml
@@ -1,0 +1,11 @@
+apiVersion: integreatly.org/v1alpha1
+kind: Installation
+metadata:
+  name: integreatly
+spec:
+  type: managed
+  namespacePrefix: redhat-rhmi-
+  selfSignedCerts: true
+  useClusterStorage: true
+  operatorsInProductNamespace: true
+  smtpSecret: redhat-rhmi-smtp

--- a/deploy/olm-catalog/integreatly-operator/integreatly-operator-1.17.0/integreatly.org_installations_crd.yaml
+++ b/deploy/olm-catalog/integreatly-operator/integreatly-operator-1.17.0/integreatly.org_installations_crd.yaml
@@ -35,6 +35,13 @@ spec:
               type: string
             namespacePrefix:
               type: string
+            operatorsInProductNamespace:
+              description: OperatorsInProductNamespace is a flag that decides if the
+                product operators should be installed in the product namespace (when
+                set to true) or in standalone namespace (when set to false, default).
+                Standalone namespace will be used only for those operators that support
+                it.
+              type: boolean
             pullSecret:
               properties:
                 name:

--- a/deploy/test/test-idp-templace.yml
+++ b/deploy/test/test-idp-templace.yml
@@ -1,0 +1,37 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: integreatly-deploy
+objects:
+  - apiVersion: operators.coreos.com/v1
+    kind: OperatorSource
+    metadata:
+      name: ${OPERATOR_SOURCE_NAME}
+      namespace: openshift-marketplace
+    spec:
+      authorizationToken: {}
+      displayName: Integreatly Operators
+      endpoint: 'https://quay.io/cnr'
+      publisher: Integreatly Publisher
+      registryNamespace: ${OPERATOR_SOURCE_REGISTRY_NAMESPACE}
+      type: appregistry
+  - apiVersion: operators.coreos.com/v1
+    kind: CatalogSourceConfig
+    metadata:
+      name: ${CATALOG_SOURCE_CONFIG_NAME}
+      namespace: openshift-marketplace
+    spec:
+      csDisplayName: ${CATALOG_SOURCE_CONFIG_NAME}
+      csPublisher: Red Hat
+      packages: integreatly
+      targetNamespace: ${NAMESPACE}
+      source: ${OPERATOR_SOURCE_NAME}
+parameters:
+  - description: The namespace to deploy into
+    displayName: Namespace
+    name: NAMESPACE
+    value: redhat-rhmi-operator
+  - description: Password used for testing users
+    displayName: Password used for testing users
+    name: PASSWORD
+    value: Password1

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -94,6 +94,13 @@ type RHMISpec struct {
 	PullSecret        PullSecretSpec `json:"pullSecret,omitempty"`
 	UseClusterStorage bool           `json:"useClusterStorage,omitempty"`
 
+	// OperatorsInProductNamespace is a flag that decides if
+	// the product operators should be installed in the product
+	// namespace (when set to true) or in standalone namespace
+	// (when set to false, default). Standalone namespace will
+	// be used only for those operators that support it.
+	OperatorsInProductNamespace bool `json:"operatorsInProductNamespace,omitempty"`
+
 	// SMTPSecret is the name of a secret in the installation
 	// namespace containing SMTP connection details. The secret
 	// must contain the following fields:

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -110,6 +110,13 @@ func schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref common.ReferenceCallback)
 							Format: "",
 						},
 					},
+					"operatorsInProductNamespace": {
+						SchemaProps: spec.SchemaProps{
+							Description: "OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"smtpSecret": {
 						SchemaProps: spec.SchemaProps{
 							Description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields:\n\nhost port tls username password",

--- a/pkg/config/amqStreams.go
+++ b/pkg/config/amqStreams.go
@@ -42,8 +42,13 @@ func (a *AMQStreams) SetNamespace(newNamespace string) {
 }
 
 func (a *AMQStreams) GetOperatorNamespace() string {
-	return a.config["NAMESPACE"] + "-operator"
+	return a.config["OPERATOR_NAMESPACE"]
 }
+
+func (a *AMQStreams) SetOperatorNamespace(newNamespace string) {
+	a.config["OPERATOR_NAMESPACE"] = newNamespace
+}
+
 func (a *AMQStreams) Read() ProductConfig {
 	return a.config
 }

--- a/pkg/config/amqonline.go
+++ b/pkg/config/amqonline.go
@@ -70,7 +70,11 @@ func (a *AMQOnline) GetNamespace() string {
 }
 
 func (a *AMQOnline) GetOperatorNamespace() string {
-	return a.config["NAMESPACE"]
+	return a.config["OPERATOR_NAMESPACE"]
+}
+
+func (a *AMQOnline) SetOperatorNamespace(newNamespace string) {
+	a.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (a *AMQOnline) GetLabelSelector() string {

--- a/pkg/config/cloudresources.go
+++ b/pkg/config/cloudresources.go
@@ -53,9 +53,15 @@ func (c *CloudResources) GetNamespace() string {
 func (c *CloudResources) SetNamespace(newNamespace string) {
 	c.Config["NAMESPACE"] = newNamespace
 }
+
 func (c *CloudResources) GetOperatorNamespace() string {
-	return c.Config["NAMESPACE"] + "-operator"
+	return c.Config["OPERATOR_NAMESPACE"]
 }
+
+func (c *CloudResources) SetOperatorNamespace(newNamespace string) {
+	c.Config["OPERATOR_NAMESPACE"] = newNamespace
+}
+
 func (c *CloudResources) Read() ProductConfig {
 	return c.Config
 }

--- a/pkg/config/codeready.go
+++ b/pkg/config/codeready.go
@@ -38,8 +38,13 @@ func (c *CodeReady) GetNamespace() string {
 }
 
 func (c *CodeReady) GetOperatorNamespace() string {
-	return c.Config["NAMESPACE"] + "-operator"
+	return c.Config["OPERATOR_NAMESPACE"]
 }
+
+func (c *CodeReady) SetOperatorNamespace(newNamespace string) {
+	c.Config["OPERATOR_NAMESPACE"] = newNamespace
+}
+
 func (c *CodeReady) GetLabelSelector() string {
 	return "middleware"
 }

--- a/pkg/config/fuse.go
+++ b/pkg/config/fuse.go
@@ -38,7 +38,11 @@ func (f *Fuse) SetNamespace(newNamespace string) {
 }
 
 func (f *Fuse) GetOperatorNamespace() string {
-	return f.config["NAMESPACE"] + "-operator"
+	return f.config["OPERATOR_NAMESPACE"]
+}
+
+func (f *Fuse) SetOperatorNamespace(newNamespace string) {
+	f.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (f *Fuse) GetHost() string {

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -7,8 +7,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
-
 	"gopkg.in/yaml.v2"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
@@ -226,14 +224,12 @@ func (m *Manager) WriteConfig(config ConfigReadable) error {
 	err = m.Client.Get(m.context, k8sclient.ObjectKey{Name: m.cfgmap.Name, Namespace: m.Namespace}, m.cfgmap)
 	if errors.IsNotFound(err) {
 		m.cfgmap.Data = map[string]string{string(config.GetProductName()): string(stringConfig)}
-		ownerutil.EnsureOwner(m.cfgmap, m.installation)
 		return m.Client.Create(m.context, m.cfgmap)
 	}
 	if m.cfgmap.Data == nil {
 		m.cfgmap.Data = map[string]string{}
 	}
 	m.cfgmap.Data[string(config.GetProductName())] = string(stringConfig)
-	ownerutil.EnsureOwner(m.cfgmap, m.installation)
 	return m.Client.Update(m.context, m.cfgmap)
 }
 

--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -44,8 +44,13 @@ func (m *Monitoring) SetNamespace(newNamespace string) {
 }
 
 func (m *Monitoring) GetOperatorNamespace() string {
-	return m.Config["NAMESPACE"] + "-operator"
+	return m.Config["OPERATOR_NAMESPACE"]
 }
+
+func (m *Monitoring) SetOperatorNamespace(newNamespace string) {
+	m.Config["OPERATOR_NAMESPACE"] = newNamespace
+}
+
 func (m *Monitoring) GetNamespacePrefix() string {
 	return m.Config["NAMESPACE_PREFIX"]
 }

--- a/pkg/config/rhsso.go
+++ b/pkg/config/rhsso.go
@@ -63,7 +63,11 @@ func (r *RHSSO) SetNamespace(newNamespace string) {
 }
 
 func (r *RHSSO) GetOperatorNamespace() string {
-	return r.Config["NAMESPACE"] + "-operator"
+	return r.Config["OPERATOR_NAMESPACE"]
+}
+
+func (r *RHSSO) SetOperatorNamespace(newNamespace string) {
+	r.Config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (r *RHSSO) GetRealm() string {

--- a/pkg/config/rhssouser.go
+++ b/pkg/config/rhssouser.go
@@ -61,8 +61,13 @@ func (r *RHSSOUser) SetNamespace(newNamespace string) {
 }
 
 func (r *RHSSOUser) GetOperatorNamespace() string {
-	return r.Config["NAMESPACE"] + "-operator"
+	return r.Config["OPERATOR_NAMESPACE"]
 }
+
+func (r *RHSSOUser) SetOperatorNamespace(newNamespace string) {
+	r.Config["OPERATOR_NAMESPACE"] = newNamespace
+}
+
 func (r *RHSSOUser) GetRealm() string {
 	return r.Config["REALM"]
 }

--- a/pkg/config/solutionExplorer.go
+++ b/pkg/config/solutionExplorer.go
@@ -37,7 +37,11 @@ func (s *SolutionExplorer) SetNamespace(newNamespace string) {
 }
 
 func (s *SolutionExplorer) GetOperatorNamespace() string {
-	return s.config["NAMESPACE"] + "-operator"
+	return s.config["OPERATOR_NAMESPACE"]
+}
+
+func (s *SolutionExplorer) SetOperatorNamespace(newNamespace string) {
+	s.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (s *SolutionExplorer) Read() ProductConfig {

--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -49,7 +49,11 @@ func (t *ThreeScale) GetNamespace() string {
 }
 
 func (t *ThreeScale) GetOperatorNamespace() string {
-	return t.config["NAMESPACE"] + "-operator"
+	return t.config["OPERATOR_NAMESPACE"]
+}
+
+func (t *ThreeScale) SetOperatorNamespace(newNamespace string) {
+	t.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (t *ThreeScale) GetLabelSelector() string {

--- a/pkg/config/ups.go
+++ b/pkg/config/ups.go
@@ -53,7 +53,11 @@ func (u *Ups) SetNamespace(newNamespace string) {
 }
 
 func (u *Ups) GetOperatorNamespace() string {
-	return u.config["NAMESPACE"] + "-operator"
+	return u.config["OPERATOR_NAMESPACE"]
+}
+
+func (u *Ups) SetOperatorNamespace(newNamespace string) {
+	u.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (u *Ups) Read() ProductConfig {

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -48,22 +48,25 @@ type Reconciler struct {
 }
 
 func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
-	amqOnlineConfig, err := configManager.ReadAMQOnline()
+	config, err := configManager.ReadAMQOnline()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve amq online config: %w", err)
 	}
 
-	if amqOnlineConfig.GetNamespace() == "" {
-		amqOnlineConfig.SetNamespace(installation.Spec.NamespacePrefix + defaultInstallationNamespace)
+	if config.GetNamespace() == "" {
+		config.SetNamespace(installation.Spec.NamespacePrefix + defaultInstallationNamespace)
+	}
+	if config.GetOperatorNamespace() == "" {
+		config.SetOperatorNamespace(config.GetNamespace())
 	}
 
-	amqOnlineConfig.SetBlackboxTargetPath("/oauth/healthz")
+	config.SetBlackboxTargetPath("/oauth/healthz")
 
 	logger := logrus.NewEntry(logrus.StandardLogger())
 
 	return &Reconciler{
 		ConfigManager: configManager,
-		Config:        amqOnlineConfig,
+		Config:        config,
 		mpm:           mpm,
 		logger:        logger,
 		Reconciler:    resources.NewReconciler(mpm),

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -49,6 +49,13 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	if config.GetNamespace() == "" {
 		config.SetNamespace(installation.Spec.NamespacePrefix + defaultInstallationNamespace)
 	}
+	if config.GetOperatorNamespace() == "" {
+		if installation.Spec.OperatorsInProductNamespace {
+			config.SetOperatorNamespace(config.GetNamespace())
+		} else {
+			config.SetOperatorNamespace(config.GetNamespace() + "-operator")
+		}
+	}
 
 	logger := logrus.NewEntry(logrus.StandardLogger())
 

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -64,6 +64,13 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	if config.GetNamespace() == "" {
 		config.SetNamespace(installation.Spec.NamespacePrefix + defaultInstallationNamespace)
 	}
+	if config.GetOperatorNamespace() == "" {
+		if installation.Spec.OperatorsInProductNamespace {
+			config.SetOperatorNamespace(config.GetNamespace())
+		} else {
+			config.SetOperatorNamespace(config.GetNamespace() + "-operator")
+		}
+	}
 
 	logger := logrus.NewEntry(logrus.StandardLogger())
 

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -133,6 +133,10 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 			if alert.Labels["alertname"] == "KubePodCrashLooping" {
 				continue
 			}
+			// FIXME: remove this condition once INTLY-5354 is addressed
+			if alert.Labels["alertname"] == "KeycloakAPIRequestDuration90PercThresholdExceeded" {
+				continue
+			}
 			if alert.State == "firing" {
 				firingalerts = append(firingalerts, string(alert.Labels["alertname"]))
 			}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-5138

**What:**
A .Spec field have been added to choose between operator installation in the same namespace as operand or in a standalone namespace.
Removed ownerReference from our main ConfigMap, because it was being removed immediately after marking Installation CR for deletion. It might contain useful information for uninstallation. A .Delete call has been added in the end of uninstallation process. 
Added "htpasswd" into .gitignore