### PR TITLE
add support to invoke functional tests locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,11 @@ test/e2e/prow: test/e2e
 test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/configmaps cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
 	operator-sdk --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
+.PHONY: test/functional
+test/functional:
+	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
+	go test ./test/functional
+
 .PHONY: install/olm
 install/olm: cluster/cleanup/olm cluster/prepare/olm cluster/prepare/configmaps cluster/prepare/smtp cluster/deploy/integreatly-rhmi-cr.yml
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,18 @@ Running unit tests:
 make test/unit
 ```
 
+### E2E tests
+
+To run E2E tests against a clean OpenShift cluster using operator-sdk:
+```
+make test/e2e
+```
+
+To run E2E tests against an existing RHMI cluster:
+```
+make test/functional
+```
+
 ## Using `ocm` for installation of RHMI
 
 If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using [OCM CLI](https://github.com/openshift-online/ocm-cli/releases):

--- a/test/README.md
+++ b/test/README.md
@@ -8,16 +8,30 @@
 
 * [`e2e`](./e2e)
   
-  The tests in this directory are executed using the operator-sdk's test command. It contains setup that are required to run tests using the operator-sdk.
+  This is used to initialise and run tests defined in `common` directory using the operator-sdk. Existing tests there should be refactored to move to the `common` directory.
+  
+  To run the `e2e` tests, execute:
+  
+  ```
+  make test/e2e
+  ```
+  
+  Because operator-sdk is used, they are useful for developing tests locally. You can run them against a clean OpenShift cluster, and operator-sdk will automatically clean up when the tests are finished.
  
 * [`functional`](./functional)
 
-  The tests in this directory will be used to build a container that can be used to run functional tests against an Integreatly cluster. See [this Dockerfile]('../Dockerfile.functional).
-  It contains setup that are required to run the tests from inside a container. 
+  This is used to initialise and run tests defined in `common` directory using `go test`. You can invoke the tests here against an existing RHMI cluster either using `go test`, or from an IDE.
   
-  Note that in order to run the tests, the container needs to have `admin` permission.
+  To run the `functional` tests, make sure you have logged in to the cluster first, then execute:
+  ```
+  make test/functional
+  ```
   
-  This container will be run as part of the [OSD Addon testing flow](https://github.com/openshift/osde2e/blob/master/docs/Addons.md). 
+  This is useful if you need to run the tests against an existing RHMI cluster for debugging or verification purposes.
+  
+  It will also be used to build the test harness image, and run tests from inside an container on a cluster. Note that in order to run the tests, the container needs to have `admin` permission. 
+  
+  This test harness image will be used as part of our own testing pipelines, as well as as part of the [OSD Addon testing flow](https://github.com/openshift/osde2e/blob/master/docs/Addons.md). 
 
 * [`metadata`](./metadata)  
   

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -13,11 +13,12 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
+	config2 "sigs.k8s.io/controller-runtime/pkg/client/config"
 	"testing"
 )
 
 func TestIntegreatly(t *testing.T) {
-	config, err := rest.InClusterConfig()
+	config, err := config2.GetConfig()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -79,22 +79,26 @@ func TestMain(t *testing.M) {
 		exitCode = t.Run()
 	})
 
-	err := writeOutputToFile(output, filepath.Join(testResultsDirectory, testOutputFileName))
-	if err != nil {
-		fmt.Printf("error while writing the test output: %v", err)
-		os.Exit(1)
-	}
+	fmt.Printf(output)
 
-	err = writeJunitReportFile(output, filepath.Join(testResultsDirectory, jUnitOutputFilename))
-	if err != nil {
-		fmt.Printf("error while writing the junit report file: %v", err)
-		os.Exit(1)
-	}
+	if _, err := os.Stat(testResultsDirectory); !os.IsNotExist(err) {
+		err := writeOutputToFile(output, filepath.Join(testResultsDirectory, testOutputFileName))
+		if err != nil {
+			fmt.Printf("error while writing the test output: %v", err)
+			os.Exit(1)
+		}
 
-	err = metadata.Instance.WriteToJSON(filepath.Join(testResultsDirectory, addonMetadataName))
-	if err != nil {
-		fmt.Printf("error while writing metadata: %v", err)
-		os.Exit(1)
+		err = writeJunitReportFile(output, filepath.Join(testResultsDirectory, jUnitOutputFilename))
+		if err != nil {
+			fmt.Printf("error while writing the junit report file: %v", err)
+			os.Exit(1)
+		}
+
+		err = metadata.Instance.WriteToJSON(filepath.Join(testResultsDirectory, addonMetadataName))
+		if err != nil {
+			fmt.Printf("error while writing metadata: %v", err)
+			os.Exit(1)
+		}
 	}
 
 	os.Exit(exitCode)


### PR DESCRIPTION
verification:

1. Login to an existing openshift cluster.
2. Run `make test/functional`. The test may pass or fail depending on if the CRD exists in the cluster.