### PR TITLE
Fix(env type): Chnage USE_CLUSTER_STORAGE to Boolean true

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
 export INSTALLATION_NAME   ?= rhmi
 export INSTALLATION_PREFIX ?= redhat-rhmi
-export USE_CLUSTER_STORAGE ?= "true"
+export USE_CLUSTER_STORAGE ?= true
 export OPERATORS_IN_PRODUCT_NAMESPACE ?= false # e2e tests and createInstallationCR() need to be updated when default is changed
 
 define wait_command


### PR DESCRIPTION
# Jira
https://issues.redhat.com/browse/INTLY-5809

# Reason
Preflight checks was failing when using `make code/run`

# Fix
Change `USE_CLUSTER_STORAGE` to boolean version over string 