### PR TITLE
Update process-csv-images script to deal with images using a sha56 digest

### DIFF
--- a/scripts/process-csv-images
+++ b/scripts/process-csv-images
@@ -43,7 +43,7 @@ process_csv_images() {
 
         image_path="$(echo $image | grep / | cut -d/ -f2-)"
         osbs_image_path="$(echo $image_path | sed 's/\//-/')"
-        delorean_image_tag="$(echo $osbs_image_path | sed 's/:/_/')"
+        delorean_image_tag="$(echo $osbs_image_path | sed 's/:/_/' | sed 's/@sha256.*$/_latest/')"
 
         osbs_image="${RH_REGISTRY_OSBS}/${osbs_image_path}"
         delorean_image="${DELOREAN_REGISTRY}:${delorean_image_tag}"


### PR DESCRIPTION

Will produce a mapping which is valid of oc image mirror:

```
registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator@sha256:0208475c26aac01766244dc7e32aec576c484646838790d4f65d8c2e63f6611b quay.io/integreatly/delorean:3scale-amp2-3scale-rhel7-operator_latest
```

