### PR TITLE
INTLY-5993 - No pdb has listed for redhat-rhmi-user-sso namespace

### DIFF
--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -278,6 +278,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		kc.Spec.Instances = 2
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{Enabled: true}
 		kc.Spec.Profile = rhsso.RHSSOProfile
+		kc.Spec.PodDisruptionBudget = keycloak.PodDisruptionBudgetConfig{Enabled: true}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
**Description**
Adds missing field to reconciler

Jira:

- https://issues.redhat.com/browse/INTLY-5993

**Verification** 

- run `make/code/compile`
- run `make/code/run`
- Install integreatly 
- Once installed, run `oc get pdb --all-namespaces | grep rhmi`
- Ensure both `redhat-rhmi-rhsso` and `redhat-rhmi-user-sso` namespaces are returned



