### PR TITLE
add initial grafana dashboards route functional tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
 	github.com/operator-framework/operator-marketplace v0.0.0-20191105191618-530c85d41ce7
 	github.com/operator-framework/operator-sdk v0.15.1
+	github.com/pkg/errors v0.8.1
 	github.com/prometheus/client_golang v1.3.0
 	github.com/sirupsen/logrus v1.4.2
 	github.com/spf13/pflag v1.0.5

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -1,0 +1,113 @@
+package common
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	v1 "github.com/openshift/api/route/v1"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+const (
+	grafanaCredsUsername = "customer-admin-1"
+	grafanaCredsPassword = "Password1"
+)
+
+func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
+	httpClient, err := buildHTTPClientFromContext(ctx)
+	if err != nil {
+		t.Fatal("failed to create test http client", err)
+	}
+	//reconcile idp setup
+	if err := createTestingIDP(context.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts); err != nil {
+		t.Fatal("failed to reconcile testing idp", err)
+	}
+	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
+	if err != nil {
+		t.Fatal("failed to get grafana route", err)
+	}
+	//perform a request that we expect to be forbidden initially
+	forbiddenReq, err := http.NewRequest(http.MethodGet, grafanaRootHostname, nil)
+	if err != nil {
+		t.Fatal("failed to build request for grafana", err)
+	}
+	forbiddenResp, err := http.DefaultClient.Do(forbiddenReq)
+	if err != nil {
+		t.Fatal("failed to perform expected forbidden request", err)
+	}
+	if forbiddenResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("unexpected status code on forbidden request, got=%+v", forbiddenResp)
+	}
+	//retrieve an openshift oauth proxy cookie
+	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
+	if err := resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, httpClient); err != nil {
+		t.Fatal("failed to login through openshift oauth proxy", err)
+	}
+	successResp, err := httpClient.Get(grafanaRootHostname)
+	if err != nil {
+		t.Fatal("failed to perform test request to grafana", err)
+	}
+	defer successResp.Body.Close()
+	if successResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code on success request, got=%+v", successResp)
+	}
+}
+
+func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
+	httpClient, err := buildHTTPClientFromContext(ctx)
+	if err != nil {
+		t.Fatal("failed to create test http client", err)
+	}
+	//reconcile idp setup
+	if err := createTestingIDP(context.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts); err != nil {
+		t.Fatal("failed to reconcile testing idp", err)
+	}
+	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
+	if err != nil {
+		t.Fatal("failed to get grafana route", err)
+	}
+	//retrieve an openshift oauth proxy cookie
+	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
+	if err = resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, httpClient); err != nil {
+		t.Fatal("failed to login through openshift oauth proxy", err)
+	}
+	//get dashboards for grafana from the external route
+	grafanaDashboardsUrl := fmt.Sprintf("%s/api/search", grafanaRootHostname)
+	dashboardResp, err := httpClient.Get(grafanaDashboardsUrl)
+	if err != nil {
+		t.Fatal("failed to perform test request to grafana", err)
+	}
+	defer dashboardResp.Body.Close()
+	if dashboardResp.StatusCode != http.StatusOK {
+		t.Fatalf("unexpected status code on success request, got=%+v", dashboardResp)
+	}
+	var dashboards []interface{}
+	if err := json.NewDecoder(dashboardResp.Body).Decode(&dashboards); err != nil {
+		t.Fatal("failed to decode grafana dashboards response", err)
+	}
+	if len(dashboards) == 0 {
+		t.Fatal("no grafana dashboards returned from grafana api")
+	}
+}
+
+func getGrafanaRoute(c client.Client) (string, error) {
+	const (
+		routeGrafanaName      = "grafana-route"
+		routeGrafanaNamespace = "redhat-rhmi-middleware-monitoring-operator"
+	)
+	testCtx := context.TODO()
+	//get grafana openshift route
+	grafanaRoute := &v1.Route{}
+	if err := c.Get(testCtx, client.ObjectKey{Name: routeGrafanaName, Namespace: routeGrafanaNamespace}, grafanaRoute); err != nil {
+		return "", fmt.Errorf("failed to get grafana route: %w", err)
+	}
+	//evaluate the grafana route hostname
+	grafanaRootHostname := grafanaRoute.Spec.Host
+	if grafanaRoute.Spec.TLS != nil {
+		grafanaRootHostname = fmt.Sprintf("https://%s", grafanaRootHostname)
+	}
+	return grafanaRootHostname, nil
+}

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/test/resources"
 	v1 "github.com/openshift/api/route/v1"
 	"net/http"

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -31,11 +31,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 		t.Fatal("failed to get grafana route", err)
 	}
 	//perform a request that we expect to be forbidden initially
