### PR TITLE
INTLY-6371-updated-cronjob_exists-alert-trigger-and-severity

### DIFF
--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -289,8 +289,8 @@ func reconcileCronjobAlerts(ctx context.Context, serverClient k8sclient.Client, 
 				"message": "CronJob {{ $labels.namespace }}/{{ $labels.cronjob }} does not exist",
 			},
 			Expr:   intstr.FromString("absent(kube_cronjob_info{cronjob=\"" + component.Name + "\", namespace=\"" + config.Namespace + "\"})"),
-			For:    "60s",
-			Labels: map[string]string{"severity": "critical"},
+			For:    "5m",
+			Labels: map[string]string{"severity": "warning"},
 		})
 	}
 


### PR DESCRIPTION
# Description
The `cronjob_exists` alert in 1.x was firing due to slow response times from the kube apiserver, which in turn caused problems with the data being gathered by kube-state-metrics.
This in turn caused the alert expression to evaluate to a truthy value, and trigger.

The duration of the trigger for the alert was increased from 1 to 5 minutes to account for this, and the severity of the alert was reduced from `critical` to `warning`
JIRA: https://issues.redhat.com/browse/INTLY-6371

## Verification
- Clone this repo
- Run the operator and wait for install
- Wait for reconcile to update alert trigger and severity
- Verify that alert has updated triggers and severity

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer