### PR TITLE
creation of grafana dashboards test

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"bytes"
 	goctx "context"
 	"encoding/json"
 	"fmt"
@@ -12,12 +11,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 
-	corev1 "k8s.io/api/core/v1"
-
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 type alertsTestRule struct {
@@ -447,46 +441,6 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	if extraCount > 0 || missingCount > 0 {
 		t.Fatal("Found missing or too many alerts")
 	}
-}
-
-func execToPod(command string, podname string, namespace string, container string, ctx *TestingContext) (string, error) {
-	req := ctx.KubeClient.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podname).
-		Namespace(namespace).
-		SubResource("exec").
-		Param("container", container)
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return "", fmt.Errorf("error adding to scheme: %v", err)
-	}
-	parameterCodec := runtime.NewParameterCodec(scheme)
-	req.VersionedParams(&corev1.PodExecOptions{
-		Container: container,
-		Command:   strings.Fields(command),
-		Stdin:     false,
-		Stdout:    true,
-		Stderr:    true,
-		TTY:       false,
-	}, parameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
-	if err != nil {
-		return "", fmt.Errorf("error while creating Executor: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  nil,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		return "", fmt.Errorf("error in Stream: %v", err)
-	}
-
-	return stdout.String(), nil
 }
 
 // difference one-way diff that return strings in sliceSource that are not in sliceTarget

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -443,24 +443,6 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	}
 }
 
-// difference one-way diff that return strings in sliceSource that are not in sliceTarget
-func difference(sliceSource, sliceTarget []string) []string {
-	// create an empty lookup map with keys from sliceTarget
-	diffSourceLookupMap := make(map[string]struct{}, len(sliceTarget))
-	for _, item := range sliceTarget {
-		diffSourceLookupMap[item] = struct{}{}
-	}
-	// use the lookup map to find items in sliceSource that are not in sliceTarget
-	// and store them in a diff slice
-	var diff []string
-	for _, item := range sliceSource {
-		if _, found := diffSourceLookupMap[item]; !found {
-			diff = append(diff, item)
-		}
-	}
-	return diff
-}
-
 // ruleDifference one-way diff that return rules in diffSource that are not in diffTarget
 func ruleDifference(diffSource, diffTarget []alertsTestRule) []alertsTestRule {
 	// create an empty lookup map with keys from diffTarget

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -1,0 +1,173 @@
+package common
+
+import (
+	"bytes"
+	goctx "context"
+	"encoding/json"
+	"fmt"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+type dashboardsTestRule struct {
+	Title string `json:"title"`
+}
+
+var expectedDashboards = []dashboardsTestRule{
+	{
+		Title: "Endpoints Detailed",
+	},
+	{
+		Title: "Endpoints Report",
+	},
+	{
+		Title: "Endpoints Summary",
+	},
+	{
+		Title: "Keycloak",
+	},
+	{
+		Title: "Resource Usage By Namespace",
+	},
+	{
+		Title: "Resource Usage By Pod",
+	},
+	{
+		Title: "Resource Usage for Cluster",
+	},
+	{
+		Title: "Syndesis - Infra - API",
+	},
+	{
+		Title: "Syndesis - Infra - DB",
+	},
+	{
+		Title: "Syndesis - Infra - Home",
+	},
+	{
+		Title: "Syndesis - Infra - JVM",
+	},
+	{
+		Title: "Syndesis - Integrations - Camel",
+	},
+	{
+		Title: "Syndesis - Integrations - Home",
+	},
+	{
+		Title: "Syndesis - Integrations - JVM",
+	},
+	{
+		Title: "UnifiedPush Operator",
+	},
+	{
+		Title: "UnifiedPush Server",
+	},
+}
+
+func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
+	pods := &corev1.PodList{}
+	opts := []k8sclient.ListOption{
+		k8sclient.InNamespace(namespacePrefix + "middleware-monitoring-operator"),
+		k8sclient.MatchingLabels{"app": "grafana"},
+	}
+
+	err := ctx.Client.List(goctx.TODO(), pods, opts...)
+	if err != nil {
+		t.Fatal("failed to list pods", err)
+	}
+
+	if len(pods.Items) != 1 {
+		t.Fatal("grafana pod not found")
+	}
+
+	type Output []dashboardsTestRule
+
+	output, err := execToGrafanaPod("curl localhost:3000/api/search",
+		pods.Items[0].ObjectMeta.Name,
+		namespacePrefix+"middleware-monitoring-operator",
+		"grafana", ctx)
+	if err != nil {
+		t.Fatal("failed to exec to pod:", err)
+	}
+
+	var grafanaApiCallOutput Output
+	err = json.Unmarshal([]byte(output), &grafanaApiCallOutput)
+	if err != nil {
+		t.Logf("Failed to unmarshall json: %s", err)
+	}
+
+	if len(grafanaApiCallOutput) == 0 {
+		t.Fatal("grafana dashboard not found : %w", grafanaApiCallOutput)
+	}
+
+	ruleDiff := dashboardDifference(grafanaApiCallOutput, expectedDashboards)
+	if len(ruleDiff) > 0 {
+		t.Fatalf("Unexpected dashboards were found. If these dashboards were intentionally added, please update this test to include them. If these dashboards were not added intentionally or you are not sure, please create a JIRA and discuss with the monitoring team on how best to proceed. Additional dashboards: %s", strings.Join(ruleDiff, ", "))
+	}
+
+	ruleDiff = dashboardDifference(expectedDashboards, grafanaApiCallOutput)
+	if len(ruleDiff) > 0 {
+		t.Fatalf("Missing dashboards were found. If the removal of these dashboards was intentional, please update this test to remove them from the check. If the removal of these dashboards was not intended or you are not sure, please create a JIRA and discuss with the monitoring team on how best to proceed. Missing dashboards: %s", strings.Join(ruleDiff, ", "))
+	}
+}
+
+func execToGrafanaPod(command string, podName string, namespace string, container string, ctx *TestingContext) (string, error) {
+	req := ctx.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container)
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   strings.Fields(command),
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error in Stream: %v", err)
+	}
+	return stdout.String(), nil
+}
+
+// dashboardDifference returns the elements in list of dashboardsTestRule `a` that aren't in list `b`.
+func dashboardDifference(a, b []dashboardsTestRule) []string {
+	diffLookupMap := make(map[string]struct{}, len(b))
+	for _, x := range b {
+		diffLookupMap[x.Title] = struct{}{}
+	}
+
+	var diff []string
+	for _, x := range a {
+		if _, found := diffLookupMap[x.Title]; !found {
+			diff = append(diff, x.Title)
+		}
+	}
+	return diff
+}

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -111,9 +111,15 @@ func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 	dashboardDiffUnexpected := difference(actualDashboardTitles, expectedDashboardTitles)
 	dashboardDiffMissing := difference(expectedDashboardTitles, actualDashboardTitles)
 
