### PR TITLE
fix generated files

### DIFF
--- a/pkg/apis/enmasse/v1beta1/zz_generated.openapi.go
+++ b/pkg/apis/enmasse/v1beta1/zz_generated.openapi.go
@@ -11,8 +11,8 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfig": schema_pkg_apis_enmasse_v1beta1_BrokeredInfraConfig(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfig": schema_pkg_apis_enmasse_v1beta1_StandardInfraConfig(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfig": schema_pkg_apis_enmasse_v1beta1_BrokeredInfraConfig(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfig": schema_pkg_apis_enmasse_v1beta1_StandardInfraConfig(ref),
 	}
 }
 
@@ -44,19 +44,19 @@ func schema_pkg_apis_enmasse_v1beta1_BrokeredInfraConfig(ref common.ReferenceCal
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.BrokeredInfraConfigStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -88,18 +88,18 @@ func schema_pkg_apis_enmasse_v1beta1_StandardInfraConfig(ref common.ReferenceCal
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1.StandardInfraConfigStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }

--- a/pkg/apis/enmasse/v1beta2/zz_generated.openapi.go
+++ b/pkg/apis/enmasse/v1beta2/zz_generated.openapi.go
@@ -11,8 +11,8 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlan":      schema_pkg_apis_enmasse_v1beta2_AddressPlan(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlan": schema_pkg_apis_enmasse_v1beta2_AddressSpacePlan(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlan":      schema_pkg_apis_enmasse_v1beta2_AddressPlan(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlan": schema_pkg_apis_enmasse_v1beta2_AddressSpacePlan(ref),
 	}
 }
 
@@ -44,19 +44,19 @@ func schema_pkg_apis_enmasse_v1beta2_AddressPlan(ref common.ReferenceCallback) c
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressPlanStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -88,18 +88,18 @@ func schema_pkg_apis_enmasse_v1beta2_AddressSpacePlan(ref common.ReferenceCallba
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2.AddressSpacePlanStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -11,9 +11,9 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.Installation":       schema_pkg_apis_integreatly_v1alpha1_Installation(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec":   schema_pkg_apis_integreatly_v1alpha1_InstallationSpec(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus": schema_pkg_apis_integreatly_v1alpha1_InstallationStatus(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.Installation":       schema_pkg_apis_integreatly_v1alpha1_Installation(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec":   schema_pkg_apis_integreatly_v1alpha1_InstallationSpec(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus": schema_pkg_apis_integreatly_v1alpha1_InstallationStatus(ref),
 	}
 }
 
@@ -45,19 +45,19 @@ func schema_pkg_apis_integreatly_v1alpha1_Installation(ref common.ReferenceCallb
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -101,7 +101,7 @@ func schema_pkg_apis_integreatly_v1alpha1_InstallationSpec(ref common.ReferenceC
 					},
 					"pullSecret": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"),
 						},
 					},
 					"useClusterStorage": {
@@ -122,7 +122,7 @@ func schema_pkg_apis_integreatly_v1alpha1_InstallationSpec(ref common.ReferenceC
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"},
 	}
 }
 
@@ -141,7 +141,7 @@ func schema_pkg_apis_integreatly_v1alpha1_InstallationStatus(ref common.Referenc
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStageStatus"),
+										Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStageStatus"),
 									},
 								},
 							},
@@ -182,6 +182,6 @@ func schema_pkg_apis_integreatly_v1alpha1_InstallationStatus(ref common.Referenc
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStageStatus"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.InstallationStageStatus"},
 	}
 }

--- a/pkg/apis/kafka.strimzi.io/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/kafka.strimzi.io/v1alpha1/zz_generated.openapi.go
@@ -11,9 +11,9 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.Kafka":       schema_pkg_apis_kafkastrimziio_v1alpha1_Kafka(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec":   schema_pkg_apis_kafkastrimziio_v1alpha1_KafkaSpec(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus": schema_pkg_apis_kafkastrimziio_v1alpha1_KafkaStatus(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.Kafka":       schema_pkg_apis_kafkastrimziio_v1alpha1_Kafka(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec":   schema_pkg_apis_kafkastrimziio_v1alpha1_KafkaSpec(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus": schema_pkg_apis_kafkastrimziio_v1alpha1_KafkaStatus(ref),
 	}
 }
 
@@ -45,19 +45,19 @@ func schema_pkg_apis_kafkastrimziio_v1alpha1_Kafka(ref common.ReferenceCallback)
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -71,24 +71,24 @@ func schema_pkg_apis_kafkastrimziio_v1alpha1_KafkaSpec(ref common.ReferenceCallb
 					"kafka": {
 						SchemaProps: spec.SchemaProps{
 							Description: "INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run \"operator-sdk generate k8s\" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html",
-							Ref:         ref("github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecKafka"),
+							Ref:         ref("github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecKafka"),
 						},
 					},
 					"zookeeper": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecZookeeper"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecZookeeper"),
 						},
 					},
 					"entityOperator": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecEntityOperator"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecEntityOperator"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecEntityOperator", "github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecKafka", "github.com/briangallagher/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecZookeeper"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecEntityOperator", "github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecKafka", "github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1.KafkaSpecZookeeper"},
 	}
 }
 

--- a/pkg/apis/monitoring/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/monitoring/v1alpha1/zz_generated.openapi.go
@@ -11,8 +11,8 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoring": schema_pkg_apis_monitoring_v1alpha1_ApplicationMonitoring(ref),
-		"github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTarget":        schema_pkg_apis_monitoring_v1alpha1_BlackboxTarget(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoring": schema_pkg_apis_monitoring_v1alpha1_ApplicationMonitoring(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTarget":        schema_pkg_apis_monitoring_v1alpha1_BlackboxTarget(ref),
 	}
 }
 
@@ -44,19 +44,19 @@ func schema_pkg_apis_monitoring_v1alpha1_ApplicationMonitoring(ref common.Refere
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.ApplicationMonitoringStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
@@ -88,18 +88,18 @@ func schema_pkg_apis_monitoring_v1alpha1_BlackboxTarget(ref common.ReferenceCall
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetSpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetSpec", "github.com/briangallagher/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetSpec", "github.com/integr8ly/integreatly-operator/pkg/apis/monitoring/v1alpha1.BlackboxTargetStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }


### PR DESCRIPTION
Command operator-sdk generate openapi seems to use the file path in generated files which resulted in github.com/briangallagher references.