### PR TITLE
Add alerts for zync and zync-database availability 

### DIFF
--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -96,19 +96,19 @@ spec:
           severity: critical
       - alert: ThreeScaleZyncPodAvailability
         annotations:
-          message:  3Scale Zync has no pods in a ready state.
+          message:  3Scale Zync has {{ "{{" }} printf "%.0f" $value {{ "}}" }} in a ready state. Expected at least 2 pod.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
         expr: |
-          absent(count((kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}",pod=~"zync-1.*"}) + on(pod) (kube_pod_container_status_running{namespace="{{ index .Params "Namespace" }}",container="zync"}))==2)
+          (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element=""})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element=""}) != 2
         for: 5m
         labels:
           severity: critical
       - alert: ThreeScaleZyncDatabasePodAvailiblity
         annotations:
-          message:  3Scale Zync-database has no pods in a ready state.
+          message:  3Scale Zync-database has {{ "{{" }} printf "%.0f" $value {{ "}}" }} in a ready state. Expected at least 1 pod.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
         expr: |
-          absent(count((kube_pod_labels{ namespace="{{ index .Params "Namespace" }}", pod=~"zync-database.*",label_threescale_component_element="database"}) + on(pod) (kube_pod_status_ready{ namespace="{{ index .Params "Namespace" }}", pod=~"zync-database.*",condition="true" })==2))
+          (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element="database"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element="database"}) != 1
         for: 5m
         labels:
           severity: critical
@@ -117,7 +117,7 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 15 pods.
         expr: |
-          absent(sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) >= 14)
+          (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) < 14
         for: 5m
         labels:
           severity: warning

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -96,31 +96,22 @@ spec:
           severity: critical
       - alert: ThreeScaleZyncPodAvailability
         annotations:
-          message:  3Scale Zync has {{ "{{" }} printf "%.0f" $value {{ "}}" }} in a ready state. Expected at least 2 pod.
+          message:  3Scale Zync has {{ "{{" }} printf "%.0f" $value {{ "}}" }} pods in a ready state. Expected a minimum of 2 pods.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
         expr: |
           (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element=""})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element=""}) != 2
         for: 5m
         labels:
           severity: critical
-      - alert: ThreeScaleZyncDatabasePodAvailiblity
+      - alert: ThreeScaleZyncDatabasePodAvailability
         annotations:
-          message:  3Scale Zync-database has {{ "{{" }} printf "%.0f" $value {{ "}}" }} in a ready state. Expected at least 1 pod.
+          message:  3Scale Zync-database has {{ "{{" }} printf "%.0f" $value {{ "}}" }} pods in a ready state. Expected a minimum of 1 pod.
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
         expr: |
           (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element="database"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{namespace="{{ index .Params "Namespace" }}", label_threescale_component="zync", label_threescale_component_element="database"}) != 1
         for: 5m
         labels:
           severity: critical
-      - alert: ThreeScalePodCount
-        annotations:
-          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 15 pods.
-        expr: |
-          (1-absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"}) < 14
-        for: 5m
-        labels:
-          severity: warning
       - alert: ThreeScalePodHighMemory
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -94,6 +94,24 @@ spec:
         for: 5m
         labels:
           severity: critical
+      - alert: ThreeScaleZyncPodAvailability
+        annotations:
+          message:  3Scale Zync has no pods in a ready state.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+        expr: |
+          absent(count((kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}",pod=~"zync-1.*"}) + on(pod) (kube_pod_container_status_running{namespace="{{ index .Params "Namespace" }}",container="zync"}))==2)
+        for: 5m
+        labels:
+          severity: critical
+      - alert: ThreeScaleZyncDatabasePodAvailiblity
+        annotations:
+          message:  3Scale Zync-database has no pods in a ready state.
+          sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
+        expr: |
+          absent(count((kube_pod_labels{ namespace="{{ index .Params "Namespace" }}", pod=~"zync-database.*",label_threescale_component_element="database"}) + on(pod) (kube_pod_status_ready{ namespace="{{ index .Params "Namespace" }}", pod=~"zync-database.*",condition="true" })==2))
+        for: 5m
+        labels:
+          severity: critical
       - alert: ThreeScalePodCount
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md


### PR DESCRIPTION
# Why
*JIRA:* https://issues.redhat.com/browse/INTLY-5290

# Verification
- checkout this branch
- run rhmi locally 
- check the application monitoring prometheus alerts for the following alerts
ThreeScaleZyncPodAvailiblity, ThreeScaleZyncDatabasePodAvailiblity
![image](https://user-images.githubusercontent.com/16667688/75030033-2a9fc800-549b-11ea-881a-cd8fbf137549.png)

- Test the alerts going to the deployment configs and scaling down the zync and zync-database pods for 5 minutes to confirm the alert triggers
![image](https://user-images.githubusercontent.com/16667688/75031394-0b566a00-549e-11ea-9a75-af8caa822675.png)
>*NOTE*: zync pods may scale up again so may need to stop the 3scale operator.