-	if len(dashboardDiffUnexpected) > 0 || len(dashboardDiffMissing) > 0 {
+	if len(dashboardDiffUnexpected) > 0 {
 		t.Logf("unexpected dashboards found: %s", strings.Join(dashboardDiffUnexpected, ", "))
+	}
+
+	if len(dashboardDiffMissing) > 0 {
 		t.Logf("missing dashboards found: %s", strings.Join(dashboardDiffMissing, ", "))
-		t.Fail()
+	}
+
+	if len(dashboardDiffUnexpected) > 0 || len(dashboardDiffMissing) > 0 {
+		t.Fatal("missing or too many dashboards found")
 	}
 }

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -99,28 +99,21 @@ func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 		t.Fatal("no grafana dashboards were found : %w", grafanaApiCallOutput)
 	}
 
-	dashboardDiffUnexpected := dashboardDifference(grafanaApiCallOutput, expectedDashboards)
-	dashboardDiffMissing := dashboardDifference(expectedDashboards, grafanaApiCallOutput)
+	var expectedDashboardTitles []string
+	for _, dashboard := range expectedDashboards {
+		expectedDashboardTitles = append(expectedDashboardTitles, dashboard.Title)
+	}
+	var actualDashboardTitles []string
+	for _, dashboard := range grafanaApiCallOutput {
+		actualDashboardTitles = append(actualDashboardTitles, dashboard.Title)
+	}
+
+	dashboardDiffUnexpected := difference(actualDashboardTitles, expectedDashboardTitles)
+	dashboardDiffMissing := difference(expectedDashboardTitles, actualDashboardTitles)
 
 	if len(dashboardDiffUnexpected) > 0 || len(dashboardDiffMissing) > 0 {
 		t.Logf("unexpected dashboards found: %s", strings.Join(dashboardDiffUnexpected, ", "))
 		t.Logf("missing dashboards found: %s", strings.Join(dashboardDiffMissing, ", "))
 		t.Fail()
 	}
-}
-
-// dashboardDifference returns the elements in list of dashboardsTestRule `diffSource` that aren't in list `diffTarget`.
-func dashboardDifference(diffSource, diffTarget []dashboardsTestRule) []string {
-	diffLookupMap := make(map[string]struct{}, len(diffTarget))
-	for _, dashboard := range diffTarget {
-		diffLookupMap[dashboard.Title] = struct{}{}
-	}
-
-	var diff []string
-	for _, x := range diffSource {
-		if _, found := diffLookupMap[x.Title]; !found {
-			diff = append(diff, x.Title)
-		}
-	}
-	return diff
 }

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -1,18 +1,13 @@
 package common
 
 import (
-	"bytes"
 	goctx "context"
 	"encoding/json"
-	"fmt"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"testing"
 
 	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/tools/remotecommand"
 )
 
 type dashboardsTestRule struct {
@@ -86,9 +81,7 @@ func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 		t.Fatal("grafana pod not found")
 	}
 
-	type Output []dashboardsTestRule
-
-	output, err := execToGrafanaPod("curl localhost:3000/api/search",
+	output, err := execToPod("curl localhost:3000/api/search",
 		pods.Items[0].ObjectMeta.Name,
 		namespacePrefix+"middleware-monitoring-operator",
 		"grafana", ctx)
@@ -96,75 +89,35 @@ func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 		t.Fatal("failed to exec to pod:", err)
 	}
 
-	var grafanaApiCallOutput Output
+	var grafanaApiCallOutput []dashboardsTestRule
 	err = json.Unmarshal([]byte(output), &grafanaApiCallOutput)
 	if err != nil {
-		t.Logf("Failed to unmarshall json: %s", err)
+		t.Logf("failed to unmarshall json: %s", err)
 	}
 
 	if len(grafanaApiCallOutput) == 0 {
-		t.Fatal("grafana dashboard not found : %w", grafanaApiCallOutput)
+		t.Fatal("no grafana dashboards were found : %w", grafanaApiCallOutput)
 	}
 
-	ruleDiff := dashboardDifference(grafanaApiCallOutput, expectedDashboards)
-	if len(ruleDiff) > 0 {
-		t.Fatalf("Unexpected dashboards were found. If these dashboards were intentionally added, please update this test to include them. If these dashboards were not added intentionally or you are not sure, please create a JIRA and discuss with the monitoring team on how best to proceed. Additional dashboards: %s", strings.Join(ruleDiff, ", "))
-	}
+	dashboardDiffUnexpected := dashboardDifference(grafanaApiCallOutput, expectedDashboards)
+	dashboardDiffMissing := dashboardDifference(expectedDashboards, grafanaApiCallOutput)
 
-	ruleDiff = dashboardDifference(expectedDashboards, grafanaApiCallOutput)
-	if len(ruleDiff) > 0 {
-		t.Fatalf("Missing dashboards were found. If the removal of these dashboards was intentional, please update this test to remove them from the check. If the removal of these dashboards was not intended or you are not sure, please create a JIRA and discuss with the monitoring team on how best to proceed. Missing dashboards: %s", strings.Join(ruleDiff, ", "))
+	if len(dashboardDiffUnexpected) > 0 || len(dashboardDiffMissing) > 0 {
+		t.Logf("unexpected dashboards found: %s", strings.Join(dashboardDiffUnexpected, ", "))
+		t.Logf("missing dashboards found: %s", strings.Join(dashboardDiffMissing, ", "))
+		t.Fail()
 	}
 }
 
