### PR TITLE
remove --confirm flag

### DIFF
--- a/scripts/process-image-manifests
+++ b/scripts/process-image-manifests
@@ -48,7 +48,7 @@ extract_manifests_from_image() {
     echo "Creating ${MANIFEST_TMP_DIR} directory"
     mkdir -p ${MANIFEST_TMP_DIR}
     echo "Extracting manifests from image '${IMAGE}' to ${MANIFEST_TMP_DIR}"
-    oc image extract $IMAGE --path /manifests/:${MANIFEST_TMP_DIR} --confirm
+    oc image extract $IMAGE --path /manifests/:${MANIFEST_TMP_DIR}
     ls -la ${MANIFEST_TMP_DIR}
 }
 


### PR DESCRIPTION
Removing the --confirm flag. As per the `oc image extract --help` this command `--confirm=false: Pass to allow extracting to non-empty directories.` As we've just created the directory I'd expect it to be empty. If it's not we probably want the script to fail.