### PR TITLE
add external database support for rhsso and user rhsso

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -13,15 +13,17 @@ type PreflightStatus string
 type StageName string
 
 var (
-	PhaseNone                 StatusPhase = ""
-	PhaseAccepted             StatusPhase = "accepted"
-	PhaseCreatingSubscription StatusPhase = "creating subscription"
-	PhaseAwaitingOperator     StatusPhase = "awaiting operator"
-	PhaseCreatingComponents   StatusPhase = "creating components"
-	PhaseAwaitingComponents   StatusPhase = "awaiting components"
-	PhaseInProgress           StatusPhase = "in progress"
-	PhaseCompleted            StatusPhase = "completed"
-	PhaseFailed               StatusPhase = "failed"
+	PhaseNone                   StatusPhase = ""
+	PhaseAccepted               StatusPhase = "accepted"
+	PhaseCreatingSubscription   StatusPhase = "creating subscription"
+	PhaseAwaitingOperator       StatusPhase = "awaiting operator"
+	PhaseAwaitingCloudResources StatusPhase = "awaiting cloud resources"
+	PhaseCreatingComponents     StatusPhase = "creating components"
+	PhaseAwaitingComponents     StatusPhase = "awaiting components"
+
+	PhaseInProgress StatusPhase = "in progress"
+	PhaseCompleted  StatusPhase = "completed"
+	PhaseFailed     StatusPhase = "failed"
 
 	InstallationTypeWorkshop InstallationType = "workshop"
 	InstallationTypeManaged  InstallationType = "managed"

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"testing"
 
 	threescalev1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
@@ -29,6 +32,8 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -125,6 +130,10 @@ func getBuildScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	err = projectv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = crov1.SchemeBuilder.AddToScheme(scheme)
 	if err != nil {
 		return nil, err
 	}
@@ -242,6 +251,31 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		},
 	}
 
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhsso-postgres-",
+			Namespace: defaultOperatorNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultOperatorNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
 	cases := []struct {
 		Name            string
 		FakeClient      k8sclient.Client
@@ -257,7 +291,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
-			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kc),
+			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kc, croPostgres, croPostgresSecret),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation: &integreatlyv1alpha1.RHMI{
@@ -595,6 +629,31 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rhsso-postgres-%s", installation.Name),
+			Namespace: defaultOperandNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultOperandNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperandNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
 	cases := []struct {
 		Name            string
 		ExpectError     bool
@@ -612,7 +671,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:            "test successful reconcile",
 			ExpectedStatus:  integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, croPostgres, croPostgresSecret),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -674,6 +733,100 @@ func TestReconciler_fullReconcile(t *testing.T) {
 
 			if status != tc.ExpectedStatus {
 				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
+			}
+		})
+	}
+}
+
+func TestReconciler_reconcileCloudResources(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+	}
+
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rhsso-postgres-%s", installation.Name),
+			Namespace: defaultOperatorNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultOperatorNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	tests := []struct {
+		name         string
+		installation *integreatlyv1alpha1.RHMI
+		fakeClient   func() k8sclient.Client
+		want         integreatlyv1alpha1.StatusPhase
+		wantErr      bool
+	}{
+		{
+			name:         "error creating postgres cr causes state failed",
+			installation: &integreatlyv1alpha1.RHMI{},
+			fakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres, croPostgresSecret)
+				mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return errors.New("test error")
+				}
+				return mockClient
+			},
+			wantErr: true,
+			want:    integreatlyv1alpha1.PhaseFailed,
+		},
+		{
+			name:         "nil secret causes state awaiting",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				pendingCroPostgres := croPostgres.DeepCopy()
+				pendingCroPostgres.Status.Phase = croTypes.PhaseInProgress
+				return moqclient.NewSigsClientMoqWithScheme(scheme, croPostgresSecret, pendingCroPostgres)
+			},
+			want: integreatlyv1alpha1.PhaseAwaitingCloudResources,
+		},
+		{
+			name:         "defined secret causes state completed",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				return moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres, croPostgresSecret)
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				logger: logrus.NewEntry(logrus.StandardLogger()),
+			}
+			got, err := r.reconcileCloudResources(context.TODO(), tt.installation, tt.fakeClient())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileCloudResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileCloudResources() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -819,6 +819,11 @@ func TestReconciler_reconcileCloudResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
 				logger: logrus.NewEntry(logrus.StandardLogger()),
