### PR TITLE
INTLY-3397: Add Fuse on Openshift uninstallation

### DIFF
--- a/pkg/products/fuseonopenshift/reconciler_test.go
+++ b/pkg/products/fuseonopenshift/reconciler_test.go
@@ -100,13 +100,20 @@ func TestFuseOnOpenShift(t *testing.T) {
 		},
 	}
 
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "installation",
+			Namespace: OperatorNamespace,
+		},
+	}
+
 	cases := []FuseOnOpenShiftScenario{
 		{
 			Name:           "test error on failed config read",
 			ExpectError:    true,
 			ExpectedError:  fmt.Sprintf("could not retrieve %[1]s config: could not read %[1]s config", integreatlyv1alpha1.ProductFuseOnOpenshift),
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			Installation:   installation,
 			FakeClient:     fakeclient.NewFakeClient(),
 			FakeConfig: &config.ConfigReadWriterMock{
 				ReadFuseOnOpenshiftFunc: func() (ready *config.FuseOnOpenshift, e error) {
@@ -120,7 +127,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test error on invalid image stream file content",
 			ExpectError:    true,
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			Installation:   installation,
 			FakeClient: fakeclient.NewFakeClient(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      templatesConfigMapName,
@@ -136,7 +143,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test error on invalid image stream",
 			ExpectError:    true,
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			Installation:   installation,
 			FakeClient: fakeclient.NewFakeClient(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      templatesConfigMapName,
@@ -156,7 +163,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test error on invalid template file content",
 			ExpectError:    true,
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			Installation:   installation,
 			FakeClient: fakeclient.NewFakeClient(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      templatesConfigMapName,
@@ -175,7 +182,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test error on invalid template object",
 			ExpectError:    true,
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			Installation:   installation,
 			FakeClient: fakeclient.NewFakeClient(&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      templatesConfigMapName,
@@ -195,8 +202,8 @@ func TestFuseOnOpenShift(t *testing.T) {
 		{
 			Name:           "test successful reconcile when resource already exists",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Installation:   &integreatlyv1alpha1.RHMI{},
-			FakeClient:     fakeclient.NewFakeClient(integreatlyImgStream),
+			Installation:   installation,
+			FakeClient:     fakeclient.NewFakeClient(integreatlyImgStream, installation),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.RHMIProductStatus{},
 			Recorder:       setupRecorder(),
@@ -205,8 +212,8 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test successful reconcile without sample cluster operator installed",
 			ExpectError:    false,
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Installation:   &integreatlyv1alpha1.RHMI{},
-			FakeClient:     fakeclient.NewFakeClient(),
+			Installation:   installation,
+			FakeClient:     fakeclient.NewFakeClient(installation),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.RHMIProductStatus{},
 			Recorder:       setupRecorder(),
@@ -215,8 +222,8 @@ func TestFuseOnOpenShift(t *testing.T) {
 			Name:           "test successful reconcile with sample cluster operator installed",
 			ExpectError:    false,
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			Installation:   &integreatlyv1alpha1.RHMI{},
-			FakeClient:     fakeclient.NewFakeClient(sampleClusterConfig, sampleClusterImgStream),
+			Installation:   installation,
+			FakeClient:     fakeclient.NewFakeClient(sampleClusterConfig, sampleClusterImgStream, installation),
 			FakeConfig:     getFakeConfig(),
 			Product:        &integreatlyv1alpha1.RHMIProductStatus{},
 			Recorder:       setupRecorder(),


### PR DESCRIPTION
## What

Remove fuse on openshift templates from the config of the samples operator during RHMI uninstall

The fuse on openshift templates and imagestreams are added to the skippedTemplates and
skippedImageStreams of the cluster config samples CR. We should ensure that they are removed
upon uninstallation of RHMI.

## Verification Steps
1. Install RHMI with fuse on openshift
   - **Verify**: `fuse-on-openshift-templates` configmap should not have an ownerReference
   - **Verify**: The RHMI CR should have the finalizer `finalizer.fuse-on-openshift.integreatly.org`
   - **Verify**: fuse on openshift templates and image streams should be added to the sample cluster config CR.
2. Delete the RHMI CR to uninstall
   - **Verify**: The fuse on openshift templates and imagestreams should be removed from the `skippedTemplates` and `skippedImageStreams` of the samples cluster config CR
   - **Verify**: RHMI CR should be deleted and uninstall completed successfully.
   - **Verify**: The `fuse-on-openshift-templates` configmap should be removed

JIRA: https://issues.redhat.com/browse/INTLY-3397