### PR TITLE
INTLY-4360  add a postgres backup cronjob to amq online

### DIFF
--- a/pkg/config/amqonline.go
+++ b/pkg/config/amqonline.go
@@ -112,6 +112,10 @@ func (a *AMQOnline) GetBackupsSecretName() string {
 	return "backups-s3-credentials"
 }
 
+func (c *AMQOnline) GetPostgresBackupSecretName() string {
+	return "enmasse-postgres-secret"
+}
+
 func (a *AMQOnline) GetBackupSchedule() string {
 	return "30 2 * * *"
 }

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/sirupsen/logrus"
 
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	cro1types "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	enmasseadminv1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/admin/v1beta1"
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
@@ -514,6 +515,10 @@ func (r *Reconciler) reconcileBackup(ctx context.Context, serverClient k8sclient
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres: %w", err)
 	}
+	if postgres.Status.Phase != cro1types.PhaseComplete {
+		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
 	// get the secret created by the cloud resources operator
 	croSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: postgres.Status.SecretRef.Name, Namespace: postgres.Status.SecretRef.Namespace}, croSec)

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -514,6 +514,12 @@ func (r *Reconciler) reconcileBackup(ctx context.Context, serverClient k8sclient
 		},
 		Components: []resources.BackupComponent{
 			{
+				Name:     "enmasse-postgres-backup",
+				Type:     "postgres",
+				Secret:   resources.BackupSecretLocation{Name: r.Config.GetPostgresBackupSecretName(), Namespace: r.Config.GetNamespace()},
+				Schedule: r.Config.GetBackupSchedule(),
+			},
+			{
 				Name:     "enmasse-pv-backup",
 				Type:     "enmasse_pv",
 				Schedule: r.Config.GetBackupSchedule(),

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -186,6 +186,21 @@ func setupRecorder() record.EventRecorder {
 }
 
 func TestReconcile_reconcileAuthServices(t *testing.T) {
+
+	postgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-postgres-",
+			Namespace: "test-namespace",
+		},
+		Spec: crov1.PostgresSpec{},
+		Status: crov1.PostgresStatus{
+			Phase: crotypes.PhaseComplete,
+			SecretRef: &crotypes.SecretRef{
+				Name:      "test-postgres-",
+				Namespace: "test-postgres-namespace",
+			},
+		},
+	}
 	scenarios := []struct {
 		Name           string
 		Client         k8sclient.Client
@@ -198,7 +213,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 	}{
 		{
 			Name:           "Test returns completed phase if successfully creating new auth services",
-			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace")),
+			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace"),postgres),
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation: &integreatlyv1alpha1.RHMI{
@@ -211,7 +226,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 		},
 		{
 			Name:           "Test returns completed phase if trying to create existing auth services",
-			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace")),
+			Client:         fake.NewFakeClientWithScheme(buildScheme(), croPostgresSecretMock("test-namespace"),postgres),
 			FakeConfig:     basicConfigMock(),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			Installation: &integreatlyv1alpha1.RHMI{
@@ -599,7 +614,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		Status: crov1.PostgresStatus{
 			Phase: crotypes.PhaseComplete,
 			SecretRef: &crotypes.SecretRef{
-				Name: "test-postgres-",
+				Name:      "test-postgres-",
 				Namespace: "test-postgres-namespace",
 			},
 		},
@@ -673,7 +688,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 	}{
 		{
 			Name:           "test successful reconcile",
-			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			ExpectedStatus: integreatlyv1alpha1.PhaseAwaitingComponents,
 			FakeClient:     moqclient.NewSigsClientMoqWithScheme(buildScheme(), ns, operatorNS, consoleSvc, installation, operatorDeployment, backupsSecretMock(), croPostgresSecretMock(installation.Namespace), postgres),
 			FakeConfig:     basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -12,6 +12,8 @@ import (
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 
 	monitoring "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	crotypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	enmassev1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/admin/v1beta1"
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta1"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis/enmasse/v1beta2"
@@ -588,6 +590,21 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
+	postgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-postgres-",
+			Namespace: "test-namespace",
+		},
+		Spec: crov1.PostgresSpec{},
+		Status: crov1.PostgresStatus{
+			Phase: crotypes.PhaseComplete,
+			SecretRef: &crotypes.SecretRef{
+				Name: "test-postgres-",
+				Namespace: "test-postgres-namespace",
+			},
+		},
+	}
+
 	installation := &integreatlyv1alpha1.RHMI{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "installation",
@@ -657,7 +674,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:           "test successful reconcile",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(buildScheme(), ns, operatorNS, consoleSvc, installation, operatorDeployment, backupsSecretMock(), croPostgresSecretMock(installation.Namespace)),
+			FakeClient:     moqclient.NewSigsClientMoqWithScheme(buildScheme(), ns, operatorNS, consoleSvc, installation, operatorDeployment, backupsSecretMock(), croPostgresSecretMock(installation.Namespace), postgres),
 			FakeConfig:     basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval) error {

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -63,6 +63,7 @@ var expectedRules = []alertsTestRule{
 		File: "redhat-rhmi-amq-online-backupjobs-exist-alerts.yaml",
 		Rules: []string{
 			"CronJobExists_redhat-rhmi-amq-online_enmasse-pv-backup",
+			"CronJobExists_redhat-rhmi-amq-online_enmasse-postgres-backup",
 		},
 	},
 	{


### PR DESCRIPTION
# Why
issue: https://issues.redhat.com/browse/INTLY-4360

# What
Add in a backup cron job for postgres to amq online 

# Verification
## See if cronjob created
- checkout this branch
- deploy rhmi
- check prometheus alerts route for the following alert rule for amq online postgres
![image](https://user-images.githubusercontent.com/16667688/75542883-8f699e00-5a18-11ea-9e85-fb4d9cf56314.png)
to see if the cron job exists
and check all projects/cron jobs to confirm enmasse-postgres-backup present. 
![image](https://user-images.githubusercontent.com/16667688/75555643-82f33e80-5a34-11ea-9623-000752febf31.png)
## Test the cronjob
- Setup the s3 bucket and access as outline in the [readme](https://github.com/integr8ly/integreatly-operator#local-setup)
- Create the job
```sh
oc create job enmasse-postgres-backup-$(date +"%Y-%m-%d-%H%M%S") --from=cronjob/enmasse-postgres-backup -n redhat-rhmi-amq-online
```
This should create a job in the form `enmasse-postgres-backup-2020-03-03-`
- Check the jobs pod logs to confirm that the backup was successful
e.g.
![image](https://user-images.githubusercontent.com/16667688/75788022-83a31200-5d5f-11ea-8b3b-aef7601e93e7.png)





