### PR TITLE
Clean test cache before running functional tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/c
 .PHONY: test/functional
 test/functional:
 	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
-	go test ./test/functional
+	go clean -testcache && go test ./test/functional
 
 .PHONY: install/olm
 install/olm: cluster/cleanup/olm cluster/cleanup/crds cluster/prepare cluster/prepare/olm/subscription deploy/integreatly-rhmi-cr.yml cluster/check/operator/deployment cluster/prepare/dms cluster/prepare/pagerduty


### PR DESCRIPTION
# Description
I was noticing a cached response when running functional tests even when I switched the target cluster which should have failed the tests.
```
ok      github.com/integr8ly/integreatly-operator/test/functional       (cached)
```

Cleaning the cachetest before each run is the change here as per https://golang.org/cmd/go/#hdr-Build_and_test_caching

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer