### PR TITLE
Collect the functional test suite output while printing it to the console

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/c
 .PHONY: test/functional
 test/functional:
 	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
-	go clean -testcache && go test ./test/functional
+	go clean -testcache && go test -v ./test/functional
 
 .PHONY: install/olm
 install/olm: cluster/cleanup/olm cluster/cleanup/crds cluster/prepare cluster/prepare/olm/subscription deploy/integreatly-rhmi-cr.yml cluster/check/operator/deployment cluster/prepare/dms cluster/prepare/pagerduty

--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -84,7 +84,7 @@ func teeOutput(f func()) string {
 
 	wg.Add(2)
 
-	go t(stdoutReader, originalStderr)
+	go t(stdoutReader, originalStdout)
 	go t(stderrReader, originalStderr)
 
 	f()


### PR DESCRIPTION
## Why

Capturing and the output of the tests and print it all only at the end make it difficult to debug a test

## How

While capturing the output into a byte Buffer we are also writing it back to the original stdout and stderr files