### PR TITLE
Stage Reporting And Availability Metric

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,9 +18,9 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/apis"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller"
+	integreatlymetrics "github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"github.com/integr8ly/integreatly-operator/version"
 
-	"github.com/prometheus/client_golang/prometheus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -47,25 +47,12 @@ var (
 	products            []string
 )
 
-// Custom metrics
-var (
-	operatorVersion = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "integreatly_version_info",
-			Help: "Integreatly operator information",
-			ConstLabels: prometheus.Labels{
-				"operator_version": version.Version,
-				"version":          version.IntegreatlyVersion,
-			},
-		},
-	)
-)
-
 var log = logf.Log.WithName("cmd")
 
 func init() {
 	// Register custom metrics with the global prometheus registry
-	customMetrics.Registry.MustRegister(operatorVersion)
+	customMetrics.Registry.MustRegister(integreatlymetrics.OperatorVersion)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatusAvailable)
 }
 
 func printVersion() {

--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -86,6 +86,8 @@ spec:
               type: string
             smtpEnabled:
               type: boolean
+            stage:
+              type: string
             stages:
               additionalProperties:
                 properties:
@@ -128,6 +130,7 @@ spec:
               type: object
           required:
           - lastError
+          - stage
           - stages
           type: object
       type: object

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -133,6 +133,7 @@ type RHMIStatus struct {
 	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
 	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
 	Stages             map[StageName]RHMIStageStatus `json:"stages"`
+	Stage              StageName                     `json:"stage"`
 	PreflightStatus    PreflightStatus               `json:"preflightStatus,omitempty"`
 	PreflightMessage   string                        `json:"preflightMessage,omitempty"`
 	LastError          string                        `json:"lastError"`

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -14,6 +14,7 @@ import (
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"github.com/integr8ly/integreatly-operator/pkg/products"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
@@ -263,6 +264,12 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// If the CR is being deleted, cancel the current context
 	// and attempt to clean up the products with finalizers
 	if installation.DeletionTimestamp != nil {
+
+		// Set metrics status to unavalible
+		metrics.RHMIStatusAvailable.Set(0)
+		installation.Status.Stage = integreatlyv1alpha1.StageName("deletion")
+		_ = r.client.Status().Update(r.context, installation)
+
 		// Cancel this context to kill all ongoing requests to the API
 		// and use a new context to handle deletion logic
 		r.cancel()
@@ -376,12 +383,16 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	if installInProgress {
 		return retryRequeue, nil
 	}
+	installation.Status.Stage = integreatlyv1alpha1.StageName("complete")
+	_ = r.client.Status().Update(r.context, installation)
+	metrics.RHMIStatusAvailable.Set(1)
 	logrus.Infof("installation completed succesfully")
 	return reconcile.Result{}, nil
 }
 
 func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha1.RHMI, installationType *Type, configManager *config.Manager) (reconcile.Result, error) {
 	logrus.Info("Running preflight checks..")
+	installation.Status.Stage = integreatlyv1alpha1.StageName("Preflight Checks")
 	result := reconcile.Result{
 		Requeue:      true,
 		RequeueAfter: 10 * time.Second,
@@ -486,6 +497,7 @@ func (r *ReconcileInstallation) checkNamespaceForProducts(ns corev1.Namespace, i
 }
 
 func (r *ReconcileInstallation) bootstrapStage(installation *integreatlyv1alpha1.RHMI, configManager config.ConfigReadWriter) (integreatlyv1alpha1.StatusPhase, error) {
+	installation.Status.Stage = integreatlyv1alpha1.BootstrapStage
 	mpm := marketplace.NewManager()
 
 	reconciler, err := NewBootstrapReconciler(configManager, installation, mpm, r.mgr.GetEventRecorderFor(string(integreatlyv1alpha1.BootstrapStage)))
@@ -508,6 +520,7 @@ func (r *ReconcileInstallation) processStage(installation *integreatlyv1alpha1.R
 	incompleteStage := false
 	var mErr error
 	productsAux := make(map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus)
+	installation.Status.Stage = stage.Name
 
 	for _, product := range stage.Products {
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,28 @@
+package metrics
+
+import (
+	"github.com/integr8ly/integreatly-operator/version"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Custom metrics
+var (
+	OperatorVersion = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "integreatly_version_info",
+			Help: "Integreatly operator information",
+			ConstLabels: prometheus.Labels{
+				"operator_version": version.Version,
+				"version":          version.IntegreatlyVersion,
+			},
+		},
+	)
+
+	RHMIStatusAvailable = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "rhmi_status_available",
+			Help: "RHMI status available",
+		},
+	)
+)


### PR DESCRIPTION
ISSUE: https://issues.redhat.com/browse/INTLY-5312

# What
Add top level stage indicator to the status block in the RHMI CR. This stage indicator shows the current stage of installation and is marked as complete when all stages have been completed.

Add a metric which indicates the availability of the install. 

# Verify
## Stage Indicator
* Start the operator install process
* Watch the RHMI CR for updates.
* During the installation, the `status.stage` should display the current stage been installed.
* Once install is complete `status.stage` == `complete`

## Metric update
* polling the metric url `curl <cluster>:8383/metrics | grep rhmi` the `rhmi_status_available` metric will be displayed.
* `rhmi_status_available` will state `0` while the installation process continues
* `rhmi_status_available` should `1` once the install is complete
* During an uninstall this metric should be set to `0` 
