### PR TITLE
INTLY-2850: Create default `rhmi-developers` group in User SSO

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/integr8ly/application-monitoring-operator v1.1.1
 	github.com/integr8ly/cloud-resource-operator v0.11.0
 	github.com/integr8ly/grafana-operator v1.3.1
-	github.com/integr8ly/keycloak-client v0.0.0-20200129153447-ae34238c1f86
+	github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/integr8ly/application-monitoring-operator v1.1.1
 	github.com/integr8ly/cloud-resource-operator v0.11.0
 	github.com/integr8ly/grafana-operator v1.3.1
-	github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc
+	github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/integr8ly/grafana-operator v1.3.1 h1:3fknUP3pI9/H0/HTxOOR5hzJVo1wPs5H
 github.com/integr8ly/grafana-operator v1.3.1/go.mod h1:uFZI5IG74KBTtqzdwAMvoFoAC3RlgF5VaJypcCzyVVs=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4 h1://E7j42AwTNj3oPVr7/yS0Ztbm7iunOppSs9VJ3nGMc=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4/go.mod h1:0WBJ5MjgAgIu9briw0EaDkpXsWIXMoRJKnE/J024+bM=
-github.com/integr8ly/keycloak-client v0.0.0-20200129153447-ae34238c1f86 h1:FxoHMz8dJsSQ/P3Yt/DYpIfDlnP37ObUt86ltwTzIUg=
-github.com/integr8ly/keycloak-client v0.0.0-20200129153447-ae34238c1f86/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
+github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc h1:1Y+aqZoLl0pO/ZtwxlLXsV7ZkBLPRIi7Li9jWuK9KFY=
+github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/integr8ly/grafana-operator v1.3.1 h1:3fknUP3pI9/H0/HTxOOR5hzJVo1wPs5H
 github.com/integr8ly/grafana-operator v1.3.1/go.mod h1:uFZI5IG74KBTtqzdwAMvoFoAC3RlgF5VaJypcCzyVVs=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4 h1://E7j42AwTNj3oPVr7/yS0Ztbm7iunOppSs9VJ3nGMc=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4/go.mod h1:0WBJ5MjgAgIu9briw0EaDkpXsWIXMoRJKnE/J024+bM=
-github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc h1:1Y+aqZoLl0pO/ZtwxlLXsV7ZkBLPRIi7Li9jWuK9KFY=
-github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
+github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe h1:HTWpcTMtbEEB+BTswEDByRcFbZDue1HLgvxdzjr8nog=
+github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -6,9 +6,10 @@ import (
 	"errors"
 	"fmt"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"testing"
+
 	"github.com/sirupsen/logrus"
 	controllerruntime "sigs.k8s.io/controller-runtime"
-	"testing"
 
 	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -843,6 +844,76 @@ func TestReconciler_reconcileCloudResources(t *testing.T) {
 	}
 }
 
+func TestReconciler_reconcileDevelopersGroup(t *testing.T) {
+	keycloakClientFactory, mockContext := createKeycloakClientFactoryMock()
+
+	r := &Reconciler{
+		logger: logrus.NewEntry(logrus.StandardLogger()),
+		Config: &config.RHSSOUser{
+			Config: map[string]string{
+				"NAMESPACE": defaultRhssoNamespace,
+			},
+		},
+		keycloakClientFactory: keycloakClientFactory,
+	}
+
+	kc := &keycloak.Keycloak{}
+	statusPhase, err := r.reconcileDevelopersGroup(kc)
+
+	if statusPhase != integreatlyv1alpha1.PhaseCompleted {
+		t.Errorf("Expected phase to be completed, got %s", statusPhase)
+	}
+	if err != nil {
+		t.Errorf("Unexpected error occurred: %s", err)
+	}
+
+	// Assert that the group `rhmi-developers` was created
+	foundGroup := false
+	var groupID string
+	for _, group := range mockContext.Groups {
+		if group.Name == developersGroupName {
+			foundGroup = true
+			groupID = group.ID
+			break
+		}
+	}
+
+	if !foundGroup {
+		t.Errorf("Group %s not found in mock Keycloak interface", developersGroupName)
+	}
+
+	// Assert that the group `rhmi-developers` is among the default groups
+	foundDefaultGroup := false
+	for _, group := range mockContext.DefaultGroups {
+		if group.Name == developersGroupName {
+			foundDefaultGroup = true
+			break
+		}
+	}
+
+	if !foundDefaultGroup {
+		t.Errorf("Group %s not found among default groups in mock Keycloak interface", developersGroupName)
+	}
+
+	// Assert that the `query-realm` role is mapped to the group
+	groupRoles, ok := mockContext.ClientRoles[groupID]
+	foundRole := false
+	if !ok {
+		t.Errorf("Group %s not found in role mappings", developersGroupName)
+	}
+
+	for _, role := range groupRoles {
+		if role.Name == developersGroupRoleName {
+			foundRole = true
+			break
+		}
+	}
+
+	if !foundRole {
+		t.Errorf("Role %s not found in role mappings for group %s", developersGroupRoleName, developersGroupName)
+	}
+}
+
 func getKcr(status keycloak.KeycloakRealmStatus) *keycloak.KeycloakRealm {
 	return &keycloak.KeycloakRealm{
 		ObjectMeta: metav1.ObjectMeta{
@@ -872,6 +943,8 @@ func getMoqKeycloakClientFactory() keycloakCommon.KeycloakClientFactory {
 		},
 	}
 
+	keycloakInterfaceMock, _ := createKeycloakInterfaceMock()
+
 	return &keycloakCommon.KeycloakClientFactoryMock{AuthenticatedClientFunc: func(kc keycloak.Keycloak) (keycloakInterface keycloakCommon.KeycloakInterface, err error) {
 		return &keycloakCommon.KeycloakInterfaceMock{CreateIdentityProviderFunc: func(identityProvider *keycloak.KeycloakIdentityProvider, realmName string) error {
 			return nil
@@ -881,6 +954,196 @@ func getMoqKeycloakClientFactory() keycloakCommon.KeycloakClientFactory {
 			return exInfo, nil
 		}, CreateAuthenticatorConfigFunc: func(authenticatorConfig *keycloak.AuthenticatorConfig, realmName string, executionID string) error {
 			return nil
-		}}, nil
+		},
+			FindGroupByNameFunc:               keycloakInterfaceMock.FindGroupByName,
+			CreateGroupFunc:                   keycloakInterfaceMock.CreateGroup,
+			MakeGroupDefaultFunc:              keycloakInterfaceMock.MakeGroupDefault,
+			ListDefaultGroupsFunc:             keycloakInterfaceMock.ListDefaultGroups,
+			CreateGroupClientRoleFunc:         keycloakInterfaceMock.CreateGroupClientRole,
+			ListGroupClientRolesFunc:          keycloakInterfaceMock.ListGroupClientRoles,
+			FindGroupClientRoleFunc:           keycloakInterfaceMock.FindGroupClientRole,
+			ListAvailableGroupClientRolesFunc: keycloakInterfaceMock.ListAvailableGroupClientRoles,
+			FindAvailableGroupClientRoleFunc:  keycloakInterfaceMock.FindAvailableGroupClientRole,
+			ListClientsFunc:                   keycloakInterfaceMock.ListClients,
+		}, nil
 	}}
+}
+
+// Mock context of the Keycloak interface. Allows to check that the operations
+// performed by the client were correct
+type mockClientContext struct {
+	Groups        []*keycloakCommon.Group
+	DefaultGroups []*keycloakCommon.Group
+	ClientRoles   map[string][]*keycloak.KeycloakUserRole
+}
+
+func createKeycloakClientFactoryMock() (keycloakCommon.KeycloakClientFactory, *mockClientContext) {
+	keycloakInterfaceMock, ctx := createKeycloakInterfaceMock()
+
+	return &keycloakCommon.KeycloakClientFactoryMock{
+		AuthenticatedClientFunc: func(_ keycloak.Keycloak) (keycloakCommon.KeycloakInterface, error) {
+			return keycloakInterfaceMock, nil
+		},
+	}, ctx
+}
+
+// Create a mock of the `KeycloakClientFactory` that creates a `KeycloakInterface` mock that
+// manages groups and their client roles ignoring realm or client parameters. This mock is
+// implemented to test the `reconcileDevelopersGroup` phase
+func createKeycloakInterfaceMock() (keycloakCommon.KeycloakInterface, *mockClientContext) {
+	context := mockClientContext{
+		Groups:        []*keycloakCommon.Group{},
+		DefaultGroups: []*keycloakCommon.Group{},
+		ClientRoles:   map[string][]*keycloak.KeycloakUserRole{},
+	}
+
+	availableGroupRoles := []*keycloak.KeycloakUserRole{
+		&keycloak.KeycloakUserRole{
+			ID:   "mock-role-1",
+			Name: "mock-role-1",
+		},
+		&keycloak.KeycloakUserRole{
+			ID:   "query-realms",
+			Name: "query-realms",
+		},
+		&keycloak.KeycloakUserRole{
+			ID:   "mock-role-2",
+			Name: "mock-role-2",
+		},
+	}
+
+	findGroupByNameFunc := func(groupName string, realmName string) (*keycloakCommon.Group, error) {
+		for _, group := range context.Groups {
+			if group.Name == groupName {
+				return group, nil
+			}
+		}
+
+		return nil, nil
+	}
+
+	createGroupFunc := func(groupName string, realmName string) (string, error) {
+		nextID := fmt.Sprintf("group-%d", len(context.Groups))
+
+		newGroup := &keycloakCommon.Group{
+			ID:   string(nextID),
+			Name: groupName,
+		}
+
+		context.Groups = append(context.Groups, newGroup)
+		context.ClientRoles[nextID] = []*keycloak.KeycloakUserRole{}
+		return nextID, nil
+	}
+
+	makeGroupDefaultFunc := func(groupID string, realmName string) error {
+		var group *keycloakCommon.Group
+
+		for _, existingGroup := range context.Groups {
+			if existingGroup.ID == groupID {
+				group = existingGroup
+				break
+			}
+		}
+
+		if group == nil {
+			return fmt.Errorf("Referenced group not found")
+		}
+
+		context.DefaultGroups = append(context.DefaultGroups, group)
+		return nil
+	}
+
+	listDefaultGroupsFunc := func(realmName string) ([]*keycloakCommon.Group, error) {
+		return context.DefaultGroups, nil
+	}
+
+	createGroupClientRoleFunc := func(role *keycloak.KeycloakUserRole, realmName, clientID, groupID string) error {
+		groupClientRoles, ok := context.ClientRoles[groupID]
+
+		if !ok {
+			return fmt.Errorf("Referenced group not found")
+		}
+
+		context.ClientRoles[groupID] = append(groupClientRoles, role)
+		return nil
+	}
+
+	listGroupClientRolesFunc := func(realmName, clientID, groupID string) ([]*keycloak.KeycloakUserRole, error) {
+		groupRoles, ok := context.ClientRoles[groupID]
+
+		if !ok {
+			return nil, fmt.Errorf("Referenced group not found")
+		}
+
+		return groupRoles, nil
+	}
+
+	listAvailableGroupClientRolesFunc := func(realmName, clientID, groupID string) ([]*keycloak.KeycloakUserRole, error) {
+		_, ok := context.ClientRoles[groupID]
+
+		if !ok {
+			return nil, fmt.Errorf("Referenced group not found")
+		}
+
+		return availableGroupRoles, nil
+	}
+
+	findGroupClientRoleFunc := func(realmName, clientID, groupID string, predicate func(*keycloak.KeycloakUserRole) bool) (*keycloak.KeycloakUserRole, error) {
+		all, err := listGroupClientRolesFunc(realmName, clientID, groupID)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, role := range all {
+			if predicate(role) {
+				return role, nil
+			}
+		}
+
+		return nil, nil
+	}
+
+	findAvailableGroupClientRoleFunc := func(realmName, clientID, groupID string, predicate func(*keycloak.KeycloakUserRole) bool) (*keycloak.KeycloakUserRole, error) {
+		all, err := listAvailableGroupClientRolesFunc(realmName, clientID, groupID)
+
+		if err != nil {
+			return nil, err
+		}
+
+		for _, role := range all {
+			if predicate(role) {
+				return role, nil
+			}
+		}
+
+		return nil, nil
+	}
+
+	listClientsFunc := func(realmName string) ([]*keycloak.KeycloakAPIClient, error) {
+		return []*keycloak.KeycloakAPIClient{
+			&keycloak.KeycloakAPIClient{
+				ID:   "client-1",
+				Name: "client1",
+			},
+			&keycloak.KeycloakAPIClient{
+				ClientID: "master-realm",
+				ID:       "master-realm",
+				Name:     "master-realm",
+			},
+		}, nil
+	}
+
+	return &keycloakCommon.KeycloakInterfaceMock{
+		FindGroupByNameFunc:               findGroupByNameFunc,
+		CreateGroupFunc:                   createGroupFunc,
+		MakeGroupDefaultFunc:              makeGroupDefaultFunc,
+		ListDefaultGroupsFunc:             listDefaultGroupsFunc,
+		CreateGroupClientRoleFunc:         createGroupClientRoleFunc,
+		ListGroupClientRolesFunc:          listGroupClientRolesFunc,
+		ListAvailableGroupClientRolesFunc: listAvailableGroupClientRolesFunc,
+		FindGroupClientRoleFunc:           findGroupClientRoleFunc,
+		FindAvailableGroupClientRoleFunc:  findAvailableGroupClientRoleFunc,
+		ListClientsFunc:                   listClientsFunc,
+	}, &context
 }

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/client.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/client.go
@@ -646,6 +646,158 @@ func (c *Client) ListAuthenticationExecutionsForFlow(flowAlias, realmName string
 	return result.([]*v1alpha1.AuthenticationExecutionInfo), err
 }
 
