### PR TITLE
Removed cronjob for postgres in codeready workspaces as never required

### DIFF
--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -346,12 +346,6 @@ func (r *Reconciler) reconcileBackups(ctx context.Context, serverClient k8sclien
 		BackendSecret: resources.BackupSecretLocation{Name: r.Config.GetBackupsSecretName(), Namespace: r.Config.GetNamespace()},
 		Components: []resources.BackupComponent{
 			{
-				Name:     "codeready-postgres-backup",
-				Type:     "postgres",
-				Secret:   resources.BackupSecretLocation{Name: r.Config.GetPostgresBackupSecretName(), Namespace: r.Config.GetNamespace()},
-				Schedule: r.Config.GetBackupSchedule(),
-			},
-			{
 				Name:     "codeready-pv-backup",
 				Type:     "codeready_pv",
 				Schedule: r.Config.GetBackupSchedule(),


### PR DESCRIPTION
## Justification:
jira: https://issues.redhat.com/browse/INTLY-5490

## Verification
- Run the integreatly-operator locally
```bash
# prepare the cluster
make cluster/prepare/project
make cluster/prepare/crd
make cluster/prepare/smtp

# Create the installation custom resource
oc create -f deploy/crds/examples/rhmi.cr.yaml

# The operator can now be run locally
make code/run
```
- go to the `redhat-rhmi-middleware-monitoring-operator` project
- check the prometheus route for monitoring alerts e.g. https://prometheus-route-redhat-rhmi-middleware-monitoring-operator.apps.aucunnin.h4m0.s1.devshift.org/alerts
- make sure there are only two alerts for codeready as shown below 
![image](https://user-images.githubusercontent.com/16667688/74846184-fb1c7e80-5327-11ea-981e-1b8c1bbb5448.png)
- check that there is no postgres pod running in codeready workspaces namespace
![image](https://user-images.githubusercontent.com/16667688/74914773-ea691880-53ba-11ea-9d77-32cab4b5ef7f.png)

