### PR TITLE
Fix router numbers on AMQ Online address and address space plans

### DIFF
--- a/pkg/products/amqonline/addressplans.go
+++ b/pkg/products/amqonline/addressplans.go
@@ -20,7 +20,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "topic",
 				Resources: v1beta2.AddressPlanResources{
 					Broker: 0.0,
-					Router: 0.0,
 				},
 			},
 		},
@@ -37,7 +36,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "queue",
 				Resources: v1beta2.AddressPlanResources{
 					Broker: 0.0,
-					Router: 0.0,
 				},
 			},
 		},
@@ -54,7 +52,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.1,
-					Broker: 0.0,
 				},
 			},
 		},
@@ -71,7 +68,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.1,
-					Broker: 0.0,
 				},
 			},
 		},
@@ -157,7 +153,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.01,
-					Broker: 0.0,
 				},
 			},
 		},
@@ -174,7 +169,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.01,
-					Broker: 0.0,
 				},
 			},
 		},
@@ -260,7 +254,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "anycast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.001,
-					Broker: 0.0,
 				},
 			},
 		},
@@ -277,7 +270,6 @@ func GetDefaultAddressPlans(ns string) []*v1beta2.AddressPlan {
 				AddressType:      "multicast",
 				Resources: v1beta2.AddressPlanResources{
 					Router: 0.001,
-					Broker: 0.0,
 				},
 			},
 		},

--- a/pkg/products/amqonline/addressspaceplans.go
+++ b/pkg/products/amqonline/addressspaceplans.go
@@ -119,7 +119,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 				AddressSpaceType: "standard",
 				ResourceLimits: v1beta2.AddressSpacePlanResourceLimits{
 					Broker:    10000.0,
-					Router:    1000.0,
+					Router:    10000.0,
 					Aggregate: 10000.0,
 				},
 				AddressPlans: []string{
@@ -160,7 +160,7 @@ func GetDefaultAddressSpacePlans(ns string) []*v1beta2.AddressSpacePlan {
 				AddressSpaceType: "standard",
 				ResourceLimits: v1beta2.AddressSpacePlanResourceLimits{
 					Broker:    10000.0,
-					Router:    1000.0,
+					Router:    10000.0,
 					Aggregate: 10000.0,
 				},
 				AddressPlans: []string{


### PR DESCRIPTION
# Description
Two changes here:
- Fixing router number from 1000 to 10000 on unlimited address space plans
- Removing `router: 0.0` on address plans now that the type has changed back to Number.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer