### PR TITLE
Functional tests failing due to incorrect alert names and storage deployment check

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -1,15 +1,10 @@
 package common
 
 import (
-	goctx "context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
-
-	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-
-	"k8s.io/apimachinery/pkg/types"
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
@@ -236,85 +231,85 @@ var expectedRules = []alertsTestRule{
 
 var expectedAWSRules = []alertsTestRule{
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-redis-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-redis-rhmi.yaml",
 		Rules: []string{
 			"3scaleRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-backend-redis-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-backend-redis-rhmi.yaml",
 		Rules: []string{
 			"3scaleRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-threescale-postgres-rhmi.yaml",
 		Rules: []string{
 			"3scalePostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-redis-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-threescale-redis-rhmi.yaml",
 		Rules: []string{
 			"3scaleRedisCacheUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-backend-redis-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-threescale-backend-redis-rhmi.yaml",
 		Rules: []string{
 			"3scaleRedisCacheUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-threescale-postgres-rhmi.yaml",
 		Rules: []string{
 			"3scalePostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-ups-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-ups-postgres-rhmi.yaml",
 		Rules: []string{
 			"upsPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-ups-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-ups-postgres-rhmi.yaml",
 		Rules: []string{
 			"upsPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-codeready-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-codeready-postgres-rhmi.yaml",
 		Rules: []string{
 			"codeready-workspacesPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-codeready-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-codeready-postgres-rhmi.yaml",
 		Rules: []string{
 			"codeready-workspacesPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-rhssouser-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-rhssouser-postgres-rhmi.yaml",
 		Rules: []string{
 			"user-ssoPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-rhssouser-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-rhssouser-postgres-rhmi.yaml",
 		Rules: []string{
 			"user-ssoPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-rhsso-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-connectivity-rule-rhsso-postgres-rhmi.yaml",
 		Rules: []string{
 			"rhssoPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-rhsso-postgres-example-rhmi.yaml",
+		File: "redhat-rhmi-operator-availability-rule-rhsso-postgres-rhmi.yaml",
 		Rules: []string{
 			"rhssoPostgresInstanceUnavailable",
 		},
@@ -322,17 +317,14 @@ var expectedAWSRules = []alertsTestRule{
 }
 
 func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
-	// get the RHMI custom resource to check what storage type is being used
-	rhmi := &v1alpha1.RHMI{}
-	ns := fmt.Sprintf("%soperator", namespacePrefix)
-	err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: installationName, Namespace: ns}, rhmi)
+	isClusterStorage, err := isClusterStorage(ctx)
 	if err != nil {
-		t.Fatal("error getting RHMI CR:", err)
+		t.Fatal("error getting isClusterStorage:", err)
 	}
 
 	// add external database alerts to list of expected rules if
 	// cluster storage is not being used
-	if rhmi.Spec.UseClusterStorage != "true" {
+	if !isClusterStorage {
 		for _, rule := range expectedAWSRules {
 			expectedRules = append(expectedRules, rule)
 		}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -231,85 +231,85 @@ var expectedRules = []alertsTestRule{
 
 var expectedAWSRules = []alertsTestRule{
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-redis-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-threescale-redis-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scaleRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-backend-redis-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-threescale-backend-redis-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scaleRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-threescale-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-threescale-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scalePostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-redis-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-threescale-redis-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scaleRedisCacheUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-backend-redis-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-threescale-backend-redis-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scaleRedisCacheUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-threescale-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-threescale-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"3scalePostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-ups-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-ups-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"upsPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-ups-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-ups-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"upsPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-codeready-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-codeready-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"codeready-workspacesPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-codeready-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-codeready-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"codeready-workspacesPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-rhssouser-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-rhssouser-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"user-ssoPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-rhssouser-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-rhssouser-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"user-ssoPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-connectivity-rule-rhsso-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-connectivity-rule-rhsso-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"rhssoPostgresConnectionFailed",
 		},
 	},
 	{
-		File: "redhat-rhmi-operator-availability-rule-rhsso-postgres-rhmi.yaml",
+		File: rhmiOperatorNamespace + "-availability-rule-rhsso-postgres-" + InstallationName + ".yaml",
 		Rules: []string{
 			"rhssoPostgresInstanceUnavailable",
 		},

--- a/test/common/constants.go
+++ b/test/common/constants.go
@@ -1,5 +1,0 @@
-package common
-
-const (
-	InstallationName = "rhmi"
-)

--- a/test/common/crd_exists.go
+++ b/test/common/crd_exists.go
@@ -4,11 +4,11 @@ import (
 	"testing"
 
 	"github.com/integr8ly/integreatly-operator/test/metadata"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestIntegreatlyCRDExists(t *testing.T, ctx *TestingContext) {
-	_, err := ctx.ExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("rhmis.integreatly.org", v1.GetOptions{})
+	_, err := ctx.ExtensionClient.ApiextensionsV1beta1().CustomResourceDefinitions().Get("rhmis.integreatly.org", metav1.GetOptions{})
 	if err != nil {
 		t.Fatal(err)
 		metadata.Instance.FoundCRD = false

--- a/test/common/cro_cr_success.go
+++ b/test/common/cro_cr_success.go
@@ -1,15 +1,13 @@
 package common
 
 import (
-	goctx "context"
 	"encoding/json"
 	"fmt"
+	"testing"
+
 	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
-	"k8s.io/apimachinery/pkg/types"
-	"testing"
 )
 
 const (
@@ -132,13 +130,12 @@ func getCustomResourceJson(ctx *TestingContext, resource string, resourceName st
 
 // Get resource provision strategy
 func getResourceStrategy(t *testing.T, ctx *TestingContext) string {
-	rhmi := &integreatlyv1alpha1.RHMI{}
-	err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: InstallationName, Namespace: requestNameSpace}, rhmi)
+	isClusterStorage, err := isClusterStorage(ctx)
 	if err != nil {
-		t.Fatal("error getting RHMI CR:", err)
+		t.Fatal("error getting isClusterStorage:", err)
 	}
 
-	if rhmi.Spec.UseClusterStorage == "false" {
+	if !isClusterStorage {
 		return externalProvider
 	}
 

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -3,9 +3,10 @@ package common
 import (
 	goctx "context"
 	"encoding/json"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"testing"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 )

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -2,11 +2,15 @@ package common
 
 import (
 	"bytes"
+	goctx "context"
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"strings"
 
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/remotecommand"
 )
 
@@ -65,4 +69,20 @@ func difference(sliceSource, sliceTarget []string) []string {
 		}
 	}
 	return diff
+}
+
+// Is the cluster using on cluster or external storage
+func isClusterStorage(ctx *TestingContext) (bool, error) {
+	rhmi := &integreatlyv1alpha1.RHMI{}
+
+	// get the RHMI custom resource to check what storage type is being used
+	err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: InstallationName, Namespace: rhmiOperatorNamespace}, rhmi)
+	if err != nil {
+		return true, fmt.Errorf("error getting RHMI CR: %v", err)
+	}
+
+	if rhmi.Spec.UseClusterStorage == "true" {
+		return true, nil
+	}
+	return false, nil
 }

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	namespacePrefix  = "redhat-rhmi-"
-	installationName = "rhmi"
+	namespacePrefix       = "redhat-rhmi-"
+	rhmiOperatorNamespace = namespacePrefix + "operator"
+	InstallationName      = "rhmi"
 )
 
 type TestingContext struct {


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-6301

The functional tests are failing under two circumstances:
1. The AWS alert names are wrong, they have the text `example` in the name
2. The deployment check is checking the storage deployments assuming they are always created on cluster. This is not the case for BYOC clusters.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer