### PR TITLE
INTLY-5944 Increase prometheus pvc storage & retention

### DIFF
--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -108,11 +108,11 @@ func (m *Monitoring) GetAdditionalScrapeConfigSecretKey() string {
 }
 
 func (m *Monitoring) GetPrometheusRetention() string {
-	return "15d"
+	return "45d"
 }
 
 func (m *Monitoring) GetPrometheusStorageRequest() string {
-	return "10Gi"
+	return "50Gi"
 }
 
 func (m *Monitoring) GetTemplateList() []string {


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-5638

The new values match what's used for RHMI 1.x by SRE.


After install, to verify:

```
oc get pvc -n redhat-rhmi-middleware-monitoring-operator
```

Verify the pvc is 50GB.

The retention size can be verified via the Prometheus UI > Status > Configuration.

Also, verify the PVCStorageWillFillIn4Days and PVCStorageWillFillIn4Hours alerts are not triggering for the prometheus pvc