### PR TITLE
Grafana Dashboards sometimes missing/overwriting each other

### DIFF
--- a/templates/monitoring/endpointsdetailed.yaml
+++ b/templates/monitoring/endpointsdetailed.yaml
@@ -1301,7 +1301,7 @@ spec:
       },
       "timezone": "",
       "title": "Endpoints Detailed",
-      "uid": "xtkCtBkiz2",
+      "uid": "",
       "version": 13
     }
   name: endpointsdetailed.json

--- a/templates/monitoring/endpointssummary.yaml
+++ b/templates/monitoring/endpointssummary.yaml
@@ -397,7 +397,7 @@ spec:
         },
         "timezone": "",
         "title": "Endpoints Summary",
-        "uid": "hZJ_054Zk",
+        "uid": "",
         "version": 4
     }
   name: endpointssummary.json

--- a/templates/monitoring/resources-by-namespace.yaml
+++ b/templates/monitoring/resources-by-namespace.yaml
@@ -770,7 +770,7 @@ spec:
         ]
       },
       "timezone": "",
-      "uid": "a9ce5290ba1d485ca67e05c0a63aa2d8",
+      "uid": "",
       "title": "Resource Usage By Namespace",
       "version": 1
     }

--- a/templates/monitoring/resources-by-pod.yaml
+++ b/templates/monitoring/resources-by-pod.yaml
@@ -818,6 +818,6 @@ spec:
       },
       "timezone": "",
       "title": "Resource Usage By Pod",
-      "uid": "c84ae905b9f54268be6be82c9a5b7dd6",
+      "uid": "",
       "version": 1
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-5640

Do an install of integreatly on OpenShift 4/OSD 4.
Check the available dashboards in the RHMI Grafana instance, 

Compare the list of dashboards against the expected list of dashboards in https://gitlab.cee.redhat.com/integreatly-qe/integreatly-test-cases/blob/master/tests/dashboards/e02-verify-that-all-dashboards-are-installed-and-all-the-graphs.md.
