### PR TITLE
INTLY-5468 - Fix invalid characters used in keycloak user meta name

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -783,7 +784,7 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 	}
 
 	for _, osUser := range added {
-		email, err := GetUserEmailFromIdentity(ctx, serverClient, osUser)
+		email, err := userHelper.GetUserEmailFromIdentity(ctx, serverClient, osUser)
 
 		if err != nil {
 			return nil, err
@@ -802,7 +803,7 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 				},
 			},
 		}
-		AppendUpdateProfileActionForUserWithoutEmail(&newKeycloakUser)
+		userHelper.AppendUpdateProfileActionForUserWithoutEmail(&newKeycloakUser)
 
 		keycloakUsers = append(keycloakUsers, newKeycloakUser)
 	}
@@ -833,7 +834,7 @@ func deleteKeycloakUsers(allKcUsers []keycloak.KeycloakAPIUser, deletedUsers []k
 		// Delete the CR
 		kcUser := &keycloak.KeycloakUser{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("generated-%v", delUser.UserName),
+				Name:      userHelper.GetValidGeneratedUserName(delUser),
 				Namespace: ns,
 			},
 		}
@@ -869,7 +870,7 @@ func OsUserInKc(osUsers []usersv1.User, kcUser keycloak.KeycloakAPIUser) bool {
 func (r *Reconciler) createOrUpdateKeycloakUser(ctx context.Context, user keycloak.KeycloakAPIUser, serverClient k8sclient.Client) (controllerutil.OperationResult, error) {
 	kcUser := &keycloak.KeycloakUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("generated-%v", user.UserName),
+			Name:      userHelper.GetValidGeneratedUserName(user),
 			Namespace: r.Config.GetNamespace(),
 		},
 	}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"strings"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -383,7 +384,7 @@ func (r *Reconciler) updateMasterRealm(ctx context.Context, serverClient k8sclie
 func (r *Reconciler) createOrUpdateKeycloakAdmin(user keycloak.KeycloakAPIUser, ctx context.Context, serverClient k8sclient.Client) (controllerutil.OperationResult, error) {
 	kcUser := &keycloak.KeycloakUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("generated-%v", user.UserName),
+			Name:      userHelper.GetValidGeneratedUserName(user),
 			Namespace: r.Config.GetNamespace(),
 		},
 	}
@@ -581,7 +582,7 @@ func deleteKeycloakUsers(allKcUsers []keycloak.KeycloakAPIUser, deletedUsers []k
 		// Delete the CR
 		kcUser := &keycloak.KeycloakUser{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      fmt.Sprintf("generated-%v", delUser.UserName),
+				Name:      userHelper.GetValidGeneratedUserName(delUser),
 				Namespace: ns,
 			},
 		}

