### PR TITLE
INTLY-5783 - Fix RHSSO version not reported on CR

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -64,6 +64,8 @@ var (
 	VersionCloudResources      ProductVersion = "0.13.0"
 	VersionFuseOnline          ProductVersion = "7.5"
 	VersionDataSync            ProductVersion = "0.9.4"
+	VersionRHSSO               ProductVersion = "8.0.1"
+	VersionRHSSOUser           ProductVersion = "8.0.1"
 
 	PreflightInProgress PreflightStatus = ""
 	PreflightSuccess    PreflightStatus = "successful"

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -534,15 +534,12 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 
 func (r *Reconciler) handleProgressPhase(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	kc := &keycloak.Keycloak{}
-	// if this errors, it can be ignored
 	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: keycloakName, Namespace: r.Config.GetNamespace()}, kc)
-	if err == nil && string(r.Config.GetProductVersion()) != kc.Status.Version {
-		r.Config.SetProductVersion(kc.Status.Version)
-		err = r.ConfigManager.WriteConfig(r.Config)
-		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, err
-		}
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
 	}
+	// The keycloak operator does not set the product version currently - should fetch from KeyCloak.Status.Version when fixed
+	r.Config.SetProductVersion(string(integreatlyv1alpha1.VersionRHSSO))
 	// The Keycloak Operator doesn't currently set the operator version
 	r.Config.SetOperatorVersion(string(integreatlyv1alpha1.OperatorVersionRHSSO))
 	err = r.ConfigManager.WriteConfig(r.Config)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -885,12 +885,15 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, serverClient k8scl
 	kc := &keycloak.Keycloak{}
 	// if this errors, it can be ignored
 	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: keycloakName, Namespace: r.Config.GetNamespace()}, kc)
-	if err == nil && string(r.Config.GetProductVersion()) != kc.Status.Version {
-		r.Config.SetProductVersion(kc.Status.Version)
-		err = r.ConfigManager.WriteConfig(r.Config)
-		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to write keycloak config: %w", err)
-		}
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	// The keycloak operator does not set the product version currently - should fetch from KeyCloak.Status.Version when fixed
+	r.Config.SetProductVersion(string(integreatlyv1alpha1.VersionRHSSOUser))
+	err = r.ConfigManager.WriteConfig(r.Config)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to write keycloak config: %w", err)
 	}
 
 	r.logger.Info("checking ready status for user-sso")

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -507,6 +507,15 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
+	// check authentication stage operand versions
+	authOperands := map[string]string{
+		string(integreatlyv1alpha1.ProductRHSSO): string(integreatlyv1alpha1.VersionRHSSO),
+	}
+	err = checkOperandVersions(t, f, namespace, integreatlyv1alpha1.AuthenticationStage, authOperands)
+	if err != nil {
+		return err
+	}
+
 	// check cloud resources stage operand versions
 	stage = integreatlyv1alpha1.StageName("cloud-resources")
 	resouceOperands := map[string]string{
@@ -536,6 +545,7 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		"codeready-workspaces": string(integreatlyv1alpha1.VersionCodeReadyWorkspaces),
 		"fuse-on-openshift":    string(integreatlyv1alpha1.VersionFuseOnOpenshift),
 		"ups":                  string(integreatlyv1alpha1.VersionUps),
+		string(integreatlyv1alpha1.ProductRHSSOUser): string(integreatlyv1alpha1.VersionRHSSOUser),
 	}
 	err = checkOperandVersions(t, f, namespace, stage, productOperands)
 	if err != nil {


### PR DESCRIPTION
## Description 
RHSSO version is set as an empty string in the RHMI CR. This is due to the Keycloak operator does not set the version in the `KeyCloak` CR status 

I have created a Jira for this is the Keycloak backlog - https://issues.redhat.com/browse/KEYCLOAK-13234

So for now, just going to use a harded value like the other products

Jira:
* https://issues.redhat.com/browse/INTLY-5783
