### PR TITLE
Automated Manifest Updates:

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -18,3 +18,8 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
 RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \
     && chmod +x ./jq \
     && cp jq /usr/bin
+
+# install yq
+RUN wget -O yq https://github.com/mikefarah/yq/releases/download/3.1.1/yq_linux_amd64 \
+    && chmod +x ./yq \
+    && cp yq /usr/bin

--- a/openshift-ci/test/run
+++ b/openshift-ci/test/run
@@ -10,6 +10,7 @@ WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'operator-sdk version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'go version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'jq --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'yq --version'
 
 docker run --rm -u $UID -v "${WORK_DIR}/../..:/integreatly-operator:z" --entrypoint=/bin/sh ${IMAGE_NAME} -c "cd /integreatly-operator && make vendor/check"
 docker run --rm -u $UID -v "${WORK_DIR}/../..:/integreatly-operator:z" --entrypoint=/bin/sh ${IMAGE_NAME} -c "cd /integreatly-operator && make code/check"

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -29,12 +29,20 @@ PRODUCT_OPERATOR=3scale-operator
 
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 
-cleanup (){
+catch() {
+    if [ "$1" == "127" ]; then
+        echo "This script depends on the package yq"
+        echo "For installation instructions visit: https://mikefarah.gitbook.io/yq/#install"
+    fi
     echo "Cleaning up ${MANIFEST_TMP_DIR}"
     rm -rf ${MANIFEST_TMP_DIR}
 }
 
-trap 'cleanup' EXIT
+trap 'catch $?' EXIT
+
+check_yq() {
+    yq > /dev/null
+}
 
 extract_manifests_from_image() {
     echo "Creating ${MANIFEST_TMP_DIR} directory"
@@ -95,6 +103,7 @@ update_package_yaml() {
 }
 
 process_image() {
+   check_yq
    echo "~~~~~~"
    echo "Process Image '$IMAGE'"
    echo "~~~~~~"

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -22,10 +22,10 @@ set -e
 
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MANIFESTS_DIR=${WORK_DIR}/../manifests
-MANIFEST_TMP_DIR=${MANIFESTS_DIR}/temp
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
 IMAGE=$1
-PRODUCT=3scale
-PRODUCT_OPERATOR=3scale-operator
+PRODUCT=$2
+PRODUCT_OPERATOR=$3
 
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -2,18 +2,21 @@
 
 # This script extracts the most recent manifests from an image containing a manifests bundle and processes it into a version that works with this operator.
 #
-# Example:
+# Example: Running the script and checking the changes produced using git status
 #
 #$ ./process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-2
-#$ tree manifests/registry-proxy.engineering.redhat.com/rh-osbs/ -L 2
-#manifests/registry-proxy.engineering.redhat.com/rh-osbs/
-#└── 3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-2
-#    ├── 0.3.0
-#    ├── 0.4.0
-#    ├── 0.4.1
-#    ├── 0.4.2
-#    ├── 0.5.0
-#    └── 3scale-operator.package.yaml
+#$ git status
+# Changes not staged for commit:
+#  (use "git add <file>..." to update what will be committed)
+#  (use "git checkout -- <file>..." to discard changes in working directory)
+#
+#	modified:   manifests/integreatly-3scale/3scale.package.yaml
+#
+#Untracked files:
+#  (use "git add <file>..." to include in what will be committed)
+#
+#	manifests/integreatly-3scale/3scale-0.5.0/
+
 
 set -e
 

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -24,7 +24,8 @@ WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 MANIFESTS_DIR=${WORK_DIR}/../manifests
 MANIFEST_TMP_DIR=${MANIFESTS_DIR}/temp
 IMAGE=$1
-FOLDER_PRODUCT_NAME=3scale
+PRODUCT=3scale
+PRODUCT_OPERATOR=3scale-operator
 
 function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
 
@@ -45,14 +46,18 @@ extract_manifests_from_image() {
 
 get_current_csv() {
     echo "Getting current csv  from existing package.yaml"
-    CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels[0].currentCSV | sed -e s/^3scale-operator.v//)
+    # The sed entry here will need to be fixed up for each product.
+    # The operator versions do not all follow the same syntax
+    CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${PRODUCT}.package.yaml channels[0].currentCSV | sed -e s/^3scale-operator.v//)
     echo $CURRENT_CSV
 }
 
 get_new_csv() {
     IMAGE_MANIFEST_FILE=$(find ${MANIFEST_TMP_DIR} -name "*.package.yaml")
-    DEFAUlT_CHANNEL=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml defaultChannel)
-    NEW_CSV=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV)
+    DEFAUlT_CHANNEL=$(yq r ${MANIFEST_TMP_DIR}/${PRODUCT_OPERATOR}.package.yaml defaultChannel)
+    NEW_CSV=$(yq r ${MANIFEST_TMP_DIR}/${PRODUCT_OPERATOR}.package.yaml channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV)
+    # The sed entry here will need to be fixed up for each product.
+    # The operator versions do not all follow the same syntax
     NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^3scale-operator.v//)
 }
 
@@ -72,20 +77,21 @@ check_versions() {
 
 copy_new_csv() {
     echo "Copying process manifests to ${MANIFESTS_DIR}"
-    NEW_CSV_FOLDER=3scale-$NEW_CSV_SEMVER
+    # The below line won't work for apicurito as it doesn't add the product name to the semver in it's folder structure
+    NEW_CSV_FOLDER=${PRODUCT}-$NEW_CSV_SEMVER
     mv ${MANIFEST_TMP_DIR}/$NEW_CSV_SEMVER ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER}
-    mv ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER} ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/
+    mv ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER} ${MANIFESTS_DIR}/integreatly-${PRODUCT}/
 }
 
 update_new_csv() {
     echo "updating csv"
-    echo "${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml"
-    yq d -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.replaces
-    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.install.spec.deployments[0].spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath metadata.annotations['olm.targetNamespaces']
+    echo "${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${PRODUCT_OPERATOR}.v$NEW_CSV_SEMVER.clusterserviceversion.yaml"
+    yq d -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${PRODUCT_OPERATOR}.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.replaces
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${PRODUCT_OPERATOR}.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.install.spec.deployments[0].spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath metadata.annotations['olm.targetNamespaces']
 }
 
 update_package_yaml() {
-    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels.\(name==integreatly\).currentCSV $NEW_CSV
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${PRODUCT}.package.yaml channels.\(name==integreatly\).currentCSV $NEW_CSV
 }
 
 process_image() {

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -47,7 +47,7 @@ get_current_csv() {
 get_new_csv() {
     IMAGE_MANIFEST_FILE=$(find ${MANIFEST_TMP_DIR} -name "*.package.yaml")
     DEFAUlT_CHANNEL=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml defaultChannel)
-    NEW_CSV=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV | sed s/^3scale-operator.v//)
+    NEW_CSV=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV)
     NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^3scale-operator.v//)
 }
 
