### PR TITLE
 [INTLY-5214] Check all alerts as part of e2e & functional tests

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -66,6 +66,12 @@ var expectedRules = []alertsTestRule{
 		},
 	},
 	{
+		File: "redhat-rhmi-codeready-workspaces-backupjobs-exist-alerts.yaml",
+		Rules: []string{
+			"CronJobExists_redhat-rhmi-codeready-workspaces_codeready-pv-backup",
+		},
+	},
+	{
 		File: "redhat-rhmi-rhsso-keycloak.yaml",
 		Rules: []string{
 			"KeycloakJavaHeapThresholdExceeded",
@@ -117,8 +123,7 @@ var expectedRules = []alertsTestRule{
 	{
 		File: "redhat-rhmi-apicurito-ksm-apicurito-alerts.yaml",
 		Rules: []string{
-			//"ApicuritoPodCount",
-			"test",
+			"ApicuritoPodCount",
 		},
 	},
 	{
@@ -142,6 +147,28 @@ var expectedRules = []alertsTestRule{
 		},
 	},
 	{
+		File: "redhat-rhmi-codeready-workspaces-ksm-codeready-alerts.yaml",
+		Rules: []string{
+			"CodeReadyPodCount",
+		},
+	},
+	{
+		File: "redhat-rhmi-3scale-ksm-3scale-alerts.yaml",
+		Rules: []string{
+			"ThreeScaleApicastStagingPod",
+			"ThreeScaleApicastProductionPod",
+			"ThreeScaleBackendWorkerPod",
+			"ThreeScaleBackendListenerPod",
+			"ThreeScaleSystemAppPod",
+			"ThreeScaleAdminUIBBT",
+			"ThreeScaleDeveloperUIBBT",
+			"ThreeScaleSystemAdminUIBBT",
+			"ThreeScalePodCount",
+			"ThreeScalePodHighMemory",
+			"ThreeScalePodHighCPU",
+		},
+	},
+	{
 		File: "redhat-rhmi-middleware-monitoring-operator-prometheus-application-monitoring-rules.yaml",
 		Rules: []string{
 			"DeadMansSwitch",
@@ -153,6 +180,12 @@ var expectedRules = []alertsTestRule{
 			"AMQOnlineConsoleAvailable",
 			"AMQOnlineKeycloakAvailable",
 			"AMQOnlineOperatorAvailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-solution-explorer-ksm-solution-explorer-alerts.yaml",
+		Rules: []string{
+			"SolutionExplorerPodCount",
 		},
 	},
 	{
@@ -202,6 +235,93 @@ var expectedRules = []alertsTestRule{
 	},
 }
 
+var expectedAWSRules = []alertsTestRule{
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-redis-example-rhmi.yaml",
+		Rules: []string{
+			"3scaleRedisCacheConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-backend-redis-example-rhmi.yaml",
+		Rules: []string{
+			"3scaleRedisCacheConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"3scalePostgresConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-threescale-redis-example-rhmi.yaml",
+		Rules: []string{
+			"3scaleRedisCacheUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-threescale-backend-redis-example-rhmi.yaml",
+		Rules: []string{
+			"3scaleRedisCacheUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-threescale-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"3scalePostgresInstanceUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-ups-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"upsPostgresConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-ups-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"upsPostgresInstanceUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-codeready-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"codeready-workspacesPostgresInstanceUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-codeready-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"codeready-workspacesPostgresConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-rhssouser-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"user-ssoPostgresConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-rhssouser-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"user-ssoPostgresInstanceUnavailable",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-connectivity-rule-rhsso-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"rhssoPostgresConnectionFailed",
+		},
+	},
+	{
+		File: "redhat-rhmi-operator-availability-rule-rhsso-postgres-example-rhmi.yaml",
+		Rules: []string{
+			"rhssoPostgresInstanceUnavailable",
+		},
+	},
+}
+
 func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	// get the RHMI custom resource to check what storage type is being used
 	rhmi := &v1alpha1.RHMI{}
@@ -213,11 +333,11 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 
 	// add external database alerts to list of expected rules if
 	// cluster storage is not being used
-	//if rhmi.Spec.UseClusterStorage != "true" {
-	//	for file, rules := range expectedExtRules {
-	//		expectedRules[file] = append(expectedRules[file], rules...)
-	//	}
-	//}
+	if rhmi.Spec.UseClusterStorage != "true" {
+		for _, rule := range expectedAWSRules {
+			expectedRules = append(expectedRules, rule)
+		}
+	}
 
 	// exec into the prometheus pod
 	output, err := execToPod("curl localhost:9090/api/v1/rules",
@@ -293,14 +413,15 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 		}
 	}
 
+	// report the status
 	missingCount := 0
 	extraCount := 0
 	for k, v := range reportMapping {
 		if v.Status != fileCorrect {
-			fmt.Println("File Name:", k)
+			fmt.Println("\nFile Name:", k)
 			fmt.Println("Missing Rules:", v.MissingRules)
 			fmt.Println("Additional Rules:", v.AdditionalRules)
-			fmt.Println("Status:\n", v.Status)
+			fmt.Println("Status:", v.Status)
 		}
 		if v.Status == fileMissing || len(v.MissingRules) > 0 {
 			missingCount++

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -488,33 +488,37 @@ func execToPod(command string, podname string, namespace string, container strin
 	return stdout.String(), nil
 }
 
-// difference returns the elements in `a` that aren't in `b`.
-func difference(a, b []string) []string {
-	mb := make(map[string]struct{}, len(b))
-	for _, x := range b {
-		mb[x] = struct{}{}
+// difference one-way diff that return strings in sliceSource that are not in sliceTarget
+func difference(sliceSource, sliceTarget []string) []string {
+	// create an empty lookup map with keys from sliceTarget
+	diffSourceLookupMap := make(map[string]struct{}, len(sliceTarget))
+	for _, item := range sliceTarget {
+		diffSourceLookupMap[item] = struct{}{}
 	}
-
+	// use the lookup map to find items in sliceSource that are not in sliceTarget
+	// and store them in a diff slice
 	var diff []string
-	for _, x := range a {
-		if _, found := mb[x]; !found {
-			diff = append(diff, x)
+	for _, item := range sliceSource {
+		if _, found := diffSourceLookupMap[item]; !found {
+			diff = append(diff, item)
 		}
 	}
 	return diff
 }
 
-// difference returns the elements in list of alertsTestRule `a` that aren't in list `b`.
-func ruleDifference(a, b []alertsTestRule) []alertsTestRule {
-	mb := make(map[string]struct{}, len(b))
-	for _, x := range b {
-		mb[x.File] = struct{}{}
+// ruleDifference one-way diff that return rules in diffSource that are not in diffTarget
+func ruleDifference(diffSource, diffTarget []alertsTestRule) []alertsTestRule {
+	// create an empty lookup map with keys from diffTarget
+	diffSourceLookupMap := make(map[string]struct{}, len(diffTarget))
+	for _, rule := range diffTarget {
+		diffSourceLookupMap[rule.File] = struct{}{}
 	}
-
+	// use the lookup map to find items in diffSource that are not in diffTarget
+	// and store them in a diff slice
 	var diff []alertsTestRule
-	for _, x := range a {
-		if _, found := mb[x.File]; !found {
-			diff = append(diff, x)
+	for _, rule := range diffSource {
+		if _, found := diffSourceLookupMap[rule.File]; !found {
+			diff = append(diff, rule)
 		}
 	}
 	return diff

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -1,0 +1,275 @@
+package common
+
+import (
+	"bytes"
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	corev1 "k8s.io/api/core/v1"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+var expectedRules = map[string][]string{
+	"/redhat-rhmi-middleware-monitoring": {
+		"DeadMansSwitch",
+		"KubePodBadConfig",
+		"KubePodCrashLooping",
+		"KubePodImagePullBackOff",
+		"KubePodNotReady",
+		"KubePodStuckCreating",
+		"ClusterSchedulableMemoryLow",
+		"ClusterSchedulableCPULow",
+		"PVCStorageAvailable",
+		"PVCStorageMetricsAvailable",
+		"CronJobNotRunInThreshold",
+		"CronJobSuspended",
+		"CronJobsFailed",
+		"JobRunningTimeExceeded",
+		"JobRunningTimeExceeded",
+		"MiddlewareMonitoringPodCount",
+	},
+	"/redhat-rhmi-3scale": {
+		"ThreeScaleAdminUIBBT",
+		"ThreeScaleApicastProductionPod",
+		"ThreeScaleApicastStagingPod",
+		"ThreeScaleBackendListenerPod",
+		"ThreeScaleBackendWorkerPod",
+		"ThreeScaleDeveloperUIBBT",
+		"ThreeScalePodCount",
+		"ThreeScalePodHighCPU",
+		"ThreeScalePodHighMemory",
+		"ThreeScaleSystemAdminUIBBT",
+		"ThreeScaleSystemAppPod",
+	},
+	"/redhat-rhmi-amq-online": {
+		"AMQOnlinePodCount",
+		"AMQOnlinePodHighMemory",
+		"AMQOnlineConsoleAvailable",
+		"AMQOnlineKeycloakAvailable",
+		"AMQOnlineOperatorAvailable",
+		"CronJobExists_redhat-rhmi-amq-online_enmasse-pv-backup",
+	},
+	"/redhat-rhmi-fuse": {
+		"FuseOnlinePodCount",
+		"FuseOnlineSyndesisServerInstanceDown",
+		"FuseOnlineSyndesisUIInstanceDown",
+		"FuseOnlineDatabaseInstanceDown",
+		"FuseOnlinePostgresExporterDown",
+		"FuseOnlineRestApiHighEndpointErrorRate",
+		"FuseOnlineRestApiHighEndpointLatency",
+		"FuseOnlineRestApiHighEndpointErrorRate",
+		"FuseOnlineRestApiHighEndpointLatency",
+		"IntegrationExchangesHighFailureRate",
+	},
+	"/redhat-rhmi-codeready": {
+		"CodeReadyPodCount",
+		"CronJobExists_redhat-rhmi-codeready-workspaces_codeready-pv-backup",
+	},
+	"/redhat-rhmi-solutionexplorer": {
+		"SolutionExplorerPodCount",
+	},
+	"/redhat-rhmi-ups": {
+		"UnifiedPushOperatorDown",
+		"UnifiedPushConsoleDown",
+		"UnifiedPushDown",
+		"UnifiedPushJavaDeadlockedThreads",
+		"UnifiedPushJavaGCTimePerMinuteScavenge",
+		"UnifiedPushJavaHeapThresholdExceeded",
+		"UnifiedPushJavaNonHeapThresholdExceeded",
+		"UnifiedPushMessagesFailures",
+	},
+	"/redhat-rhmi-rhsso": {
+		"KeycloakAPIRequestDuration90PercThresholdExceeded",
+		"KeycloakAPIRequestDuration99.5PercThresholdExceeded",
+		"KeycloakInstanceNotAvailable",
+		"KeycloakJavaDeadlockedThreads",
+		"KeycloakJavaGCTimePerMinuteMarkSweep",
+		"KeycloakJavaGCTimePerMinuteScavenge",
+		"KeycloakJavaHeapThresholdExceeded",
+		"KeycloakJavaNonHeapThresholdExceeded",
+		"KeycloakLoginFailedThresholdExceeded",
+	},
+	"/redhat-rhmi-user-sso": {
+		"KeycloakAPIRequestDuration90PercThresholdExceeded",
+		"KeycloakAPIRequestDuration99.5PercThresholdExceeded",
+		"KeycloakInstanceNotAvailable",
+		"KeycloakJavaDeadlockedThreads",
+		"KeycloakJavaGCTimePerMinuteMarkSweep",
+		"KeycloakJavaGCTimePerMinuteScavenge",
+		"KeycloakJavaHeapThresholdExceeded",
+		"KeycloakJavaNonHeapThresholdExceeded",
+		"KeycloakLoginFailedThresholdExceeded",
+	},
+}
+
+var expectedExtRules = map[string][]string{
+	"/redhat-rhmi-3scale": {
+		"ThreeScalePostgresUnavailable",
+		"ThreeScalePostgresConnectivity",
+		"BackendRedisUnavailable",
+		"BackendRedisConnectivity",
+		"SystemRedisUnavailable",
+		"SystemRedisConnectivity",
+	},
+	"/redhat-rhmi-codeready": {
+		"CodeReadyPostgresUnavailable",
+		"CodeReadyPostgresConnectivity",
+	},
+	"/redhat-rhmi-ups": {
+		"UPSPostgresUnavailable",
+		"UPSPostgresConnectivity",
+	},
+	"/redhat-rhmi-user-sso": {
+		"UserSSOPostgresUnavailable",
+		"UserSSOPostgresConnectivity",
+	},
+	"/redhat-rhmi-sso": {
+		"SSOPostgresUnavailable",
+		"SSOPostgresConnectivity",
+	},
+	"/redhat-rhmi-amq-online": {
+		"AMQOnlineSSOPostgresUnavailable",
+		"AMQOnlineSSOPostgresConnectivity",
+	},
+}
+
+func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
+	// get the RHMI custom resource to check what storage type is being used
+	rhmi := &v1alpha1.RHMI{}
+	ns := fmt.Sprintf("%soperator", namespacePrefix)
+	err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: installationName, Namespace: ns}, rhmi)
+	if err != nil {
+		t.Fatal("error getting RHMI CR:", err)
+	}
+
+	// add external database alerts to list of expected rules if
+	// cluster storage is not being used
+	if !rhmi.Spec.UseClusterStorage {
+		for file, rules := range expectedExtRules {
+			expectedRules[file] = append(expectedRules[file], rules...)
+		}
+	}
+
+	// exec into the prometheus pod
+	output, err := execToPod("curl localhost:9090/api/v1/rules",
+		"prometheus-application-monitoring-0",
+		namespacePrefix+"middleware-monitoring-operator",
+		"prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to exec to pod:", err)
+	}
+
+	// get all found rules from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		t.Fatal("Failed to unmarshal json:", err)
+	}
+	var rulesResult prometheusv1.RulesResult
+	err = json.Unmarshal([]byte(promApiCallOutput.Data), &rulesResult)
+	if err != nil {
+		t.Fatal("Failed to unmarshal json:", err)
+	}
+
+	var diff []string
+	actualRules := make(map[string][]string, 0)
+	for file, rules := range expectedRules {
+		// build a map of found rules for each file name. The difference
+		// between this actual map and the expected map will provide any missing rules
+		for _, group := range rulesResult.Groups {
+			if !strings.Contains(group.File, file) {
+				continue
+			}
+			// create an empty entry in the map
+			if _, ok := actualRules[file]; !ok {
+				actualRules[file] = []string{}
+			}
+			// add found rules to the actual rules map
+			for _, rule := range group.Rules {
+				switch v := rule.(type) {
+				case prometheusv1.RecordingRule:
+					rule := rule.(prometheusv1.RecordingRule)
+					actualRules[file] = append(actualRules[file], rule.Name)
+				case prometheusv1.AlertingRule:
+					rule := rule.(prometheusv1.AlertingRule)
+					actualRules[file] = append(actualRules[file], rule.Name)
+				default:
+					fmt.Printf("unknown rule type %s", v)
+				}
+			}
+		}
+		// get the diff between the two lists of rules
+		diff = append(diff, difference(rules, actualRules[file])...)
+	}
+	// output the missing rules
+	if len(diff) != 0 {
+		t.Fatalf("Missing alerts: %v:", diff)
+	}
+}
+
+func execToPod(command string, podname string, namespace string, container string, ctx *TestingContext) (string, error) {
+	req := ctx.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podname).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container)
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   strings.Fields(command),
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error in Stream: %v", err)
+	}
+
+	return stdout.String(), nil
+}
+
+// difference returns the elements in `a` that aren't in `b`.
+func difference(a, b []string) []string {
+	mb := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		mb[x] = struct{}{}
+	}
+
+	var diff []string
+	for _, x := range a {
+		if _, found := mb[x]; !found {
+			diff = append(diff, x)
+		}
+	}
+	return diff
+}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -155,7 +155,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 
 	// add external database alerts to list of expected rules if
 	// cluster storage is not being used
-	if !rhmi.Spec.UseClusterStorage {
+	if rhmi.Spec.UseClusterStorage != "true" {
 		for file, rules := range expectedExtRules {
 			expectedRules[file] = append(expectedRules[file], rules...)
 		}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -111,6 +111,9 @@ var expectedRules = []alertsTestRule{
 			"ClusterSchedulableCPULow",
 			"PVCStorageAvailable",
 			"PVCStorageMetricsAvailable",
+			"PVCStorageWillFillIn4Days",
+			"PVCStorageWillFillIn4Hours",
+			"PersistentVolumeErrors",
 		},
 	},
 	{
@@ -163,9 +166,10 @@ var expectedRules = []alertsTestRule{
 			"ThreeScaleAdminUIBBT",
 			"ThreeScaleDeveloperUIBBT",
 			"ThreeScaleSystemAdminUIBBT",
-			"ThreeScalePodCount",
 			"ThreeScalePodHighMemory",
 			"ThreeScalePodHighCPU",
+			"ThreeScaleZyncPodAvailability",
+			"ThreeScaleZyncDatabasePodAvailability",
 		},
 	},
 	{
@@ -385,6 +389,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	// build up a reportMapping of missing or unexpected files
 	reportMapping := make(map[string]*alertsTestReport, 0)
 
+	// unexpected/additional
 	// if an unexpected file is found, add it to the reportMapping
 	ruleDiff := ruleDifference(actualRules, expectedRules)
 	for _, rule := range ruleDiff {
@@ -394,6 +399,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 		}
 	}
 
+	// missing file
 	// if an expected file is not found, add it to the reportMapping
 	ruleDiff = ruleDifference(expectedRules, actualRules)
 	for _, rule := range ruleDiff {
@@ -420,7 +426,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 		if v.Status != fileCorrect {
 			fmt.Println("\nFile Name:", k)
 			fmt.Println("Missing Rules:", v.MissingRules)
-			fmt.Println("Additional Rules:", v.AdditionalRules)
+			fmt.Println("Unexpected Rules:", v.AdditionalRules)
 			fmt.Println("Status:", v.Status)
 		}
 		if v.Status == fileMissing || len(v.MissingRules) > 0 {
@@ -498,7 +504,7 @@ func difference(a, b []string) []string {
 	return diff
 }
 
-// difference returns the elements in list of PrometheusRule `a` that aren't in list `b`.
+// difference returns the elements in list of alertsTestRule `a` that aren't in list `b`.
 func ruleDifference(a, b []alertsTestRule) []alertsTestRule {
 	mb := make(map[string]struct{}, len(b))
 	for _, x := range b {
@@ -521,8 +527,8 @@ func buildReport(actualRule, expectedRule alertsTestRule, report *alertsTestRepo
 		report = newDefaultReport(fileCorrect)
 	}
 	// build report
-	report.MissingRules = append(report.MissingRules, difference(actualRule.Rules, expectedRule.Rules)...)
-	report.AdditionalRules = append(report.AdditionalRules, difference(expectedRule.Rules, actualRule.Rules)...)
+	report.MissingRules = append(report.MissingRules, difference(expectedRule.Rules, actualRule.Rules)...)
+	report.AdditionalRules = append(report.AdditionalRules, difference(actualRule.Rules, expectedRule.Rules)...)
 	if len(report.MissingRules) != 0 || len(report.AdditionalRules) != 0 {
 		report.Status = fileExists
 	}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -5,11 +5,11 @@ var (
 		// Add all the tests that should be executed in both e2e and osd suites here.
 		// It is an array so the tests will be executed in the same order as they defined here.
 		{"Verify CRD Exists", TestIntegreatlyCRDExists},
-		{"Verify alerts exist", TestIntegreatlyAlertsExist},
 	}
 
 	AFTER_INSTALL_TESTS = []TestCase{
 		{"Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},
 		{"Verify Deployment Config resources have the expected replicas", TestDeploymentConfigExpectedReplicas},
+		{"Verify alerts exist", TestIntegreatlyAlertsExist},
 	}
 )

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -5,6 +5,7 @@ var (
 		// Add all the tests that should be executed in both e2e and osd suites here.
 		// It is an array so the tests will be executed in the same order as they defined here.
 		{"Verify CRD Exists", TestIntegreatlyCRDExists},
+		{"Verify alerts exist", TestIntegreatlyAlertsExist},
 	}
 
 	AFTER_INSTALL_TESTS = []TestCase{

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -1,11 +1,19 @@
 package common
 
 import (
+	"encoding/json"
+	"testing"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
+)
+
+const (
+	namespacePrefix  = "redhat-rhmi-"
+	installationName = "rhmi"
 )
 
 type TestingContext struct {
@@ -18,4 +26,12 @@ type TestingContext struct {
 type TestCase struct {
 	Description string
 	Test        func(t *testing.T, ctx *TestingContext)
+}
+
+type prometheusAPIResponse struct {
+	Status    string                 `json:"status"`
+	Data      json.RawMessage        `json:"data"`
+	ErrorType prometheusv1.ErrorType `json:"errorType"`
+	Error     string                 `json:"error"`
+	Warnings  []string               `json:"warnings,omitempty"`
 }

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -134,7 +134,6 @@ func waitForProductDeployment(t *testing.T, f *framework.Framework, ctx *framewo
 }
 
 func integreatlyMonitoringTest(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
-
 	type apiResponse struct {
 		Status    string                 `json:"status"`
 		Data      json.RawMessage        `json:"data"`

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -2,6 +2,8 @@ package functional
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis"
 	"github.com/integr8ly/integreatly-operator/test/common"
 	"k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
@@ -14,7 +16,6 @@ import (
 	"k8s.io/client-go/restmapper"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 	config2 "sigs.k8s.io/controller-runtime/pkg/client/config"
-	"testing"
 )
 
 func TestIntegreatly(t *testing.T) {
@@ -28,6 +29,11 @@ func TestIntegreatly(t *testing.T) {
 	}
 	t.Run("Integreatly Happy Path Tests", func(t *testing.T) {
 		for _, test := range common.ALL_TESTS {
+			t.Run(test.Description, func(t *testing.T) {
+				test.Test(t, testingContext)
+			})
+		}
+		for _, test := range common.AFTER_INSTALL_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
 				test.Test(t, testingContext)
 			})


### PR DESCRIPTION
### Description 
Check all alerts exist as part of e2e and functional tests 
- Alerts we expected that weren't found 
- Alerts that were found and not expected 

### Verification
- Log in to an existing Openshift 4 cluster 
- Install integreatly from master
- Check out this branch and run `make test/functional`. The test is common to both e2e and functional tests, so running the functional ones is just quicker 
- See that the output of the test is as expected (e.g. try comment out some of the expected alerts, verify that the report output is correct) 