### PR TITLE
added make ocm/cleanup

### DIFF
--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -125,6 +125,7 @@ ocm/aws/create_access_key:
 # Cleanup AWS resources for BYOC clusters that are to be retired soon
 .PHONY: ocm/cleanup
 ocm/cleanup:
+	@mkdir -p ocm
 	@$(call get_byoc_clusters_to_be_retired_soon)
 	@for cluster_id in $(CLUSTER_IDS); do \
 		echo "Removing RHMI CR from cluster: $$($(OCM) get /api/clusters_mgmt/v1/clusters/$$cluster_id | jq --raw-output '.name')" && \


### PR DESCRIPTION
## Description

JIRA: https://issues.redhat.com/browse/INTLY-5518

Make command that checks if there are any soon to be retired BYOC clusters (2 hours) and if so, it deletes RHMI CR from them, so that AWS resources are released.

This command should be run periodically by Jenkins pipeline to make sure, there are no leftovers in AWS.