+				Config: &config.RHSSO{
+					Config: map[string]string{
+						"NAMESPACE": defaultOperatorNamespace,
+					},
+				},
 			}
 			got, err := r.reconcileCloudResources(context.TODO(), tt.installation, tt.fakeClient())
 			if (err != nil) != tt.wantErr {

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -178,6 +178,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.reconcileCloudResources(ctx, installation, serverClient)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile cloud resources", err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileComponents(ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile components", err)
@@ -199,6 +205,20 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
+func (r *Reconciler) reconcileCloudResources(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	r.logger.Info("Reconciling Keycloak external database instance")
+	postgresName := fmt.Sprintf("rhssouser-postgres-%s", installation.Name)
+	credentialSec, err := resources.ReconcileRHSSOPostgresCredentials(ctx, installation, serverClient, postgresName, r.Config.GetNamespace())
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "")
+	}
+	// postgres provisioning is still in progress
+	if credentialSec == nil {
+		return integreatlyv1alpha1.PhaseAwaitingCloudResources, nil
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
 func (r *Reconciler) reconcileComponents(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	r.logger.Info("Reconciling Keycloak components")
 	kc := &keycloak.Keycloak{
@@ -212,6 +232,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		kc.Spec.Extensions = []string{
 			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
 		}
+		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Labels = getMasterLabels()
 		kc.Spec.Instances = 2
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{Enabled: true}

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -820,6 +820,11 @@ func TestReconciler_reconcileCloudResources(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			r := &Reconciler{
 				logger: logrus.NewEntry(logrus.StandardLogger()),
+				Config: &config.RHSSOUser{
+					Config: map[string]string{
+						"NAMESPACE": defaultRhssoNamespace,
+					},
+				},
 			}
 			got, err := r.reconcileCloudResources(context.TODO(), tt.installation, tt.fakeClient())
 			if (err != nil) != tt.wantErr {

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"github.com/sirupsen/logrus"
+	controllerruntime "sigs.k8s.io/controller-runtime"
 	"testing"
 
 	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
@@ -31,6 +34,8 @@ import (
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -116,7 +121,10 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	err = crov1.SchemeBuilder.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
 	return scheme, err
 }
 
@@ -241,6 +249,31 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		},
 	}
 
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhssouser-postgres-",
+			Namespace: defaultOperatorNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultOperatorNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
 	cases := []struct {
 		Name                  string
 		FakeClient            k8sclient.Client
@@ -257,13 +290,16 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
-			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group),
+			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group, croPostgres, croPostgresSecret),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation: &integreatlyv1alpha1.RHMI{
 				TypeMeta: metav1.TypeMeta{
 					Kind:       integreatlyv1alpha1.SchemaGroupVersionKind.Kind,
 					APIVersion: integreatlyv1alpha1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Namespace: defaultOperatorNamespace,
 				},
 			},
 			ExpectedStatus:        integreatlyv1alpha1.PhaseCompleted,
@@ -286,6 +322,9 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				TypeMeta: metav1.TypeMeta{
 					Kind:       integreatlyv1alpha1.SchemaGroupVersionKind.Kind,
 					APIVersion: integreatlyv1alpha1.SchemeGroupVersion.String(),
+				},
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Namespace: defaultOperatorNamespace,
 				},
 			},
 			ExpectError:           true,
@@ -588,6 +627,31 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		Users: nil,
 	}
 
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rhssouser-postgres-%s", installation.Name),
+			Namespace: defaultRhssoNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultRhssoNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultRhssoNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
 	cases := []struct {
 		Name                  string
 		ExpectError           bool
@@ -606,7 +670,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:            "test successful reconcile",
 			ExpectedStatus:  integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -675,6 +739,100 @@ func TestReconciler_fullReconcile(t *testing.T) {
 	}
 }
 