--- a/pkg/resources/user/userHelper.go
+++ b/pkg/resources/user/userHelper.go
@@ -1,17 +1,21 @@
-package rhsso
+package user
 
 import (
 	"context"
 	"fmt"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	usersv1 "github.com/openshift/api/user/v1"
+	"regexp"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
 )
 
 // Helper for User associated functions
 
 const (
-	updateProfileAction = "UPDATE_PROFILE"
+	updateProfileAction         = "UPDATE_PROFILE"
+	invalidCharacterReplacement = "-"
+	generatedNameSuffix         = "generated-"
 )
 
 func GetUserEmailFromIdentity(ctx context.Context, serverClient k8sclient.Client, user usersv1.User) (string, error) {
@@ -40,4 +44,26 @@ func AppendUpdateProfileActionForUserWithoutEmail(keycloakUser *keycloak.Keycloa
 	if keycloakUser.Email == "" {
 		keycloakUser.RequiredActions = []string{updateProfileAction}
 	}
+}
+
+func GetValidGeneratedUserName(keycloakUser keycloak.KeycloakAPIUser) string {
+	// Regex for only alphanumeric values
+	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")
+
+	// Replace all non-alphanumeric values with the replacement character
+	processedString := reg.ReplaceAllString(strings.ToLower(keycloakUser.UserName), invalidCharacterReplacement)
+
+	// Remove occurrence of replacement character at end of string
+	processedString = strings.TrimSuffix(processedString, invalidCharacterReplacement)
+
+	for _, federatedIdentity := range keycloakUser.FederatedIdentities {
+		userId := federatedIdentity.UserID
+		// Append user id to name to ensure uniqueness
+		if userId != "" {
+			processedString = fmt.Sprintf("%s-%s", processedString, federatedIdentity.UserID)
+			break
+		}
+	}
+
+	return fmt.Sprintf("%v%v", generatedNameSuffix, processedString)
 }

--- a/pkg/resources/user/userHelper_test.go
+++ b/pkg/resources/user/userHelper_test.go
@@ -1,7 +1,8 @@
-package rhsso
+package user
 
 import (
 	"context"
+	"fmt"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	userv1 "github.com/openshift/api/user/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,6 +104,56 @@ func TestAppendUpdateProfileActionForUserWithoutEmail(t *testing.T) {
 
 			if !tt.AddedRequiredAction && len(tt.KeyCloakUser.RequiredActions) != 0 {
 				t.Fatal("Expected user to not be updated with required action but was")
+			}
+		})
+	}
+}
+
+func TestGetValidGeneratedUserName(t *testing.T) {
+
+	tests := []struct {
+		Name                  string
+		KeyCloakUser          keycloak.KeycloakAPIUser
+		ExpectedGeneratedName string
+	}{
+		{
+			Name: "Test - Username is lower cased",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				UserName: "TEST",
+			},
+			ExpectedGeneratedName: fmt.Sprintf("%s%s", generatedNameSuffix, "test"),
+		},
+		{
+			Name: "Test - Username is lower cased and invalid characters replaced",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				UserName: "TEST_USER@Example.com",
+			},
+			ExpectedGeneratedName: fmt.Sprintf("%s%s%s%s%s%s%s%s", generatedNameSuffix, "test", invalidCharacterReplacement, "user", invalidCharacterReplacement, "example", invalidCharacterReplacement, "com"),
+		},
+		{
+			Name: "Test - Username replacement character is not added to the end of generated name",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				UserName: "Tester01#",
+			},
+			ExpectedGeneratedName: fmt.Sprintf("%s%s", generatedNameSuffix, "tester01"),
+		},
+		{
+			Name: "Test - UserId is added to generated name",
+			KeyCloakUser: keycloak.KeycloakAPIUser{
+				UserName: "Tester.01#",
+				FederatedIdentities: []keycloak.FederatedIdentity{
+					{
+						UserID: "54d19771-aab6-49bb-913f-ce94e0ae5600",
+					},
+				},
+			},
+			ExpectedGeneratedName: fmt.Sprintf("%s%s%s%s", generatedNameSuffix, "tester", invalidCharacterReplacement, "01-54d19771-aab6-49bb-913f-ce94e0ae5600"),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			if got := GetValidGeneratedUserName(tt.KeyCloakUser); got != tt.ExpectedGeneratedName {
+				t.Errorf("GetValidGeneratedUserName() = %v, want %v", got, tt.ExpectedGeneratedName)
 			}
 		})
 	}


### PR DESCRIPTION
## Description
Jira
* https://issues.redhat.com/browse/INTLY-5468

## Verification
* Checkout this branch and install integreatly
* Run the IDP sccript
```
PASSWORD=Password1 ./scripts/setup-sso-idp.sh 
```
* Create a keycloak user with special characters to the testing-ipd realm
```
apiVersion: keycloak.org/v1alpha1
kind: KeycloakUser
metadata:
  name: test-user-irregular-username
  namespace: redhat-rhmi-rhsso
spec:
  realmSelector:
    matchLabels:
      sso: testing-idp
  user:
    lastName: Tester01
    enabled: true
    emailVerified: true
    clientRoles:
      account:
        - manage-account
        - view-profile
      broker:
        - read-token
    username: tester@example.com!!
    firstName: Test
    credentials:
      - type: password
        value: Password1
    email: tester@example.com!!!
```
* In a private window, sign into openshift console with this user
* Check that the generated keycloak user for the keycloal realm doesn't not contain the special characters in it's resource name
  * Should be named `generated-tester-example-com-<userId>`
### Github IDP Test (Optional)
* If you have a github username with a uppercase letter, try setting up Github IDP on cluster and sign into cluster using your github user name
* Generated keycloak user in openshift realm should be all lower case 
 
