### PR TITLE
fix: jq compile error on linux OS

### DIFF
--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -9,8 +9,6 @@ OCM_CLUSTER_LIFESPAN=4
 RHMI_OPERATOR_NS=redhat-rhmi-operator
 # Path to the new cluster's kubeconfig
 CLUSTER_KUBECONFIG="ocm/cluster.kubeconfig"
-# Whether to use BYOC method (specify your own AWS credentials)
-BYOC=false
 
 define get_cluster_id
 	@$(eval OCM_CLUSTER_ID=$(shell mkdir -p ocm && touch ocm/cluster-details.json && jq -r .id < ocm/cluster-details.json ))
@@ -99,17 +97,10 @@ ocm/cluster/delete:
 ocm/cluster.json: export OCM_CLUSTER_REGION := eu-west-1
 ocm/cluster.json:
 	@mkdir -p ocm
-	@jq '\
-	.expiration_timestamp = "$(OCM_CLUSTER_EXPIRATION_TIMESTAMP)" | \
-	.name = "$(OCM_CLUSTER_NAME)" | \
-	.region.id = "$(OCM_CLUSTER_REGION)"' < templates/ocm-cluster/cluster-template.json > ocm/cluster.json
+	@jq '.expiration_timestamp = "$(OCM_CLUSTER_EXPIRATION_TIMESTAMP)" | .name = "$(OCM_CLUSTER_NAME)" | .region.id = "$(OCM_CLUSTER_REGION)"' < templates/ocm-cluster/cluster-template.json > ocm/cluster.json
 	@if [ "${BYOC}" = true ]; then\
-	  jq '\
-	  .byoc = true | \
-	  .aws.access_key_id = "$(ACCESS_KEY)" | \
-	  .aws.secret_access_key = "$(SECRET_KEY)" | \
-	  .aws.account_id = "$(AWS_ACCOUNT_ID)"' < ocm/cluster.json > ocm/cluster.json.tmp \
-	  && mv ocm/cluster.json.tmp ocm/cluster.json;\
+		jq '.byoc = true | .aws.access_key_id = "$(ACCESS_KEY)" | .aws.secret_access_key = "$(SECRET_KEY)" | .aws.account_id = "$(AWS_ACCOUNT_ID)"' < ocm/cluster.json > ocm/cluster.json.tmp \
+		&& mv ocm/cluster.json.tmp ocm/cluster.json;\
 	fi
 	@cat ocm/cluster.json
 


### PR DESCRIPTION
For some reason, Linux slaves do not like line endings with slash in `jq` commands:
```
12:20:05  + make BYOC=true OCM_CLUSTER_LIFESPAN=5 ocm/cluster.json
12:20:05  jq: error: syntax error, unexpected INVALID_CHARACTER, expecting $end (Unix shell quoting issues?) at <top-level>, line 1:
12:20:05  \
12:20:05  jq: 1 compile error
12:20:05  make: *** [ocm/cluster.json] Error 3
```

Removing the slashes fixes it. Verified on Jenkins slave.