-	forbiddenReq, err := http.NewRequest(http.MethodGet, grafanaRootHostname, nil)
-	if err != nil {
-		t.Fatal("failed to build request for grafana", err)
-	}
-	forbiddenResp, err := http.DefaultClient.Do(forbiddenReq)
+	forbiddenResp, err := httpClient.Get(grafanaRootHostname)
 	if err != nil {
 		t.Fatal("failed to perform expected forbidden request", err)
 	}
@@ -82,6 +78,7 @@ func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 		t.Fatal("failed to perform test request to grafana", err)
 	}
 	defer dashboardResp.Body.Close()
+	//there is an existing dashboard check, so confirm a valid response structure
 	if dashboardResp.StatusCode != http.StatusOK {
 		t.Fatalf("unexpected status code on success request, got=%+v", dashboardResp)
 	}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -21,5 +21,7 @@ var (
 		{"Verify CRO BlobStorage CRs Successful", TestCROBlobStorageSuccessfulState},
 		{"Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
 		{"Verify all products routes are created", TestIntegreatlyRoutesExist},
+		{"Verify Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
+		{"Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
 	}
 )

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -76,7 +76,7 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(masterURL, "customer-admin-1", DefaultPassword, httpClient); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, httpClient); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -65,7 +65,7 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// get rhmi developer user tokens
-	if err := resources.DoAuthOpenshiftUser(masterURL, "test-user-1", DefaultPassword, httpClient); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "test-user-1", DefaultPassword, httpClient); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -44,7 +44,7 @@ func DoAuthOpenshiftUser(authPageURL string, username string, password string, h
 		return fmt.Errorf("failed to parse url %s: %w", authPageURL, err)
 	}
 	if parsedURL.Scheme == "" {
-		authPageURL = fmt.Sprintf("https://%s")
+		authPageURL = fmt.Sprintf("https://%s", authPageURL)
 	}
 	if err := openshiftClientSetup(authPageURL, username, password, httpClient); err != nil {
 		return fmt.Errorf("error occurred during oauth login: %w", err)

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -6,6 +6,7 @@ import (
 	"github.com/headzoo/surf/errors"
 	"gopkg.in/headzoo/surf.v1"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -37,8 +38,15 @@ type CallbackOptions struct {
 }
 
 // doAuthOpenshiftUser this function expects users and IDP to be created via `./scripts/setup-sso-idp.sh`
-func DoAuthOpenshiftUser(masterURL string, username string, password string, httpClient *http.Client) error {
-	if err := openshiftClientSetup(fmt.Sprintf("https://%s/auth/login", masterURL), username, password, httpClient); err != nil {
+func DoAuthOpenshiftUser(authPageURL string, username string, password string, httpClient *http.Client) error {
+	parsedURL, err := url.Parse(authPageURL)
+	if err != nil {
+		return fmt.Errorf("failed to parse url %s: %w", authPageURL, err)
+	}
+	if parsedURL.Scheme == "" {
+		authPageURL = fmt.Sprintf("https://%s")
+	}
+	if err := openshiftClientSetup(authPageURL, username, password, httpClient); err != nil {
 		return fmt.Errorf("error occurred during oauth login: %w", err)
 	}
 	return nil


### PR DESCRIPTION
add initial grafana dashboard tests from the external route
exposed in openshift.

this commit also adds functionality for logging in via the
openshift oauth proxy.

the two tests added in this commit:
- ensure the external route returns a 200 response code when a
  user is authenticated.
- ensure dashboards are returned from the external grafana route.