### PR TITLE
INTLY-5500 - Get email from identity when creating keycloak user

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -773,11 +773,13 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 	}
 
 	for _, osUser := range added {
-		email := osUser.Name
-		if !strings.Contains(email, "@") {
-			email = email + "@example.com"
+		email, err := GetUserEmailFromIdentity(ctx, serverClient, osUser)
+
+		if err != nil {
+			return nil, err
 		}
-		keycloakUsers = append(keycloakUsers, keycloak.KeycloakAPIUser{
+
+		newKeycloakUser := keycloak.KeycloakAPIUser{
 			Enabled:       true,
 			UserName:      osUser.Name,
 			EmailVerified: true,
@@ -789,7 +791,10 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 					UserName:         osUser.Name,
 				},
 			},
-		})
+		}
+		AppendUpdateProfileActionForUserWithoutEmail(&newKeycloakUser)
+
+		keycloakUsers = append(keycloakUsers, newKeycloakUser)
 	}
 
 	if err != nil && !k8serr.IsNotFound(err) {

--- a/pkg/products/rhsso/userHelper.go
+++ b/pkg/products/rhsso/userHelper.go
@@ -1,0 +1,43 @@
+package rhsso
+
+import (
+	"context"
+	"fmt"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	usersv1 "github.com/openshift/api/user/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Helper for User associated functions
+
+const (
+	updateProfileAction = "UPDATE_PROFILE"
+)
+
+func GetUserEmailFromIdentity(ctx context.Context, serverClient k8sclient.Client, user usersv1.User) (string, error) {
+	email := ""
+
+	// User can have multiple identities
+	for _, identityName := range user.Identities {
+		identity := &usersv1.Identity{}
+		err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: identityName}, identity)
+
+		if err != nil {
+			return "", fmt.Errorf("failed to get identity provider: %w", err)
+		}
+
+		// Get first identity with email and break loop
+		if identity.Extra["email"] != "" {
+			email = identity.Extra["email"]
+			break
+		}
+	}
+
+	return email, nil
+}
+
+func AppendUpdateProfileActionForUserWithoutEmail(keycloakUser *keycloak.KeycloakAPIUser) {
+	if keycloakUser.Email == "" {
+		keycloakUser.RequiredActions = []string{updateProfileAction}
+	}
+}

--- a/pkg/products/rhsso/userHelper_test.go
+++ b/pkg/products/rhsso/userHelper_test.go
@@ -1,0 +1,109 @@
+package rhsso
+
+import (
+	"context"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	userv1 "github.com/openshift/api/user/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+const (
+	testIdentity = "test-identity"
+	testEmail    = "test@email.com"
+)
+
+func TestGetUserEmailFromIdentity(t *testing.T) {
+
+	scheme := runtime.NewScheme()
+	err := userv1.AddToScheme(scheme)
+
+	if err != nil {
+		t.Fatalf("Error creating build scheme")
+	}
+
+	tests := []struct {
+		Name          string
+		FakeClient    k8sclient.Client
+		User          userv1.User
+		ExpectedEmail string
+		ExpectedError bool
+	}{
+		{
+			Name: "Test get email from identity",
+			FakeClient: fake.NewFakeClientWithScheme(scheme, &userv1.Identity{
+				ObjectMeta: v1.ObjectMeta{
+					Name: testIdentity,
+				},
+				Extra: map[string]string{"email": testEmail},
+			}),
+			User: userv1.User{
+				Identities: []string{testIdentity},
+			},
+			ExpectedEmail: testEmail,
+			ExpectedError: false,
+		},
+		{
+			Name:       "Test error getting identity",
+			FakeClient: fake.NewFakeClientWithScheme(scheme),
+			User: userv1.User{
+				Identities: []string{testIdentity},
+			},
+			ExpectedEmail: "",
+			ExpectedError: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			got, err := GetUserEmailFromIdentity(context.TODO(), tt.FakeClient, tt.User)
+			if (err != nil) != tt.ExpectedError {
+				t.Errorf("GetUserEmailFromIdentity() error = %v, ExpectedErr %v", err, tt.ExpectedError)
+				return
+			}
+			if got != tt.ExpectedEmail {
+				t.Errorf("GetUserEmailFromIdentity() got = %v, want %v", got, tt.ExpectedEmail)
+			}
+		})
+	}
+}
+
+func TestAppendUpdateProfileActionForUserWithoutEmail(t *testing.T) {
+
+	tests := []struct {
+		Name                string
+		KeyCloakUser        keycloak.KeycloakAPIUser
+		AddedRequiredAction bool
+	}{
+		{
+			Name: "Test Update Profile action is added for user with empty email",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				Email:           "",
+				RequiredActions: []string{},
+			},
+			AddedRequiredAction: true,
+		},
+		{
+			Name: "Test Update Profile action is not added for user with email",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				Email:           testEmail,
+				RequiredActions: []string{},
+			},
+			AddedRequiredAction: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			AppendUpdateProfileActionForUserWithoutEmail(&tt.KeyCloakUser)
+			if tt.AddedRequiredAction && len(tt.KeyCloakUser.RequiredActions) != 1 {
+				t.Fatal("Expected user to be updated with required action but wasn't")
+			}
+
+			if !tt.AddedRequiredAction && len(tt.KeyCloakUser.RequiredActions) != 0 {
+				t.Fatal("Expected user to not be updated with required action but was")
+			}
+		})
+	}
+}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -452,15 +452,10 @@ func addKeycloakUsers(keycloakUsers []keycloak.KeycloakAPIUser, added []usersv1.
 
 	for _, osUser := range added {
 
-		email := osUser.Name
-		if !strings.Contains(email, "@") {
-			email = email + "@example.com"
-		}
 		keycloakUsers = append(keycloakUsers, keycloak.KeycloakAPIUser{
 			Enabled:       true,
 			UserName:      osUser.Name,
 			EmailVerified: true,
-			Email:         email,
 			FederatedIdentities: []keycloak.FederatedIdentity{
 				{
 					IdentityProvider: idpAlias,


### PR DESCRIPTION
## Description
Currently `@example.com` is appended to the username and used as the email as the user created in the openshift realm. Instead we should try to fetch the email from the associated `Identity` resource, from the Openshift user and use this value when creating the `KeyCloakUser`. 

If for some reason no email is found in the associated `Identity`, an `Update Profile` action is added to the created `KeyCloakUser` forcing them to add an email when first try to login to CodeReady or 3Scale Products

Jira:
* https://issues.redhat.com/browse/INTLY-5500
## Verification
* Install Integreatly onto cluster from this branch
* Run the IDP Script to create sample users 
```
PASSWORD=Password1 ./scripts/setup-sso-idp.sh
```
* Login into RHSSO as admin (credentials can be found at `credential-rhsso` secret)
* Remove the email of the `customer-admin01` user from the`Testing-IDP realm` and save
* Open a private browser window
  * Log into the openshift console for `customer-admin01` using `testing-idp`
      * Wait for a minute to allow the reconcile to create the KeycloakUser in the `openshift` realm
      * Check RHSSO openshift realm, the user does not have an email
  * Using `customer-admin01`, try log into Codeready or 3Scale
    * Verify the user is asked to update profile with email, first name and last name
    * Update profile and check RHSSO openshift realm, the user details have been updated
* Close the private window and reopen a new one
  *  Log into the openshift console for `test-user01` using `testing-idp`
      * Wait for a minute to allow the reconcile to create the KeycloakUser in the `openshift` realm
      *  Check RHSSO openshift realm, the user has the expected email address 
  * Try logging into codeready or 3scale using `test-user01`
  * Verify user is logged in without being asked to update profile