### PR TITLE
add manifest/check command to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ OPERATOR_SDK_VERSION=0.15.1
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "${QUAY_PASSWORD}"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
+IMAGE_MAPPINGS?=$(shell sh -c "find manifests/ -name image_mirror_mapping")
 
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
@@ -269,3 +270,14 @@ vendor/check: vendor/fix
 vendor/fix:
 	go mod tidy
 	go mod vendor
+
+.PHONY: manifest/check/image_mirror_mapping
+manifest/check/image_mirror_mapping:
+ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
+		$(error found image_mirror_mapping in $(IMAGE_MAPPINGS))
+else
+		@echo "No image_mirror_mapping files found in manifests directory"
+endif
+
+.PHONY: manifest/check
+manifest/check: manifest/check/image_mirror_mapping

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,6 @@ OPERATOR_SDK_VERSION=0.15.1
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "${QUAY_PASSWORD}"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
-IMAGE_MAPPINGS?=$(shell sh -c "find manifests/ -name image_mirror_mapping")
 
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
@@ -270,14 +269,3 @@ vendor/check: vendor/fix
 vendor/fix:
 	go mod tidy
 	go mod vendor
-
-.PHONY: manifest/check/image_mirror_mapping
-manifest/check/image_mirror_mapping:
-ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
-		$(error found image_mirror_mapping in $(IMAGE_MAPPINGS))
-else
-		@echo "No image_mirror_mapping files found in manifests directory"
-endif
-
-.PHONY: manifest/check
-manifest/check: manifest/check/image_mirror_mapping

--- a/make/manifest.mk
+++ b/make/manifest.mk
@@ -1,0 +1,12 @@
+IMAGE_MAPPINGS?=$(shell sh -c "find manifests/ -name image_mirror_mapping")
+
+.PHONY: manifest/check/image_mirror_mapping
+manifest/check/image_mirror_mapping:
+ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
+		$(error found image_mirror_mapping in $(IMAGE_MAPPINGS))
+else
+		@echo "No image_mirror_mapping files found in manifests directory"
+endif
+
+.PHONY: manifest/check
+manifest/check: manifest/check/image_mirror_mapping


### PR DESCRIPTION
Add manifest/check command to Makefile so we can check if any image_mirror_mapping files exist and block them from getting back to master

To verify:

1. Checkout this branch
1. run `make manifest/check`
2. run `touch manifests/integreatly-3scale/image_mirror_mapping`
3. make manifest/check
4. rm manifests/integreatly-3scale/image_mirror_mapping