### PR TITLE
Remove pod count as it isn't needed to check pods are ready

### DIFF
--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -214,12 +214,7 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, client k8sclient.C
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to check amq streams installation: %w", err)
 	}
 
-	//expecting 8 pods in total
-	if len(pods.Items) < 8 {
-		return integreatlyv1alpha1.PhaseInProgress, nil
-	}
-
-	//and they should all be ready
+	//checking pods are all ready
 checkPodStatus:
 	for _, pod := range pods.Items {
 		for _, cnd := range pod.Status.Conditions {

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -214,6 +214,11 @@ func (r *Reconciler) handleProgressPhase(ctx context.Context, client k8sclient.C
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to check amq streams installation: %w", err)
 	}
 
+	//expecting 8 pods in total
+	if len(pods.Items) == 8 {
+		return integreatlyv1alpha1.PhaseInProgress, nil
+	}
+
 	//checking pods are all ready
 checkPodStatus:
 	for _, pod := range pods.Items {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

removed the pod count as it didn't match the number of pods actually deployed.
It is not needed since the checkPodStatus ensures pods are ready.
To verify, change install type to workshop and install as normal. Solution explorer should deploy along with AMQ Streams. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer