### PR TITLE
Add process-csv-images script 

### DIFF
--- a/scripts/process-csv-images
+++ b/scripts/process-csv-images
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+# This script processes a given cluster service version file (csv) to replace all occurrences of internal image registries with a deloeran version and generate an image_mirror_mapping file.
+#
+# Example: Running the script and checking the changes produced
+#
+#$ ./scripts/process-csv-images manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml 3scale
+#$ grep delorean manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml
+#    image: quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-system-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-zync-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-memcached-rhel7_3scale2.8
+#$ cat manifests/integreatly-3scale/image_mirror_mapping
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-backend-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-system-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-system-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-zync-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-zync-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-memcached-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-memcached-rhel7_3scale2.8
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../manifests
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
+
+RH_REGISTRY_PROD=registry.redhat.io
+RH_REGISTRY_STAGE=registry.stage.redhat.io
+RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
+DELOREAN_REGISTRY=quay.io/integreatly/delorean
+
+collect_csv_images() {
+    csv_images=(`grep -o $RH_REGISTRY_STAGE.* $1 || true`)
+}
+
+process_csv_images() {
+    echo "Generate Image Mirror Mapping for $2"
+    image_mirror_mapping=${MANIFESTS_DIR}/integreatly-${2}/image_mirror_mapping
+
+    for image in "${csv_images[@]}"
+    do
+        echo "Processing image $image"
+
+        image_path="$(echo $image | grep / | cut -d/ -f2-)"
+        osbs_image_path="$(echo $image_path | sed 's/\//-/')"
+        delorean_image_path="$(echo $osbs_image_path | sed 's/:/_/')"
+
+        osbs_image="${RH_REGISTRY_OSBS}/${osbs_image_path}"
+        delorean_image="${DELOREAN_REGISTRY}/${delorean_image_path}"
+
+        echo "CSV Image: ${image}"
+        echo "OSBS Image: ${osbs_image}"
+        echo "Delorean Image: ${delorean_image}"
+
+        #Update image reference in csv to use delorean registry
+        sed -i.bak "s|${image}|${delorean_image}|g" $1
+        rm $1.bak
+
+        #Add the image mapping if it doesn't already exist
+        osbs_delorean_map="${osbs_image} ${delorean_image}"
+        grep -qxF "$osbs_delorean_map" $image_mirror_mapping || echo $osbs_delorean_map >> $image_mirror_mapping
+    done
+}
+
+CSV=$1
+PRODUCT=$2
+
+process_csv() {
+    echo "~~~~~~"
+    echo "Process CSV '$CSV' for Product $PRODUCT"
+    echo "~~~~~~"
+
+    if [ ! -f "$CSV" ]; then
+        echo "$CSV does not exist"
+        exit 1
+    fi
+
+    collect_csv_images $CSV
+    process_csv_images $CSV $PRODUCT
+}
+
+process_csv


### PR DESCRIPTION
* Update csv with delorean registry image urls
* Generates a image_mirror_mapping in the operators manifest directory

Verify using:

```
$ ./scripts/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-3 3scale 3scale-operator
$ ./scripts/process-csv-images manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml 3scale
$ cat manifests/integreatly-3scale/image_mirror_mapping 
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-backend-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-system-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-system-rhel7_3scale2.8
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-zync-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-zync-rhel7_3scale2.8
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-memcached-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-memcached-rhel7_3scale2.8
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator@sha256:0208475c26aac01766244dc7e32aec576c484646838790d4f65d8c2e63f6611b quay.io/integreatly/delorean/3scale-amp2-3scale-rhel7-operator@sha256_0208475c26aac01766244dc7e32aec576c484646838790d4f65d8c2e63f6611b


```

