### PR TITLE
INTLY-5683 Check the available pvc storage threshold before triggerin…

### DIFF
--- a/templates/monitoring/kube_state_metrics_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_alerts.yaml
@@ -92,7 +92,12 @@ spec:
         annotations:
           message: The {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} PVC will run of disk space in the next 4 days.
         expr: |
-          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info)  <= 0
+          (
+            predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[6h], 4 * 24 * 3600) <= 0
+              AND
+            kubelet_volume_stats_available_bytes{job="kubelet"} / kubelet_volume_stats_capacity_bytes{job="kubelet"} < 0.25
+          )
+          * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}
         for: 15m
         labels:
           severity: warning
@@ -100,7 +105,12 @@ spec:
         annotations:
           message: The {{ "{{" }} $labels.persistentvolumeclaim {{ "}}" }} PVC will run of disk space in the next 4 hours.
         expr: |
-          ((sum by(persistentvolumeclaim, namespace) (predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 3600)) * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}) * on (persistentvolumeclaim, namespace) kube_persistentvolumeclaim_info) <= 0
+          (
+            predict_linear(kubelet_volume_stats_available_bytes{job="kubelet"}[1h], 4 * 3600) <= 0
+              AND
+            kubelet_volume_stats_available_bytes{job="kubelet"} / kubelet_volume_stats_capacity_bytes{job="kubelet"} < 0.25
+          )
+          * on(namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key="middleware"}
         for: 15m
         labels:
           severity: critical


### PR DESCRIPTION
…g prediction alerts

This change is to prevent alerts triggering soon after an install where the initial working set of storage is written to the volume in a short space of time, resulting in a false positive alert.
Now, the alerts should only trigger if the storage is predicted to fill in the next 4 days/4 hours *and* the storage usage has fallen below a certain percentage (0.5 / 50%).

To verify, either modify the threshold percentage in the alert so it detects some pvcs that meed the threshold AND are predicted to run out of storage soon (typically syndesis-db & syndesis-prometheus),
or fill up a mounted volume in a pv until it reaches the threshold.
The relevant alert should trigger in either case.

cc @alanmoran @pat-cremin @sclarkso @brizrobbo  I'd be interested in your thoughts on this as it's related to recent triggering alerts in RHMI 1

also cc @obrienrobert for review as it's something we discussed recently.