### PR TITLE
add imagePullSecret to csv

### DIFF
--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -28,6 +28,7 @@ RH_REGISTRY_PROD=registry.redhat.io
 RH_REGISTRY_STAGE=registry.stage.redhat.io
 RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
 DELOREAN_REGISTRY=quay.io/integreatly/delorean
+IMAGE_PULL_SECRET=integreatly-delorean-pull-secret
 
 collect_csv_images() {
     csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*\|'${RH_REGISTRY_STAGE}'.*' $1 | sed 's/"//' || true`)
@@ -69,6 +70,17 @@ process_csv_images() {
     done
 }
 
+update_image_pull_secret() {
+  current_csv=$(get_current_csv_file $PRODUCT)
+  case $PRODUCT in
+  "amq-online")
+    yq w -i ${current_csv} spec.install.spec.deployments[0].spec.template.spec.imagePullSecrets[0].name ${IMAGE_PULL_SECRET}
+    ;;
+  *)
+    echo "skipping pull secret"
+  esac
+}
+
 PRODUCT=$1
 
 process_csv() {
@@ -82,3 +94,6 @@ process_csv() {
 }
 
 process_csv
+if [[ ! -s ${MANIFESTS_DIR}/integreatly-${PRODUCT}/image_mirror_mapping ]]; then
+  update_image_pull_secret
+fi

--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -94,6 +94,6 @@ process_csv() {
 }
 
 process_csv
-if [[ ! -s ${MANIFESTS_DIR}/integreatly-${PRODUCT}/image_mirror_mapping ]]; then
+if [[ -s ${MANIFESTS_DIR}/integreatly-${PRODUCT}/image_mirror_mapping ]]; then
   update_image_pull_secret
 fi


### PR DESCRIPTION
The amq-online csv does not include an imagePullSecrets var but the deployment of the operator defaults to the enmasse-operator dockercfg, this blocks image pulls for the mirrored images.

This pr adds a step to the image manifest processing script which will add an imagePullSecrets var for the secret we are specifying in the installation cr spec (and which will be shared to all namespaces with this pr https://github.com/integr8ly/integreatly-operator/pull/497).

Defaulting to integreatly-delorean-pull-secret which is the name of the secret when copied from quay.