### PR TITLE
🚨 Fix alerts that only group by container

### DIFF
--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -3,10 +3,10 @@ kind: PrometheusRule
 metadata:
   name: ksm-3scale-alerts
   namespace: {{ index .Params "Namespace" }}
-spec:   
-  groups: 
+spec:
+  groups:
     - name: 3scale.rules
-      rules: 
+      rules:
       - alert: ThreeScaleApicastStagingPod
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
@@ -112,23 +112,23 @@ spec:
         for: 5m
         labels:
           severity: critical
-      - alert: ThreeScalePodHighMemory
+      - alert: ThreeScaleContainerHighMemory
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
+          message: The {{ "{{" }} $labels.container {{ "}}" }} Container in the {{ "{{" }} $labels.pod {{ "}}" }} Pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
           scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
         expr: |
-          sum by(container) (container_memory_usage_bytes{container!="",namespace="{{ index .Params "Namespace" }}"}) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
+          sum by(container, pod) (container_memory_usage_bytes{container!="",namespace="{{ index .Params "Namespace" }}"}) / sum by(container, pod) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
         for: 15m
         labels:
           severity: warning
-      - alert: ThreeScalePodHighCPU
+      - alert: ThreeScaleContainerHighCPU
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-          message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available CPU for longer than 15 minutes.
+          message: The {{ "{{" }} $labels.container {{ "}}" }} Container in the {{ "{{" }} $labels.pod {{ "}}" }} Pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available CPU for longer than 15 minutes.
           scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/3scale-scaling.md
         expr: |
-          sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="{{ index .Params "Namespace" }}"}) by (container) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ index .Params "Namespace" }}"}) by (container) * 100 > 90
+          sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace="{{ index .Params "Namespace" }}"}) by (container, pod) / sum(kube_pod_container_resource_limits_cpu_cores{namespace="{{ index .Params "Namespace" }}"}) by (container, pod) * 100 > 90
         for: 15m
         labels:
           severity: warning

--- a/templates/monitoring/kube_state_metrics_amqonline_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_amqonline_alerts.yaml
@@ -16,13 +16,13 @@ spec:
           for: 5m
           labels:
             severity: critical
-        - alert: AMQOnlinePodHighMemory
+        - alert: AMQOnlineContainerHighMemory
           annotations:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: The {{ "{{" }} $labels.container {{ "}}" }} pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
+            message: The {{ "{{" }} $labels.container {{ "}}" }} Container in the {{ "{{" }} $labels.pod {{ "}}" }} Pod has been using {{ "{{" }} printf "%.0f" $value {{ "}}" }}% of available memory for longer than 15 minutes.
             scaling_plan: https://github.com/integr8ly/middleware-load-testing/blob/master/sops/amq-scaling.md
           expr: |
-            sum by(container) (container_memory_usage_bytes{container!="",namespace="{{ index .Params "Namespace" }}"}) / sum by(container) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
+            sum by(container, pod) (container_memory_usage_bytes{container!="",namespace="{{ index .Params "Namespace" }}"}) / sum by(container, pod) (kube_pod_container_resource_limits_memory_bytes{namespace="{{ index .Params "Namespace" }}"}) * 100 > 90
           for: 15m
           labels:
             severity: warning

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -110,7 +110,7 @@ var expectedRules = []alertsTestRule{
 		File: "redhat-rhmi-amq-online-ksm-amqonline-alerts.yaml",
 		Rules: []string{
 			"AMQOnlinePodCount",
-			"AMQOnlinePodHighMemory",
+			"AMQOnlineContainerHighMemory",
 		},
 	},
 	{
@@ -150,8 +150,8 @@ var expectedRules = []alertsTestRule{
 			"ThreeScaleAdminUIBBT",
 			"ThreeScaleDeveloperUIBBT",
 			"ThreeScaleSystemAdminUIBBT",
-			"ThreeScalePodHighMemory",
-			"ThreeScalePodHighCPU",
+			"ThreeScaleContainerHighMemory",
+			"ThreeScaleContainerHighCPU",
 			"ThreeScaleZyncPodAvailability",
 			"ThreeScaleZyncDatabasePodAvailability",
 		},


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->


JIRA: https://issues.redhat.com/browse/INTLY-6496

More than one Pod in the namespace could have a shared container name,
leading to incorrect alerts.

For example, if a container was exceeding 90% of its memory limit and
we wanted to alert on that; we wouldn't get alerted if it was summing
the usage and limits of more than one container (unless the sums also
happened to exceed 90% of the total limits for all of those containers
combined).

This change also renames the relevant alerts to make it clearer that
they're per Container rather than per Pod, and adds more context to
the descriptions.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer

## Verification Steps

Since these alerts pick up on _all_ pod/containers in their respective namespaces, the following commands will cause all 3 to trigger:

```
oc run intly-6496-trigger-amq-memory -n redhat-rhmi-amq-online --image='polinux/stress' --limits='memory=100Mi' --restart='Never' --command -- "stress" "--vm" "1" "--vm-bytes" "90M" "--vm-hang" "1200"

oc run intly-6496-trigger-3scale-memory -n redhat-rhmi-3scale --image='polinux/stress' --limits='memory=100Mi' --restart='Never' --command -- "stress" "--vm" "1" "--vm-bytes" "90M" "--vm-hang" "1200"

oc run intly-6496-trigger-3scale-cpu -n redhat-rhmi-3scale --image='polinux/stress' --limits='cpu=1050m' --restart='Never' --command -- "stress" "--cpu" "1" "--vm-hang" "1200"
```

## Verification Cleanup

```
oc delete po intly-6496-trigger-amq-memory -n redhat-rhmi-amq-online
oc delete po intly-6496-trigger-3scale-memory -n redhat-rhmi-3scale
oc delete po intly-6496-trigger-3scale-cpu -n redhat-rhmi-3scale
```