### PR TITLE
feat: ocm template - byoc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,14 +146,26 @@ make test/unit
 
 ## Using `ocm` for installation of RHMI
 
-If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using [OCM CLI](https://github.com/openshift-online/ocm-cli/releases):
+If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using [OCM CLI](https://github.com/openshift-online/ocm-cli/releases). If you want to spin up a cluster using BYOC (your own AWS credentials), follow the additional steps marked as `BYOC`:
 
 1. Download the CLI tool and add it to your PATH
 2. Export [OCM_TOKEN](https://github.com/openshift-online/ocm-cli#log-in): `export OCM_TOKEN="<TOKEN_VALUE>"`
+
+**BYOC**
+Make sure you have credentials for IAM user with admin access to AWS and other IAM user called "osdCcsAdmin" created in AWS, also with admin access.
+Export the credentials for your IAM user, set BYOC variable to `true` and create a new access key for "osdCcsAdmin" user:
+```
+export AWS_ACCOUNT_ID=<REPLACE_ME>
+export AWS_ACCESS_KEY_ID=<REPLACE_ME>
+export AWS_SECRET_ACCESS_KEY=<REPLACE_ME>
+export BYOC=true
+make ocm/aws/create_access_key
+```
+
 3. Create cluster template: `make ocm/cluster.json`.
 
 This command will generate `ocm/cluster.json` file with generated cluster name. This file will be used as a template to create your cluster via OCM CLI.
-By default, it will set the expiration timestamp for a cluster for 4 hours, meaning your cluster will be automatically deleted after 4 hours after you generated this template. If you want to change the default timestamp, you can update it in `ocm/cluster.json` or delete the whole line from the file if you don't want your cluster to be deleted automatically at all.
+By default, it will set the expiration timestamp for a cluster for 4 hours, meaning your cluster will be automatically deleted after 4 hours after you generated this template. If you want to change the default timestamp, you can update it in `ocm/cluster.json` or delete the whole line from the file if you don't want your cluster to be deleted automatically at all. 
 
 4. Create the cluster: `make ocm/cluster/create`.
 
@@ -169,6 +181,7 @@ oc --config ocm/cluster.kubeconfig projects
 Run `make ocm/install/rhmi-addon` to trigger the installation. Once the installation is completed, the installation CR with RHMI components info will be printed to the console.
 
 7. If you want to delete your cluster, run `make ocm/cluster/delete`
+**BYOC**
 
 ## Release
 

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -25,10 +25,20 @@ define save_cluster_credentials
 	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin | tee ocm/cluster-credentials.json
 endef
 
+define get_aws_credentials
+	$(eval ACCESS_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .AccessKeyId < ocm/aws.json))
+	$(eval SECRET_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .SecretAccessKey < ocm/aws.json))
+endef
+
 ifeq ($(UNAME), Linux)
 	OCM_CLUSTER_EXPIRATION_TIMESTAMP=$(shell date --date="${OCM_CLUSTER_LIFESPAN} hour" "+%FT%TZ")
 else ifeq ($(UNAME), Darwin)
 	OCM_CLUSTER_EXPIRATION_TIMESTAMP=$(shell date -v+${OCM_CLUSTER_LIFESPAN}H "+%FT%TZ")
+endif
+
+ifeq ($(BYOC), true)
+	ACCESS_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .AccessKeyId < ocm/aws.json)
+	SECRET_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .SecretAccessKey < ocm/aws.json)
 endif
 
 .PHONY: ocm/version
@@ -100,9 +110,14 @@ ocm/cluster.json:
 	@if [ $(BYOC) = true ]; then\
 	  jq '\
 	  .byoc = true | \
-	  .aws.access_key_id = "$(AWS_ACCESS_KEY_ID)" | \
-	  .aws.secret_access_key = "$(AWS_SECRET_ACCESS_KEY)" | \
+	  .aws.access_key_id = "$(ACCESS_KEY)" | \
+	  .aws.secret_access_key = "$(SECRET_KEY)" | \
 	  .aws.account_id = "$(AWS_ACCOUNT_ID)"' < ocm/cluster.json > ocm/cluster.json.tmp \
 	  && mv ocm/cluster.json.tmp ocm/cluster.json;\
 	fi
 	@cat ocm/cluster.json
+
+.PHONY: ocm/aws/create_access_key
+ocm/aws/create_access_key:
+	@mkdir -p ocm
+	@aws iam create-access-key --user-name osdCcsAdmin | jq -r .AccessKey | tee ocm/aws.json

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -25,11 +25,6 @@ define save_cluster_credentials
 	@$(OCM) get /api/clusters_mgmt/v1/clusters/${OCM_CLUSTER_ID}/credentials | jq -r .admin | tee ocm/cluster-credentials.json
 endef
 
-define get_aws_credentials
-	$(eval ACCESS_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .AccessKeyId < ocm/aws.json))
-	$(eval SECRET_KEY=$(shell mkdir -p ocm && touch ocm/aws.json && jq -r .SecretAccessKey < ocm/aws.json))
-endef
-
 ifeq ($(UNAME), Linux)
 	OCM_CLUSTER_EXPIRATION_TIMESTAMP=$(shell date --date="${OCM_CLUSTER_LIFESPAN} hour" "+%FT%TZ")
 else ifeq ($(UNAME), Darwin)

--- a/templates/ocm-cluster/cluster-template.json
+++ b/templates/ocm-cluster/cluster-template.json
@@ -1,11 +1,13 @@
 {
-  "name": "OCM_CLUSTER_NAME",
-  "region": {
-    "id": "OCM_CLUSTER_REGION"
-  },
-  "expiration_timestamp": "OCM_CLUSTER_EXPIRATION_TIMESTAMP",
+  "byoc": false,
+  "managed": true,
+  "multi_az": false,
+  "name": "my_cluster_name",
   "nodes" : {
     "compute" : 4,
     "compute_machine_type" : {"id" : "m5.xlarge" }
+  },
+  "region": {
+    "id": "eu-west-1"
   }
 }


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-5451

* `make ocm/aws/create_access_key` to generate access key via aws CLI
  * expects following env vars to be exported/passed as a parameter:
  * `AWS_ACCESS_KEY_ID`,      `AWS_ACCOUNT_ID`,         `AWS_SECRET_ACCESS_KEY`
* `make BYOC=true ocm/cluster.json` to generate a cluster config with aws credentials

I'll update the readme shortly