### PR TITLE
INTLY-5840 - setup default roles in User SSO only once

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
-	github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 // indirect
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,6 @@ github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzfe
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
-github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 h1:76J+StfuBgQoDIEqBliiA/ua9UhUDN1EyC6e0YkJFzc=
-github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/config/rhssouser.go
+++ b/pkg/config/rhssouser.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+	"strconv"
 
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -106,6 +107,17 @@ func (r *RHSSOUser) SetProductVersion(version string) {
 
 func (r *RHSSOUser) SetOperatorVersion(operator string) {
 	r.Config["OPERATOR"] = operator
+}
+
+func (r *RHSSOUser) SetDevelopersGroupConfigured(configured bool) {
+	r.Config["DEVELOPERS_GROUP_CONFIGURED"] = strconv.FormatBool(configured)
+}
+
+func (r *RHSSOUser) GetDevelopersGroupConfigured() (bool, error) {
+	if r.Config["DEVELOPERS_GROUP_CONFIGURED"] == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(r.Config["DEVELOPERS_GROUP_CONFIGURED"])
 }
 
 func (r *RHSSOUser) Validate() error {

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -333,9 +333,21 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to reconcile first broker login authentication flow: %w", err)
 	}
 
-	phase, err = r.reconcileDevelopersGroup(kc)
+	rolesConfigured, err := r.Config.GetDevelopersGroupConfigured()
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile rhmi-developers group: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if !rolesConfigured {
+		phase, err = r.reconcileDevelopersGroup(kc)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile rhmi-developers group: %w", err)
+		}
+
+		r.Config.SetDevelopersGroupConfigured(true)
+		err = r.ConfigManager.WriteConfig(r.Config)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not update keycloak config for user-sso: %w", err)
+		}
 	}
 
 	// Reconcile dedicated-admins group

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -894,6 +894,7 @@ func TestReconciler_reconcileDevelopersGroup(t *testing.T) {
 				"NAMESPACE": defaultRhssoNamespace,
 			},
 		},
+		ConfigManager:         basicConfigMock(),
 		keycloakClientFactory: keycloakClientFactory,
 	}
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/INTLY-5840

Verify that:
User SSO reconciler adds roles to "rhmi-developers" Keycloak group only once, during the installation.
If a role is removed, it should not be re-added by the operator.
Verify that redhat-rhmi-installation-config contains:
`DEFAULT_ROLES_CONFIGURED: "true"` in "rhssouser" section.