### PR TITLE
INTLY-6399 Add test for default user email address

### DIFF
--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -1,0 +1,173 @@
+package common
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"net/http/cookiejar"
+	"testing"
+	"time"
+
+	goctx "context"
+
+	keycloakv1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	userv1 "github.com/openshift/api/user/v1"
+	"golang.org/x/net/publicsuffix"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	usernameNoEmail   = "autotest-user01"
+	usernameWithEmail = "autotest-user02"
+	existingEmail     = "autotest-nondefault-user02@hotmail.com"
+)
+
+// TestDefaultUserEmail verifies that a user syncronized from the IDP have a
+// default email adress if no email is present from the IDP.
+//
+// Verify that the email address is generated as <username>@rhmi.io
+func TestDefaultUserEmail(t *testing.T, ctx *TestingContext) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: ctx.SelfSignedCerts},
+	}
+
+	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	if err != nil {
+		t.Fatalf("error occurred creating a new cookie jar: %v", err)
+	}
+
+	httpClient := &http.Client{
+		Transport: tr,
+		Jar:       jar,
+	}
+
+	err = createTestingIDP(goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
+	if err != nil {
+		t.Fatalf("Error occurred creating testing IDP: %v", err)
+	}
+
+	// Create user with no email
+	// the default email for this user will be <user name>@rhmi.io
+	userNoEmail, identityNoEmail, err := createUserTestingIDP(ctx, usernameNoEmail, nil)
+	if err != nil {
+		t.Fatalf("Unexpected error creating User: %v", err)
+	}
+	// Clean up the user resource
+	defer deleteUser(ctx, userNoEmail, identityNoEmail)
+
+	// Create user with email
+	// different that the default generated email
+	userWithEmail, identityWithEmail, err := createUserTestingIDP(ctx, usernameWithEmail, func(identity *userv1.Identity) {
+		identity.Extra = map[string]string{
+			"email": existingEmail,
+		}
+	})
+	if err != nil {
+		t.Fatalf("Unexpected error creating User: %v", err)
+	}
+
+	// Cleanup the user resource
+	defer deleteUser(ctx, userWithEmail, identityWithEmail)
+
+	rhssoNamespace := fmt.Sprintf("%srhsso", NamespacePrefix)
+
+	// Get the keycloak CR for each user
+	keycloakUser1, err := waitForKeycloakUser(ctx, 5*time.Minute, rhssoNamespace, usernameNoEmail)
+	if err != nil {
+		t.Fatalf("Unexpected error querying KeycloakUser %s: %v", usernameNoEmail, err)
+	}
+
+	keycloakUser2, err := waitForKeycloakUser(ctx, 5*time.Minute, rhssoNamespace, usernameWithEmail)
+	if err != nil {
+		t.Fatalf("Unexpected error querying KeycloakUser %s: %v", usernameWithEmail, err)
+		return
+	}
+
+	// Assert that the user with no email has the default generated email
+	expectedEmail := fmt.Sprintf("%s@rhmi.io", usernameNoEmail)
+	if keycloakUser1.Spec.User.Email != expectedEmail {
+		t.Errorf("Unexpected email for generated KeycloakUser: Expected %s, got %s", expectedEmail, keycloakUser1.Spec.User.Email)
+	}
+
+	// Assert that the user with email has its own email
+	if keycloakUser2.Spec.User.Email != existingEmail {
+		t.Errorf("Unexpected email for generated KeycloakUser: Expected %s, got %s", existingEmail, keycloakUser2.Spec.User.Email)
+	}
+}
+
+func createUserTestingIDP(ctx *TestingContext, userName string, mutateIdentity func(*userv1.Identity)) (*userv1.User, *userv1.Identity, error) {
+	identityName := fmt.Sprintf("%s:%s", TestingIDPRealm, userName)
+
+	identity := &userv1.Identity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: identityName,
+		},
+		ProviderName:     TestingIDPRealm,
+		ProviderUserName: userName,
+	}
+
+	if mutateIdentity != nil {
+		mutateIdentity(identity)
+	}
+
+	if err := ctx.Client.Create(goctx.TODO(), identity); err != nil {
+		if !k8serr.IsAlreadyExists(err) {
+			return nil, nil, err
+		}
+	}
+
+	var user = &userv1.User{
+		ObjectMeta: v1.ObjectMeta{
+			Name: userName,
+		},
+		Identities: []string{
+			identityName,
+		},
+	}
+
+	if err := ctx.Client.Create(goctx.TODO(), user); err != nil {
+		return nil, nil, err
+	}
+
+	return user, identity, nil
+}
+
+func deleteUser(ctx *TestingContext, user *userv1.User, identity *userv1.Identity) error {
+	// Delete the user
+	if err := ctx.Client.Delete(goctx.TODO(), user); err != nil {
+		return err
+	}
+
+	// Delete the identity
+	return ctx.Client.Delete(goctx.TODO(), identity)
+}
+
+func waitForKeycloakUser(ctx *TestingContext, timeout time.Duration, namespace, userName string) (*keycloakv1.KeycloakUser, error) {
+	began := time.Now()
+
+	for {
+		// If it timed out, return an error
+		if time.Now().After(began.Add(timeout)) {
+			return nil, fmt.Errorf("Timeout after %v", timeout)
+		}
+
+		// Get the list of users in the RHSSO namespace
+		list := &keycloakv1.KeycloakUserList{}
+		err := ctx.Client.List(goctx.TODO(), list, k8sclient.InNamespace(namespace))
+
+		// If an error occurred, return the error
+		if err != nil {
+			return nil, err
+		}
+
+		// Look for the matching user in the user list and send it if it's
+		// found
+		for _, keycloakUser := range list.Items {
+			if keycloakUser.Spec.User.UserName == userName {
+				return &keycloakUser, nil
+			}
+		}
+	}
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -26,5 +26,6 @@ var (
 		{"Verify Alerts are not firing apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
 		{"Verify Codeready CRUDL permissions", TestCodereadyCrudlPermisssions},
 		{"A09 - Verify Subscription Install Plan Strategy", TestSubscriptionInstallPlanType},
+		{"Verify users with no email get default email", TestDefaultUserEmail},
 	}
 )


### PR DESCRIPTION
# Description
Add test to ensure that users from the IDP have an email address
in the KeycloakUser CR that's generated by the operator.

If the user from the IDP has no email address, a dummy one will be
generated as <user name>@rhmi.io. Otherwise, the user email address
will remain:

Create two Openshift users, one with email address and one without it,
and test that the KeycloakUser CRs have the expected email addresses.

> With testing IDP related code borrowed from [INTLY-5437 PR](https://github.com/integr8ly/integreatly-operator/pull/510/)

## Steps to verify

1. Run the `TestDefaultUserEmail` test on a cluster with the operator running
2. While the test is still running:
    1. Check that 2 new users are created (`oc get users`)
    2. Check that 2 new identities are created (`oc get identities`) and assert that `testing-idp:autotest-user02` has en associated email (`oc describe identity/testing-idp:autotest-user02`)
      2. Check that 2 matching KeycloakUser CRs are reconciled (`oc get keycloakusers.keycloak.org -n redhat-rhmi-rhsso`)
  3. Assert that the test finishes successfully and the users and their identities are deleted

