### PR TITLE
update keycloak operator image

### DIFF
--- a/manifests/integreatly-rhsso/rhsso-8.0.1/keycloakoperator.8.0.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/rhsso-8.0.1/keycloakoperator.8.0.1.clusterserviceversion.yaml
@@ -5,7 +5,7 @@ metadata:
     capabilities: Basic Install
     categories: security
     certified: 'False'
-    containerImage: 'quay.io/wei_lee/keycloak-operator:intly'
+    containerImage: 'quay.io/integreatly/keycloak-operator-rhmi:all-rhmi-branches'
     createdAt: 2019-11-08 00:00:00
     description: 'An Operator for installing and managing Keycloak'
     repository: 'https://github.com/keycloak/keycloak-operator'
@@ -185,7 +185,7 @@ spec:
                             fieldPath: metadata.name
                       - name: OPERATOR_NAME
                         value: keycloak-operator
-                    image: quay.io/pb82/keycloak-operator:all-rhmi-branches
+                    image: quay.io/integreatly/keycloak-operator-rhmi:all-rhmi-branches
                     imagePullPolicy: Always
                     name: keycloak-operator
                     resources: {}


### PR DESCRIPTION
Instead of pointing to a fork and image in a private account, this PR updates the keycloak operator image to one based on a fork in the integreatly org (https://github.com/integr8ly/keycloak-operator-rhmi/tree/all-branches) hosted on the integreatly quay repo.