### PR TITLE
remove sre users from rhmi group

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/integr8ly/keycloak-client v0.0.0-20200302145927-c6e3f0174498
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
+	github.com/matryer/moq v0.0.0-20200310130814-7721994d1b54 // indirect
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/go.sum
+++ b/go.sum
@@ -631,6 +631,10 @@ github.com/markbates/inflect v1.0.4/go.mod h1:1fR9+pO2KHEO9ZRtto13gDwwZaAKstQzfe
 github.com/marten-seemann/qtls v0.2.3/go.mod h1:xzjG7avBwGGbdZ8dTGxlBnLArsVKLvwmjgmPuiQEcYk=
 github.com/martinlindhe/base36 v0.0.0-20180729042928-5cda0030da17/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
 github.com/martinlindhe/base36 v1.0.0/go.mod h1:+AtEs8xrBpCeYgSLoY/aJ6Wf37jtBuR0s35750M27+8=
+github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268 h1:76J+StfuBgQoDIEqBliiA/ua9UhUDN1EyC6e0YkJFzc=
+github.com/matryer/moq v0.0.0-20200125112110-7615cbe60268/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
+github.com/matryer/moq v0.0.0-20200310130814-7721994d1b54 h1:p8zN0Xu28xyEkPpqLbFXAnjdgBVvTJCpfOtoDf/+/RQ=
+github.com/matryer/moq v0.0.0-20200310130814-7721994d1b54/go.mod h1:9ELz6aaclSIGnZBoaSLZ3NAl1VTufbOrXBPvtcy6WiQ=
 github.com/mattbaird/jsonpatch v0.0.0-20171005235357-81af80346b1a/go.mod h1:M1qoD/MqPgTZIk0EWKB38wE28ACRfVcn+cU08jyArI0=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	usersv1 "github.com/openshift/api/user/v1"
