### PR TITLE
Allow dedicated-admins group to modify amq online configs

### DIFF
--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -25,6 +25,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -147,7 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.reconcileBrokerConfigs(ctx, serverClient, GetDefaultBrokeredInfraConfigs(ns), GetDefaultStandardInfraConfigs(ns))
+	phase, err = r.reconcileInfraConfigs(ctx, serverClient, GetDefaultBrokeredInfraConfigs(ns), GetDefaultStandardInfraConfigs(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile broker configs", err)
 		return phase, err
@@ -162,6 +163,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.reconcileAddressSpacePlans(ctx, serverClient, GetDefaultAddressSpacePlans(ns))
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile address space plans", err)
+		return phase, err
+	}
+
+	phase, err = r.reconcileServiceAdmin(ctx, serverClient, GetServiceAdminRole(ns))
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile service admin role to dedicated admins group", err)
 		return phase, err
 	}
 
@@ -364,7 +371,7 @@ func (r *Reconciler) reconcileStandardAuthenticationService(ctx context.Context,
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func (r *Reconciler) reconcileBrokerConfigs(ctx context.Context, serverClient k8sclient.Client, brokeredCfgs []*enmassev1beta1.BrokeredInfraConfig, stdCfgs []*enmassev1beta1.StandardInfraConfig) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileInfraConfigs(ctx context.Context, serverClient k8sclient.Client, brokeredCfgs []*enmassev1beta1.BrokeredInfraConfig, stdCfgs []*enmassev1beta1.StandardInfraConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.logger.Info("reconciling default infra configs")
 
 	for _, bic := range brokeredCfgs {
@@ -409,6 +416,40 @@ func (r *Reconciler) reconcileAddressSpacePlans(ctx context.Context, serverClien
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create address space plan %v: %w", asp, err)
 		}
 	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) reconcileServiceAdmin(ctx context.Context, serverClient k8sclient.Client, serviceAdminRole *rbacv1.Role) (integreatlyv1alpha1.StatusPhase, error) {
+	r.logger.Info("reconciling service admin role to the dedicated admins group")
+
+	err := serverClient.Create(ctx, serviceAdminRole)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create service admin role %v: %w", serviceAdminRole, err)
+	}
+
+	// Bind the amq online service admin role to the dedicated-admins group
+	serviceAdminRoleBinding := &rbacv1.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "dedicated-admins-service-admin",
+			Namespace: r.Config.GetNamespace(),
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: serviceAdminRole.GetName(),
+			Kind: "Role",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Name: "dedicated-admins",
+				Kind: "Group",
+			},
+		},
+	}
+
+	err = serverClient.Create(ctx, serviceAdminRoleBinding)
+	if err != nil && !k8serr.IsAlreadyExists(err) {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create service admin role binding %v: %w", serviceAdminRoleBinding, err)
+	}
+
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
@@ -540,4 +581,21 @@ func (r *Reconciler) reconcilePrometheusRule(ctx context.Context, client k8sclie
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+// Get the amq online service admin role
+func GetServiceAdminRole(ns string) *rbacv1.Role {
+	return &rbacv1.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "enmasse.io:service-admin",
+			Namespace: ns,
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{"admin.enmasse.io"},
+				Resources: []string{"addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"},
+				Verbs:     []string{"create", "get", "update", "delete", "list", "watch", "patch"},
+			},
+		},
+	}
 }

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -12,9 +12,7 @@ import (
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 
 	enmassev1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/admin/v1beta1"
-	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1"
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1"
-	"github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	kafkav1 "github.com/integr8ly/integreatly-operator/pkg/apis/kafka.strimzi.io/v1alpha1"
@@ -162,7 +160,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 		Recorder       record.EventRecorder
 	}{
 		{
-			Name:           "Test returns none phase if successfully creating new auth services",
+			Name:           "Test returns completed phase if successfully creating new auth services",
 			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace")),
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
@@ -175,7 +173,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 			Recorder: setupRecorder(),
 		},
 		{
-			Name:           "Test returns none phase if trying to create existing auth services",
+			Name:           "Test returns completed phase if trying to create existing auth services",
 			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace")),
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
@@ -206,20 +204,20 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 	}
 }
 
