### PR TITLE
dont unassign 3scale admin role in workshop mode

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -806,7 +806,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 			if err != nil || res.StatusCode != http.StatusOK {
 				return integreatlyv1alpha1.PhaseInProgress, err
 			}
-		} else if !userIsOpenshiftAdmin(tsUser, openshiftAdminGroup) && tsUser.UserDetails.Role != memberRole {
+		} else if !userIsOpenshiftAdmin(tsUser, openshiftAdminGroup) && tsUser.UserDetails.Role != memberRole && installation.Spec.Type != string(integreatlyv1alpha1.InstallationTypeWorkshop) {
 			res, err := r.tsClient.SetUserAsMember(tsUser.UserDetails.Id, *accessToken)
 			if err != nil || res.StatusCode != http.StatusOK {
 				return integreatlyv1alpha1.PhaseInProgress, err


### PR DESCRIPTION
Check for workshop mode also when assigning `member` role to 3scale users: we want to make sure that users who got admin permissions but are not Openshift admins get to keep the permissions in workshop mode. This is required to be able to complete the Walkthroughs. 