### PR TITLE
process-csv-images script updates

### DIFF
--- a/scripts/csv_helper
+++ b/scripts/csv_helper
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../manifests
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
+
+get_current_csv() {
+    echo "$(yq r ${MANIFESTS_DIR}/integreatly-${1}/${1}.package.yaml channels[0].currentCSV)"
+}
+
+get_current_csv_file() {
+    echo "$(grep -lR "name: $(get_current_csv $1)" ${MANIFESTS_DIR}/integreatly-$1/)"
+}

--- a/scripts/process-csv-images
+++ b/scripts/process-csv-images
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 
-# This script processes a given cluster service version file (csv) to replace all occurrences of internal image registries with a deloeran version and generate an image_mirror_mapping file.
+# This script locates the current cluster service version file (csv) for a given product and replaces all occurrences of internal image registries with a deloeran version and generates an image_mirror_mapping file.
 #
 # Example: Running the script and checking the changes produced
 #
-#$ ./scripts/process-csv-images manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml 3scale
+#$ ./scripts/process-csv-images 3scale
 #$ grep delorean manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml
 #    image: quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
 #    image: quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
@@ -21,8 +21,8 @@
 set -e
 
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-MANIFESTS_DIR=${WORK_DIR}/../manifests
-MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
+
+source $WORK_DIR/csv_helper
 
 RH_REGISTRY_PROD=registry.redhat.io
 RH_REGISTRY_STAGE=registry.stage.redhat.io
@@ -43,10 +43,10 @@ process_csv_images() {
 
         image_path="$(echo $image | grep / | cut -d/ -f2-)"
         osbs_image_path="$(echo $image_path | sed 's/\//-/')"
-        delorean_image_path="$(echo $osbs_image_path | sed 's/:/_/')"
+        delorean_image_tag="$(echo $osbs_image_path | sed 's/:/_/')"
 
         osbs_image="${RH_REGISTRY_OSBS}/${osbs_image_path}"
-        delorean_image="${DELOREAN_REGISTRY}/${delorean_image_path}"
+        delorean_image="${DELOREAN_REGISTRY}:${delorean_image_tag}"
 
         echo "CSV Image: ${image}"
         echo "OSBS Image: ${osbs_image}"
@@ -62,21 +62,16 @@ process_csv_images() {
     done
 }
 
-CSV=$1
-PRODUCT=$2
+PRODUCT=$1
 
 process_csv() {
     echo "~~~~~~"
-    echo "Process CSV '$CSV' for Product $PRODUCT"
+    echo "Process CSV images for Product $PRODUCT"
     echo "~~~~~~"
 
-    if [ ! -f "$CSV" ]; then
-        echo "$CSV does not exist"
-        exit 1
-    fi
-
-    collect_csv_images $CSV
-    process_csv_images $CSV $PRODUCT
+    current_csv=$(get_current_csv_file $PRODUCT)
+    collect_csv_images $current_csv
+    process_csv_images $current_csv $PRODUCT
 }
 
 process_csv


### PR DESCRIPTION
* Add csv_helper bash script
* Update process-csv-images script:
   * Use helper method to get current csv file for the product
   * Fix delorean image path/tag

Process CSV script now executes like:

```
./scripts/process-csv-images 3scale
```

Helper method can be used outside of other bash scripts like:

```
$ . ./scripts/csv_helper && get_current_csv_file 3scale
/home/mnairn/go/src/github.com/integr8ly/integreatly-operator/scripts/../manifests/integreatly-3scale/3scale-0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml

$ . ./scripts/csv_helper && get_current_csv 3scale
3scale-operator.v0.4.0

 $ . ./scripts/csv_helper && get_current_csv_file codeready-workspaces
/home/mnairn/go/src/github.com/integr8ly/integreatly-operator/scripts/../manifests/integreatly-codeready-workspaces/codeready-workspaces-2.0.0/codeready-workspaces.2.0.0.clusterserviceversion.yaml

$ . ./scripts/csv_helper && get_current_csv codeready-workspaces
crwoperator.v2.0.0
```

So could be used in a jenkins pipeline if required:

```
script {
    current_csv_file = sh(returnStdout: true, script: '. ./scripts/csv_helper && get_current_csv_file 3scale')
}
```