+func TestReconciler_reconcileCloudResources(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultRhssoNamespace,
+		},
+	}
+
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("rhssouser-postgres-%s", installation.Name),
+			Namespace: defaultRhssoNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultRhssoNamespace,
+			},
+		},
+	}
+
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultRhssoNamespace,
+		},
+		Data: map[string][]byte{},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	tests := []struct {
+		name         string
+		installation *integreatlyv1alpha1.RHMI
+		fakeClient   func() k8sclient.Client
+		want         integreatlyv1alpha1.StatusPhase
+		wantErr      bool
+	}{
+		{
+			name:         "error creating postgres cr causes state failed",
+			installation: &integreatlyv1alpha1.RHMI{},
+			fakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres, croPostgresSecret)
+				mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return errors.New("test error")
+				}
+				return mockClient
+			},
+			wantErr: true,
+			want:    integreatlyv1alpha1.PhaseFailed,
+		},
+		{
+			name:         "nil secret causes state awaiting",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				pendingCroPostgres := croPostgres.DeepCopy()
+				pendingCroPostgres.Status.Phase = croTypes.PhaseInProgress
+				return moqclient.NewSigsClientMoqWithScheme(scheme, croPostgresSecret, pendingCroPostgres)
+			},
+			want: integreatlyv1alpha1.PhaseAwaitingCloudResources,
+		},
+		{
+			name:         "defined secret causes state completed",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				return moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres, croPostgresSecret)
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				logger: logrus.NewEntry(logrus.StandardLogger()),
+			}
+			got, err := r.reconcileCloudResources(context.TODO(), tt.installation, tt.fakeClient())
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileCloudResources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileCloudResources() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func getKcr(status keycloak.KeycloakRealmStatus) *keycloak.KeycloakRealm {
 	return &keycloak.KeycloakRealm{
 		ObjectMeta: metav1.ObjectMeta{
@@ -698,7 +856,7 @@ func getKcr(status keycloak.KeycloakRealmStatus) *keycloak.KeycloakRealm {
 
 func getMoqKeycloakClientFactory() keycloakCommon.KeycloakClientFactory {
 	exInfo := []*keycloak.AuthenticationExecutionInfo{
-		&keycloak.AuthenticationExecutionInfo{
+		{
 			ProviderID: "identity-provider-redirector",
 			ID:         "123-123-123",
 		},

--- a/pkg/resources/rhsso.go
+++ b/pkg/resources/rhsso.go
@@ -1,0 +1,75 @@
+package resources
+
+import (
+	"context"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/pkg/errors"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	croUtil "github.com/integr8ly/cloud-resource-operator/pkg/resources"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	databaseSecretName = "keycloak-db-secret"
+
+	databaseSecretKeyDatabase  = "POSTGRES_DATABASE"
+	databaseSecretKeyExtPort   = "POSTGRES_EXTERNAL_PORT"
+	databaseSecretKeyExtHost   = "POSTGRES_EXTERNAL_ADDRESS"
+	databaseSecretKeyPassword  = "POSTGRES_PASSWORD"
+	databaseSecretKeyUsername  = "POSTGRES_USERNAME"
+	databaseSecretKeySuperuser = "POSTGRES_SUPERUSER"
+)
+
+//ReconcileRHSSOPostgresCredentials Provisions postgres and creates external database secret based on Installation CR, secret will be nil while the postgres instance is provisioning
+func ReconcileRHSSOPostgresCredentials(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client, name, ns string) (*corev1.Secret, error) {
+	postgresNS := installation.Namespace
+	postgresTier := "production"
+	postgres, err := croUtil.ReconcilePostgres(ctx, serverClient, postgresNS, installation.Spec.Type, postgresTier, name, postgresNS, name, postgresNS, func(cr metav1.Object) error {
+		owner.AddIntegreatlyOwnerAnnotations(cr, installation)
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to provision postgres instance while reconciling rhsso postgres credentials, %s", name)
+	}
+	if postgres.Status.Phase != types.PhaseComplete {
+		return nil, nil
+	}
+	postgresSec := &corev1.Secret{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: postgres.Status.SecretRef.Name, Namespace: postgres.Status.SecretRef.Namespace}, postgresSec)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to get postgres credential secret while reconciling rhsso postgres credentials, %s", name)
+	}
+	// create secret using the default name which the keycloak operator expects
+	keycloakSec := &corev1.Secret{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      databaseSecretName,
+			Namespace: ns,
+		},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, keycloakSec, func() error {
+		owner.AddIntegreatlyOwnerAnnotations(keycloakSec, installation)
+		if keycloakSec.Data == nil {
+			keycloakSec.Data = map[string][]byte{}
+		}
+		// based on https://github.com/keycloak/keycloak-operator/blob/d6203c6206bcf011023a289620f93d03cd755810/docs/external-database.asciidoc
+		keycloakSec.Data[databaseSecretKeyDatabase] = postgresSec.Data["database"]
+		keycloakSec.Data[databaseSecretKeyExtPort] = postgresSec.Data["port"]
+		keycloakSec.Data[databaseSecretKeyExtHost] = postgresSec.Data["host"]
+		keycloakSec.Data[databaseSecretKeyPassword] = postgresSec.Data["password"]
+		keycloakSec.Data[databaseSecretKeyUsername] = postgresSec.Data["username"]
+		keycloakSec.Data[databaseSecretKeySuperuser] = []byte("false")
+		return nil
+	})
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create keycloak external database secret, %s", name)
+	}
+	return keycloakSec, nil
+}

--- a/pkg/resources/rhsso_test.go
+++ b/pkg/resources/rhsso_test.go
@@ -1,0 +1,165 @@
+package resources
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	defaultOperatorNamespace = "test"
+)
+
+func TestReconcileRHSSOPostgresCredentials(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := crov1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: controllerruntime.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+	}
+
+	//completed postgres that points at the secret croPostgresSecret
+	croPostgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+		Status: crov1.PostgresStatus{
+			Phase: croTypes.PhaseComplete,
+			SecretRef: &croTypes.SecretRef{
+				Name:      "test",
+				Namespace: defaultOperatorNamespace,
+			},
+		},
+	}
+
+	testSecretValDatabase := "testDatabase"
+	testSecretValExtPort := "5432"
+	testSecretValExtHost := "testExtHost"
+	testSecretValPassword := "testPassword"
+	testSecretValUsername := "testUsername"
+	//secret created by the cloud resource operator postgres reconciler
+	croPostgresSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{
+			"database": []byte(testSecretValDatabase),
+			"port":     []byte(testSecretValExtPort),
+			"host":     []byte(testSecretValExtHost),
+			"password": []byte(testSecretValPassword),
+			"username": []byte(testSecretValUsername),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}
+
+	tests := []struct {
+		name         string
+		postgresName string
+		installation *integreatlyv1alpha1.RHMI
+		fakeClient   func() k8sclient.Client
+		want         *corev1.Secret
+		wantErr      bool
+	}{
+		{
+			name:         "error returned when postgres cannot be provisioned",
+			postgresName: "test",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres, croPostgresSecret)
+				mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return errors.New("test error")
+				}
+				return mockClient
+			},
+			wantErr: true,
+		},
+		{
+			name:         "nil returned when postgres phase is not complete",
+			postgresName: "test",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				pendingPostgres := croPostgres.DeepCopy()
+				pendingPostgres.Status.Phase = croTypes.PhaseInProgress
+				return moqclient.NewSigsClientMoqWithScheme(scheme, pendingPostgres, croPostgresSecret)
+			},
+			want: nil,
+		},
+		{
+			name:         "error returned when postgres credential secret cannot be found",
+			postgresName: "test",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				return moqclient.NewSigsClientMoqWithScheme(scheme, croPostgres)
+			},
+			wantErr: true,
+		},
+		{
+			name:         "secret returned on successful reconcile",
+			postgresName: "test",
+			installation: installation,
+			fakeClient: func() k8sclient.Client {
+				return fake.NewFakeClientWithScheme(scheme, croPostgres, croPostgresSecret)
+			},
+			want: &corev1.Secret{
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Name:      databaseSecretName,
+					Namespace: defaultOperatorNamespace,
+				},
+				Data: map[string][]byte{
+					databaseSecretKeyDatabase:  []byte(testSecretValDatabase),
+					databaseSecretKeyExtPort:   []byte(testSecretValExtPort),
+					databaseSecretKeyExtHost:   []byte(testSecretValExtHost),
+					databaseSecretKeyPassword:  []byte(testSecretValPassword),
+					databaseSecretKeyUsername:  []byte(testSecretValUsername),
+					databaseSecretKeySuperuser: []byte("false"),
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReconcileRHSSOPostgresCredentials(context.TODO(), tt.installation, tt.fakeClient(), tt.postgresName, defaultOperatorNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileRHSSOPostgresCredentials() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("got should be nil, got = %s", got)
+				}
+				return
+			}
+			if got.Name != tt.want.Name {
+				t.Errorf("secret names do not match, got = %s, want %s", got.Name, tt.want.Name)
+			}
+			for key, val := range tt.want.Data {
+				if !bytes.Equal(val, got.Data[key]) {
+					t.Errorf("ReconcileRHSSOPostgresCredentials() got = %v, want %v", got.Data, tt.want.Data)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
currently the rhsso custom resources are not setting their
external database flags to enabled in rhmi. both rhsso instances
should be using the cloud resource operator to provision any
requried storage services.

this change ensures that the cloud resource operator provisions a
postgres instance for both rhsso and user rhsso.

verification:
- run an installation
- ensure that rhsso is provisioned successfully
- ensure that user rhsso is provisioned successfully
- ensure logging into to both sso succeeds and some resource
  (e.g. users) can be created
- ensure the keycloak cr for rhsso and user rhsso have external
  storage enabled
- ensure that the cloud resource operator successfully provisioned
  storage for rhsso and user rhsso

ensure these checks are done against aws and in-cluster setups for
the cloud resource operator.