### PR TITLE
[INTLY-6019] Verify that no alerts are firing apart from DeadMansSwitch 

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -327,7 +327,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	// exec into the prometheus pod
 	output, err := execToPod("curl localhost:9090/api/v1/rules",
 		"prometheus-application-monitoring-0",
-		NamespacePrefix+"middleware-monitoring-operator",
+		MonitoringOperatorNamespace,
 		"prometheus", ctx)
 	if err != nil {
 		t.Fatal("failed to exec to pod:", err)
@@ -337,12 +337,12 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	var promApiCallOutput prometheusAPIResponse
 	err = json.Unmarshal([]byte(output), &promApiCallOutput)
 	if err != nil {
-		t.Fatal("Failed to unmarshal json:", err)
+		t.Fatal("failed to unmarshal json:", err)
 	}
 	var rulesResult prometheusv1.RulesResult
 	err = json.Unmarshal([]byte(promApiCallOutput.Data), &rulesResult)
 	if err != nil {
-		t.Fatal("Failed to unmarshal json:", err)
+		t.Fatal("failed to unmarshal json:", err)
 	}
 
 	// convert prometheus rule to PrometheusRule type

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -1,0 +1,66 @@
+package common
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+)
+
+const deadMansSwitch = "DeadMansSwitch"
+
+func TestIntegreatlyAlertsFiring(t *testing.T, ctx *TestingContext) {
+	output, err := execToPod("curl localhost:9090/api/v1/alerts",
+		"prometheus-application-monitoring-0",
+		MonitoringOperatorNamespace,
+		"prometheus",
+		ctx)
+	if err != nil {
+		t.Fatal("Failed to exec to prometheus pod:", err)
+	}
+
+	// get all found rules from the prometheus api
+	var promApiCallOutput prometheusAPIResponse
+	err = json.Unmarshal([]byte(output), &promApiCallOutput)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal json: %s", err)
+	}
+	var alertsResult prometheusv1.AlertsResult
+	err = json.Unmarshal(promApiCallOutput.Data, &alertsResult)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal json: %s", err)
+	}
+
+	// check if any alerts other than DeadMansSwitch are firing or pending
+	var firingAlerts []string
+	var pendingAlerts []string
+	for _, alert := range alertsResult.Alerts {
+		alertName := alert.Labels["alertname"]
+
+		// dead mans switch is not firing, so fail the test
+		if alertName == deadMansSwitch && alert.State != prometheusv1.AlertStateFiring {
+			t.Fatalf("Alert: %s is not firing", deadMansSwitch)
+		}
+		// check for pending or firing alerts
+		if alertName != deadMansSwitch {
+			if alert.State == prometheusv1.AlertStateFiring {
+				firingAlerts = append(firingAlerts, string(alertName))
+			}
+			if alert.State == prometheusv1.AlertStatePending {
+				pendingAlerts = append(pendingAlerts, string(alertName))
+			}
+		}
+	}
+
+	// report the firing or pending alerts and fail the test
+	if len(firingAlerts) > 0 {
+		t.Logf("The following alerts were fired: %s", strings.Join(firingAlerts, ", "))
+	}
+	if len(pendingAlerts) > 0 {
+		t.Logf("The following alerts were pending: %s", strings.Join(pendingAlerts, ", "))
+	}
+	if len(firingAlerts) > 0 || len(pendingAlerts) > 0 {
+		t.Fatal("Found pending or firing alerts")
+	}
+}

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -2,51 +2,134 @@ package common
 
 import (
 	"encoding/json"
+	"fmt"
+	"strings"
 	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
 
 const deadMansSwitch = "DeadMansSwitch"
 
+// alertsTestMetadata contains metadata about the alert
+type alertTestMetadata struct {
+	alertName string
+	podName   string
+	namespace string
+}
+
+// alertsFiringError is a custom alerts error
+type alertsFiringError struct {
+	alertsPending        []alertTestMetadata
+	alertsFiring         []alertTestMetadata
+	deadMansSwitchFiring bool
+}
+
+// Error implements the error interface and returns a readable output message
+func (e *alertsFiringError) Error() string {
+	var str strings.Builder
+	if e.deadMansSwitchFiring {
+		str.WriteString("\nThe following alerts were not fired, but were expected to be firing:")
+		str.WriteString(fmt.Sprintf("\n\talert: %s", deadMansSwitch))
+	}
+	if len(e.alertsPending) != 0 {
+		str.WriteString("\nThe following alerts were pending:")
+		for _, alert := range e.alertsPending {
+			str.WriteString(fmt.Sprintf("\n\talert: %s, for pod: %s, in namespace: %s", alert.alertName, alert.podName, alert.namespace))
+		}
+	}
+	if len(e.alertsFiring) != 0 {
+		str.WriteString("\nThe following alerts were fired:")
+		for _, alert := range e.alertsFiring {
+			str.WriteString(fmt.Sprintf("\n\talert: %s, for pod: %s, in namespace: %s", alert.alertName, alert.podName, alert.namespace))
+		}
+	}
+	return str.String()
+}
+
+// isNotEmpty checks whether or not the error contains firing or pending alerts
+func (e *alertsFiringError) isNotEmpty() bool {
+	return !e.deadMansSwitchFiring || len(e.alertsPending) != 0 || len(e.alertsPending) != 0
+}
+
 func TestIntegreatlyAlertsFiring(t *testing.T, ctx *TestingContext) {
+	var lastError error
+
+	// retry the tests every minute for up to 15 minutes
+	monitoringTimeout := 15 * time.Minute
+	monitoringRetryInterval := 1 * time.Minute
+	err := wait.Poll(monitoringRetryInterval, monitoringTimeout, func() (done bool, err error) {
+		if newErr := getFiringOrPendingAlerts(ctx); newErr != nil {
+			lastError = newErr
+			if _, ok := newErr.(*alertsFiringError); ok {
+				return false, nil
+			}
+			return false, err
+		}
+		return true, nil
+	})
+	if err != nil {
+		t.Fatal(lastError.Error())
+	}
+}
+
+func getFiringOrPendingAlerts(ctx *TestingContext) error {
 	output, err := execToPod("curl localhost:9090/api/v1/alerts",
 		"prometheus-application-monitoring-0",
 		MonitoringOperatorNamespace,
 		"prometheus",
 		ctx)
 	if err != nil {
-		t.Fatal("Failed to exec to prometheus pod:", err)
+		return fmt.Errorf("failed to exec to prometheus pod: %w", err)
 	}
 
 	// get all found rules from the prometheus api
 	var promApiCallOutput prometheusAPIResponse
 	err = json.Unmarshal([]byte(output), &promApiCallOutput)
 	if err != nil {
-		t.Fatalf("Failed to unmarshal json: %s", err)
+		return fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 	var alertsResult prometheusv1.AlertsResult
 	err = json.Unmarshal(promApiCallOutput.Data, &alertsResult)
 	if err != nil {
-		t.Fatalf("Failed to unmarshal json: %s", err)
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	// create a custom alerts error to keep track of all pending and firing alerts
+	alertsError := &alertsFiringError{
+		alertsPending:        []alertTestMetadata{},
+		alertsFiring:         []alertTestMetadata{},
+		deadMansSwitchFiring: true,
 	}
 
 	// check if any alerts other than DeadMansSwitch are firing or pending
 	for _, alert := range alertsResult.Alerts {
-		alertName := alert.Labels["alertname"]
+		alertName := string(alert.Labels["alertname"])
+		alertMetadata := alertTestMetadata{
+			alertName: alertName,
+			podName:   string(alert.Labels["pod"]),
+			namespace: string(alert.Labels["namespace"]),
+		}
 
-		// dead mans switch is not firing, so fail the test
+		// check if dead mans switch is firing
 		if alertName == deadMansSwitch && alert.State != prometheusv1.AlertStateFiring {
-			t.Errorf("Alert: %s is not firing", deadMansSwitch)
+			alertsError.deadMansSwitchFiring = false
 		}
 		// check for pending or firing alerts
 		if alertName != deadMansSwitch {
 			if alert.State == prometheusv1.AlertStateFiring {
-				t.Errorf("The following alert was fired: %s", alertName)
+				alertsError.alertsFiring = append(alertsError.alertsFiring, alertMetadata)
 			}
 			if alert.State == prometheusv1.AlertStatePending {
-				t.Errorf("The following alert was pending: %s", alertName)
+				alertsError.alertsPending = append(alertsError.alertsPending, alertMetadata)
 			}
 		}
 	}
+	if alertsError.isNotEmpty() {
+		return alertsError
+	}
+	return nil
 }

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -69,7 +69,7 @@ var expectedDashboards = []dashboardsTestRule{
 func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 	pods := &corev1.PodList{}
 	opts := []k8sclient.ListOption{
-		k8sclient.InNamespace(NamespacePrefix + "middleware-monitoring-operator"),
+		k8sclient.InNamespace(MonitoringOperatorNamespace),
 		k8sclient.MatchingLabels{"app": "grafana"},
 	}
 
@@ -84,7 +84,7 @@ func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {
 
 	output, err := execToPod("curl localhost:3000/api/search",
 		pods.Items[0].ObjectMeta.Name,
-		NamespacePrefix+"middleware-monitoring-operator",
+		MonitoringOperatorNamespace,
 		"grafana", ctx)
 	if err != nil {
 		t.Fatal("failed to exec to pod:", err)

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -13,8 +13,7 @@ var (
 		{"Verify Dedicated Admin User Permissions are Correct", TestDedicatedAdminUserPermissions},
 		{"Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},
 		{"Verify Deployment Config resources have the expected replicas", TestDeploymentConfigExpectedReplicas},
-		{"Verify Stateful Set resources have the expected repliaces", TestStatefulSetsExpectedReplicas},
-		{"Verify alerts exist", TestIntegreatlyAlertsExist},
+		{"Verify Stateful Set resources have the expected replicas", TestStatefulSetsExpectedReplicas},
 		{"Verify dashboards exist", TestIntegreatlyDashboardsExist},
 		{"Verify CRO Postgres CRs Successful", TestCROPostgresSuccessfulState},
 		{"Verify CRO Redis CRs Successful", TestCRORedisSuccessfulState},
@@ -23,5 +22,7 @@ var (
 		{"Verify all products routes are created", TestIntegreatlyRoutesExist},
 		{"Verify Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
 		{"Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
+		{"Verify Alerts exist", TestIntegreatlyAlertsExist},
+		{"Verify Alerts are not firing apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
 	}
 )

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -12,9 +12,10 @@ import (
 )
 
 const (
-	NamespacePrefix       = "redhat-rhmi-"
-	RHMIOperatorNamespace = NamespacePrefix + "operator"
-	InstallationName      = "rhmi"
+	InstallationName            = "rhmi"
+	NamespacePrefix             = "redhat-rhmi-"
+	RHMIOperatorNamespace       = NamespacePrefix + "operator"
+	MonitoringOperatorNamespace = NamespacePrefix + "middleware-monitoring-operator"
 )
 
 type TestingContext struct {


### PR DESCRIPTION
## Description
There is an existing test in the `e2e` package which ensures that no alerts are firing apart from `DeadMansSwitch`. 
This moves all remaining monitoring tests to the `common` package, which is executed for both e2e and functional tests, ensuring that these tests are run in both BYOC and non-BYOC environments. 

Jira: https://issues.redhat.com/browse/INTLY-6019

## Verification
- Log in to an existing Openshift 4 cluster
- Install integreatly from master
- Check out this branch and run make test/functional. The test is common to both e2e and functional tests, so running the functional ones is just quicker
- See that the output of the test is as expected, for example: 
   - If `DeadMansSwitch` is firing, the test continues, and if it's not firing the test fails
   - If any other alert is firing or pending, the test fails (e.g, try scale down replicas of the solution explorer deployment, this should cause the `SolutionExplorerPodCount` alert to fire)  
