### PR TITLE
fix: check array length before indexing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
-	github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 // indirect
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/go.sum
+++ b/go.sum
@@ -631,8 +631,6 @@ github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzfe
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
-github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 h1:76J+StfuBgQoDIEqBliiA/ua9UhUDN1EyC6e0YkJFzc=
-github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -727,7 +727,7 @@ func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []user
 
 func kcUserInDedicatedAdmins(kcUser keycloak.KeycloakAPIUser, admins []usersv1.User) bool {
 	for _, admin := range admins {
-		if kcUser.FederatedIdentities[0].UserID == string(admin.UID) {
+		if len(kcUser.FederatedIdentities) >= 1 && kcUser.FederatedIdentities[0].UserID == string(admin.UID) {
 			return true
 		}
 	}
@@ -762,7 +762,7 @@ func contains(items []string, find string) bool {
 
 func getKeyCloakUser(admin usersv1.User, kcUsers []keycloak.KeycloakAPIUser) *keycloak.KeycloakAPIUser {
 	for _, kcUser := range kcUsers {
-		if kcUser.FederatedIdentities[0].UserID == string(admin.UID) {
+		if len(kcUser.FederatedIdentities) >= 1 && kcUser.FederatedIdentities[0].UserID == string(admin.UID) {
 			return &kcUser
 		}
 	}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -465,7 +465,7 @@ func GetKeycloakUsers(ctx context.Context, serverClient k8sclient.Client, ns str
 		return nil, err
 	}
 
-	mappedUsers := make([]keycloak.KeycloakAPIUser, len(users.Items))
+	var mappedUsers []keycloak.KeycloakAPIUser
 	for _, user := range users.Items {
 		if strings.HasPrefix(user.ObjectMeta.Name, userHelper.GeneratedNamePrefix) {
 			mappedUsers = append(mappedUsers, user.Spec.User)


### PR DESCRIPTION
Fixes a crash when users are added to OpenShift but have not yet logged in (and thus the federated identities array is empty).

Verification steps:

1) Install Integreatly
2) Run the `setup-sso-idp.sh` script to create an IDP and some users
3) leave the operator running: it will crash after a while