### PR TITLE
INTLY-5943 - Add permission for getting identities resource

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -315,3 +315,12 @@ rules:
       - delete
       
   # END Permissions needed for our namespaces, but not given by "admin" role
+
+  # Permission to fetch identity to get email for created Keycloak users in openshift realm
+  - apiGroups:
+      - user.openshift.io
+    resources:
+      - identities
+    verbs:
+      - get
+  # END Permission to fetch identity to get email for created Keycloak users in openshift realm


### PR DESCRIPTION
## Description
Adds missing permission for the rhmi-operator service account to get `Identity` resource

Jira:
* https://issues.redhat.com/browse/INTLY-5943

## Verification
* Run `make cluster/prepare/local`
* Install integreatly using this branch running the service account `make code/run/service_account`
* When RHSSO has been installed, run the IDP script `PASSWORD=Password1 ./scripts/setup-sso-idp.sh`
* Sign into openshift console using one of these generated users
* Ensure RHSSO in RHMI CR does not fail
* Check the logged in user has been added to RHSSO openshift realm
  * Admin credentials can be found in the `credential-rhsso` secret