### PR TITLE
add all products to installed_services env var

### DIFF
--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -356,7 +356,7 @@ func (r *Reconciler) getInstalledProducts(installation *integreatlyv1alpha1.RHMI
 	// Ensure that ups is not added to the installed products
 	products := make(map[integreatlyv1alpha1.ProductName]productInfo)
 	for name, info := range installedProducts {
-		if name != integreatlyv1alpha1.ProductAMQOnline && name != integreatlyv1alpha1.ProductUps && info.Host != "" {
+		if info.Host != "" {
 			id := r.getProductID(name)
 			products[id] = productInfo{
 				Host:    info.Host,


### PR DESCRIPTION
UPS and AMQ Online were not included in the `INSTALLED_SERVICES` env var that is added to the webapp.