+func (c *Client) FindGroupByName(groupName string, realmName string) (*Group, error) {
+	// Get a list of the groups in the realm
+	tGroups, err := c.list(fmt.Sprintf("realms/%s/groups", realmName), "Group", func(body []byte) (T, error) {
+		var groups []*Group
+		err := json.Unmarshal(body, &groups)
+		return groups, err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate through the list of groups and return
+	// the one that matches the name
+	groups := tGroups.([]*Group)
+	for _, group := range groups {
+		if group.Name == groupName {
+			return group, nil
+		}
+	}
+
+	// If the loop finishes without finding the group,
+	// return nil
+	return nil, nil
+}
+
+func (c *Client) CreateGroup(groupName string, realmName string) (string, error) {
+	group := Group{
+		Name: groupName,
+	}
+
+	// Create the new group
+	err := c.create(group, fmt.Sprintf("realms/%s/groups", realmName), "group")
+	if err != nil {
+		return "", err
+	}
+
+	createdGroup, err := c.FindGroupByName(groupName, realmName)
+
+	if err != nil {
+		return "", err
+	}
+
+	return createdGroup.ID, nil
+}
+
+func (c *Client) MakeGroupDefault(groupID string, realmName string) error {
+	// Get the existing default groups to check if the group is already
+	// default
+	defaultGroups, err := c.ListDefaultGroups(realmName)
+
+	if err != nil {
+		return err
+	}
+
+	// If the group is in the list, return
+	for _, defaultGroup := range defaultGroups {
+		if defaultGroup.ID == groupID {
+			return nil
+		}
+	}
+
+	// If not, perform the update
+	return c.update(nil, fmt.Sprintf("realms/%s/default-groups/%s", realmName, groupID), "Realms")
+}
+
+func (c *Client) ListDefaultGroups(realmName string) ([]*Group, error) {
+	groups, err := c.list(fmt.Sprintf("realms/%s/default-groups", realmName), "Default group", func(body []byte) (T, error) {
+		var groups []*Group
+		err := json.Unmarshal(body, &groups)
+		return groups, err
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	return groups.([]*Group), nil
+}
+
+func (c *Client) CreateGroupClientRole(role *v1alpha1.KeycloakUserRole, realmName, clientID, groupID string) error {
+	return c.create(
+		[]*v1alpha1.KeycloakUserRole{role},
+		fmt.Sprintf("realms/%s/groups/%s/role-mappings/clients/%s", realmName, groupID, clientID),
+		"group-client-role",
+	)
+}
+
+func (c *Client) ListAvailableGroupClientRoles(realmName, clientID, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	path := fmt.Sprintf("realms/%s/groups/%s/role-mappings/clients/%s/available", realmName, groupID, clientID)
+	objects, err := c.list(path, "groupRealmRoles", func(body []byte) (t T, e error) {
+		var groupClientRoles []*v1alpha1.KeycloakUserRole
+		err := json.Unmarshal(body, &groupClientRoles)
+		return groupClientRoles, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if objects == nil {
+		return nil, nil
+	}
+	return objects.([]*v1alpha1.KeycloakUserRole), err
+}
+
+func (c *Client) FindAvailableGroupClientRole(realmName, clientID, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+	availableRoles, err := c.ListAvailableGroupClientRoles(realmName, clientID, groupID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, role := range availableRoles {
+		if predicate(role) {
+			return role, nil
+		}
+	}
+
+	return nil, nil
+}
+
+func (c *Client) ListGroupClientRoles(realmName, clientID, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	path := fmt.Sprintf("realms/%s/groups/%s/role-mappings/clients/%s", realmName, groupID, clientID)
+	objects, err := c.list(path, "groupClientRoles", func(body []byte) (t T, e error) {
+		var groupClientRoles []*v1alpha1.KeycloakUserRole
+		err := json.Unmarshal(body, &groupClientRoles)
+		return groupClientRoles, err
+	})
+	if err != nil {
+		return nil, err
+	}
+	if objects == nil {
+		return nil, nil
+	}
+	return objects.([]*v1alpha1.KeycloakUserRole), err
+}
+
+func (c *Client) FindGroupClientRole(realmName, clientID, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+	groupRoles, err := c.ListGroupClientRoles(realmName, clientID, groupID)
+
+	if err != nil {
+		return nil, err
+	}
+
+	for _, role := range groupRoles {
+		if predicate(role) {
+			return role, nil
+		}
+	}
+
+	return nil, nil
+}
+
 func (c *Client) Ping() error {
 	u := c.URL + "/auth/"
 	req, err := http.NewRequest("GET", u, nil)
@@ -754,6 +906,17 @@ type KeycloakInterface interface {
 	UpdateUser(specUser *v1alpha1.KeycloakAPIUser, realmName string) error
 	DeleteUser(userID, realmName string) error
 	ListUsers(realmName string) ([]*v1alpha1.KeycloakAPIUser, error)
+
+	FindGroupByName(groupName string, realmName string) (*Group, error)
+	CreateGroup(group string, realmName string) (string, error)
+	MakeGroupDefault(groupID string, realmName string) error
+	ListDefaultGroups(realmName string) ([]*Group, error)
+
+	CreateGroupClientRole(role *v1alpha1.KeycloakUserRole, realmName, clientID, groupID string) error
+	ListGroupClientRoles(realmName, clientID, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
+	FindGroupClientRole(realmName, clientID, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error)
+	ListAvailableGroupClientRoles(realmName, clientID, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
+	FindAvailableGroupClientRole(realmName, clientID, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error)
 
 	CreateIdentityProvider(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error
 	GetIdentityProvider(alias, realmName string) (*v1alpha1.KeycloakIdentityProvider, error)

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
@@ -9,57 +9,62 @@ import (
 )
 
 var (
-	lockKeycloakInterfaceMockCreateAuthenticatorConfig           sync.RWMutex
-	lockKeycloakInterfaceMockCreateClient                        sync.RWMutex
-	lockKeycloakInterfaceMockCreateFederatedIdentity             sync.RWMutex
-	lockKeycloakInterfaceMockCreateGroup                         sync.RWMutex
-	lockKeycloakInterfaceMockCreateGroupClientRole               sync.RWMutex
-	lockKeycloakInterfaceMockCreateIdentityProvider              sync.RWMutex
-	lockKeycloakInterfaceMockCreateRealm                         sync.RWMutex
-	lockKeycloakInterfaceMockCreateUser                          sync.RWMutex
-	lockKeycloakInterfaceMockCreateUserClientRole                sync.RWMutex
-	lockKeycloakInterfaceMockCreateUserRealmRole                 sync.RWMutex
-	lockKeycloakInterfaceMockDeleteAuthenticatorConfig           sync.RWMutex
-	lockKeycloakInterfaceMockDeleteClient                        sync.RWMutex
-	lockKeycloakInterfaceMockDeleteIdentityProvider              sync.RWMutex
-	lockKeycloakInterfaceMockDeleteRealm                         sync.RWMutex
-	lockKeycloakInterfaceMockDeleteUser                          sync.RWMutex
-	lockKeycloakInterfaceMockDeleteUserClientRole                sync.RWMutex
-	lockKeycloakInterfaceMockDeleteUserRealmRole                 sync.RWMutex
-	lockKeycloakInterfaceMockFindAvailableGroupClientRole        sync.RWMutex
-	lockKeycloakInterfaceMockFindGroupByName                     sync.RWMutex
-	lockKeycloakInterfaceMockFindGroupClientRole                 sync.RWMutex
-	lockKeycloakInterfaceMockFindUserByEmail                     sync.RWMutex
-	lockKeycloakInterfaceMockFindUserByUsername                  sync.RWMutex
-	lockKeycloakInterfaceMockGetAuthenticatorConfig              sync.RWMutex
-	lockKeycloakInterfaceMockGetClient                           sync.RWMutex
-	lockKeycloakInterfaceMockGetClientInstall                    sync.RWMutex
-	lockKeycloakInterfaceMockGetClientSecret                     sync.RWMutex
-	lockKeycloakInterfaceMockGetIdentityProvider                 sync.RWMutex
-	lockKeycloakInterfaceMockGetRealm                            sync.RWMutex
-	lockKeycloakInterfaceMockGetUser                             sync.RWMutex
-	lockKeycloakInterfaceMockGetUserFederatedIdentities          sync.RWMutex
-	lockKeycloakInterfaceMockListAuthenticationExecutionsForFlow sync.RWMutex
-	lockKeycloakInterfaceMockListAvailableGroupClientRoles       sync.RWMutex
-	lockKeycloakInterfaceMockListAvailableUserClientRoles        sync.RWMutex
-	lockKeycloakInterfaceMockListAvailableUserRealmRoles         sync.RWMutex
-	lockKeycloakInterfaceMockListClients                         sync.RWMutex
-	lockKeycloakInterfaceMockListDefaultGroups                   sync.RWMutex
-	lockKeycloakInterfaceMockListGroupClientRoles                sync.RWMutex
-	lockKeycloakInterfaceMockListIdentityProviders               sync.RWMutex
-	lockKeycloakInterfaceMockListRealms                          sync.RWMutex
-	lockKeycloakInterfaceMockListUserClientRoles                 sync.RWMutex
-	lockKeycloakInterfaceMockListUserRealmRoles                  sync.RWMutex
-	lockKeycloakInterfaceMockListUsers                           sync.RWMutex
-	lockKeycloakInterfaceMockMakeGroupDefault                    sync.RWMutex
-	lockKeycloakInterfaceMockPing                                sync.RWMutex
-	lockKeycloakInterfaceMockRemoveFederatedIdentity             sync.RWMutex
-	lockKeycloakInterfaceMockUpdateAuthenticatorConfig           sync.RWMutex
-	lockKeycloakInterfaceMockUpdateClient                        sync.RWMutex
-	lockKeycloakInterfaceMockUpdateIdentityProvider              sync.RWMutex
-	lockKeycloakInterfaceMockUpdatePassword                      sync.RWMutex
-	lockKeycloakInterfaceMockUpdateRealm                         sync.RWMutex
-	lockKeycloakInterfaceMockUpdateUser                          sync.RWMutex
+	lockKeycloakInterfaceMockCreateAuthenticatorConfig            sync.RWMutex
+	lockKeycloakInterfaceMockCreateClient                         sync.RWMutex
+	lockKeycloakInterfaceMockCreateFederatedIdentity              sync.RWMutex
+	lockKeycloakInterfaceMockCreateGroup                          sync.RWMutex
+	lockKeycloakInterfaceMockCreateGroupClientRole                sync.RWMutex
+	lockKeycloakInterfaceMockCreateGroupRealmRole                 sync.RWMutex
+	lockKeycloakInterfaceMockCreateIdentityProvider               sync.RWMutex
+	lockKeycloakInterfaceMockCreateRealm                          sync.RWMutex
+	lockKeycloakInterfaceMockCreateUser                           sync.RWMutex
+	lockKeycloakInterfaceMockCreateUserClientRole                 sync.RWMutex
+	lockKeycloakInterfaceMockCreateUserRealmRole                  sync.RWMutex
+	lockKeycloakInterfaceMockDeleteAuthenticatorConfig            sync.RWMutex
+	lockKeycloakInterfaceMockDeleteClient                         sync.RWMutex
+	lockKeycloakInterfaceMockDeleteIdentityProvider               sync.RWMutex
+	lockKeycloakInterfaceMockDeleteRealm                          sync.RWMutex
+	lockKeycloakInterfaceMockDeleteUser                           sync.RWMutex
+	lockKeycloakInterfaceMockDeleteUserClientRole                 sync.RWMutex
+	lockKeycloakInterfaceMockDeleteUserRealmRole                  sync.RWMutex
+	lockKeycloakInterfaceMockFindAuthenticationExecutionForFlow   sync.RWMutex
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole         sync.RWMutex
+	lockKeycloakInterfaceMockFindGroupByName                      sync.RWMutex
+	lockKeycloakInterfaceMockFindGroupClientRole                  sync.RWMutex
+	lockKeycloakInterfaceMockFindUserByEmail                      sync.RWMutex
+	lockKeycloakInterfaceMockFindUserByUsername                   sync.RWMutex
+	lockKeycloakInterfaceMockGetAuthenticatorConfig               sync.RWMutex
+	lockKeycloakInterfaceMockGetClient                            sync.RWMutex
+	lockKeycloakInterfaceMockGetClientInstall                     sync.RWMutex
+	lockKeycloakInterfaceMockGetClientSecret                      sync.RWMutex
+	lockKeycloakInterfaceMockGetIdentityProvider                  sync.RWMutex
+	lockKeycloakInterfaceMockGetRealm                             sync.RWMutex
+	lockKeycloakInterfaceMockGetUser                              sync.RWMutex
+	lockKeycloakInterfaceMockGetUserFederatedIdentities           sync.RWMutex
+	lockKeycloakInterfaceMockListAuthenticationExecutionsForFlow  sync.RWMutex
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles        sync.RWMutex
+	lockKeycloakInterfaceMockListAvailableGroupRealmRoles         sync.RWMutex
+	lockKeycloakInterfaceMockListAvailableUserClientRoles         sync.RWMutex
+	lockKeycloakInterfaceMockListAvailableUserRealmRoles          sync.RWMutex
+	lockKeycloakInterfaceMockListClients                          sync.RWMutex
+	lockKeycloakInterfaceMockListDefaultGroups                    sync.RWMutex
+	lockKeycloakInterfaceMockListGroupClientRoles                 sync.RWMutex
+	lockKeycloakInterfaceMockListGroupRealmRoles                  sync.RWMutex
+	lockKeycloakInterfaceMockListIdentityProviders                sync.RWMutex
+	lockKeycloakInterfaceMockListRealms                           sync.RWMutex
+	lockKeycloakInterfaceMockListUserClientRoles                  sync.RWMutex
+	lockKeycloakInterfaceMockListUserRealmRoles                   sync.RWMutex
+	lockKeycloakInterfaceMockListUsers                            sync.RWMutex
+	lockKeycloakInterfaceMockMakeGroupDefault                     sync.RWMutex
+	lockKeycloakInterfaceMockPing                                 sync.RWMutex
+	lockKeycloakInterfaceMockRemoveFederatedIdentity              sync.RWMutex
+	lockKeycloakInterfaceMockUpdateAuthenticationExecutionForFlow sync.RWMutex
+	lockKeycloakInterfaceMockUpdateAuthenticatorConfig            sync.RWMutex
+	lockKeycloakInterfaceMockUpdateClient                         sync.RWMutex
+	lockKeycloakInterfaceMockUpdateIdentityProvider               sync.RWMutex
+	lockKeycloakInterfaceMockUpdatePassword                       sync.RWMutex
+	lockKeycloakInterfaceMockUpdateRealm                          sync.RWMutex
+	lockKeycloakInterfaceMockUpdateUser                           sync.RWMutex
 )
 
 // Ensure, that KeycloakInterfaceMock does implement KeycloakInterface.
@@ -86,6 +91,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             CreateGroupClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) error {
 // 	               panic("mock out the CreateGroupClientRole method")
+//             },
+//             CreateGroupRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, groupID string) error {
+// 	               panic("mock out the CreateGroupRealmRole method")
 //             },
 //             CreateIdentityProviderFunc: func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error {
 // 	               panic("mock out the CreateIdentityProvider method")
@@ -122,6 +130,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             DeleteUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error {
 // 	               panic("mock out the DeleteUserRealmRole method")
+//             },
+//             FindAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, predicate func(*v1alpha1.AuthenticationExecutionInfo) bool) (*v1alpha1.AuthenticationExecutionInfo, error) {
+// 	               panic("mock out the FindAuthenticationExecutionForFlow method")
 //             },
 //             FindAvailableGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
 // 	               panic("mock out the FindAvailableGroupClientRole method")
@@ -168,6 +179,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             ListAvailableGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
 // 	               panic("mock out the ListAvailableGroupClientRoles method")
 //             },
+//             ListAvailableGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the ListAvailableGroupRealmRoles method")
+//             },
 //             ListAvailableUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
 // 	               panic("mock out the ListAvailableUserClientRoles method")
 //             },
@@ -182,6 +196,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             ListGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
 // 	               panic("mock out the ListGroupClientRoles method")
+//             },
+//             ListGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the ListGroupRealmRoles method")
 //             },
 //             ListIdentityProvidersFunc: func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error) {
 // 	               panic("mock out the ListIdentityProviders method")
@@ -206,6 +223,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             RemoveFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error {
 // 	               panic("mock out the RemoveFederatedIdentity method")
+//             },
+//             UpdateAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, execution *v1alpha1.AuthenticationExecutionInfo) error {
+// 	               panic("mock out the UpdateAuthenticationExecutionForFlow method")
 //             },
 //             UpdateAuthenticatorConfigFunc: func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string) error {
 // 	               panic("mock out the UpdateAuthenticatorConfig method")
@@ -247,6 +267,9 @@ type KeycloakInterfaceMock struct {
 	// CreateGroupClientRoleFunc mocks the CreateGroupClientRole method.
 	CreateGroupClientRoleFunc func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) error
 
+	// CreateGroupRealmRoleFunc mocks the CreateGroupRealmRole method.
+	CreateGroupRealmRoleFunc func(role *v1alpha1.KeycloakUserRole, realmName string, groupID string) error
+
 	// CreateIdentityProviderFunc mocks the CreateIdentityProvider method.
 	CreateIdentityProviderFunc func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error
 
@@ -282,6 +305,9 @@ type KeycloakInterfaceMock struct {
 
 	// DeleteUserRealmRoleFunc mocks the DeleteUserRealmRole method.
 	DeleteUserRealmRoleFunc func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error
+
+	// FindAuthenticationExecutionForFlowFunc mocks the FindAuthenticationExecutionForFlow method.
+	FindAuthenticationExecutionForFlowFunc func(flowAlias string, realmName string, predicate func(*v1alpha1.AuthenticationExecutionInfo) bool) (*v1alpha1.AuthenticationExecutionInfo, error)
 
 	// FindAvailableGroupClientRoleFunc mocks the FindAvailableGroupClientRole method.
 	FindAvailableGroupClientRoleFunc func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error)
@@ -328,6 +354,9 @@ type KeycloakInterfaceMock struct {
 	// ListAvailableGroupClientRolesFunc mocks the ListAvailableGroupClientRoles method.
 	ListAvailableGroupClientRolesFunc func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
 
+	// ListAvailableGroupRealmRolesFunc mocks the ListAvailableGroupRealmRoles method.
+	ListAvailableGroupRealmRolesFunc func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
+
 	// ListAvailableUserClientRolesFunc mocks the ListAvailableUserClientRoles method.
 	ListAvailableUserClientRolesFunc func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error)
 
@@ -342,6 +371,9 @@ type KeycloakInterfaceMock struct {
 
 	// ListGroupClientRolesFunc mocks the ListGroupClientRoles method.
 	ListGroupClientRolesFunc func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
+
+	// ListGroupRealmRolesFunc mocks the ListGroupRealmRoles method.
+	ListGroupRealmRolesFunc func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
 
 	// ListIdentityProvidersFunc mocks the ListIdentityProviders method.
 	ListIdentityProvidersFunc func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error)
@@ -366,6 +398,9 @@ type KeycloakInterfaceMock struct {
 
 	// RemoveFederatedIdentityFunc mocks the RemoveFederatedIdentity method.
 	RemoveFederatedIdentityFunc func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error
+
+	// UpdateAuthenticationExecutionForFlowFunc mocks the UpdateAuthenticationExecutionForFlow method.
+	UpdateAuthenticationExecutionForFlowFunc func(flowAlias string, realmName string, execution *v1alpha1.AuthenticationExecutionInfo) error
 
 	// UpdateAuthenticatorConfigFunc mocks the UpdateAuthenticatorConfig method.
 	UpdateAuthenticatorConfigFunc func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string) error
@@ -427,6 +462,15 @@ type KeycloakInterfaceMock struct {
 			RealmName string
 			// ClientID is the clientID argument value.
 			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
+		}
+		// CreateGroupRealmRole holds details about calls to the CreateGroupRealmRole method.
+		CreateGroupRealmRole []struct {
+			// Role is the role argument value.
+			Role *v1alpha1.KeycloakUserRole
+			// RealmName is the realmName argument value.
+			RealmName string
 			// GroupID is the groupID argument value.
 			GroupID string
 		}
@@ -521,6 +565,15 @@ type KeycloakInterfaceMock struct {
 			RealmName string
 			// UserID is the userID argument value.
 			UserID string
+		}
+		// FindAuthenticationExecutionForFlow holds details about calls to the FindAuthenticationExecutionForFlow method.
+		FindAuthenticationExecutionForFlow []struct {
+			// FlowAlias is the flowAlias argument value.
+			FlowAlias string
+			// RealmName is the realmName argument value.
+			RealmName string
+			// Predicate is the predicate argument value.
+			Predicate func(*v1alpha1.AuthenticationExecutionInfo) bool
 		}
 		// FindAvailableGroupClientRole holds details about calls to the FindAvailableGroupClientRole method.
 		FindAvailableGroupClientRole []struct {
@@ -635,6 +688,13 @@ type KeycloakInterfaceMock struct {
 			// GroupID is the groupID argument value.
 			GroupID string
 		}
+		// ListAvailableGroupRealmRoles holds details about calls to the ListAvailableGroupRealmRoles method.
+		ListAvailableGroupRealmRoles []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// GroupID is the groupID argument value.
+			GroupID string
+		}
 		// ListAvailableUserClientRoles holds details about calls to the ListAvailableUserClientRoles method.
 		ListAvailableUserClientRoles []struct {
 			// RealmName is the realmName argument value.
@@ -667,6 +727,13 @@ type KeycloakInterfaceMock struct {
 			RealmName string
 			// ClientID is the clientID argument value.
 			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
+		}
+		// ListGroupRealmRoles holds details about calls to the ListGroupRealmRoles method.
+		ListGroupRealmRoles []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
 			// GroupID is the groupID argument value.
 			GroupID string
 		}
@@ -717,6 +784,15 @@ type KeycloakInterfaceMock struct {
 			UserID string
 			// RealmName is the realmName argument value.
 			RealmName string
+		}
+		// UpdateAuthenticationExecutionForFlow holds details about calls to the UpdateAuthenticationExecutionForFlow method.
+		UpdateAuthenticationExecutionForFlow []struct {
+			// FlowAlias is the flowAlias argument value.
+			FlowAlias string
+			// RealmName is the realmName argument value.
+			RealmName string
+			// Execution is the execution argument value.
+			Execution *v1alpha1.AuthenticationExecutionInfo
 		}
 		// UpdateAuthenticatorConfig holds details about calls to the UpdateAuthenticatorConfig method.
 		UpdateAuthenticatorConfig []struct {
@@ -951,6 +1027,45 @@ func (mock *KeycloakInterfaceMock) CreateGroupClientRoleCalls() []struct {
 	lockKeycloakInterfaceMockCreateGroupClientRole.RLock()
 	calls = mock.calls.CreateGroupClientRole
 	lockKeycloakInterfaceMockCreateGroupClientRole.RUnlock()
+	return calls
+}
+
+// CreateGroupRealmRole calls CreateGroupRealmRoleFunc.
+func (mock *KeycloakInterfaceMock) CreateGroupRealmRole(role *v1alpha1.KeycloakUserRole, realmName string, groupID string) error {
+	if mock.CreateGroupRealmRoleFunc == nil {
+		panic("KeycloakInterfaceMock.CreateGroupRealmRoleFunc: method is nil but KeycloakInterface.CreateGroupRealmRole was just called")
+	}
+	callInfo := struct {
+		Role      *v1alpha1.KeycloakUserRole
+		RealmName string
+		GroupID   string
+	}{
+		Role:      role,
+		RealmName: realmName,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockCreateGroupRealmRole.Lock()
+	mock.calls.CreateGroupRealmRole = append(mock.calls.CreateGroupRealmRole, callInfo)
+	lockKeycloakInterfaceMockCreateGroupRealmRole.Unlock()
+	return mock.CreateGroupRealmRoleFunc(role, realmName, groupID)
+}
+
+// CreateGroupRealmRoleCalls gets all the calls that were made to CreateGroupRealmRole.
+// Check the length with:
+//     len(mockedKeycloakInterface.CreateGroupRealmRoleCalls())
+func (mock *KeycloakInterfaceMock) CreateGroupRealmRoleCalls() []struct {
+	Role      *v1alpha1.KeycloakUserRole
+	RealmName string
+	GroupID   string
+} {
+	var calls []struct {
+		Role      *v1alpha1.KeycloakUserRole
+		RealmName string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockCreateGroupRealmRole.RLock()
+	calls = mock.calls.CreateGroupRealmRole
+	lockKeycloakInterfaceMockCreateGroupRealmRole.RUnlock()
 	return calls
 }
 
@@ -1387,6 +1502,45 @@ func (mock *KeycloakInterfaceMock) DeleteUserRealmRoleCalls() []struct {
 	lockKeycloakInterfaceMockDeleteUserRealmRole.RLock()
 	calls = mock.calls.DeleteUserRealmRole
 	lockKeycloakInterfaceMockDeleteUserRealmRole.RUnlock()
+	return calls
+}
+
+// FindAuthenticationExecutionForFlow calls FindAuthenticationExecutionForFlowFunc.
+func (mock *KeycloakInterfaceMock) FindAuthenticationExecutionForFlow(flowAlias string, realmName string, predicate func(*v1alpha1.AuthenticationExecutionInfo) bool) (*v1alpha1.AuthenticationExecutionInfo, error) {
+	if mock.FindAuthenticationExecutionForFlowFunc == nil {
+		panic("KeycloakInterfaceMock.FindAuthenticationExecutionForFlowFunc: method is nil but KeycloakInterface.FindAuthenticationExecutionForFlow was just called")
+	}
+	callInfo := struct {
+		FlowAlias string
+		RealmName string
+		Predicate func(*v1alpha1.AuthenticationExecutionInfo) bool
+	}{
+		FlowAlias: flowAlias,
+		RealmName: realmName,
+		Predicate: predicate,
+	}
+	lockKeycloakInterfaceMockFindAuthenticationExecutionForFlow.Lock()
+	mock.calls.FindAuthenticationExecutionForFlow = append(mock.calls.FindAuthenticationExecutionForFlow, callInfo)
+	lockKeycloakInterfaceMockFindAuthenticationExecutionForFlow.Unlock()
+	return mock.FindAuthenticationExecutionForFlowFunc(flowAlias, realmName, predicate)
+}
+
+// FindAuthenticationExecutionForFlowCalls gets all the calls that were made to FindAuthenticationExecutionForFlow.
+// Check the length with:
+//     len(mockedKeycloakInterface.FindAuthenticationExecutionForFlowCalls())
+func (mock *KeycloakInterfaceMock) FindAuthenticationExecutionForFlowCalls() []struct {
+	FlowAlias string
+	RealmName string
+	Predicate func(*v1alpha1.AuthenticationExecutionInfo) bool
+} {
+	var calls []struct {
+		FlowAlias string
+		RealmName string
+		Predicate func(*v1alpha1.AuthenticationExecutionInfo) bool
+	}
+	lockKeycloakInterfaceMockFindAuthenticationExecutionForFlow.RLock()
+	calls = mock.calls.FindAuthenticationExecutionForFlow
+	lockKeycloakInterfaceMockFindAuthenticationExecutionForFlow.RUnlock()
 	return calls
 }
 
@@ -1931,6 +2085,41 @@ func (mock *KeycloakInterfaceMock) ListAvailableGroupClientRolesCalls() []struct
 	return calls
 }
 
+// ListAvailableGroupRealmRoles calls ListAvailableGroupRealmRolesFunc.
+func (mock *KeycloakInterfaceMock) ListAvailableGroupRealmRoles(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	if mock.ListAvailableGroupRealmRolesFunc == nil {
+		panic("KeycloakInterfaceMock.ListAvailableGroupRealmRolesFunc: method is nil but KeycloakInterface.ListAvailableGroupRealmRoles was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		GroupID   string
+	}{
+		RealmName: realmName,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockListAvailableGroupRealmRoles.Lock()
+	mock.calls.ListAvailableGroupRealmRoles = append(mock.calls.ListAvailableGroupRealmRoles, callInfo)
+	lockKeycloakInterfaceMockListAvailableGroupRealmRoles.Unlock()
+	return mock.ListAvailableGroupRealmRolesFunc(realmName, groupID)
+}
+
+// ListAvailableGroupRealmRolesCalls gets all the calls that were made to ListAvailableGroupRealmRoles.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListAvailableGroupRealmRolesCalls())
+func (mock *KeycloakInterfaceMock) ListAvailableGroupRealmRolesCalls() []struct {
+	RealmName string
+	GroupID   string
+} {
+	var calls []struct {
+		RealmName string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockListAvailableGroupRealmRoles.RLock()
+	calls = mock.calls.ListAvailableGroupRealmRoles
+	lockKeycloakInterfaceMockListAvailableGroupRealmRoles.RUnlock()
+	return calls
+}
+
 // ListAvailableUserClientRoles calls ListAvailableUserClientRolesFunc.
 func (mock *KeycloakInterfaceMock) ListAvailableUserClientRoles(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
 	if mock.ListAvailableUserClientRolesFunc == nil {
@@ -2103,6 +2292,41 @@ func (mock *KeycloakInterfaceMock) ListGroupClientRolesCalls() []struct {
 	lockKeycloakInterfaceMockListGroupClientRoles.RLock()
 	calls = mock.calls.ListGroupClientRoles
 	lockKeycloakInterfaceMockListGroupClientRoles.RUnlock()
+	return calls
+}
+
+// ListGroupRealmRoles calls ListGroupRealmRolesFunc.
+func (mock *KeycloakInterfaceMock) ListGroupRealmRoles(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	if mock.ListGroupRealmRolesFunc == nil {
+		panic("KeycloakInterfaceMock.ListGroupRealmRolesFunc: method is nil but KeycloakInterface.ListGroupRealmRoles was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		GroupID   string
+	}{
+		RealmName: realmName,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockListGroupRealmRoles.Lock()
+	mock.calls.ListGroupRealmRoles = append(mock.calls.ListGroupRealmRoles, callInfo)
+	lockKeycloakInterfaceMockListGroupRealmRoles.Unlock()
+	return mock.ListGroupRealmRolesFunc(realmName, groupID)
+}
+
+// ListGroupRealmRolesCalls gets all the calls that were made to ListGroupRealmRoles.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListGroupRealmRolesCalls())
+func (mock *KeycloakInterfaceMock) ListGroupRealmRolesCalls() []struct {
+	RealmName string
+	GroupID   string
+} {
+	var calls []struct {
+		RealmName string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockListGroupRealmRoles.RLock()
+	calls = mock.calls.ListGroupRealmRoles
+	lockKeycloakInterfaceMockListGroupRealmRoles.RUnlock()
 	return calls
 }
 
@@ -2365,6 +2589,45 @@ func (mock *KeycloakInterfaceMock) RemoveFederatedIdentityCalls() []struct {
 	lockKeycloakInterfaceMockRemoveFederatedIdentity.RLock()
 	calls = mock.calls.RemoveFederatedIdentity
 	lockKeycloakInterfaceMockRemoveFederatedIdentity.RUnlock()
+	return calls
+}
+
+// UpdateAuthenticationExecutionForFlow calls UpdateAuthenticationExecutionForFlowFunc.
+func (mock *KeycloakInterfaceMock) UpdateAuthenticationExecutionForFlow(flowAlias string, realmName string, execution *v1alpha1.AuthenticationExecutionInfo) error {
+	if mock.UpdateAuthenticationExecutionForFlowFunc == nil {
+		panic("KeycloakInterfaceMock.UpdateAuthenticationExecutionForFlowFunc: method is nil but KeycloakInterface.UpdateAuthenticationExecutionForFlow was just called")
+	}
+	callInfo := struct {
+		FlowAlias string
+		RealmName string
+		Execution *v1alpha1.AuthenticationExecutionInfo
+	}{
+		FlowAlias: flowAlias,
+		RealmName: realmName,
+		Execution: execution,
+	}
+	lockKeycloakInterfaceMockUpdateAuthenticationExecutionForFlow.Lock()
+	mock.calls.UpdateAuthenticationExecutionForFlow = append(mock.calls.UpdateAuthenticationExecutionForFlow, callInfo)
+	lockKeycloakInterfaceMockUpdateAuthenticationExecutionForFlow.Unlock()
+	return mock.UpdateAuthenticationExecutionForFlowFunc(flowAlias, realmName, execution)
+}
+
+// UpdateAuthenticationExecutionForFlowCalls gets all the calls that were made to UpdateAuthenticationExecutionForFlow.
+// Check the length with:
+//     len(mockedKeycloakInterface.UpdateAuthenticationExecutionForFlowCalls())
+func (mock *KeycloakInterfaceMock) UpdateAuthenticationExecutionForFlowCalls() []struct {
+	FlowAlias string
+	RealmName string
+	Execution *v1alpha1.AuthenticationExecutionInfo
+} {
+	var calls []struct {
+		FlowAlias string
+		RealmName string
+		Execution *v1alpha1.AuthenticationExecutionInfo
+	}
+	lockKeycloakInterfaceMockUpdateAuthenticationExecutionForFlow.RLock()
+	calls = mock.calls.UpdateAuthenticationExecutionForFlow
+	lockKeycloakInterfaceMockUpdateAuthenticationExecutionForFlow.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
@@ -12,6 +12,8 @@ var (
 	lockKeycloakInterfaceMockCreateAuthenticatorConfig           sync.RWMutex
 	lockKeycloakInterfaceMockCreateClient                        sync.RWMutex
 	lockKeycloakInterfaceMockCreateFederatedIdentity             sync.RWMutex
+	lockKeycloakInterfaceMockCreateGroup                         sync.RWMutex
+	lockKeycloakInterfaceMockCreateGroupClientRole               sync.RWMutex
 	lockKeycloakInterfaceMockCreateIdentityProvider              sync.RWMutex
 	lockKeycloakInterfaceMockCreateRealm                         sync.RWMutex
 	lockKeycloakInterfaceMockCreateUser                          sync.RWMutex
@@ -24,6 +26,9 @@ var (
 	lockKeycloakInterfaceMockDeleteUser                          sync.RWMutex
 	lockKeycloakInterfaceMockDeleteUserClientRole                sync.RWMutex
 	lockKeycloakInterfaceMockDeleteUserRealmRole                 sync.RWMutex
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole        sync.RWMutex
+	lockKeycloakInterfaceMockFindGroupByName                     sync.RWMutex
+	lockKeycloakInterfaceMockFindGroupClientRole                 sync.RWMutex
 	lockKeycloakInterfaceMockFindUserByEmail                     sync.RWMutex
 	lockKeycloakInterfaceMockFindUserByUsername                  sync.RWMutex
 	lockKeycloakInterfaceMockGetAuthenticatorConfig              sync.RWMutex
@@ -35,14 +40,18 @@ var (
 	lockKeycloakInterfaceMockGetUser                             sync.RWMutex
 	lockKeycloakInterfaceMockGetUserFederatedIdentities          sync.RWMutex
 	lockKeycloakInterfaceMockListAuthenticationExecutionsForFlow sync.RWMutex
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles       sync.RWMutex
 	lockKeycloakInterfaceMockListAvailableUserClientRoles        sync.RWMutex
 	lockKeycloakInterfaceMockListAvailableUserRealmRoles         sync.RWMutex
 	lockKeycloakInterfaceMockListClients                         sync.RWMutex
+	lockKeycloakInterfaceMockListDefaultGroups                   sync.RWMutex
+	lockKeycloakInterfaceMockListGroupClientRoles                sync.RWMutex
 	lockKeycloakInterfaceMockListIdentityProviders               sync.RWMutex
 	lockKeycloakInterfaceMockListRealms                          sync.RWMutex
 	lockKeycloakInterfaceMockListUserClientRoles                 sync.RWMutex
 	lockKeycloakInterfaceMockListUserRealmRoles                  sync.RWMutex
 	lockKeycloakInterfaceMockListUsers                           sync.RWMutex
+	lockKeycloakInterfaceMockMakeGroupDefault                    sync.RWMutex
 	lockKeycloakInterfaceMockPing                                sync.RWMutex
 	lockKeycloakInterfaceMockRemoveFederatedIdentity             sync.RWMutex
 	lockKeycloakInterfaceMockUpdateAuthenticatorConfig           sync.RWMutex
@@ -71,6 +80,12 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             CreateFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error {
 // 	               panic("mock out the CreateFederatedIdentity method")
+//             },
+//             CreateGroupFunc: func(group string, realmName string) (string, error) {
+// 	               panic("mock out the CreateGroup method")
+//             },
+//             CreateGroupClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) error {
+// 	               panic("mock out the CreateGroupClientRole method")
 //             },
 //             CreateIdentityProviderFunc: func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error {
 // 	               panic("mock out the CreateIdentityProvider method")
@@ -108,6 +123,15 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             DeleteUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error {
 // 	               panic("mock out the DeleteUserRealmRole method")
 //             },
+//             FindAvailableGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the FindAvailableGroupClientRole method")
+//             },
+//             FindGroupByNameFunc: func(groupName string, realmName string) (*Group, error) {
+// 	               panic("mock out the FindGroupByName method")
+//             },
+//             FindGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the FindGroupClientRole method")
+//             },
 //             FindUserByEmailFunc: func(email string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
 // 	               panic("mock out the FindUserByEmail method")
 //             },
@@ -141,6 +165,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             ListAuthenticationExecutionsForFlowFunc: func(flowAlias string, realmName string) ([]*v1alpha1.AuthenticationExecutionInfo, error) {
 // 	               panic("mock out the ListAuthenticationExecutionsForFlow method")
 //             },
+//             ListAvailableGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the ListAvailableGroupClientRoles method")
+//             },
 //             ListAvailableUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
 // 	               panic("mock out the ListAvailableUserClientRoles method")
 //             },
@@ -149,6 +176,12 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             ListClientsFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIClient, error) {
 // 	               panic("mock out the ListClients method")
+//             },
+//             ListDefaultGroupsFunc: func(realmName string) ([]*Group, error) {
+// 	               panic("mock out the ListDefaultGroups method")
+//             },
+//             ListGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 	               panic("mock out the ListGroupClientRoles method")
 //             },
 //             ListIdentityProvidersFunc: func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error) {
 // 	               panic("mock out the ListIdentityProviders method")
@@ -164,6 +197,9 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 //             },
 //             ListUsersFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIUser, error) {
 // 	               panic("mock out the ListUsers method")
+//             },
+//             MakeGroupDefaultFunc: func(groupID string, realmName string) error {
+// 	               panic("mock out the MakeGroupDefault method")
 //             },
 //             PingFunc: func() error {
 // 	               panic("mock out the Ping method")
@@ -205,6 +241,12 @@ type KeycloakInterfaceMock struct {
 	// CreateFederatedIdentityFunc mocks the CreateFederatedIdentity method.
 	CreateFederatedIdentityFunc func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error
 
+	// CreateGroupFunc mocks the CreateGroup method.
+	CreateGroupFunc func(group string, realmName string) (string, error)
+
+	// CreateGroupClientRoleFunc mocks the CreateGroupClientRole method.
+	CreateGroupClientRoleFunc func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) error
+
 	// CreateIdentityProviderFunc mocks the CreateIdentityProvider method.
 	CreateIdentityProviderFunc func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error
 
@@ -241,6 +283,15 @@ type KeycloakInterfaceMock struct {
 	// DeleteUserRealmRoleFunc mocks the DeleteUserRealmRole method.
 	DeleteUserRealmRoleFunc func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error
 
+	// FindAvailableGroupClientRoleFunc mocks the FindAvailableGroupClientRole method.
+	FindAvailableGroupClientRoleFunc func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error)
+
+	// FindGroupByNameFunc mocks the FindGroupByName method.
+	FindGroupByNameFunc func(groupName string, realmName string) (*Group, error)
+
+	// FindGroupClientRoleFunc mocks the FindGroupClientRole method.
+	FindGroupClientRoleFunc func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error)
+
 	// FindUserByEmailFunc mocks the FindUserByEmail method.
 	FindUserByEmailFunc func(email string, realm string) (*v1alpha1.KeycloakAPIUser, error)
 
@@ -274,6 +325,9 @@ type KeycloakInterfaceMock struct {
 	// ListAuthenticationExecutionsForFlowFunc mocks the ListAuthenticationExecutionsForFlow method.
 	ListAuthenticationExecutionsForFlowFunc func(flowAlias string, realmName string) ([]*v1alpha1.AuthenticationExecutionInfo, error)
 
+	// ListAvailableGroupClientRolesFunc mocks the ListAvailableGroupClientRoles method.
+	ListAvailableGroupClientRolesFunc func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
+
 	// ListAvailableUserClientRolesFunc mocks the ListAvailableUserClientRoles method.
 	ListAvailableUserClientRolesFunc func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error)
 
@@ -282,6 +336,12 @@ type KeycloakInterfaceMock struct {
 
 	// ListClientsFunc mocks the ListClients method.
 	ListClientsFunc func(realmName string) ([]*v1alpha1.KeycloakAPIClient, error)
+
+	// ListDefaultGroupsFunc mocks the ListDefaultGroups method.
+	ListDefaultGroupsFunc func(realmName string) ([]*Group, error)
+
+	// ListGroupClientRolesFunc mocks the ListGroupClientRoles method.
+	ListGroupClientRolesFunc func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error)
 
 	// ListIdentityProvidersFunc mocks the ListIdentityProviders method.
 	ListIdentityProvidersFunc func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error)
@@ -297,6 +357,9 @@ type KeycloakInterfaceMock struct {
 
 	// ListUsersFunc mocks the ListUsers method.
 	ListUsersFunc func(realmName string) ([]*v1alpha1.KeycloakAPIUser, error)
+
+	// MakeGroupDefaultFunc mocks the MakeGroupDefault method.
+	MakeGroupDefaultFunc func(groupID string, realmName string) error
 
 	// PingFunc mocks the Ping method.
 	PingFunc func() error
@@ -348,6 +411,24 @@ type KeycloakInterfaceMock struct {
 			UserID string
 			// RealmName is the realmName argument value.
 			RealmName string
+		}
+		// CreateGroup holds details about calls to the CreateGroup method.
+		CreateGroup []struct {
+			// Group is the group argument value.
+			Group string
+			// RealmName is the realmName argument value.
+			RealmName string
+		}
+		// CreateGroupClientRole holds details about calls to the CreateGroupClientRole method.
+		CreateGroupClientRole []struct {
+			// Role is the role argument value.
+			Role *v1alpha1.KeycloakUserRole
+			// RealmName is the realmName argument value.
+			RealmName string
+			// ClientID is the clientID argument value.
+			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
 		}
 		// CreateIdentityProvider holds details about calls to the CreateIdentityProvider method.
 		CreateIdentityProvider []struct {
@@ -441,6 +522,35 @@ type KeycloakInterfaceMock struct {
 			// UserID is the userID argument value.
 			UserID string
 		}
+		// FindAvailableGroupClientRole holds details about calls to the FindAvailableGroupClientRole method.
+		FindAvailableGroupClientRole []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// ClientID is the clientID argument value.
+			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
+			// Predicate is the predicate argument value.
+			Predicate func(*v1alpha1.KeycloakUserRole) bool
+		}
+		// FindGroupByName holds details about calls to the FindGroupByName method.
+		FindGroupByName []struct {
+			// GroupName is the groupName argument value.
+			GroupName string
+			// RealmName is the realmName argument value.
+			RealmName string
+		}
+		// FindGroupClientRole holds details about calls to the FindGroupClientRole method.
+		FindGroupClientRole []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// ClientID is the clientID argument value.
+			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
+			// Predicate is the predicate argument value.
+			Predicate func(*v1alpha1.KeycloakUserRole) bool
+		}
 		// FindUserByEmail holds details about calls to the FindUserByEmail method.
 		FindUserByEmail []struct {
 			// Email is the email argument value.
@@ -516,6 +626,15 @@ type KeycloakInterfaceMock struct {
 			// RealmName is the realmName argument value.
 			RealmName string
 		}
+		// ListAvailableGroupClientRoles holds details about calls to the ListAvailableGroupClientRoles method.
+		ListAvailableGroupClientRoles []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// ClientID is the clientID argument value.
+			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
+		}
 		// ListAvailableUserClientRoles holds details about calls to the ListAvailableUserClientRoles method.
 		ListAvailableUserClientRoles []struct {
 			// RealmName is the realmName argument value.
@@ -536,6 +655,20 @@ type KeycloakInterfaceMock struct {
 		ListClients []struct {
 			// RealmName is the realmName argument value.
 			RealmName string
+		}
+		// ListDefaultGroups holds details about calls to the ListDefaultGroups method.
+		ListDefaultGroups []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+		}
+		// ListGroupClientRoles holds details about calls to the ListGroupClientRoles method.
+		ListGroupClientRoles []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// ClientID is the clientID argument value.
+			ClientID string
+			// GroupID is the groupID argument value.
+			GroupID string
 		}
 		// ListIdentityProviders holds details about calls to the ListIdentityProviders method.
 		ListIdentityProviders []struct {
@@ -563,6 +696,13 @@ type KeycloakInterfaceMock struct {
 		}
 		// ListUsers holds details about calls to the ListUsers method.
 		ListUsers []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+		}
+		// MakeGroupDefault holds details about calls to the MakeGroupDefault method.
+		MakeGroupDefault []struct {
+			// GroupID is the groupID argument value.
+			GroupID string
 			// RealmName is the realmName argument value.
 			RealmName string
 		}
@@ -733,6 +873,84 @@ func (mock *KeycloakInterfaceMock) CreateFederatedIdentityCalls() []struct {
 	lockKeycloakInterfaceMockCreateFederatedIdentity.RLock()
 	calls = mock.calls.CreateFederatedIdentity
 	lockKeycloakInterfaceMockCreateFederatedIdentity.RUnlock()
+	return calls
+}
+
+// CreateGroup calls CreateGroupFunc.
+func (mock *KeycloakInterfaceMock) CreateGroup(group string, realmName string) (string, error) {
+	if mock.CreateGroupFunc == nil {
+		panic("KeycloakInterfaceMock.CreateGroupFunc: method is nil but KeycloakInterface.CreateGroup was just called")
+	}
+	callInfo := struct {
+		Group     string
+		RealmName string
+	}{
+		Group:     group,
+		RealmName: realmName,
+	}
+	lockKeycloakInterfaceMockCreateGroup.Lock()
+	mock.calls.CreateGroup = append(mock.calls.CreateGroup, callInfo)
+	lockKeycloakInterfaceMockCreateGroup.Unlock()
+	return mock.CreateGroupFunc(group, realmName)
+}
+
+// CreateGroupCalls gets all the calls that were made to CreateGroup.
+// Check the length with:
+//     len(mockedKeycloakInterface.CreateGroupCalls())
+func (mock *KeycloakInterfaceMock) CreateGroupCalls() []struct {
+	Group     string
+	RealmName string
+} {
+	var calls []struct {
+		Group     string
+		RealmName string
+	}
+	lockKeycloakInterfaceMockCreateGroup.RLock()
+	calls = mock.calls.CreateGroup
+	lockKeycloakInterfaceMockCreateGroup.RUnlock()
+	return calls
+}
+
+// CreateGroupClientRole calls CreateGroupClientRoleFunc.
+func (mock *KeycloakInterfaceMock) CreateGroupClientRole(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) error {
+	if mock.CreateGroupClientRoleFunc == nil {
+		panic("KeycloakInterfaceMock.CreateGroupClientRoleFunc: method is nil but KeycloakInterface.CreateGroupClientRole was just called")
+	}
+	callInfo := struct {
+		Role      *v1alpha1.KeycloakUserRole
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}{
+		Role:      role,
+		RealmName: realmName,
+		ClientID:  clientID,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockCreateGroupClientRole.Lock()
+	mock.calls.CreateGroupClientRole = append(mock.calls.CreateGroupClientRole, callInfo)
+	lockKeycloakInterfaceMockCreateGroupClientRole.Unlock()
+	return mock.CreateGroupClientRoleFunc(role, realmName, clientID, groupID)
+}
+
+// CreateGroupClientRoleCalls gets all the calls that were made to CreateGroupClientRole.
+// Check the length with:
+//     len(mockedKeycloakInterface.CreateGroupClientRoleCalls())
+func (mock *KeycloakInterfaceMock) CreateGroupClientRoleCalls() []struct {
+	Role      *v1alpha1.KeycloakUserRole
+	RealmName string
+	ClientID  string
+	GroupID   string
+} {
+	var calls []struct {
+		Role      *v1alpha1.KeycloakUserRole
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockCreateGroupClientRole.RLock()
+	calls = mock.calls.CreateGroupClientRole
+	lockKeycloakInterfaceMockCreateGroupClientRole.RUnlock()
 	return calls
 }
 
@@ -1172,6 +1390,127 @@ func (mock *KeycloakInterfaceMock) DeleteUserRealmRoleCalls() []struct {
 	return calls
 }
 
+// FindAvailableGroupClientRole calls FindAvailableGroupClientRoleFunc.
+func (mock *KeycloakInterfaceMock) FindAvailableGroupClientRole(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+	if mock.FindAvailableGroupClientRoleFunc == nil {
+		panic("KeycloakInterfaceMock.FindAvailableGroupClientRoleFunc: method is nil but KeycloakInterface.FindAvailableGroupClientRole was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+		Predicate func(*v1alpha1.KeycloakUserRole) bool
+	}{
+		RealmName: realmName,
+		ClientID:  clientID,
+		GroupID:   groupID,
+		Predicate: predicate,
+	}
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole.Lock()
+	mock.calls.FindAvailableGroupClientRole = append(mock.calls.FindAvailableGroupClientRole, callInfo)
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole.Unlock()
+	return mock.FindAvailableGroupClientRoleFunc(realmName, clientID, groupID, predicate)
+}
+
+// FindAvailableGroupClientRoleCalls gets all the calls that were made to FindAvailableGroupClientRole.
+// Check the length with:
+//     len(mockedKeycloakInterface.FindAvailableGroupClientRoleCalls())
+func (mock *KeycloakInterfaceMock) FindAvailableGroupClientRoleCalls() []struct {
+	RealmName string
+	ClientID  string
+	GroupID   string
+	Predicate func(*v1alpha1.KeycloakUserRole) bool
+} {
+	var calls []struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+		Predicate func(*v1alpha1.KeycloakUserRole) bool
+	}
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole.RLock()
+	calls = mock.calls.FindAvailableGroupClientRole
+	lockKeycloakInterfaceMockFindAvailableGroupClientRole.RUnlock()
+	return calls
+}
+
+// FindGroupByName calls FindGroupByNameFunc.
+func (mock *KeycloakInterfaceMock) FindGroupByName(groupName string, realmName string) (*Group, error) {
+	if mock.FindGroupByNameFunc == nil {
+		panic("KeycloakInterfaceMock.FindGroupByNameFunc: method is nil but KeycloakInterface.FindGroupByName was just called")
+	}
+	callInfo := struct {
+		GroupName string
+		RealmName string
+	}{
+		GroupName: groupName,
+		RealmName: realmName,
+	}
+	lockKeycloakInterfaceMockFindGroupByName.Lock()
+	mock.calls.FindGroupByName = append(mock.calls.FindGroupByName, callInfo)
+	lockKeycloakInterfaceMockFindGroupByName.Unlock()
+	return mock.FindGroupByNameFunc(groupName, realmName)
+}
+
+// FindGroupByNameCalls gets all the calls that were made to FindGroupByName.
+// Check the length with:
+//     len(mockedKeycloakInterface.FindGroupByNameCalls())
+func (mock *KeycloakInterfaceMock) FindGroupByNameCalls() []struct {
+	GroupName string
+	RealmName string
+} {
+	var calls []struct {
+		GroupName string
+		RealmName string
+	}
+	lockKeycloakInterfaceMockFindGroupByName.RLock()
+	calls = mock.calls.FindGroupByName
+	lockKeycloakInterfaceMockFindGroupByName.RUnlock()
+	return calls
+}
+
+// FindGroupClientRole calls FindGroupClientRoleFunc.
+func (mock *KeycloakInterfaceMock) FindGroupClientRole(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+	if mock.FindGroupClientRoleFunc == nil {
+		panic("KeycloakInterfaceMock.FindGroupClientRoleFunc: method is nil but KeycloakInterface.FindGroupClientRole was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+		Predicate func(*v1alpha1.KeycloakUserRole) bool
+	}{
+		RealmName: realmName,
+		ClientID:  clientID,
+		GroupID:   groupID,
+		Predicate: predicate,
+	}
+	lockKeycloakInterfaceMockFindGroupClientRole.Lock()
+	mock.calls.FindGroupClientRole = append(mock.calls.FindGroupClientRole, callInfo)
+	lockKeycloakInterfaceMockFindGroupClientRole.Unlock()
+	return mock.FindGroupClientRoleFunc(realmName, clientID, groupID, predicate)
+}
+
+// FindGroupClientRoleCalls gets all the calls that were made to FindGroupClientRole.
+// Check the length with:
+//     len(mockedKeycloakInterface.FindGroupClientRoleCalls())
+func (mock *KeycloakInterfaceMock) FindGroupClientRoleCalls() []struct {
+	RealmName string
+	ClientID  string
+	GroupID   string
+	Predicate func(*v1alpha1.KeycloakUserRole) bool
+} {
+	var calls []struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+		Predicate func(*v1alpha1.KeycloakUserRole) bool
+	}
+	lockKeycloakInterfaceMockFindGroupClientRole.RLock()
+	calls = mock.calls.FindGroupClientRole
+	lockKeycloakInterfaceMockFindGroupClientRole.RUnlock()
+	return calls
+}
+
 // FindUserByEmail calls FindUserByEmailFunc.
 func (mock *KeycloakInterfaceMock) FindUserByEmail(email string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
 	if mock.FindUserByEmailFunc == nil {
@@ -1553,6 +1892,45 @@ func (mock *KeycloakInterfaceMock) ListAuthenticationExecutionsForFlowCalls() []
 	return calls
 }
 
+// ListAvailableGroupClientRoles calls ListAvailableGroupClientRolesFunc.
+func (mock *KeycloakInterfaceMock) ListAvailableGroupClientRoles(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	if mock.ListAvailableGroupClientRolesFunc == nil {
+		panic("KeycloakInterfaceMock.ListAvailableGroupClientRolesFunc: method is nil but KeycloakInterface.ListAvailableGroupClientRoles was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}{
+		RealmName: realmName,
+		ClientID:  clientID,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles.Lock()
+	mock.calls.ListAvailableGroupClientRoles = append(mock.calls.ListAvailableGroupClientRoles, callInfo)
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles.Unlock()
+	return mock.ListAvailableGroupClientRolesFunc(realmName, clientID, groupID)
+}
+
+// ListAvailableGroupClientRolesCalls gets all the calls that were made to ListAvailableGroupClientRoles.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListAvailableGroupClientRolesCalls())
+func (mock *KeycloakInterfaceMock) ListAvailableGroupClientRolesCalls() []struct {
+	RealmName string
+	ClientID  string
+	GroupID   string
+} {
+	var calls []struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles.RLock()
+	calls = mock.calls.ListAvailableGroupClientRoles
+	lockKeycloakInterfaceMockListAvailableGroupClientRoles.RUnlock()
+	return calls
+}
+
 // ListAvailableUserClientRoles calls ListAvailableUserClientRolesFunc.
 func (mock *KeycloakInterfaceMock) ListAvailableUserClientRoles(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
 	if mock.ListAvailableUserClientRolesFunc == nil {
@@ -1655,6 +2033,76 @@ func (mock *KeycloakInterfaceMock) ListClientsCalls() []struct {
 	lockKeycloakInterfaceMockListClients.RLock()
 	calls = mock.calls.ListClients
 	lockKeycloakInterfaceMockListClients.RUnlock()
+	return calls
+}
+
+// ListDefaultGroups calls ListDefaultGroupsFunc.
+func (mock *KeycloakInterfaceMock) ListDefaultGroups(realmName string) ([]*Group, error) {
+	if mock.ListDefaultGroupsFunc == nil {
+		panic("KeycloakInterfaceMock.ListDefaultGroupsFunc: method is nil but KeycloakInterface.ListDefaultGroups was just called")
+	}
+	callInfo := struct {
+		RealmName string
+	}{
+		RealmName: realmName,
+	}
+	lockKeycloakInterfaceMockListDefaultGroups.Lock()
+	mock.calls.ListDefaultGroups = append(mock.calls.ListDefaultGroups, callInfo)
+	lockKeycloakInterfaceMockListDefaultGroups.Unlock()
+	return mock.ListDefaultGroupsFunc(realmName)
+}
+
+// ListDefaultGroupsCalls gets all the calls that were made to ListDefaultGroups.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListDefaultGroupsCalls())
+func (mock *KeycloakInterfaceMock) ListDefaultGroupsCalls() []struct {
+	RealmName string
+} {
+	var calls []struct {
+		RealmName string
+	}
+	lockKeycloakInterfaceMockListDefaultGroups.RLock()
+	calls = mock.calls.ListDefaultGroups
+	lockKeycloakInterfaceMockListDefaultGroups.RUnlock()
+	return calls
+}
+
+// ListGroupClientRoles calls ListGroupClientRolesFunc.
+func (mock *KeycloakInterfaceMock) ListGroupClientRoles(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+	if mock.ListGroupClientRolesFunc == nil {
+		panic("KeycloakInterfaceMock.ListGroupClientRolesFunc: method is nil but KeycloakInterface.ListGroupClientRoles was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}{
+		RealmName: realmName,
+		ClientID:  clientID,
+		GroupID:   groupID,
+	}
+	lockKeycloakInterfaceMockListGroupClientRoles.Lock()
+	mock.calls.ListGroupClientRoles = append(mock.calls.ListGroupClientRoles, callInfo)
+	lockKeycloakInterfaceMockListGroupClientRoles.Unlock()
+	return mock.ListGroupClientRolesFunc(realmName, clientID, groupID)
+}
+
+// ListGroupClientRolesCalls gets all the calls that were made to ListGroupClientRoles.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListGroupClientRolesCalls())
+func (mock *KeycloakInterfaceMock) ListGroupClientRolesCalls() []struct {
+	RealmName string
+	ClientID  string
+	GroupID   string
+} {
+	var calls []struct {
+		RealmName string
+		ClientID  string
+		GroupID   string
+	}
+	lockKeycloakInterfaceMockListGroupClientRoles.RLock()
+	calls = mock.calls.ListGroupClientRoles
+	lockKeycloakInterfaceMockListGroupClientRoles.RUnlock()
 	return calls
 }
 
@@ -1817,6 +2265,41 @@ func (mock *KeycloakInterfaceMock) ListUsersCalls() []struct {
 	lockKeycloakInterfaceMockListUsers.RLock()
 	calls = mock.calls.ListUsers
 	lockKeycloakInterfaceMockListUsers.RUnlock()
+	return calls
+}
+
+// MakeGroupDefault calls MakeGroupDefaultFunc.
+func (mock *KeycloakInterfaceMock) MakeGroupDefault(groupID string, realmName string) error {
+	if mock.MakeGroupDefaultFunc == nil {
+		panic("KeycloakInterfaceMock.MakeGroupDefaultFunc: method is nil but KeycloakInterface.MakeGroupDefault was just called")
+	}
+	callInfo := struct {
+		GroupID   string
+		RealmName string
+	}{
+		GroupID:   groupID,
+		RealmName: realmName,
+	}
+	lockKeycloakInterfaceMockMakeGroupDefault.Lock()
+	mock.calls.MakeGroupDefault = append(mock.calls.MakeGroupDefault, callInfo)
+	lockKeycloakInterfaceMockMakeGroupDefault.Unlock()
+	return mock.MakeGroupDefaultFunc(groupID, realmName)
+}
+
+// MakeGroupDefaultCalls gets all the calls that were made to MakeGroupDefault.
+// Check the length with:
+//     len(mockedKeycloakInterface.MakeGroupDefaultCalls())
+func (mock *KeycloakInterfaceMock) MakeGroupDefaultCalls() []struct {
+	GroupID   string
+	RealmName string
+} {
+	var calls []struct {
+		GroupID   string
+		RealmName string
+	}
+	lockKeycloakInterfaceMockMakeGroupDefault.RLock()
+	calls = mock.calls.MakeGroupDefault
+	lockKeycloakInterfaceMockMakeGroupDefault.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
@@ -1,0 +1,8 @@
+package common
+
+// Group representation
+// https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_grouprepresentation
+type Group struct {
+	Name string `json:"name,omitempty"`
+	ID   string `json:"id,omitempty"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/integr8ly/cloud-resource-operator/pkg/resources
 github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
-# github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc
+# github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/joho/godotenv v1.3.0
 github.com/joho/godotenv

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/integr8ly/cloud-resource-operator/pkg/resources
 github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
-# github.com/integr8ly/keycloak-client v0.0.0-20200129153447-ae34238c1f86
+# github.com/integr8ly/keycloak-client v0.0.0-20200225080707-ccc77cd8b2cc
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/joho/godotenv v1.3.0
 github.com/joho/godotenv


### PR DESCRIPTION
Add phase in reconciliation that:

1. Creates a `rhmi-developers` group
2. Makes it a default group
3. Maps the `query-realms` role to the group

This allows the developer users to view the realm by default instead
of getting a `Forbidden` message on first login.

This operation is idempotent.