### PR TITLE
add default rhsso email address when one not present:

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -802,6 +802,10 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 			return nil, err
 		}
 
+		if email == "" {
+			email = osUser.Name + "@rhmi.io"
+		}
+
 		newKeycloakUser := keycloak.KeycloakAPIUser{
 			Enabled:       true,
 			UserName:      osUser.Name,


### PR DESCRIPTION
# Description
add default rhsso email address when one not present:
This is to support the syncing of users in 3Scale. 3Scale fails to create a user without an email address and subsequently the product fails to install. 

## How to test
run ./scripts/setup-htpass-idp.sh

Verify that the 2 users, customer-admin and test-user are created in cluster RHSSO with default email addresses, customer-admin@rhmi.io, test-user@rhmi.io

Log into 3Scale as the admin (use system-seed secret) and verify that the keycloak users have synced from Keycloak, customer-admin as a 3Scale admin and test-user as a member