### PR TITLE
INTLY-5436: Tests to verify that all routes have been created

### DIFF
--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -1,0 +1,228 @@
+package common
+
+import (
+	"fmt"
+	"testing"
+
+	goctx "context"
+
+	routev1 "github.com/openshift/api/route/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var expectedRoutes = map[string][]ExpectedRoute{
+	"3scale": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "backend",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-api-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "apicast-staging",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-api-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "apicast-production",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-master-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-master",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-provider-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-developer",
+		},
+		ExpectedRoute{
+			Name:            "zync-3scale-provider-",
+			IsGeneratedName: true,
+			isTLS:           true,
+			ServiceName:     "system-provider",
+		},
+	},
+
+	"amq-online": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "console",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "standard-authservice",
+			isTLS: true,
+		},
+	},
+
+	"codeready-workspaces": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "codeready",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "devfile-registry",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "plugin-registry",
+			isTLS: true,
+		},
+	},
+
+	"fuse": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "syndesis",
+			isTLS: true,
+		},
+	},
+
+	"middleware-monitoring-operator": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "alertmanager-route",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "grafana-route",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "prometheus-route",
+			isTLS: true,
+		},
+	},
+
+	"rhsso": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: false,
+		},
+		ExpectedRoute{
+			Name:  "keycloak-edge",
+			isTLS: true,
+		},
+	},
+
+	"solution-explorer": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "tutorial-web-app",
+			isTLS: true,
+		},
+	},
+
+	"ups": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "ups-unifiedpush-proxy",
+			isTLS: true,
+		},
+	},
+
+	"user-sso": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: false,
+		},
+		ExpectedRoute{
+			Name:  "keycloak-edge",
+			isTLS: true,
+		},
+	},
+
+	"apicurito": []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "apicurito",
+			isTLS: true,
+		},
+		ExpectedRoute{
+			Name:  "fuse-apicurito-generator",
+			isTLS: true,
+		},
+	},
+}
+
+// TestIntegreatlyRoutesExist tests that the routes for all the products are created
+func TestIntegreatlyRoutesExist(t *testing.T, ctx *TestingContext) {
+	for product, routes := range expectedRoutes {
+		for _, expectedRoute := range routes {
+			foundRoute, err := getRoute(t, ctx, product, expectedRoute)
+			if err != nil {
+				t.Errorf("Failed checking route %v for product %v: %v",
+					expectedRoute.Name, product, err)
+
+				continue
+			}
+
+			foundTLS := isTLS(foundRoute)
+			if foundTLS != expectedRoute.isTLS {
+				t.Errorf("Failed checking route %s for product %s: Expected TLS to be %v but got %v",
+					expectedRoute.Name, product, expectedRoute.isTLS, foundTLS)
+			}
+		}
+	}
+}
+
+func getRoute(t *testing.T, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	if expectedRoute.IsGeneratedName {
+		return getRouteByGeneratedName(t, ctx, product, expectedRoute)
+	}
+
+	return getRouteByName(t, ctx, product, expectedRoute)
+}
+
+// getRouteByName finds a Route by searching for a route that has a matching name
+// to expectedRoute.Name
+func getRouteByName(t *testing.T, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	route := &routev1.Route{}
+	err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: expectedRoute.Name, Namespace: namespacePrefix + product}, route)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return route, nil
+}
+
+// getRouteByGeneratedName finds a Route by querying the product routes and finding the
+// first route with a generated name that matches expectedRoute.Name and pointing
+// to a service that matches expectedRoute.ServiceName
+func getRouteByGeneratedName(t *testing.T, ctx *TestingContext, product string, expectedRoute ExpectedRoute) (*routev1.Route, error) {
+	routes := &routev1.RouteList{}
+
+	// Get the routes for the product
+	err := ctx.Client.List(goctx.TODO(), routes, &k8sclient.ListOptions{
+		Namespace: namespacePrefix + product,
+	})
+
+	if err != nil {
+		return nil, fmt.Errorf("Error obtaining routes for product %s", product)
+	}
+
+	// Iterate through the routes and look for the one that matches the expected one.
+	// If it's found, check if TLS matches the expected
+	for _, route := range routes.Items {
+		// Skip routes that don't point to services
+		if route.Spec.To.Kind != "Service" {
+			continue
+		}
+
+		generatedName := route.GetObjectMeta().GetGenerateName()
+		to := route.Spec.To.Name
+
+		if expectedRoute.Name == generatedName && expectedRoute.ServiceName == to {
+			return &route, nil
+		}
+	}
+
+	// The loop finished and the expected route wasn't found, return an error
+	return nil, fmt.Errorf("Expected route with generated name %v to service %v was not found for product %v",
+		expectedRoute.Name, expectedRoute.ServiceName, product)
+}
+
+func isTLS(route *routev1.Route) bool {
+	return route.Spec.TLS.Termination == routev1.TLSTerminationEdge ||
+		route.Spec.TLS.Termination == routev1.TLSTerminationReencrypt
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -17,5 +17,6 @@ var (
 		{"Verify CRO Redis CRs Successful", TestCRORedisSuccessfulState},
 		{"Verify CRO BlobStorage CRs Successful", TestCROBlobStorageSuccessfulState},
 		{"Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
+		{"Verify all products routes are created", TestIntegreatlyRoutesExist},
 	}
 )

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -47,3 +47,19 @@ type Product struct {
 	Name             string
 	ExpectedReplicas int32
 }
+
+// ExpectedRoute contains the data of a route that is expected to be found
+type ExpectedRoute struct {
+	// Name is either the name of the route or the generated name (if the
+	// `IsGeneratedName` field is true)
+	Name string
+
+	isTLS bool
+
+	// ServiceName is the name of the service that the route points to (used
+	// when the name is generated as there can be multiple routes with the same
+	// generated name)
+	ServiceName string
+
+	IsGeneratedName bool
+}

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -21,9 +21,7 @@ import (
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-
-	routev1 "github.com/openshift/api/route/v1"
-
+	
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -528,28 +526,6 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	// check routes were created by checking hardcoded number of routes
-	// would be nice if expected routes can be dynamically discovered
-	expectedRoutes := map[string]int{
-		"3scale":                         6,
-		"amq-online":                     2,
-		"apicurito":                      2,
-		"codeready-workspaces":           3,
-		"fuse":                           1,
-		"middleware-monitoring-operator": 3,
-		"rhsso":                          2,
-		"solution-explorer":              1,
-		"ups":                            1,
-		"user-sso":                       2,
-	}
-
-	for product, numberRoutes := range expectedRoutes {
-		err = checkRoutes(t, f, product, numberRoutes)
-		if err != nil {
-			return err
-		}
-	}
-
 	// check no failed PVCs
 	pvcNamespaces := []string{
 		string(integreatlyv1alpha1.Product3Scale),
@@ -611,18 +587,6 @@ func checkOperandVersions(t *testing.T, f *framework.Framework, namespace string
 		}
 	}
 
-	return nil
-}
-
-func checkRoutes(t *testing.T, f *framework.Framework, product string, numberRoutes int) error {
-	routes := &routev1.RouteList{}
-	err := f.Client.List(goctx.TODO(), routes, &k8sclient.ListOptions{Namespace: intlyNamespacePrefix + product})
-	if err != nil {
-		return fmt.Errorf("Error getting routes for %s namespace: %w", product, err)
-	}
-	if len(routes.Items) != numberRoutes {
-		return fmt.Errorf("Expected %v routes in %v%v namespace. Found %v", numberRoutes, intlyNamespacePrefix, product, len(routes.Items))
-	}
 	return nil
 }
 

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -21,7 +21,7 @@ import (
 
 	framework "github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/operator-framework/operator-sdk/pkg/test/e2eutil"
-	
+
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 


### PR DESCRIPTION
Create and add test to the `AFTER_INSTALL_TESTS` list that enumerates the expected routes
that must have been created and checks that they exist in the cluster.

Remove test logic that becomes redundant after adding this test.