@@ -67,7 +67,7 @@ update_new_csv() {
 }
 
 update_package_yaml() {
-    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels.(name==integreatly).currentCSV 3scale-operator.v0.5.0
+    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels.\(name==integreatly\).currentCSV $NEW_CSV
 }
 
 process_image() {
@@ -78,7 +78,7 @@ process_image() {
    get_current_csv
    get_new_csv
    copy_new_csv
-   update__new_csv
+   update_new_csv
    update_package_yaml
 }
 

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+
+# This script extracts the most recent manifests from an image containing a manifests bundle and processes it into a version that works with this operator.
+#
+# Example:
+#
+#$ ./process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-2
+#$ tree manifests/registry-proxy.engineering.redhat.com/rh-osbs/ -L 2
+#manifests/registry-proxy.engineering.redhat.com/rh-osbs/
+#└── 3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-2
+#    ├── 0.3.0
+#    ├── 0.4.0
+#    ├── 0.4.1
+#    ├── 0.4.2
+#    ├── 0.5.0
+#    └── 3scale-operator.package.yaml
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../manifests
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/temp
+IMAGE=$1
+FOLDER_PRODUCT_NAME=3scale
+
+cleanup (){
+    echo "Cleaning up ${MANIFEST_TMP_DIR}"
+    rm -rf ${MANIFEST_TMP_DIR}
+}
+
+trap 'cleanup' EXIT
+
+extract_manifests_from_image() {
+    echo "Creating ${MANIFEST_TMP_DIR} directory"
+    mkdir -p ${MANIFEST_TMP_DIR}
+    echo "Extracting manifests from image '${IMAGE}' to ${MANIFEST_TMP_DIR}"
+    oc image extract $IMAGE --path /manifests/:${MANIFEST_TMP_DIR} --confirm
+    ls -la ${MANIFEST_TMP_DIR}
+}
+
+get_current_csv() {
+    echo "Getting current csv  from existing package.yaml"
+    CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels[0].currentCSV | sed -e s/^3scale-operator.v//)
+    echo $CURRENT_CSV
+}
+
+get_new_csv() {
+    IMAGE_MANIFEST_FILE=$(find ${MANIFEST_TMP_DIR} -name "*.package.yaml")
+    DEFAUlT_CHANNEL=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml defaultChannel)
+    NEW_CSV=$(yq r ${MANIFEST_TMP_DIR}/3scale-operator.package.yaml channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV | sed s/^3scale-operator.v//)
+    NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^3scale-operator.v//)
+}
+
+copy_new_csv() {
+    echo "Copying process manifests to ${MANIFESTS_DIR}"
+    # Need to check here that the version is not the same, if it is do we need to do an update?
+    NEW_CSV_FOLDER=3scale-$NEW_CSV_SEMVER
+    mv ${MANIFEST_TMP_DIR}/$NEW_CSV_SEMVER ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER}
+    mv ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER} ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/
+}
+
+update_new_csv() {
+    echo "updating csv"
+    echo "${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml"
+    yq d -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.replaces
+    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/${NEW_CSV_FOLDER}/3scale-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml spec.install.spec.deployments[0].spec.template.spec.containers[0].env[0].valueFrom.fieldRef.fieldPath metadata.annotations['olm.targetNamespaces']
+}
+
+update_package_yaml() {
+    yq w -i ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/3scale.package.yaml channels.(name==integreatly).currentCSV 3scale-operator.v0.5.0
+}
+
+process_image() {
+   echo "~~~~~~"
+   echo "Process Image '$IMAGE'"
+   echo "~~~~~~"
+   extract_manifests_from_image
+   get_current_csv
+   get_new_csv
+   copy_new_csv
+   update__new_csv
+   update_package_yaml
+}
+
+process_image

