### PR TITLE
fix: no empty strings in address space resources

### DIFF
--- a/pkg/products/amqonline/addressplans.go
+++ b/pkg/products/amqonline/addressplans.go
@@ -20,6 +20,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "topic",
 				Resources: v1beta2.AddressPlanResources{
 					Broker: "0.0",
+					Router: "0.0",
 				},
 			},
 		},
@@ -36,6 +37,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "queue",
 				Resources: v1beta2.AddressPlanResources{
 					Broker: "0.0",
+					Router: "0.0",
 				},
 			},
 		},
@@ -52,6 +54,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.1",
+					Broker: "0.0",
 				},
 			},
 		},
@@ -68,6 +71,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.1",
+					Broker: "0.0",
 				},
 			},
 		},
@@ -153,6 +157,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.01",
+					Broker: "0.0",
 				},
 			},
 		},
@@ -169,6 +174,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.01",
+					Broker: "0.0",
 				},
 			},
 		},
@@ -254,6 +260,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.001",
+					Broker: "0.0",
 				},
 			},
 		},
@@ -270,6 +277,7 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: "0.001",
+					Broker: "0.0",
 				},
 			},
 		},


### PR DESCRIPTION
AMQ Online does not allow empty strings in an address plan resouce. Router or Broker can be either left out be defined. The spec however does not include `omitempty` which means even empty strings will be serialized to yaml. Instead of modifying the spec, this PR sets the previously undefined strings to `"0.0"`. This is the equivalent of not having them in the yaml.

Verification steps:

1. Create an address space in the AMQ Online console
2. Create one address of each type, standard and brokered
3. Make sure that all addresses are created successfully