-func execToGrafanaPod(command string, podName string, namespace string, container string, ctx *TestingContext) (string, error) {
-	req := ctx.KubeClient.CoreV1().RESTClient().Post().
-		Resource("pods").
-		Name(podName).
-		Namespace(namespace).
-		SubResource("exec").
-		Param("container", container)
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		return "", fmt.Errorf("error adding to scheme: %v", err)
-	}
-	parameterCodec := runtime.NewParameterCodec(scheme)
-	req.VersionedParams(&corev1.PodExecOptions{
-		Container: container,
-		Command:   strings.Fields(command),
-		Stdin:     false,
-		Stdout:    true,
-		Stderr:    true,
-		TTY:       false,
-	}, parameterCodec)
-
-	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
-	if err != nil {
-		return "", fmt.Errorf("error while creating Executor: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	err = exec.Stream(remotecommand.StreamOptions{
-		Stdin:  nil,
-		Stdout: &stdout,
-		Stderr: &stderr,
-		Tty:    false,
-	})
-	if err != nil {
-		return "", fmt.Errorf("error in Stream: %v", err)
-	}
-	return stdout.String(), nil
-}
-
-// dashboardDifference returns the elements in list of dashboardsTestRule `a` that aren't in list `b`.
-func dashboardDifference(a, b []dashboardsTestRule) []string {
-	diffLookupMap := make(map[string]struct{}, len(b))
-	for _, x := range b {
-		diffLookupMap[x.Title] = struct{}{}
+// dashboardDifference returns the elements in list of dashboardsTestRule `diffSource` that aren't in list `diffTarget`.
+func dashboardDifference(diffSource, diffTarget []dashboardsTestRule) []string {
+	diffLookupMap := make(map[string]struct{}, len(diffTarget))
+	for _, dashboard := range diffTarget {
+		diffLookupMap[dashboard.Title] = struct{}{}
 	}
 
 	var diff []string
-	for _, x := range a {
+	for _, x := range diffSource {
 		if _, found := diffLookupMap[x.Title]; !found {
 			diff = append(diff, x.Title)
 		}

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -1,0 +1,50 @@
+package common
+
+import (
+	"bytes"
+	"fmt"
+	corev1 "k8s.io/api/core/v1"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+func execToPod(command string, podName string, namespace string, container string, ctx *TestingContext) (string, error) {
+	req := ctx.KubeClient.CoreV1().RESTClient().Post().
+		Resource("pods").
+		Name(podName).
+		Namespace(namespace).
+		SubResource("exec").
+		Param("container", container)
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return "", fmt.Errorf("error adding to scheme: %v", err)
+	}
+	parameterCodec := runtime.NewParameterCodec(scheme)
+	req.VersionedParams(&corev1.PodExecOptions{
+		Container: container,
+		Command:   strings.Fields(command),
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       false,
+	}, parameterCodec)
+
+	exec, err := remotecommand.NewSPDYExecutor(ctx.KubeConfig, "POST", req.URL())
+	if err != nil {
+		return "", fmt.Errorf("error while creating Executor: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdin:  nil,
+		Stdout: &stdout,
+		Stderr: &stderr,
+		Tty:    false,
+	})
+	if err != nil {
+		return "", fmt.Errorf("error in Stream: %v", err)
+	}
+	return stdout.String(), nil
+}

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -48,3 +48,21 @@ func execToPod(command string, podName string, namespace string, container strin
 	}
 	return stdout.String(), nil
 }
+
+// difference one-way diff that return strings in sliceSource that are not in sliceTarget
+func difference(sliceSource, sliceTarget []string) []string {
+	// create an empty lookup map with keys from sliceTarget
+	diffSourceLookupMap := make(map[string]struct{}, len(sliceTarget))
+	for _, item := range sliceTarget {
+		diffSourceLookupMap[item] = struct{}{}
+	}
+	// use the lookup map to find items in sliceSource that are not in sliceTarget
+	// and store them in a diff slice
+	var diff []string
+	for _, item := range sliceSource {
+		if _, found := diffSourceLookupMap[item]; !found {
+			diff = append(diff, item)
+		}
+	}
+	return diff
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -11,6 +11,7 @@ var (
 		{"Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},
 		{"Verify Deployment Config resources have the expected replicas", TestDeploymentConfigExpectedReplicas},
 		{"Verify alerts exist", TestIntegreatlyAlertsExist},
+		{"Verify dashboards exist", TestIntegreatlyDashboardsExist},
 		{"Verify CRO Postgres CRs Successful", TestCROPostgresSuccessfulState},
 		{"Verify CRO Redis CRs Successful", TestCRORedisSuccessfulState},
 		{"Verify CRO BlobStorage CRs Successful", TestCROBlobStorageSuccessfulState},


### PR DESCRIPTION
## Description

https://issues.redhat.com/browse/INTLY-5729

These changes automate the following test: https://gitlab.cee.redhat.com/integreatly-qe/integreatly-test-cases/blob/master/tests/dashboards/e02-verify-that-all-dashboards-are-installed-and-all-the-graphs.md

## Verification

- Login to an OS4 cluster with RHMI installed
- Using this branch, run the functional tests: `make test/functional`, the test should initially pass, as the expected dashboards should match the list of dashboards in Grafana.
- Modify the list of  `expectedDashboards` in the `dashboards_exits` file by changing the names of the some of the existing dashboards in the list, and also by adding new dashboard to the list. Ensure that the tests fails accordingly, and that the failure message is clear and concise.
- Login to Grafana as the admin user (login credentails are stored as a secret in the `middleware-monitoring` namespace) and add a new dashboard. Ensure the test detects the new dashboard, and that the test fails accordingly. Additionally, adding the title of the newly created dashboard to the list should allow the test to pass.