--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -26,6 +26,8 @@ MANIFEST_TMP_DIR=${MANIFESTS_DIR}/temp
 IMAGE=$1
 FOLDER_PRODUCT_NAME=3scale
 
+function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+
 cleanup (){
     echo "Cleaning up ${MANIFEST_TMP_DIR}"
     rm -rf ${MANIFEST_TMP_DIR}
@@ -54,9 +56,22 @@ get_new_csv() {
     NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^3scale-operator.v//)
 }
 
+check_versions() {
+    if [ $(ver $NEW_CSV_SEMVER) -eq $(ver $CURRENT_CSV) ]
+    then
+        echo "Versions are the same so EXIT"
+        exit
+    fi
+    if [ $(ver $NEW_CSV_SEMVER) -lt $(ver $CURRENT_CSV) ]
+    then
+        echo "There is a newer version of the CSV present so EXIT"
+        exit
+    fi
+    echo "Newer version found, continuing"
+}
+
 copy_new_csv() {
     echo "Copying process manifests to ${MANIFESTS_DIR}"
-    # Need to check here that the version is not the same, if it is do we need to do an update?
     NEW_CSV_FOLDER=3scale-$NEW_CSV_SEMVER
     mv ${MANIFEST_TMP_DIR}/$NEW_CSV_SEMVER ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER}
     mv ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER} ${MANIFESTS_DIR}/integreatly-${FOLDER_PRODUCT_NAME}/
@@ -80,6 +95,7 @@ process_image() {
    extract_manifests_from_image
    get_current_csv
    get_new_csv
+   check_versions
    copy_new_csv
    update_new_csv
    update_package_yaml


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/INTLY-4795

**Pre-req**
yq v3
The script verifys yq is installed. ~Replace the line inside check_yq function to `slkfjsdf >/dev/null` and the script will fail with an error. Or run it on a machine that doesn't have yq installed.~ no verification required here. It's working here https://integreatly-qe-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/view/Delorean%202.0/job/delorean-2-ews/job/3scale/job/discovery/23/console

**What**
Adding script which will be called by Jenkins pipeline. 
Extract the manifest 
Get the current version of the csv on the branch
Get the most recent version of the csv on from the manifest
Create a new folder for the new version and move the csv there.
Update csv to remove `replaces` and updates the namespace env var.

NOTE: For 3scale only for now.

**Verification**
Run `scripts/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-3 3scale 3scale-operator`

- [ ] Verify that there is a new folder under `manifests/integreatly-3scale` titled `3scale-0.5.0` which contains a copy of the csv.
- [ ] Verify that the replaces entry has been removed from `manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml` 
- [ ] Verify that the WATCH_NAMESPACES under the container vars value is `metadata.annotations['olm.targetNamespaces']`
- [ ] Verify that `manifest/integreatly-3scale/3scale.package.yaml` has the new CSV `3scale-operator.v0.5.0`
- [ ] Running `git status` results in output that matches
```
Changes not staged for commit:
  (use "git add <file>..." to update what will be committed)
  (use "git checkout -- <file>..." to discard changes in working directory)

	modified:   manifests/integreatly-3scale/3scale.package.yaml

Untracked files:
  (use "git add <file>..." to include in what will be committed)

	manifests/integreatly-3scale/3scale-0.5.0/

```

**Cleanup**
`git checkout manifests/integreatly-3scale/3scale.package.yaml`
`rm -rf manifests/integreatly-3scale/3scale-0.5.0`

**Verification of exit on same or newer existing csv version**
- [ ] Update the version of the csv in `/manifests/integreatly-3scale/3scale.package.json` to 0.6.0 aka greater than the targeted image manifest csv.
Run the script as above - it will exit without processing the csv

- [ ] Update the version as above to 0.5.0 - aka the same as the targeted image manifest csv.
Run the script as above - it will exit without processing the csv.
