### PR TITLE
INTLY-5589: Create dedicated-admins and realm-managers groups

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/integr8ly/application-monitoring-operator v1.1.1
 	github.com/integr8ly/cloud-resource-operator v0.11.0
 	github.com/integr8ly/grafana-operator v1.3.1
-	github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe
+	github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
+	github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 // indirect
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/integr8ly/grafana-operator v1.3.1 h1:3fknUP3pI9/H0/HTxOOR5hzJVo1wPs5H
 github.com/integr8ly/grafana-operator v1.3.1/go.mod h1:uFZI5IG74KBTtqzdwAMvoFoAC3RlgF5VaJypcCzyVVs=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4 h1://E7j42AwTNj3oPVr7/yS0Ztbm7iunOppSs9VJ3nGMc=
 github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4/go.mod h1:0WBJ5MjgAgIu9briw0EaDkpXsWIXMoRJKnE/J024+bM=
-github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe h1:HTWpcTMtbEEB+BTswEDByRcFbZDue1HLgvxdzjr8nog=
-github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
+github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498 h1:3sBq8ts5JGMH+Hbda2amjlCamU2Z8NawRWyr7q9+hwM=
+github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498/go.mod h1:3aF3pEGJPLSW2bb1h9jNo1p9SwCt8LKrq86G5jzh4q0=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,8 @@ github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzfe
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
+github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 h1:76J+StfuBgQoDIEqBliiA/ua9UhUDN1EyC6e0YkJFzc=
+github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -373,7 +373,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	_ = r.client.Status().Update(r.context, installation)
 	metrics.RHMIStatusAvailable.Set(1)
 	logrus.Infof("installation completed succesfully")
-	return reconcile.Result{}, nil
+	return reconcile.Result{Requeue: true, RequeueAfter: 5 * time.Minute}, nil
 }
 
 func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha1.RHMI, installationType *Type, configManager *config.Manager) (reconcile.Result, error) {

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
@@ -3,6 +3,7 @@ package common
 // Group representation
 // https://www.keycloak.org/docs-api/9.0/rest-api/index.html#_grouprepresentation
 type Group struct {
-	Name string `json:"name,omitempty"`
-	ID   string `json:"id,omitempty"`
+	Name      string   `json:"name,omitempty"`
+	ID        string   `json:"id,omitempty"`
+	SubGroups []*Group `json:"subGroups,omitempty"`
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -117,7 +117,7 @@ github.com/integr8ly/cloud-resource-operator/pkg/resources
 github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.0.2-0.20200103111057-03d7fa884db4
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
-# github.com/integr8ly/keycloak-client v0.0.0-20200226115136-9879bc925afe
+# github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/joho/godotenv v1.3.0
 github.com/joho/godotenv


### PR DESCRIPTION
Implement functionallity in RHSSO User operator to create a dedicated-admins group
with a realm-managers child group.
The dedicated-admins group has the manage-users and view-realm client roles,
and the realm-managers group has a manage-realm role for each role that is
created.
Implement functionallity to add the dedicated admin generated users from
Openshift to the dedicated-admins and realm-managers groups.

Refactor the logic to reconcile Keycloak groups based on a `keycloakGroupSpec`
struct that contains the desired status of the group.

## Verification

Running on a cluster, set up the SSO IdP
```sh
PASSWORD=Password1 ./scripts/setup-sso-idp.sh
```
Log in the User SSO as the `customer-admin01` user and check that (_Note: it might take a couple of minutes for the admin permissions to propagate after first login_):

- [ ] A group in the User SSO instance called `dedicated-admins` is created
  - [ ] The group has the `manage-users` role mapped to the `master-realm` client
  - [ ] The group has the `view-realm` role mapped to the `master-realm` client
  - [ ] A child group of the `dedicated-admins` group called `realm-managers` is created
    - [ ] The group has the `manage-realm` role mapped to the `master-realm` client
    - [ ] Create a new realm and, after reconciliation, the group has the all roles except `impersonation` mapped to the `<realm name>-realm` client
- [ ] The dedicated admin users from the Openshift IdP are members of the `dedicated-admins` and `realm-managers` groups in SSO 