-func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
+func TestReconcile_reconcileInfraConfigs(t *testing.T) {
 	scenarios := []struct {
 		Name                 string
 		Client               k8sclient.Client
 		FakeConfig           *config.ConfigReadWriterMock
 		Installation         *integreatlyv1alpha1.RHMI
 		ExpectedStatus       integreatlyv1alpha1.StatusPhase
-		BrokeredInfraConfigs []*v1beta1.BrokeredInfraConfig
-		StandardInfraConfigs []*v1beta1.StandardInfraConfig
+		BrokeredInfraConfigs []*enmassev1beta1.BrokeredInfraConfig
+		StandardInfraConfigs []*enmassev1beta1.StandardInfraConfig
 		FakeMPM              *marketplace.MarketplaceInterfaceMock
 		Recorder             record.EventRecorder
 	}{
 		{
-			Name:                 "Test returns none phase if successfully creating new address space plans",
+			Name:                 "Test returns completed phase if successfully creating new infra configs",
 			Client:               fake.NewFakeClientWithScheme(buildScheme()),
 			FakeConfig:           basicConfigMock(),
 			BrokeredInfraConfigs: GetDefaultBrokeredInfraConfigs(defaultNamespace),
@@ -229,8 +227,8 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			Recorder:             setupRecorder(),
 		},
 		{
-			Name:                 "Test returns none phase if trying to create existing address space plans",
-			Client:               fake.NewFakeClientWithScheme(buildScheme()),
+			Name:                 "Test returns completed phase if trying to create existing infra configs",
+			Client:               fake.NewFakeClientWithScheme(buildScheme(), GetDefaultBrokeredInfraConfigs(defaultNamespace)[0], GetDefaultStandardInfraConfigs(defaultNamespace)[0]),
 			BrokeredInfraConfigs: GetDefaultBrokeredInfraConfigs(defaultNamespace),
 			StandardInfraConfigs: GetDefaultStandardInfraConfigs(defaultNamespace),
 			FakeConfig:           basicConfigMock(),
@@ -246,7 +244,7 @@ func TestReconcile_reconcileBrokerConfigs(t *testing.T) {
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
-			phase, err := r.reconcileBrokerConfigs(context.TODO(), s.Client, s.BrokeredInfraConfigs, s.StandardInfraConfigs)
+			phase, err := r.reconcileInfraConfigs(context.TODO(), s.Client, s.BrokeredInfraConfigs, s.StandardInfraConfigs)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -264,12 +262,12 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 		FakeConfig     *config.ConfigReadWriterMock
 		Installation   *integreatlyv1alpha1.RHMI
 		ExpectedStatus integreatlyv1alpha1.StatusPhase
-		AddressPlans   []*v1beta2.AddressPlan
+		AddressPlans   []*enmassev1beta2.AddressPlan
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
 		Recorder       record.EventRecorder
 	}{
 		{
-			Name:           "Test returns none phase if successfully creating new address space plans",
+			Name:           "Test returns completed phase if successfully creating new address plans",
 			Client:         fake.NewFakeClientWithScheme(buildScheme()),
 			FakeConfig:     basicConfigMock(),
 			AddressPlans:   GetDefaultAddressPlans(defaultNamespace),
@@ -278,8 +276,8 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 			Recorder:       setupRecorder(),
 		},
 		{
-			Name:           "Test returns none phase if trying to create existing address space plans",
-			Client:         fake.NewFakeClientWithScheme(buildScheme()),
+			Name:           "Test returns completed phase if trying to create existing address plans",
+			Client:         fake.NewFakeClientWithScheme(buildScheme(), GetDefaultAddressPlans(defaultNamespace)[0]),
 			AddressPlans:   GetDefaultAddressPlans(defaultNamespace),
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
@@ -312,12 +310,12 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 		FakeConfig        *config.ConfigReadWriterMock
 		Installation      *integreatlyv1alpha1.RHMI
 		ExpectedStatus    integreatlyv1alpha1.StatusPhase
-		AddressSpacePlans []*v1beta2.AddressSpacePlan
+		AddressSpacePlans []*enmassev1beta2.AddressSpacePlan
 		FakeMPM           *marketplace.MarketplaceInterfaceMock
 		Recorder          record.EventRecorder
 	}{
 		{
-			Name:              "Test returns none phase if successfully creating new address space plans",
+			Name:              "Test returns completed phase if successfully creating new address space plans",
 			Client:            fake.NewFakeClientWithScheme(buildScheme()),
 			FakeConfig:        basicConfigMock(),
 			AddressSpacePlans: GetDefaultAddressSpacePlans(defaultNamespace),
@@ -326,8 +324,8 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 			Recorder:          setupRecorder(),
 		},
 		{
-			Name:              "Test returns none phase if trying to create existing address space plans",
-			Client:            fake.NewFakeClientWithScheme(buildScheme()),
+			Name:              "Test returns completed phase if trying to create existing address space plans",
+			Client:            fake.NewFakeClientWithScheme(buildScheme(), GetDefaultAddressSpacePlans(defaultNamespace)[0]),
 			AddressSpacePlans: GetDefaultAddressSpacePlans(defaultNamespace),
 			FakeConfig:        basicConfigMock(),
 			ExpectedStatus:    integreatlyv1alpha1.PhaseCompleted,
@@ -343,6 +341,54 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 				t.Fatalf("could not create reconciler %v", err)
 			}
 			phase, err := r.reconcileAddressSpacePlans(context.TODO(), s.Client, s.AddressSpacePlans)
+			if err != nil {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if phase != s.ExpectedStatus {
+				t.Fatalf("expected status %s but got %s", s.ExpectedStatus, phase)
+			}
+		})
+	}
+}
+
+func TestReconcile_reconcileServiceAdmin(t *testing.T) {
+	scenarios := []struct {
+		Name             string
+		Client           k8sclient.Client
+		FakeConfig       *config.ConfigReadWriterMock
+		Installation     *integreatlyv1alpha1.RHMI
+		ExpectedStatus   integreatlyv1alpha1.StatusPhase
+		ServiceAdminRole *rbacv1.Role
+		FakeMPM          *marketplace.MarketplaceInterfaceMock
+		Recorder         record.EventRecorder
+	}{
+		{
+			Name:             "Test returns completed phase if successfully creating amq online service admin role and role binding",
+			Client:           fake.NewFakeClientWithScheme(buildScheme()),
+			FakeConfig:       basicConfigMock(),
+			ServiceAdminRole: GetServiceAdminRole(defaultNamespace),
+			ExpectedStatus:   integreatlyv1alpha1.PhaseCompleted,
+			Installation:     basicInstallation(),
+			Recorder:         setupRecorder(),
+		},
+		{
+			Name:             "Test returns completed phase if trying to create existing amq online service admin role and role binding",
+			Client:           fake.NewFakeClientWithScheme(buildScheme(), GetServiceAdminRole(defaultNamespace)),
+			FakeConfig:       basicConfigMock(),
+			ServiceAdminRole: GetServiceAdminRole(defaultNamespace),
+			ExpectedStatus:   integreatlyv1alpha1.PhaseCompleted,
+			Installation:     basicInstallation(),
+			Recorder:         setupRecorder(),
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.Name, func(t *testing.T) {
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder)
+			if err != nil {
+				t.Fatalf("could not create reconciler %v", err)
+			}
+			phase, err := r.reconcileServiceAdmin(context.TODO(), s.Client, s.ServiceAdminRole)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-4805

### What
Giving the dedicated-admins group all permissions on AMQ Online configurations in the AMQ Online managed namespace. This will give them the ability to modify infra configs, authentication services, address space plans and address plans without the need to open up a JIRA with CS-SRE.