@@ -19,10 +20,6 @@ import (
 var (
 	log = logf.Log.WithName("controller_user")
 	// A set of pre configured groups used to exclude a user from rhmi specific groups
-	exclusionGroups = []string{
-		"layered-cs-sre-admins",
-		"osd-sre-admins",
-	}
 )
 
 // Add creates a new User Controller and adds it to the Manager. The Manager will set fields on the Controller
@@ -100,28 +97,10 @@ func mapUserNames(users *usersv1.UserList, groups *usersv1.GroupList) []string {
 	var result = []string{}
 	for _, user := range users.Items {
 		// Certain users such as sre do not need to be added
-		if !userInExclusionGroup(user, groups) {
+		if !userHelper.UserInExclusionGroup(user, groups) {
 			result = append(result, user.Name)
 		}
 	}
 
 	return result
-}
-
-func userInExclusionGroup(user usersv1.User, groups *usersv1.GroupList) bool {
-
-	// Below is a slightly complex way to determine if the user exists in an exlcusion group
-	// Ideally we would use the user.Groups field but this does not seem to get populated.
-	for _, group := range groups.Items {
-		for _, xGroup := range exclusionGroups {
-			if group.Name == xGroup {
-				for _, groupUser := range group.Users {
-					if groupUser == user.Name {
-						return true
-					}
-				}
-			}
-		}
-	}
-	return false
 }

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -25,16 +25,6 @@ var (
 	}
 )
 
-var (
-	defaultOperandNamespace = "rhsso"
-	keycloakName            = "rhsso"
-	keycloakRealmName       = "openshift"
-	defaultSubscriptionName = "rhmi-rhsso"
-	idpAlias                = "openshift-v4"
-	githubIdpAlias          = "github"
-	manifestPackage         = "integreatly-rhsso"
-)
-
 // Add creates a new User Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, products []string) error {

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -47,6 +47,10 @@ var (
 	githubIdpAlias            = "github"
 	manifestPackage           = "integreatly-rhsso"
 	adminCredentialSecretName = "credential-" + keycloakName
+	exclusionGroups           = []string{
+		"layered-cs-sre-admins",
+		"osd-sre-admins",
+	}
 )
 
 const (
@@ -766,9 +770,9 @@ func containsIdentityProvider(providers []*keycloak.KeycloakIdentityProvider, al
 	return false
 }
 
-func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []usersv1.User) (added []usersv1.User, deleted []keycloak.KeycloakAPIUser) {
+func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []usersv1.User, groups *usersv1.GroupList) (added []usersv1.User, deleted []keycloak.KeycloakAPIUser) {
 	for _, osUser := range openshiftUsers {
-		if !kcContainsOsUser(keycloakUsers, osUser) {
+		if !kcContainsOsUser(keycloakUsers, osUser) && !userInExclusionGroup(osUser, groups) {
 			added = append(added, osUser)
 		}
 	}
@@ -782,13 +786,38 @@ func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []user
 	return added, deleted
 }
 
+func userInExclusionGroup(user usersv1.User, groups *usersv1.GroupList) bool {
+
+	// Below is a slightly complex way to determine if the user exists in an exlcusion group
+	// Ideally we would use the user.Groups field but this does not seem to get populated.
+	for _, group := range groups.Items {
+		for _, xGroup := range exclusionGroups {
+			if group.Name == xGroup {
+				for _, groupUser := range group.Users {
+					if groupUser == user.Name {
+						return true
+					}
+				}
+			}
+		}
+	}
+	return false
+}
+
 func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string) ([]keycloak.KeycloakAPIUser, error) {
 	openshiftUsers := &usersv1.UserList{}
 	err := serverClient.List(ctx, openshiftUsers)
 	if err != nil {
 		return nil, err
 	}
-	added, deletedUsers := getUserDiff(keycloakUsers, openshiftUsers.Items)
+
+	groups := &usersv1.GroupList{}
+	err = serverClient.List(ctx, groups)
+	if err != nil {
+		return nil, err
+	}
+
+	added, deletedUsers := getUserDiff(keycloakUsers, openshiftUsers.Items, groups)
 
 	keycloakUsers, err = deleteKeycloakUsers(keycloakUsers, deletedUsers, ns, ctx, serverClient)
 	if err != nil {

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -385,6 +385,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 
 	// Create / update the synchronized users
 	for _, user := range users {
+		if user.UserName == "" {
+			continue
+		}
 		or, err = r.createOrUpdateKeycloakAdmin(user, ctx, serverClient)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create/update the customer admin user: %w", err)
@@ -680,6 +683,11 @@ func getOsUsersInAdminsGroup(groups usersv1.GroupList) (users []string) {
 func deleteKeycloakUsers(allKcUsers []keycloak.KeycloakAPIUser, deletedUsers []keycloak.KeycloakAPIUser, ns string, ctx context.Context, serverClient k8sclient.Client) ([]keycloak.KeycloakAPIUser, error) {
 
 	for _, delUser := range deletedUsers {
+
+		if delUser.UserName == "" {
+			continue
+		}
+
 		// Remove from all users list
 		for i, user := range allKcUsers {
 			// ID is not populated, have to use UserName. Should be unique on master Realm

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -16,8 +16,13 @@ echo user added customer-admin ${PASSWORD}
 htpasswd -b htpasswd test-user ${PASSWORD}
 echo user added test-user ${PASSWORD}
 
+htpasswd -b htpasswd sre-user-1 ${PASSWORD}
+echo user added sre-user-1 ${PASSWORD}
+
 oc delete secret htpasswd-secret -n openshift-config
 oc create secret generic htpasswd-secret --from-file=htpasswd=htpasswd -n openshift-config
 oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "name": "htpasswd_provider", "challenge": true, "login": true, "mappingMethod": "claim", "type": "HTPasswd", "htpasswd": { "fileData": { "name": "htpasswd-secret" } } }] } }'
 
 oc adm groups add-users dedicated-admins customer-admin
+oc adm groups add-users osd-sre-admins sre-user-1
+#uMlQslDI4V0Mpgnc

--- a/scripts/setup-htpass-idp.sh
+++ b/scripts/setup-htpass-idp.sh
@@ -25,4 +25,3 @@ oc patch oauth cluster --type=merge -p '{ "spec": { "identityProviders": [{ "nam
 
 oc adm groups add-users dedicated-admins customer-admin
 oc adm groups add-users osd-sre-admins sre-user-1
-#uMlQslDI4V0Mpgnc


### PR DESCRIPTION
### What

The RHMI developer group is a catchall for developers on the cluster, it used to ensure developers have the right cluster perms and the right access to products. At the moment it is also adding SRE users, these users don't need to be set up in 3scale etc.

### How to test
Create a user in the following groups:
user1: dedicated-admins
user2: osd-sre-admins
Create a third user in no group. 
user3:

Run the RHMI-Operator and **log in with all 3 users**

#### Verify

1. Verify that user1 and user3 get added to the rhmi-developers group
2. Verify that user2 does not get added to the rhmi-developers group
3. Verify that user1 and user3 get added to the RHSSO OpenShift realm
4. Verify that user2 does not get added to the cluster RHSSO OpenShift realm
5. Verify that user1 and user3 get added as 3Scale users
6. Verify that user2 does not get added as a 3Scale users
