### PR TITLE
Add missing pvc alerts

### DIFF
--- a/templates/monitoring/kube_state_metrics_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_alerts.yaml
@@ -88,3 +88,27 @@ spec:
         for: 15m
         labels:
           severity: warning
+      - alert: PVCStorageWillFillIn4Days
+        annotations:
+          message: The {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} PVC will run of disk space in the next 4 days.
+        expr: |
+          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info)  <= 0
+        for: 15m
+        labels:
+          severity: warning
+      - alert: PVCStorageWillFillIn4Hours
+        annotations:
+          message: The {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} PVC will run of disk space in the next 4 hours.
+        expr: |
+          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info) <= 0
+        for: 15m
+        labels:
+          severity: critical
+      - alert: PersistentVolumeErrors
+        annotations:
+          message: The PVC {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} is in status {{ "{{" }} $labels.phase {{ "}}" }} in namespace {{ "{{" }} $labels.namespace {{ "}}" }}
+        expr: |
+          (sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~"Failed|Pending|Lost"}) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) > 0
+        for: 15m
+        labels:
+          severity: critical

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -172,6 +172,12 @@ func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framew
 			if alert.Labels["alertname"] == "KeycloakAPIRequestDuration90PercThresholdExceeded" {
 				continue
 			}
+
+			// FIXME: remove this condition once INTLY-5638 is addressed
+			if alert.Labels["alertname"] == "PVCStorageWillFillIn4Days" || alert.Labels["alertname"] == "PVCStorageWillFillIn4Hours" {
+				continue
+			}
+
 			if alert.State == "firing" {
 				firingalerts = append(firingalerts, string(alert.Labels["alertname"]))
 			}


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/INTLY-5466

## Verification

- Perform an install via this branch
- Ensure that the below alerts were successfully created within `prometheus`, in the `rhmi-middleware-monitoring` namespace:

![pv_alerts](https://user-images.githubusercontent.com/47980969/75142964-143c7b00-56ec-11ea-9833-bfd90fb09dba.png)

- View the expression in Prometheus for both the `PVCStorageWillFillIn4Days` and `PVCStorageWillFillIn4Hours` alerts, and remove the `<= 0` part of the expression. The expression should return a value for all of the available PVCs.
