### PR TITLE
backup and restore 3scale secrets for namespace restoration

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -80,6 +80,12 @@ var threeScaleAdminDetailsSecret = &corev1.Secret{
 	Data: map[string][]byte{},
 }
 
+var threeScaleApiCastSecret = &corev1.Secret{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "system-master-apicast",
+	},
+	Data: map[string][]byte{},
+}
 var threeScaleServiceDiscoveryConfigMap = &corev1.ConfigMap{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "system",
@@ -386,6 +392,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
 	s3CredentialsSecret.Namespace = integreatlyOperatorNamespace
 	threeScaleAdminDetailsSecret.Namespace = threeScaleInstallationNamepsace
+	threeScaleApiCastSecret.Namespace = threeScaleInstallationNamepsace
 	threeScaleServiceDiscoveryConfigMap.Namespace = threeScaleInstallationNamepsace
 	systemEnvConfigMap.Namespace = threeScaleInstallationNamepsace
 	oauthClientSecrets.Namespace = integreatlyOperatorNamespace
@@ -396,6 +403,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		s3CredentialsSecret,
 		configManagerConfigMap,
 		threeScaleAdminDetailsSecret,
+		threeScaleApiCastSecret,
 		threeScaleServiceDiscoveryConfigMap,
 		systemEnvConfigMap,
 		testDedicatedAdminsGroup,

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -187,7 +187,6 @@ func TestThreeScale(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestReconciler_reconcileBlobStorage(t *testing.T) {


### PR DESCRIPTION
Backup the 3scale system seed and master apicast secrets into the rhmi-operator namespace and restore them from there (in case the namespace gets removed).