### PR TITLE
bumps backup container image version

### DIFF
--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -218,7 +218,7 @@ func reconcileCronjob(ctx context.Context, serverClient k8sclient.Client, config
 							Containers: []corev1.Container{
 								{
 									Name:            "backup-cronjob",
-									Image:           "quay.io/omatskiv/backup-container:latest", //FIXME - workaround until we merge https://github.com/integr8ly/backup-container-image/pull/53
+									Image:           "quay.io/integreatly/backup-container:1.0.13",
 									ImagePullPolicy: "Always",
 									Command: []string{
 										"/opt/intly/tools/entrypoint.sh",


### PR DESCRIPTION
# Description

Bumps the backup container image version to fix an error on AMQ PV backups where container doesn't exit with an error on permissions error

https://issues.redhat.com/browse/INTLY-4625

# Verification Steps

- Ensure the version of backup container image is 1.0.13

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

