### PR TITLE
[WIP] Refactor common.TestCase type for better encapsulation

### DIFF
--- a/test/common/pdbs_exist.go
+++ b/test/common/pdbs_exist.go
@@ -6,8 +6,12 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var (
-	namespaces = []Namespace{
+type podDisruptionBudgetTestExecutor struct {
+	namespaces []Namespace
+}
+
+var PodDisruptionBudgetTest = podDisruptionBudgetTestExecutor{
+	namespaces: []Namespace{
 		{
 			Name: "redhat-rhmi-rhsso",
 			PodDisruptionBudgetNames: []string{
@@ -34,11 +38,11 @@ var (
 		// 		"zync-que",
 		// 	},
 		// },
-	}
-)
+	},
+}
 
-func TestIntegreatlyPodDisruptionBudgetsExist(t *testing.T, ctx *TestingContext) {
-	for _, namespace := range namespaces {
+func (e *podDisruptionBudgetTestExecutor) RunTest(t *testing.T, ctx *TestingContext) {
+	for _, namespace := range e.namespaces {
 		for _, podDisruptionBudgetName := range namespace.PodDisruptionBudgetNames {
 			_, err := ctx.KubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace.Name).Get(podDisruptionBudgetName, v1.GetOptions{})
 			if err != nil {

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -1,21 +1,9 @@
 package common
 
 var (
-	ALL_TESTS = []TestCase{
-		// Add all the tests that should be executed in both e2e and osd suites here.
-		// It is an array so the tests will be executed in the same order as they defined here.
-		{"Verify CRD Exists", TestIntegreatlyCRDExists},
-	}
+	ALL_TESTS = []TestCase{}
 
 	AFTER_INSTALL_TESTS = []TestCase{
-		{"Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},
-		{"Verify Deployment Config resources have the expected replicas", TestDeploymentConfigExpectedReplicas},
-		{"Verify Stateful Set resources have the expected repliaces", TestStatefulSetsExpectedReplicas},
-		{"Verify alerts exist", TestIntegreatlyAlertsExist},
-		{"Verify dashboards exist", TestIntegreatlyDashboardsExist},
-		{"Verify CRO Postgres CRs Successful", TestCROPostgresSuccessfulState},
-		{"Verify CRO Redis CRs Successful", TestCRORedisSuccessfulState},
-		{"Verify CRO BlobStorage CRs Successful", TestCROBlobStorageSuccessfulState},
-		{"Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
+		{"Verify PodDisruptionBudgets exist", &PodDisruptionBudgetTest},
 	}
 )

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -26,7 +26,11 @@ type TestingContext struct {
 
 type TestCase struct {
 	Description string
-	Test        func(t *testing.T, ctx *TestingContext)
+	Executor    TestExecutor
+}
+
+type TestExecutor interface {
+	RunTest(t *testing.T, ctx *TestingContext)
 }
 
 type prometheusAPIResponse struct {

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -87,7 +87,7 @@ func TestIntegreatly(t *testing.T) {
 	t.Run("integreatly", func(t *testing.T) {
 		for _, test := range common.ALL_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
-				test.Test(t, testingContext)
+				test.Executor.RunTest(t, testingContext)
 			})
 		}
 
@@ -97,7 +97,7 @@ func TestIntegreatly(t *testing.T) {
 
 		for _, test := range common.AFTER_INSTALL_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
-				test.Test(t, testingContext)
+				test.Executor.RunTest(t, testingContext)
 			})
 		}
 	})

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -30,12 +30,12 @@ func TestIntegreatly(t *testing.T) {
 	t.Run("Integreatly Happy Path Tests", func(t *testing.T) {
 		for _, test := range common.ALL_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
-				test.Test(t, testingContext)
+				test.Executor.RunTest(t, testingContext)
 			})
 		}
 		for _, test := range common.AFTER_INSTALL_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
-				test.Test(t, testingContext)
+				test.Executor.RunTest(t, testingContext)
 			})
 		}
 	})


### PR DESCRIPTION
Simple demostration on refactoring the `TestCase` struct with
an interface instead of a function field to improve encapsulation
of the different tests within the `common` package.

Refactor `pdbs_exist.go` as an example of implementing the `TestExecutor` interface.

**⚠️ Only one test is included and all the other tests were removed for the sake of simplicity ⚠️**

## Further improvements
* A `Cleanup` function in the `TestExecutor` interface to clean up any possible temporal resources that might have been created just for the test