### PR TITLE
Upgrading AMQ Online to 1.4

### DIFF
--- a/manifests/integreatly-amq-online/amq-online-1.4.0/addresses.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/addresses.crd.yaml
@@ -1,0 +1,181 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addresses.enmasse.io
+  labels:
+    app: enmasse
+    enmasse-component: tenant-api
+spec:
+  group: enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: Address
+    listKind: AddressList
+    singular: address
+    plural: addresses
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+  - name: Address
+    type: string
+    description: The address
+    priority: 0
+    JSONPath: .spec.address
+  - name: Type
+    type: string
+    description: The address type
+    priority: 1
+    JSONPath: .spec.type
+  - name: Plan
+    type: string
+    priority: 1
+    description: The address plan
+    JSONPath: .spec.plan
+  - name: Ready
+    type: boolean
+    priority: 0
+    description: The readiness of the address
+    JSONPath: .status.isReady
+  - name: Phase
+    type: string
+    priority: 0
+    description: The phase of the address
+    JSONPath: .status.phase
+  - name: Status
+    type: string
+    priority: 1
+    description: The status of the address
+    JSONPath: .status.messages
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: Address describes a destination for sending and receiving messages. An Address has a type, which defines the semantics of sending messages to and receiving messages from that address. This resource is created by messaging tenants.
+      properties:
+        spec:
+          type: object
+          required:
+            - address
+            - type
+            - plan
+          properties:
+            address:
+              type: string
+              description: "Messaging address."
+              pattern: "^[^\\s]+$"
+            type:
+              type: string
+              description: "Address type for this address."
+              enum:
+                - anycast
+                - multicast
+                - queue
+                - topic
+                - subscription
+            plan:
+              type: string
+              description: "Plan referenced by this address."
+            topic:
+              type: string
+              description: "Address of topic that this subscription refers to (only applicable to subscription types)."
+            subscription:
+              type: object
+              description: "Properties that can be set for subscription type addresses."
+              properties:
+                maxConsumers:
+                  type: integer
+                  description: "Maximum number of concurrent consumers that can be attached to this subscription. If unspecified, 1 consumer is allowed per subscription"
+            forwarders:
+              type: array
+              description: "Address forwarders for this address."
+              items:
+                type: object
+                required:
+                  - name
+                  - remoteAddress
+                  - direction
+                properties:
+                  name:
+                    type: string
+                    description: "Forwarder name."
+                  remoteAddress:
+                    type: string
+                    description: "Remote address to forward to. Must be prefixed with connector name."
+                  direction:
+                    type: string
+                    enum:
+                      - in
+                      - out
+        status:
+          type: object
+          properties:
+            isReady:
+              description: "Whether address is ready to use or not."
+              type: boolean
+            phase:
+              type: string
+              description: "Phase of address."
+            messages:
+              type: array
+              description: "Status and error messages for address."
+              items:
+                type: string
+            brokerStatuses:
+              type: array
+              description: "The status of this address in brokers."
+              items:
+                type: object
+                properties:
+                  clusterId:
+                    type: string
+                  brokerId:
+                    type: string
+                  state:
+                    type: string
+                    enum:
+                      - Active
+                      - Migrating
+                      - Draining
+            subscription:
+              type: object
+              description: "Applied properties for subscription type addresses."
+              properties:
+                maxConsumers:
+                  type: integer
+                  description: "Maximum number of concurrent consumers that can be attached to this subscription."
+            planStatus:
+              type: object
+              required:
+                - name
+                - partitions
+                - resources
+              properties:
+                name:
+                  type: string
+                partitions:
+                  type: integer
+                resources:
+                  type: object
+            forwarders:
+              type: array
+              description: "Forwarder status for this address."
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    pattern: "[a-zA-Z0-9]+"
+                  isReady:
+                    type: boolean
+                  messages:
+                    type: array
+                    items:
+                      type: string

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/addressplans.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/addressplans.crd.yaml
@@ -1,0 +1,104 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressPlan
+    listKind: AddressPlanList
+    singular: addressplan
+    plural: addressplans
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  additionalPrinterColumns:
+  - name: Phase
+    type: string
+    priority: 0
+    description: The phase of the address plan
+    JSONPath: .status.phase
+  - name: Status
+    type: string
+    priority: 1
+    description: The status of the address plan
+    JSONPath: .status.message
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: AddressPlan describes the resource usage and common properties of an address. This resource is created by the service administrator.
+      properties:
+        status:
+          properties:
+            phase:
+              type: string
+              description: "Phase of the address plan."
+            message:
+              type: string
+              description: "Status and error messages for the address plan."
+        spec:
+          type: object
+          required:
+            - addressType
+            - resources
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressType:
+              type: string
+            partitions:
+              type: integer
+            resources:
+              type: object
+              properties:
+                router:
+                  type: number
+                broker:
+                  type: number
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressType:
+          type: string
+        requiredResources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - credit
+            properties:
+              name:
+                type: string
+              credit:
+                type: number

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaceplans.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaceplans.crd.yaml
@@ -1,0 +1,116 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressspaceplans.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta2
+  scope: Namespaced
+  names:
+    kind: AddressSpacePlan
+    listKind: AddressSpacePlanList
+    singular: addressspaceplan
+    plural: addressspaceplans
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta2
+      served: true
+      storage: true
+    - name: v1beta1
+      served: true
+      storage: false
+    - name: v1alpha1
+      served: true
+      storage: false
+  additionalPrinterColumns:
+  - name: Phase
+    type: string
+    priority: 0
+    description: The phase of the address space plan
+    JSONPath: .status.phase
+  - name: Status
+    type: string
+    priority: 1
+    description: The status of the address space plan
+    JSONPath: .status.message
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: AddressSpacePlan describes the allowed resource usage of an address space. This resource is created by the service administrator.
+      properties:
+        status:
+          properties:
+            phase:
+              type: string
+              description: "Phase of the address space plan."
+            message:
+              type: string
+              description: "Status and error messages for the address space plan."
+        spec:
+          type: object
+          required:
+            - addressSpaceType
+            - resourceLimits 
+            - addressPlans
+            - infraConfigRef
+          properties:
+            displayName:
+              type: string
+            displayOrder:
+              type: integer
+            shortDescription:
+              type: string
+            longDescription:
+              type: string
+            addressSpaceType:
+              type: string
+            infraConfigRef:
+              type: string
+            resourceLimits:
+              type: object
+              properties:
+                aggregate:
+                  type: number
+                router:
+                  type: number
+                broker:
+                  type: number
+            addressPlans:
+              type: array
+              items:
+                type: string
+        displayName:
+          type: string
+        displayOrder:
+          type: integer
+        shortDescription:
+          type: string
+        longDescription:
+          type: string
+        uuid:
+          type: string
+        addressSpaceType:
+          type: string
+        resources:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - max
+            properties:
+              name:
+                type: string
+              max:
+                type: number
+        addressPlans:
+          type: array
+          items:
+            type: string

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaces.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaces.crd.yaml
@@ -1,0 +1,442 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressspaces.enmasse.io
+  labels:
+    app: enmasse
+    enmasse-component: tenant-api
+spec:
+  group: enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: AddressSpace
+    listKind: AddressSpaceList
+    singular: addressspace
+    plural: addressspaces
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The address space type
+    priority: 1
+    JSONPath: .spec.type
+  - name: Plan
+    type: string
+    priority: 1
+    description: The address space plan
+    JSONPath: .spec.plan
+  - name: Ready
+    type: boolean
+    priority: 0
+    description: The readiness of the address space
+    JSONPath: .status.isReady
+  - name: Phase
+    type: string
+    priority: 0
+    description: The phase of the address space
+    JSONPath: .status.phase
+  - name: Status
+    type: string
+    priority: 1
+    description: The status of the address space
+    JSONPath: .status.messages
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: AddressSpace is a group of addresses that can be accessed through a single connection (per protocol). An AddressSpace can support multiple protocols, as defined by the type. This resource is created by messaging tenants.
+      properties:
+        spec:
+          type: object
+          required:
+            - type
+            - plan
+          properties:
+            type:
+              type: string
+              description: "The type of address space."
+              enum: ["standard", "brokered"]
+            plan:
+              type: string
+              description: "The name of the address space plan to apply."
+            authenticationService:
+              type: object
+              description: "The authentication service to use for authenticating messaging clients."
+              properties:
+                name:
+                  type: string
+                  description: "The name of the authentication service."
+                type:
+                  type: string
+                overrides:
+                  type: object
+                  properties:
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    realm:
+                      type: string
+            endpoints:
+              type: array
+              description: "Endpoints configured for this address space."
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                    description: "Endpoint name. Use to uniquely identify an endpoint."
+                  service:
+                    type: string
+                    description: "Service referenced by this endpoint."
+                    enum:
+                      - messaging
+                      - mqtt
+                      - console
+                  cert:
+                    type: object
+                    description: "Configure certificates to be used for this endpoint."
+                    properties:
+                      provider:
+                        type: string
+                        description: "Certificate provider to use for this endpoint."
+                        enum:
+                          - wildcard
+                          - certBundle
+                          - openshift
+                          - selfsigned
+                      secretName:
+                        type: string
+                      tlsCert:
+                        type: string
+                        description: "TLS certificate to use for 'certBundle' provider."
+                      tlsKey:
+                        type: string
+                        description: "TLS key to use for 'certBundle' provider."
+                  exports:
+                    type: array
+                    description: "Export address space information."
+                    items:
+                      type: object
+                      properties:
+                        kind:
+                          type: string
+                          description: "Type of resource to export address space information into."
+                          enum:
+                            - ConfigMap
+                            - Secret
+                            - Service
+                        name:
+                          description: "Name of resource to export address space information into."
+                          type: string
+                  expose:
+                    description: "Expose configuration of this endpoint."
+                    type: object
+                    anyOf:
+                      - required:
+                          - type
+                          - loadBalancerPorts
+                        properties:
+                          type:
+                            type: string
+                            description: "Expose this endpoint as LoadBalancer service."
+                            enum:
+                              - loadbalancer
+                          annotations:
+                            type: object
+                          loadBalancerPorts:
+                            type: array
+                            items:
+                              type: string
+                          loadBalancerSourceRanges:
+                            type: array
+                            items:
+                              type: string
+                      - required:
+                          - type
+                          - routeTlsTermination
+                        properties:
+                          type:
+                            type: string
+                            description: "Expose this endpoint as an OpenShift route."
+                            enum:
+                              - route
+                          annotations:
+                            type: object
+                            description: "Annotations to set on the created endpoint."
+                          routeHost:
+                            type: string
+                          routeServicePort:
+                            type: string
+                            description: "Service port. Valid values are 'amqps' for the messaging service, 'secure-mqtt' for the mqtt service, and 'https' for the console service."
+                            enum:
+                              - amqps
+                              - https
+                              - secure-mqtt
+                          routeTlsTermination:
+                            type: string
+                            enum:
+                              - passthrough
+                              - reencrypt
+            networkPolicy:
+              type: object
+              description: "Define NetworkPolicy for this address space."
+              properties:
+                ingress:
+                  type: array
+                  items:
+                    type: object
+                egress:
+                  type: array
+                  items:
+                    type: object
+            connectors:
+              type: array
+              description: "External AMQP connections."
+              items:
+                type: object
+                required:
+                  - name
+                  - endpointHosts
+                properties:
+                  name:
+                    type: string
+                    description: "Connector name. Used to uniquely identify a connector."
+                    pattern: "[a-zA-Z0-9]+"
+                  endpointHosts:
+                    type: array
+                    description: "Endpoints to connect to. First entry is used as primary, additional entries are considered failovers."
+                    minItems: 1
+                    items:
+                      type: object
+                      required:
+                        - host
+                      properties:
+                        host:
+                          type: string
+                        port:
+                          type: integer
+                  tls:
+                    type: object
+                    description: "TLS configuration for the connector. If not specified, TLS will not be used."
+                    properties:
+                      caCert:
+                        description: "CA certificate to be used by the connector."
+                        anyOf:
+                          - type: string
+                            properties:
+                              value:
+                                type: string
+                                description: "Value of field"
+                          - type: object
+                            properties:
+                              valueFromSecret:
+                                type: object
+                                description: "Secret containing value."
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                    description: "Name of Secret containing value."
+                                  key:
+                                    type: string
+                                    description: "Key to use for looking up entry."
+                      clientCert:
+                        description: "Client certificate to be used by the connector."
+                        anyOf:
+                          - type: string
+                            properties:
+                              value:
+                                type: string
+                                description: "Value of field"
+                          - type: object
+                            properties:
+                              valueFromSecret:
+                                type: object
+                                description: "Secret containing value."
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                    description: "Name of Secret containing value."
+                                  key:
+                                    type: string
+                                    description: "Key to use for looking up entry."
+                      clientKey:
+                        description: "Client key to be used by the connector."
+                        anyOf:
+                          - type: string
+                            properties:
+                              value:
+                                type: string
+                                description: "Value of field"
+                          - type: object
+                            properties:
+                              valueFromSecret:
+                                type: object
+                                description: "Secret containing value."
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                    description: "Name of Secret containing value."
+                                  key:
+                                    type: string
+                                    description: "Key to use for looking up entry."
+                  credentials:
+                    type: object
+                    description: "Credentials used when connecting to endpoints. Either 'username' and 'password', or 'secret' must be defined."
+                    properties:
+                      username:
+                        description: "Username to use for connector."
+                        anyOf:
+                          - type: object
+                            properties:
+                              value:
+                                type: string
+                                description: "Value of field"
+                          - type: object
+                            properties:
+                              valueFromSecret:
+                                type: object
+                                description: "Secret containing value."
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                    description: "Name of Secret containing value."
+                                  key:
+                                    type: string
+                                    description: "Key to use for looking up entry."
+                      password:
+                        description: "Password to use for connector."
+                        anyOf:
+                          - type: string
+                            properties:
+                              value:
+                                type: string
+                                description: "Value of field"
+                          - type: object
+                            properties:
+                              valueFromSecret:
+                                type: object
+                                description: "Secret containing value."
+                                required:
+                                  - name
+                                properties:
+                                  name:
+                                    type: string
+                                    description: "Name of Secret containing value."
+                                  key:
+                                    type: string
+                                    description: "Key to use for looking up entry."
+                  addresses:
+                    type: array
+                    description: "Addresses to make be accessible via this address space."
+                    items:
+                      type: object
+                      required:
+                        - name
+                        - pattern
+                      properties:
+                        name:
+                          type: string
+                          description: "Identifier of address pattern. Used to uniquely identify a pattern."
+                        pattern:
+                          type: string
+                          description: "Pattern used to match addresses. The pattern will be prefixed by the connector name and a forward slash ('myconnector/'). A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence."
+                          pattern: "([^/#*]+|\\*|#)(/([^/#*]+|\\*|#))*"
+        status:
+          type: object
+          properties:
+            isReady:
+              description: "Whether address space is ready to use or not."
+              type: boolean
+            phase:
+              type: string
+              description: "Phase of address space."
+            messages:
+              type: array
+              description: "Status and error messages for address space."
+              items:
+                type: string
+            caCert:
+              description: "CA certificate for endpoints."
+              type: string
+            routers:
+              type: array
+              description: "Router status for this address space."
+              items:
+                type: object
+                required:
+                  - id
+                properties:
+                  id:
+                    type: string
+                  undelivered:
+                    type: integer
+                  neighbors:
+                    type: array
+                    items:
+                      type: string
+            connectors:
+              type: array
+              description: "Connector status for this address space."
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  isReady:
+                    type: boolean
+                  messages:
+                    type: array
+                    items:
+                      type: string
+            endpointStatuses:
+              type: array
+              description: "Endpoint status for this address space."
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  externalHost:
+                    type: string
+                  externalPorts:
+                    type: array
+                    items:
+                      type: object
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                  serviceHost:
+                    type: string
+                  servicePorts:
+                    type: array
+                    items:
+                      type: object
+                      name:
+                        type: string
+                      port:
+                        type: integer
+                  messages:
+                    type: array
+                    items:
+                      type: string
+
+

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaceschemas.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/addressspaceschemas.crd.yaml
@@ -1,0 +1,25 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: addressspaceschemas.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: enmasse.io
+  version: v1beta1
+  scope: Cluster
+  names:
+    kind: AddressSpaceSchema
+    listKind: AddressSpaceSchemaList
+    singular: addressspaceschema
+    plural: addressspaceschemas
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: AddressSpaceSchema describes the available plans and authentication services for an address space type.

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/amq-online.1.4.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/amq-online.1.4.0.clusterserviceversion.yaml
@@ -227,6 +227,7 @@ metadata:
         }
       ]
 spec:
+  replaces: amqonline.1.3.1
   maturity: stable
   displayName: Red Hat Integration - AMQ Online
   description: "**Red Hat Integration - AMQ Online** provides messaging as a managed

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/amq-online.1.4.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/amq-online.1.4.0.clusterserviceversion.yaml
@@ -1,0 +1,1070 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: amq-online.1.4.0
+  namespace: placeholder
+  labels:
+    app: enmasse
+  annotations:
+    categories: "Streaming & Messaging"
+    certified: "false"
+    description: Red Hat Integration - AMQ Online provides messaging as a managed
+      service on OpenShift
+    containerImage: registry.redhat.io/amq7/amq-online-1-controller-manager-rhel7-operator:1.4
+    createdAt: 2019-02-19T00:00:00Z
+    capabilities: Seamless Upgrades
+    repository: ""
+    support: Red Hat, Inc
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "StandardInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "1Gi",
+                "storage": "5Gi"
+              },
+              "addressFullPolicy": "FAIL"
+            },
+            "router": {
+              "linkCapacity": 50,
+              "resources": {
+                "memory": "512Mi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "BrokeredInfraConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "broker": {
+              "resources": {
+                "memory": "4Gi"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressPlan",
+          "metadata": {
+            "name": "standard-small-queue"
+          },
+          "spec": {
+            "addressType": "queue",
+            "shortDescription": "Small Queue",
+            "resources": {
+              "router": 0.01,
+              "broker": 0.1
+            }
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta2",
+          "kind": "AddressSpacePlan",
+          "metadata": {
+            "name": "standard-small"
+          },
+          "spec": {
+            "addressSpaceType": "standard",
+            "infraConfigRef": "default",
+            "shortDescription": "Small Address Space Plan",
+            "resourceLimits": {
+              "router": 1.0,
+              "broker": 2.0,
+              "aggregate": 2.0
+            },
+            "addressPlans": [
+              "standard-small-queue"
+            ]
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "AuthenticationService",
+          "metadata": {
+            "name": "standard-authservice"
+          },
+          "spec": {
+            "type": "standard",
+            "standard": {
+              "storage": {
+                "claimName": "standard-authservice",
+                "deleteClaim": true,
+                "size": "1Gi",
+                "type": "persistent-claim"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpace",
+          "metadata": {
+            "name": "myspace"
+          },
+          "spec": {
+            "plan": "standard-small",
+            "type": "standard"
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "Address",
+          "metadata": {
+            "name": "myspace.myqueue"
+          },
+          "spec": {
+            "address": "myqueue",
+            "plan": "standard-small-queue",
+            "type": "queue"
+          }
+        },
+        {
+          "apiVersion": "user.enmasse.io/v1beta1",
+          "kind": "MessagingUser",
+          "metadata": {
+            "name": "myspace.user"
+          },
+          "spec": {
+            "authentication": {
+              "password": "ZW5tYXNzZQ==",
+              "type": "password"
+            },
+            "authorization": [
+              {
+                "addresses": [
+                  "myqueue"
+                ],
+                "operations": [
+                  "send",
+                  "recv"
+                ]
+              }
+            ],
+            "username": "user"
+          }
+        },
+        {
+          "apiVersion": "admin.enmasse.io/v1beta1",
+          "kind": "ConsoleService",
+          "metadata": {
+            "name": "console"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "iot.enmasse.io/v1alpha1",
+          "kind": "IoTConfig",
+          "metadata": {
+            "name": "default"
+          },
+          "spec": {
+            "adapters": {
+              "mqtt": {
+                "endpoint": {
+                  "secretNameStrategy": {
+                    "secretName": "iot-mqtt-adapter-tls"
+                  }
+                }
+              }
+            },
+            "services": {
+              "deviceRegistry": {
+                "file": {
+                  "numberOfDevicesPerTenant": 1000
+                }
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "enmasse.io/v1beta1",
+          "kind": "AddressSpaceSchema",
+          "metadata": {
+            "name": "undefined"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "iot.enmasse.io/v1alpha1",
+          "kind": "IoTProject",
+          "metadata": {
+            "name": "iot"
+          },
+          "spec": {
+            "downstreamStrategy": {
+              "managedStrategy": {
+                "addressSpace": {
+                  "name": "iot",
+                  "plan": "standard-unlimited"
+                },
+                "addresses": {
+                  "command": {
+                    "plan": "standard-small-anycast"
+                  },
+                  "event": {
+                    "plan": "standard-small-queue"
+                  },
+                  "telemetry": {
+                    "plan": "standard-small-anycast"
+                  }
+                }
+              }
+            }
+          }
+        }
+      ]
+spec:
+  maturity: stable
+  displayName: Red Hat Integration - AMQ Online
+  description: "**Red Hat Integration - AMQ Online** provides messaging as a managed
+    service on OpenShift.\nWith Red Hat Integration - AMQ Online, administrators can
+    configure a cloud-native,\nmulti-tenant messaging service either in the cloud
+    or on premise.\nDevelopers can provision messaging using the Red Hat Integration
+    - AMQ Online Console.\nMultiple development teams can provision the brokers and
+    queues from the\nconsole, without requiring each team to install, configure, deploy,\nmaintain,
+    or patch any software. \n\n**The core capabilities include:**\n\n  * **Built-in
+    authentication and authorization** - Use the built-in authentication service or\n
+    \   plug in your own authentication service for authentication and\n    authorization
+    of messaging clients.\n\n  * **Self-service messaging for applications** - The
+    service administrator deploys\n    and manages the messaging infrastructure, while
+    applications can request\n    messaging resources regardless of the messaging
+    infrastructure.\n\n  * **Support for a wide variety of messaging patterns** -
+    Choose between\n    JMS-style messaging with strict guarantees, or messaging that
+    supports\n    a larger number of connections and higher throughput.\n\n## Post-installation
+    tasks\n\nTo fully use Red Hat Integration - AMQ Online, you need to create a few\ninfrastructure
+    components after the installation, including:\n\n  * An authentication service\n
+    \ * Infrastructure configuration for the standard and brokered address space\n
+    \ * Address and address space plans\n  * (Optional) Create RBAC roles to allow
+    users to discover available plans\n  * (Optional) Create RBAC roles to allow users
+    to self-manage addresses and\n    address spaces.\n\nFor a complete overview of
+    how to configure Red Hat Integration - AMQ Online, see\n[Configuring Red Hat Integration
+    - AMQ Online](https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/installing_and_managing_amq_online_on_openshift/configuring-messaging).\n\n###
+    Quickstart infrastructure configuration\n\nIf you simply want to get started quickly,
+    you can import the following\nYAML by saving the content to a file and apply it
+    by running the \n`oc apply -f <file>` command. You can also split the content
+    (at the `---` marker)\nand import the single YAML document using the Web UI: \n\n~~~yaml\n---\napiVersion:
+    admin.enmasse.io/v1beta1\nkind: StandardInfraConfig\nmetadata:\n  name: default\n---\napiVersion:
+    admin.enmasse.io/v1beta2\nkind: AddressPlan\nmetadata:\n  name: standard-small-queue\nspec:\n
+    \ addressType: queue\n  resources:\n    router: 0.01\n    broker: 0.1\n---\napiVersion:
+    admin.enmasse.io/v1beta2\nkind: AddressSpacePlan\nmetadata:\n  name: standard-small\nspec:\n
+    \ addressSpaceType: standard\n  infraConfigRef: default\n  addressPlans:\n  -
+    standard-small-queue\n  resourceLimits:\n    router: 2.0\n    broker: 3.0\n    aggregate:
+    4.0\n---\napiVersion: admin.enmasse.io/v1beta1\nkind: AuthenticationService\nmetadata:\n
+    \ name: standard-authservice\nspec:\n  type: standard\n  standard:\n    storage:\n
+    \     claimName: standard-authservice\n      deleteClaim: true\n      size: 1Gi\n
+    \     type: persistent-claim\n~~~\n\n### Create RBAC roles to allow users to discover
+    available plans\n\nFor users to discover the available plans, cluster-wide roles
+    to read the available\nschema can be created.  Import the following YAML by saving
+    the content to a file and apply it by running the \n`oc apply -f <file>` command.
+    You can also split the content (at the `---` marker)\nand import the single YAML
+    document using the Web UI: \n\n~~~yaml\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
+    ClusterRole\nmetadata:\n  name: enmasse.io:schema\n  labels:\n    app: enmasse\nrules:\n
+    \ - apiGroups: [ \"enmasse.io\" ]\n    resources: [ \"addressspaceschemas\" ]\n
+    \   verbs: [ \"get\", \"list\", \"watch\" ]\n---\napiVersion: rbac.authorization.k8s.io/v1\nkind:
+    ClusterRoleBinding\nmetadata:\n  name: \"enmasse.io:schema\"\n  labels:\n    app:
+    enmasse\nroleRef:\n  apiGroup: rbac.authorization.k8s.io\n  kind: ClusterRole\n
+    \ name: enmasse.io:schema\nsubjects:\n- kind: Group\n  name: system:authenticated\n~~~\n\n###
+    Creating infrastructure using the Web UI\n\nYou must create a new instance of
+    each of the following custom resources. You can\nuse the example data directly,
+    which is provided when using the\nWeb UI:\n\n  * *Authentication Service* – Create
+    an authentication service.\n  * *Brokered Infra Config* – Create the broker infrastructure
+    configuration.\n  * *Standard Infra Config* – Create the standard infrastructure\n
+    \   configuration.\n\nYou must also create at least one address space plan and
+    one address plan.\n\n*Note*: The name of the address space plan and address plan
+    is required\nlater when creating new addresses. Some examples use specific plan\nnames,
+    which might not be available in your environment. You can\ncreate those plans,
+    or edit the examples to use different plan names.\n\n## Configuration for messaging
+    tenants\n\nWhile service administrators perform the infrastructure configuration,
+    the following\nresources are for the actual users of the system, the messaging
+    tenants.\n\nYou need to create those resources to satisfy your particular use
+    case.\n\n  * *Address space* – A container for addresses\n  * *Address* – A messaging
+    address (address, topic, queue, and so on)\n  * *Messaging user* – Manages access
+    to an address\n\n## Enabling the IoT messaging layer (tech-preview)\n\nRed Hat
+    Integration - AMQ Online contains an IoT messaging layer, which is not enabled\nby
+    default. You may enable it by creating an `IoTConfig` resource, in the\nnamespace
+    of the Red Hat Integration - AMQ Online installation. The name of the resource\nmust
+    be `default`.\n\nYou can then create resources of the type `IoTProject`, which
+    allow you to\nregister and connect devices via HTTP, MQTT, Sigfox and LoRaWAN.\n\n*Note:*
+    The default `IoTConfig` example uses the \"file based\" device registry.\nIt allows
+    you to quicky evaluate the IoT layer. However you must not use this\nin any productive
+    environment.\n\n*Note:* The default `IoTConfig` examples configures the MQTT adapter
+    with an\nexplicit TLS key/certificate stored in the secret `iot-mqtt-adapter-tls`.
+    You\nmust provide this secret, under the configured name, in order for the\nMQTT
+    protocol adapter to pick it up.\n\n*Note*: The `IoTProject` examples assume that
+    you have deployed the example\nplans. If you did not deploy the example plans,
+    or changed their names, you\nmust adapt the names in the IoT examples as well.\n\nFor
+    more information on the IoT layer, see: [Getting Started with Internet of Things
+    (IoT) on Red Hat Integration - AMQ Online](https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/installing_and_managing_amq_online_on_openshift/index)\n"
+  version: 1.4.0
+  keywords: ["amq", "messaging", "amqp", "iot", "mqtt"]
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAIj5JREFUeNrsnX1wVOW9x5/dBBIgLxvAKFFkGape0Zo4tFNfppLcueKlRQlzi0A7HRKsdG5va5Iy3r96b7Ktf9w71Ztgp+OI1Sx3Wt/wDol2ZLRqFjuibaEktmClRQJULOElGxKSAHm553dyTrpJNpvz9pzzPOd8vzPbDUKzZ3fP5/v8fr/neX5PiEHS6qPrWUR5KtP+WK49L1EeUe3n1L+3qnblkdR+7lQex7WfE/rf33xi/O8hyRTCRyAF6GUa1PRcqoFdLthlJjSj6NBMo1MxhnZ8ezAAyDzs5RroZQ6M4J6qcMOW9qJvfqd94MC+jv7f/jpx3VO7YAowACgF+HIN+JUCjur24P9aFVv0RPOE/3bpsML/rNmJ4XNde/s/2Ju4qq4hgbsABhDEEX6t34CfCf50uvLXTjYy0J8Y+vR4a/LlZkQIMABfQl+pjfCV7O8FOhZ0+NPpcudfOofPn2np2RXfu+i/drTg7oEByAz9Wg36SFDetx34p0QHJz5JhnLntPS99Vpr0Te+DTOAAUgR3tcEDXoe8Kczg0t/PtwyOjiwvWDNg0gTYADCQE+gV2ngR4P6OfCEf7IG2n/TmRVZsP2TlTfEsQYBBuAV+OXK02YN/kDLTfhTNXIhyUYGB+LJ53fsxGwCDMAt8An4+iCP9iLAP1lUPLx06GBMSQ/i+FZgADzC/FotzI/gExEL/lQN93QnL33Usf3EhoompAcwALvgRzXoqwC++PBPNoLR/ovx5EvPblfSg058YzAAs+DXI7+XE/7JdYLLx4/G+97+ZQxGAAMwGurX49OQH/7JRhAuiMT+tCSE1AAGgBw/SPCjRgADyAR/FUNVPxDwTzCC5PnO/vfeDvysQSjA4NOqvUbm4w05gN+AEZw7k+j/IFEX1NWFoQCCH9FG/FqgHWz4dfV3/Y31dp1u6v5qWSxoaUEoYPDTGv1m5PmAX9fg4CDr7e1Vfx69kEwOf3q8umTlvS0wAH+BH9XAR7gP+NPCPyEt+OTjxOW3Xq1e8oMfd8IA5Idfn9bDqM8ZfiWXVqfbBg93TPjvWQWFLGd5GctVHuGCiNDwpyh5Zd/bsWsrNzXBAOTN9Xdj1OcHP7X36n2zlfW90aJAb6yGNuu6KJt7RznLv28ty1tVKSr84xrpPpcIFy1YV1xcnIQBINcH/Ip6Xomz7me3G4Z+OmUp0UDRQ7Vs/pYa1yIDM/Dr8nNtIOQz8FHh5wh/35st7HSsTu3j56TcMgIr8E+IBk6f8t1MQchH8Jdpo34ZcHYWfsrrP9tWrYT7fAdASg/oOihFEA3+FLVTgfC6r3+rHQaAkN/38FNh79OH17HhC+4NegvrGtjC2noR4ddFH0Z1cXGx9ClB2Afw02q+3YDfefgp1z+xocJV+ElnGxvUiENQ+Jl2r+3+2x/aG2W/B7Ilz/dR5ecIv1MQWhG9PsnOWgRO8I/ryu/erdVSz3Wy1gXCksJPH3ob4Pcn/E5cB2/4L/3yRdbX8AjT7sE27Z6UTlkSwk8f+B6G3Xtc4Ke5/VPf3cRGLw0Kcb3qUWKhkKnCoIvw67pGeWz8biH7zU971BOUpVFIMvir2FixD+IAP1X7Kee3O7/PQ9e/1GbIBDyAf7KqlXQgjhTAefgbAD8/+Ennn9suJPwkI6mAAPCTmrV7FSmAg/DTnYvFPRzhp8U9NN0nqig6yZQKCAK/rnIlHYgq6UArIgBn4K8CxvzgJ51tjAn/XrqfbRozArHh11Wl3bswAMAvNvw0+uvTbiKL1iNMvk5B4ZfGBMKCgh9RHgcBP3/4ST2v7JTmfZ1/drss8KeawEFt3QoMwAj8bGyOH2v6XYBfNYBdcWneG0UrNDUoCfy6ynpHWNu7JeKZgIgRAOB3EX6Cyendfbx15tWXZIKfKfCzwZGxxWuimYBQBqDlS4DfJfhJtNlHNl367a9lg388EmBjy9dhANPAj5zfRfhVA3h/r3Tv9cqB92SEX1e5EgU0wwAAv+fwk9ze6eeUho78UUb4dVWJYgJhAeBvAPzewC9rCkAa7b0gK/ypJtAYaANIOZYL8gB+mTXy2QmZ4ddVq5hAVSANQNvVh7X9gN+aAZw6KTv8upoVE6gMlAFoe6d3A2PA75UEgT/VBMoCYQDaQh/07wP8tpR1461+gZ9d/WBV5M5D53aPjo5GfG8A2siPuX5B4KdOvDIqlF/oF/jZjY3NLDsyPzpw9OM2XxuA1sCzHCiLM/LLagDZN97iG/h1zVl2U1lvx/5mXxqA1robe/oFC/vn3imfH9PobzYCEB1+XXm3rai6+PGhKl8ZQMqhHZBgOX/u8lLpPpNZK+7yJfzjpnzj8sYzr71c5gsDQNFPXPjVEWdVpXSfy+zy1b6FX1Nk4Zr1zW5sHHIjAqCFPij6CQh/6mtJZQArV/sZfl1lX/r9qUapDQB5v/jwq6+3frM0n03O/RsN5f+Swz9mdFcvqurt2F8ppQGkhP6QwPCrOecd5dLMBuSs2RgI+MdTtNtWNB9/oiEqnQEwnNcnBfy6FtaJvyVj1oq7ZywA+gl+vR6waPN3mqUyAGX0p7C/HEjLAb/++jyO5XY0Utn2o6DBP2Z8C64qP//O67VSGIACP4Ur2OEnEfzjN2y9uIfd5m7ayrIzLP/1K/y6iipW1/NIBXhEAJjykxB+Nb9eXiakCRD487Y9Flj4eaYCjp4NqFX9scvPZfipqWffmy3sysnjaY/2otV+tOCHQvxwwczeTMdwiXJOAFX8C57ePe3oHxD4x9V/5HD1vJtuiQtnAFrV/xhGf3fgH9EOyaA++Wa6+pIJ0LTfTHP/natv9/ycQMCfVtTDbWkoFEqKZgAUO2LOnzP8BD4d4knHZNnp50fTflT5n84IvD4pGPBPr8unP4vnXFNSLYwBaGv9DwJtvvBTD/+/PrzO0T7+FBFc98zuaVMDL9IBwD+zet5PVETuqkjY/T1OFQEbgTZf+AnCY0pY7vQhHtQU9OjdS1VzSSe6XioMZhW4k9nRXH/Rq/sB/0zGfdOtjjBnOwLQGntixR9n+Gkk5ikC/PqX2tSZgHQi46Fr4NVFmEb9edt+lHGlH+CfoupQKBT3zAC0wh+F/lEgLi/8Rk1AjxjoKHGnjIDAn7NpqzrPn2mNP+CfqqGe7mR2YZGtgqBdA2hgWPTDDX6CjApxbopMYNl7x2acLqSUgWYg6BqtpCW0pVd9rFw94+YewJ9RMcUAGlw3AEz78YWfqvA8cn4jyl9Vya59xthyjoGBAZb8/Qds6MA+9bQeatc9/NmJCW27Ka8fe75LbeZJz0Y7+gD+GWVrWjDbxgvXAn4+8JMozPbq1N7eN1vUkX2mvQF0RHdfX59asMu20aUX8NtSpO/DA1QQtJQnWooAtPX+x4A5H/gJfKrMeylaJ0CpQCb4JTyi22/wp4qiANMjhtVpQOT9nOAn9byy0/P3QSY0XaEP8IunkZERS0yaNgBt9K8C6nzgVw1gV1yI99OzayfglwD+oaEhdvZ4Z9XhHz4adSMCqAHq/OCn6rpXuf9k0QYjwC8+/MlkkoXy8lnePavquRqAVvnH6M8JfvWmfbNVmPdFew30NADwiwv/6Oio+ufZi6NVXV1dEW4GwFD55wo/qf/9hFDvjyISwC8+/CrMY1OrpjbkmZ0GRPjPEX7SyIWkUO/xYtdpNgT4uYiiq/4P9k74b0b6NqSDPyVqq3m3hDXdc4oZupEMTwNizT9/+El/WhIS6n3SIh7amQf4nTN4I9u56f6i7dqTuzVngj9F1cXFxXGnUwBM/XGGP0gKIvxUVKX1HWcbG2bs5UB7QNR/2xQzCz8b7uk2zKohA1BG/3KGDT+AH/BbFgFNvRzMNnEhs6DNYEbhJ2UVFkU7X28pdzIC2Izb1h34c5eLdYqa2YM4AX96+O3s6FTN4wf/Zgh+XbOX3lDjiAFg6s/dkT9cINYki9ljuAH/RNGajq5Yne3fM/jCDnblwD7D/z57wVWVRhYGGYkAAL+LYT918BVJWQ5t8glqtZ9G/mGHZnb6Yt8zd98+sLHKCQOoAfzu5fz5q9YKNfo7kQIEFf5M+ymsiLZY05Zrw9HkvLzNtgxAa/YZBfzuibrxiHJQJzXsAPx2cn/nN3Vdeu1F49GbgWLgTBFADeD34LXXi5F1GTmJF/BPLx6rOoePHDJn4kuWbbZjAJWA34vX937SJVyy2Fb4j+W9jMumLuq2ZCqNy8mptGQA2jFfEcDvvsYO7Wjw9Bry6n8C+AU0gNRWa4bSgIJI5ETiV5VWIoC1gN87zd9S41ktgHJ/q6M/4J9o5I7/Tq2/ohnlLi9da8UAKgG/hyF4QcST66HKf179k4BfUAOg1MyCzEUAQQv/RV3eS7vC3Lwu/UguK4t/AH+a74/Dmg6LkVnkyFOPV5qJAFYC/mBd30zn8QF+K9/dZse/IzpHwYry7rlvrRkDqAT8wblOwM8vBZiptboZzZnh9KRMyr7q6nJDBhCUxT+y7eqj612656DjeeVMh3ECfnuie8yJg1Xp+6Hj02woevQXPyszEgGUA34xRasEqVc/TRHavamomJTX8CRyfheigOJ6ewf5qgenKt+V3Y1Z+fc+MIXtUJoIoM3PJuCX/fzUWYa2iVLr7sFpjvaebsTPuX+DrVV+gN+8zr/0HOv694dcTc8ma7j7XGLRTTdXzGQAo4BfLumbTi4d6mC9Hb9LA/1d6ohv5CBOwO+89GYel/e/p+7oM7qYh9Zj0JSsU1uyR3p72DXLbghNawBa5582wC+n0L1XXPhTm3nQ53jptZfYlQPvpR3xCXyK0JxuxkLq37+vIvqVysR4bSEI+T/gB/xeiKC/cOHClE4+BLeegqU2+QjlF3A5ZHVCNFiymBif1gBWAn7AD/idgZ9G/uHh4RlqMne5el3hOXMnMB72cwQA+AG/l/BT+C+aQtnZ5WkNQJv/B/yAH/D7FH71O2jbw94t+TvrYT+O/oAf8AP+qep59UX22X8+MoH1VAMoBfyAH/D7Hv4JrKcaQBngB/yA3/fwT2DdNwYA+AE/4DcE/1QDkL0ACPgBP+A3DL8qvRCoRwBRwA/4AX8w4E+NAsIyh/+AH/ADfkvwjw/6ugGUAn7AD/gDA/848/pS4AjgH9tVR2e4977Ryi4dbp9wpluudmJP3n1rWf6qSu6HeAJ+wM8R/vEIQN0NKNMWYB7w01bas40xU+e40XUsrKvn0vkV8AN+zvCruucUC4W047+7gwg/NdWg01t7lVHfqqg7z8LaesAP+KWCX1MR1QDKggg/hfjHVt9uC37S2cYG9unD61QzAfyAXyL4SWXhoMJ/YkOFY0c3kYnQ77NjAoAf8LsMPylCRcDyoIX9BOuwAyP2BIAVU6F04tpndgN+j+Cn75bMuP/9vaq505/pmZqpkuigjvxVa8f/HHD41QiAagANyg/1QYCfRPCbKfaZvrnrG1nRllrA7yL8BDkVcalJqhFR4Xb+QzXTfk8BgZ8UoxRgSVDgpxuEJ/xjNYGY4VQA8Nsf8btidezo3UsNw68bxmnt/zf5fggQ/KRSMoBoEODX4eQtSi2MvA7gd6aOc/65JluRA/0OMpEAwq/WAMJBgZ8W+PA4r326SAPw84ffzHkImUQmcur7m4MGvyoygIjf4Vdv4jdaXXsfFAX0TTO9CPjth/08irgX/u9/2cWWnwcKfor+hVkHwHttP+/cf8rrvb8X8HMo+P314XWOwz8eJSqf3dCRPwYF/nED8D38er7npiaHp4DfmdSKt5FfbHgkKPCPpwC+h9/t0X+y4QB+Z+RGEZciAPo8gwC/5wbg5y29ugEAfofCcxeLuIPP7wgE/J4aAPbzA35T1+ZiEZeigJHPTvoefs8MwG34c5e7X+ekY7gBv7MRgJu6nNjje/g9MQAvRn5q3sFj337G1yxZDPgdTKd4Vf4zRQF+h991A/Ay7J97R7nLEcBdgN9BA3BbI6dO+h5+Vw3A65w//761rqcAgB8SGX7XDECEgl/eqkrX0oCc+zey8KLFgB8SGn5XDECkaj/18HMl3dj6KOCXXKH8At/Dz90ARJvqo+vhPSOQu2mro6M/4He/fkPKvvFW38PP1QBEneenjj1ZnFp6003j5OgP+FOM1eWp3GwONRzR4OdmACIv8qE6wPUvtTluAqH8Qpb/xE71GfBzuKfWb3Yx/C/kMosjGvxcDECGFX7UE85JE6CRP/L8O46F/oB/qqiI65bmKGlcEOB33ABkWt5LJhDdc9B2fjm7fDUreHo34HchcqP7y43RP9dhAxAVft0A2oMG/+R0gK7b7BQhzfMXPN3C8h9H2O+WqOFqFucj2aiG49T3KTr8ijqpK3Abs9ka3C8be2jbcN8brepzunZTFOpnK7khzfM7XSUG/MZEewKoKQiXAUE19d1BgZ+UsG0AQdjVNzAwwPr6+rj9fsBvEqxX4uoZDE6KDJ3gd2r0lwB+1QAoBegE/NOLtvQCfrFU8C+bWeEPfwr47StJBnAc8E8PP7b0iiW9dXf2V9azQpp5sbnrkgp+AYWf1BEG/IBfNvj11t3q9Osv3rFUuNOLuPO2PRZU+FVRDYDy/zbAD/hlgn/K3/f2sMt796iNPK4c2Kf+OV2oz6uIKyP8itaZMgDAD/hFhD+dqKXXcMqefl79GSSGn1RBBkATq92AH/D7BX43JTH8pKIQ/a9iAqOAH/AD/kDBz+45xUJ6ETAB+AE/4A8O/ExbAawbQBLwA37AHxj4SZ2pBtAB+AE/4A8M/OPMh1PDAcAP+AF/IOCfEgF0An7AD/gDA//4oB/S/0QzAYAf8AP+QMCvzgCkRgCscMOWdsAP+AG//+FPTfnHDaDom99pB/yAH/D7Hv70BjBwYF8H4Af8gN/38JM6phhA/29/nXDr1emsN+q6Q48Rzoc+An7AD/inaJz10ARYDh0czeHUf51aOfXs2qlCP/mkV+rHl7+qkhU9VOPo8V2A375RpzuYk3r0hy325gP83ksvAE41gCOH2nJuWF7uKCSH29npWJ0KvhHRTAQ1fwzbbP4I+M2LorFexaj1voiZjuQmo6aOynToqtGW3YBfjNFfMYCKtAZw8f22BuVLdewAPau92+jmuu6Z3cxqNAL4zYN/tjGmfl/DFlIy+r7o3MVMbbsBvzCKKQbQMKUGoNYBPtib8Bp+PfQ8saFCjR4AP1/4u59rYkfvXsrOK8/DFusx9H3Rd02/J12kB/jFzP+nRACkyyePjdrNwwncY6tvt32ludoJPkbTAcBvbtSn9tpGUzMzWljXwBbW1gN+wfP/KRGAemMM9Nu+I5xq2Uy9+c8/tx3wOwy/btA84CedbWxQ7wHAL/bon9YAhj493mo39B887Nyaou5nm2acKgT85tOrdNV9R+FS7oOjq25jV7rPAX5x1DqjASRfbrY1LFAF2UkNa5VpwO9M2P+pEvYPc157MT6YHPkj64s9AvhligCue2pX++XOv1geHjLB6rSpAH7zqZmT0ZkRUZfewRd2AH7v1ank/+0zGoA66p4/Y4niS5xurnQ3LeA3aaKKMfMwZyPq3/FjtUsv4Bdr9J/WAHp2xfdaDdd5aHK+CvjNixZjeSXq0U8mAPjFyv+nNYBF/7Wj5cqJT5IivgvAb+HmfyXOveg34+f62oueRQGAnyWV8L/FsAGQQrlzTMeLTq7jTxUtOQX81tX97HYh7sKB558G/N5oWpanNYC+t15rtWIAWTbX8KcTLQgC/NbTJ7cLf9OJju4C/OKE/xkNoOgb37aUBhjdGGJGI5//AuC3qD6PCn9pv8dTJ9WpQcAvRvif0QBUMP582PTdU7h+s6NXT8c/Z315FeC3WjM5JFafl2EXDADwGwv/ZzSA0cEB08mjukXUwShg3vcfA/w2UwCRNHLqJOB3VzstG0DBmgfbB9p/Y/oOouaiTtQCZpevVh+A37p4rfe3bEgH9gF+90SLfxKWDYCUFVlgOgqg3Xu0i8+OCdD57Xn1TwJ+CPBzGv0NGcAnK2+IW+nbl6Nt5bUyNUijfsHTu1kovxDwQ4DfuuK2DeDmEyw5MjgQt/LqZAJL9xxk87fUGoscShaz/Md3qg/A70+F8gsAvztqUcL/TtsGQEo+v2On1augdKC4vpEte++Y2uuPioSpqQHN8VMrqUjjz1nRqweQ8zssfRGVKKLUDvC7IkOpe8gwQMf+fGx29HNRHleKRT78RDsAaSmwKMpreJLlrNkI+PmKin9LDQ3QhiE6dDAG+OUL++feuVKoO3PWirsBP38ZZtWwARSseTA+3NOdBPxy5fwipQAU/ocXLQb8fEWMtjhuACpQH3VsB/zywK+OuFr/fhGUc/9GwO9C7q+E/0kuBnBiQ0WTE1EA4HdXTi/PtiKa1clZswHw81eTmX9sygBoSnC0/2Ic8MsDv2oAX6vitlXbqOZs2mp5ahfwG1bczOivGrPZVzjT2BCdv6XmmJWjuwD/zKKlu9RabfhCD+t/PzHh72j6NOeWMgXmJWpYbwZq+r3UDdir0b/o1f2WDADwm9JSI3P/tgyANPDh/ubcz6+oAvz24U89j89szz79UFUK8Y0co+bVlCAt7LKyvgPwmx79TR/IYckAzEYBgD89+HbO45ssWlBFpytnOp+PXpOiADcbhOQqof+8bY8BfgFHf8sGQBodHW1QnuoBv3n4zzbF1ANPeDRRJSMo1lZcem0CVPW3sqEL8Lsz+tsygI+uZ5EbPjx/LKuwKAL4jcFPub1bvflp/wWd2Ds5SqPjurpPHmfnH7qfa3cewO+aktrob2k0CVt9VZoRyLQuAPBPurGVUJ/O43Mr/KbTficfAaaf1Tc8Zx4rfP4dNTznIQr5Ab9r2m4VflsRwHgU0HHuYFZkfhTwN2cM+enATC+UpfVmmH1zadqDOqlBR1/se4506qFlvnO3/cjShh/A7/7ob9sASBd++XJV/lfXNwP+9OqK1amjsZciEyjc0cpCn7s54+eqnuBjwQgI/DlbH1We77J0fYDfsqoV+ON2fkHIiasYOtvVlrXgqnLAPzXsd+qodLsyOhdPdQE6xGNIiQwy1QgIer1lm531/YDfstoV+G+3fV84cSVKFFCW9cUvH7wYygL8+vUquT7l/CKJQnPK/c2ITvMZTokKsm+8xbFmLYDflipm6vfnmgGQ/vaH9sbw1SW1gH9sqo3gF60jL2muEqpTuO61AL8tWZ72m6ywU1fU/dWy2OiFZDLo8JNogY+I8JMoz3frcA7Az0XEmGMnvTpmADQtOPzp8eqgw0/ge130m9EEnvgPwC+v6uxU/bkZAKlk5b0tw598nAgq/ProL7quHHiPa39+wM9NCbtVf64GQLr81qvVWpgSOPhp9Bep/14mDb7wNOCXL/R3fErJcQNY8oMfd17Z93YsaPCrN/krO6W5my4n9qgVfsAvjWJWNvu4bgCkays3NY10n0sECX71Rt8Vl+qOIhMA/NKE/lwKS2FeVxwuWrDOzKyA7PBT+C9q5T9TLQDwBzP0524AxcXFhmcF/NLJRzbxjAAAv2Oq5hH6czcAEs0KjJw+1eR3+NX3cahDyruLx5oAwO+YaMFPC88XCPN+B7RASHlq9zP8JDe77DgpJ3YBAn4uohuqjveLcDcAWiCUbmrQb917Rzh093FDww5GAIDf2bzfyQU/nhkA6bqvf6s9tZDhx9bdskYAgF9I0Wo/V26osFvvqLi4WK0HoG8/4IdmzPvjbr1Ytpvv7JrPl9V9dD2j/tXlgB/wQ1Pzfqd2+QkXAaRoHWP2wxvR4M810Jcf8EMZ1Kk8XD+5xXUDoKKgVg9I+gV+9YO0cFKSCMq2eFw34HdUxMI6N4p+IkQAZALtWiTgm7Bf1ggglF8A+L1XtVtFPyEMQDOBBDO5xFHknD/nllI5IwCTHXwBPxf4W7x68bCX71wxgbjyFJMdftJ0J/GILLPn9QF+x9XkZsVfOAPQTKBBeYrLDD+JDuqULQ2YZSL/B/yOi6b76ry+iLAIn4RiAtXTmYBMU310Sq9MylmzAfB7B78Q/eLDonwi6UxAtnn+vFWVUoX/Rtp7A37HlRAFfqEMIMUE2mWEX08DMh3PLZJyN30b8Lsvy7NfgTAATRUK/O2yrvCjE3llyP1nOsYL8HOBv8KLuX6pDIAWCinwVzCLqwW9Xt5LUcDCugah78S8hicBP+AXNgJg2gdFJpCQCX5d87fUqEYgouhkoExn+QF+53N+UeEnhUT/9N4tYUR0lSzw6xLxbEAK/Que3g343VNcpIKfNBHApGhg2ilCUeEn5SwvY4ueEOeawiWLWf7jccAP+CcoS4ZPsrmXtVbnM9ptc4cM8OuihUGzFkdZ35ut3oZ5+YWs4CcvsqyS6wG/O6IVfv8qw4VmyfKJKibwhmICx5UfK2WAfzwSuLmUDc0vZpfaXvcOfiXsn27NP+B3XLS2/79ludgsmT5ZxQTaFROg9rv/rMCfKzr8o6OjLElHIyy7WRl9F4+dx3f5kmuvT9BHnn8HI787oiLfJgX+F2W66JCMn/S7JazszkPndmdH5kdFh39oaGj8v1EL7osNj7hyPHfupq1s3rbHkPO7o042tp9fusaQIVk/cQWwyMDRj9vmLLupTAb4UzWw48ds4IUdbLS3x/HXpkr/nK2PZlzoA/gdlbBz/L42AF29Hfub825bUSUL/OP/ToF/UDEBp4yAwM+5fwPLWbMx478D/I5Kikq/rw2AdPHjQ1Vzb1zeqPwYkQH+yaJOyXRMF9UIzJgBTe3NXrlaAX+jocYegN/RfL/O6738MIAUnXnt5bKFa9ZTVbBMJvgni0yADusgIxhSny9MAD5rkfJQYM++6daMK/oAP9eQv1rGfN/XBkB6t4RFvvT7U42zr15UJSP8vAT4nQv5tZE/6Zc3FPLjt9Tbsb8y77YVzW6kBIA/MCG/p737eCnsx28rv/QLLSf+J3b7lXNnEoAf8NsU3UO3+xF+30YAqTr/zuu1RRWr652OBgB/IEb9mAJ+k5/fZNjv3+L8f/xKk9PRAOAPzKjf5Pc3GgrSt0rThbOvXtSYXVgUAfzQNKO+L6b3YADTAxzp+/BAo5XFQ4Df14ozn1X4kQKkc7xQKJlf+oVqJS2ouHL+bDvgD7z0pbzVQYM/kBGAlbQA8CPchwH4WLSA6IsfHKvNXRytYZNmCwC/L8HfzsaadiSD/mHAANLUB3Kjy6qyCyKAH3k+DCCIOv5EQ3T+P62pH4wsqBqdMw/w+wN8mtPvxEcBAzCswz98NJp3z6r62YujVWEDx2gBfoAPA/Churq6qC5QO3whWZNVEIkAfuT4MIAAioqF/9DeVTnc012fVVgUBfxCiUb5mPJoAfgwAP532+st5bOX3lCTveCqSsDvqWiTznYF+gQ+ChiAJ3WCwgc2VoXn5W3mFRUA/rSj/U421pIL+T0MQKCoYMmyzaGcnEqnagWAf0JuT6P9Toz2MADhdSLxq8rc5aVr2dhBJhHAbwv6Vr/ux4cBBEBHnnq8Mu+e+9ZmX3V1ufLHKOCfMbxPAHoYgC919Bc/K8u/94Hy4e5za0PZ2eXp1hcEEH4VeHr2S7NNGABkuG4wq2RxeXjO3JVkCL1te4IAPwG/VwMe+TwMANJFx54pT5QqlLKxFudlkr+ldu3RgREeBgBZN4UyrX5Qqj2XCQh6pwY6PbcDdhgAxNcYIpoRRFIMoZT9fdYhygwWHTNlKdqDlNQA14FPaqBj5Z2k+n8BBgCYs/pPRyOn1wAAAABJRU5ErkJggg==
+    mediatype: image/png
+  maintainers:
+  - name: Red Hat, Inc
+    email: customerservice@redhat.com
+  provider:
+    name: Red Hat, Inc
+  labels:
+    app: enmasse
+  selector:
+    matchLabels:
+      app: enmasse
+  links:
+  - name: Product Page
+    url: https://access.redhat.com/products/red-hat-amq
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_online_on_openshift/index
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  relatedImages:
+  - name: address-space-controller
+    image: registry.redhat.io/amq7/amq-online-1-address-space-controller:1.4
+  - name: standard-controller
+    image: registry.redhat.io/amq7/amq-online-1-standard-controller:1.4
+  - name: router
+    image: registry.redhat.io/amq7/amq-interconnect:1.7
+  - name: broker
+    image: registry.redhat.io/amq7/amq-broker:7.6
+  - name: broker-plugin
+    image: registry.redhat.io/amq7/amq-online-1-broker-plugin:1.4
+  - name: topic-forwarder
+    image: registry.redhat.io/amq7/amq-online-1-topic-forwarder:1.4
+  - name: agent
+    image: registry.redhat.io/amq7/amq-online-1-agent:1.4
+  - name: none-authservice
+    image: registry.redhat.io/amq7/amq-online-1-none-auth-service:1.4
+  - name: keycloak
+    image: registry.redhat.io/redhat-sso-7/sso73-openshift:latest
+  - name: keycloak-plugin
+    image: registry.redhat.io/amq7/amq-online-1-auth-plugin:1.4
+  - name: mqtt-gateway
+    image: registry.redhat.io/amq7/amq-online-1-mqtt-gateway:1.4
+  - name: mqtt-lwt
+    image: registry.redhat.io/amq7/amq-online-1-mqtt-lwt:1.4
+  - name: console-init
+    image: registry.redhat.io/amq7/amq-online-1-console-init:1.4
+  - name: console-proxy-openshift
+    image: registry.redhat.io/openshift3/oauth-proxy:latest
+  - name: console-proxy-kubernetes
+    image: quay.io/pusher/oauth2_proxy:latest
+  - name: console-server
+    image: registry.redhat.io/amq7/amq-online-1-console-server-rhel7:1.4
+  - name: controller-manager
+    image: registry.redhat.io/amq7/amq-online-1-controller-manager-rhel7-operator:1.4
+  - name: iot-proxy-configurator
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-proxy-configurator:1.4
+  - name: iot-auth-service
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-auth-service:1.4
+  - name: iot-device-registry-file
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-device-registry-file:1.4
+  - name: iot-device-registry-infinispan
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-device-registry-datagrid:1.4
+  - name: iot-http-adapter
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-http-adapter:1.4
+  - name: iot-mqtt-adapter
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-mqtt-adapter:1.4
+  - name: iot-lorawan-adapter
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-lorawan-adapter-rhel7:1.4
+  - name: iot-sigfox-adapter
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-sigfox-adapter-rhel7:1.4
+  - name: iot-tenant-service
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-tenant-service:1.4
+  - name: iot-tenant-cleaner
+    image: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-tenant-cleaner-rhel7:1.4
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: ["apps"]
+          resources: ["deployments", "deployments/finalizers", "replicasets"]
+          verbs: ["get", "list", "watch", "update", "create", "patch", "delete"]
+        - apiGroups: [""]
+          resources: ["configmaps", "secrets", "persistentvolumeclaims", "services",
+            "services/finalizers", "pods"]
+          verbs: ["get", "list", "watch", "update", "create", "patch", "delete"]
+        - apiGroups: ["", "route.openshift.io"]
+          resources: ["routes", "routes/custom-host", "routes/status"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["apps.openshift.io"]
+          resources: ["deploymentconfigs"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["servicemonitors"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["admin.enmasse.io"]
+          resources: ["authenticationservices", "authenticationservices/finalizers",
+            "consoleservices", "consoleservices/finalizers", "addressplans", "addressplans/finalizers",
+            "addressspaceplans", "addressspaceplans/finalizers"]
+          verbs: ["get", "list", "watch", "update", "create", "patch"]
+        - apiGroups: ["iot.enmasse.io"]
+          resources: ["iotconfigs", "iotconfigs/finalizers", "iotconfigs/status",
+            "iotprojects", "iotprojects/finalizers", "iotprojects/status"]
+          verbs: ["get", "list", "watch", "update", "create", "patch"]
+        - apiGroups: ["batch"]
+          resources: ["jobs"]
+          verbs: ["get", "list", "watch", "update", "create", "patch", "delete"]
+      - serviceAccountName: console-server
+        rules:
+        - apiGroups: ["admin.enmasse.io"]
+          resources: ["authenticationservices", "addressplans", "addressspaceplans"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["services"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs: ["get"]
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: ["admin.enmasse.io"]
+          resources: ["addressplans", "addressspaceplans", "brokeredinfraconfigs",
+            "standardinfraconfigs", "authenticationservices"]
+          verbs: ["patch", "get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs: ["get", "list"]
+        - apiGroups: [""]
+          resources: ["configmaps", "configmaps/finalizers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs: ["create", "update", "patch", "get", "list"]
+        - apiGroups: [""]
+          resources: ["services", "secrets", "persistentvolumeclaims"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+        - apiGroups: ["networking.k8s.io", "extensions"]
+          resources: ["networkpolicies"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+        - apiGroups: ["route.openshift.io", ""]
+          resources: ["routes", "routes/custom-host", "routes/status"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+        - apiGroups: ["apps", "extensions"]
+          resources: ["statefulsets", "deployments", "replicasets"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+        - apiGroups: ["policy"]
+          resources: ["poddisruptionbudgets"]
+          verbs: ["create", "update", "get", "patch", "list", "watch", "delete"]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: ["admin.enmasse.io"]
+          resources: ["addressplans", "addressspaceplans", "brokeredinfraconfigs",
+            "standardinfraconfigs", "authenticationservices"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["pods", "secrets"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["configmaps", "configmaps/finalizers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs: ["create", "update", "patch", "get", "list"]
+        - apiGroups: [""]
+          resources: ["persistentvolumeclaims", "services"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+        - apiGroups: ["apps"]
+          resources: ["statefulsets", "deployments"]
+          verbs: ["create", "update", "patch", "get", "list", "delete"]
+      clusterPermissions:
+      - serviceAccountName: address-space-controller
+        rules:
+        - apiGroups: ["enmasse.io"]
+          resources: ["addressspaces", "addresses", "addressspaceschemas", "addressspaces/finalizers",
+            "addresses/finalizers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["user.enmasse.io"]
+          resources: ["messagingusers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+      - serviceAccountName: address-space-admin
+        rules:
+        - apiGroups: ["enmasse.io"]
+          resources: ["addressspaces"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["enmasse.io"]
+          resources: ["addresses", "addresses/finalizers", "addressspaces/finalizers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+      - serviceAccountName: standard-authservice
+        rules:
+        - apiGroups: ["authentication.k8s.io"]
+          resources: ["tokenreviews"]
+          verbs: ["create"]
+      - serviceAccountName: enmasse-operator
+        rules:
+        - apiGroups: ["oauth.openshift.io"]
+          resources: ["oauthclients"]
+          verbs: ["create", "get", "update", "list", "watch"]
+        - apiGroups: ["user.enmasse.io"]
+          resources: ["messagingusers", "messagingusers/finalizers", "messagingusers/status"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["iot.enmasse.io"]
+          resources: ["iotprojects", "iotprojects/finalizers", "iotprojects/status"]
+          verbs: ["get", "list", "watch", "update", "create", "patch", "delete"]
+        - apiGroups: ["enmasse.io"]
+          resources: ["addressspaces", "addresses"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["apiregistration.k8s.io"]
+          resources: ["apiservices"]
+          resourceNames: ["v1alpha1.enmasse.io", "v1beta1.enmasse.io", "v1alpha1.user.enmasse.io",
+            "v1beta1.user.enmasse.io"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["monitoring.coreos.com"]
+          resources: ["prometheusrules", "servicemonitors"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["integreatly.org"]
+          resources: ["grafanadashboards", "grafanadashboards/finalizers"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+        - apiGroups: ["console.openshift.io"]
+          resources: ["consolelinks"]
+          verbs: ["create", "update", "patch", "get", "list", "watch", "delete"]
+      - serviceAccountName: console-server
+        rules:
+        - apiGroups: ["enmasse.io"]
+          resources: ["addressspaces", "addresses", "addressspaceschemas"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs: ["get", "list", "watch"]
+      - serviceAccountName: iot-device-registry
+        rules:
+        - apiGroups: ["authentication.k8s.io"]
+          resources: ["tokenreviews"]
+          verbs: ["create"]
+        - apiGroups: ["authorization.k8s.io"]
+          resources: ["subjectaccessreviews"]
+          verbs: ["create"]
+        - apiGroups: ["iot.enmasse.io"]
+          resources: ["iotprojects"]
+          verbs: ["get", "list", "watch"]
+      - serviceAccountName: iot-protocol-adapter
+        rules:
+        - apiGroups: ["iot.enmasse.io"]
+          resources: ["iotprojects"]
+          verbs: ["get", "list", "watch"]
+      - serviceAccountName: iot-tenant-service
+        rules:
+        - apiGroups: ["iot.enmasse.io"]
+          resources: ["iotprojects"]
+          verbs: ["get", "list", "watch"]
+      deployments:
+      - name: enmasse-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: enmasse
+              name: enmasse-operator
+          template:
+            metadata:
+              labels:
+                app: enmasse
+                name: enmasse-operator
+            spec:
+              affinity:
+                nodeAffinity:
+                  preferredDuringSchedulingIgnoredDuringExecution:
+                  - weight: 1
+                    preference:
+                      matchExpressions:
+                      - key: node-role.enmasse.io/operator-infra
+                        operator: In
+                        values:
+                        - "true"
+              serviceAccountName: enmasse-operator
+              containers:
+              - name: controller
+                image: registry.redhat.io/amq7/amq-online-1-controller-manager-rhel7-operator:1.4
+                imagePullPolicy: Always
+                env:
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: IOT_CONFIG_NAME
+                  value: "default"
+                - name: OPERATOR_NAME
+                  value: "enmasse-operator"
+                - name: IMAGE_PULL_POLICY
+                  value: "Always"
+                - name: CONTROLLER_DISABLE_ALL
+                  value: "true"
+                - name: CONTROLLER_ENABLE_UPGRADER
+                  value: "true"
+                - name: CONTROLLER_ENABLE_IOT_PROJECT
+                  value: "true"
+                - name: CONTROLLER_ENABLE_IOT_CONFIG
+                  value: "true"
+                - name: CONTROLLER_ENABLE_AUTHENTICATION_SERVICE
+                  value: "true"
+                - name: CONTROLLER_ENABLE_ADDRESS_SPACE_CONTROLLER
+                  value: "true"
+                - name: CONTROLLER_ENABLE_MESSAGING_USER
+                  value: "true"
+                - name: ADDRESS_SPACE_CONTROLLER_MEMORY_LIMIT
+                  value: "1Gi"
+                - name: ADDRESS_SPACE_CONTROLLER_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-address-space-controller:1.4
+                - name: CONTROLLER_MANAGER_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-controller-manager-rhel7-operator:1.4
+                - name: IOT_AUTH_SERVICE_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-auth-service:1.4
+                - name: IOT_DEVICE_REGISTRY_FILE_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-device-registry-file:1.4
+                - name: IOT_DEVICE_REGISTRY_INFINISPAN_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-device-registry-datagrid:1.4
+                - name: IOT_HTTP_ADAPTER_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-http-adapter:1.4
+                - name: IOT_MQTT_ADAPTER_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-mqtt-adapter:1.4
+                - name: IOT_LORAWAN_ADAPTER_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-lorawan-adapter-rhel7:1.4
+                - name: IOT_SIGFOX_ADAPTER_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-sigfox-adapter-rhel7:1.4
+                - name: IOT_TENANT_CLEANER_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-tenant-cleaner-rhel7:1.4
+                - name: IOT_TENANT_SERVICE_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-tenant-service:1.4
+                - name: IOT_PROXY_CONFIGURATOR_IMAGE
+                  value: registry.redhat.io/amq7-tech-preview/amq-online-1-iot-proxy-configurator:1.4
+                - name: ROUTER_IMAGE
+                  value: registry.redhat.io/amq7/amq-interconnect:1.7
+                - name: STANDARD_CONTROLLER_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-standard-controller:1.4
+                - name: AGENT_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-agent:1.4
+                - name: BROKER_IMAGE
+                  value: registry.redhat.io/amq7/amq-broker:7.6
+                - name: BROKER_PLUGIN_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-broker-plugin:1.4
+                - name: TOPIC_FORWARDER_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-topic-forwarder:1.4
+                - name: MQTT_GATEWAY_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-mqtt-gateway:1.4
+                - name: MQTT_LWT_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-mqtt-lwt:1.4
+                - name: NONE_AUTHSERVICE_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-none-auth-service:1.4
+                - name: KEYCLOAK_IMAGE
+                  value: registry.redhat.io/redhat-sso-7/sso73-openshift:latest
+                - name: KEYCLOAK_PLUGIN_IMAGE
+                  value: registry.redhat.io/amq7/amq-online-1-auth-plugin:1.4
+                - name: CONTROLLER_ENABLE_CONSOLE_SERVICE
+                  value: "true"
+                - name: CONSOLE_INIT_IMAGE
+                  value: "registry.redhat.io/amq7/amq-online-1-console-init:1.4"
+                - name: CONSOLE_SERVER_IMAGE
+                  value: "registry.redhat.io/amq7/amq-online-1-console-server-rhel7:1.4"
+                - name: CONSOLE_PROXY_OPENSHIFT_IMAGE
+                  value: "registry.redhat.io/openshift3/oauth-proxy:latest"
+                - name: CONSOLE_PROXY_KUBERNETES_IMAGE
+                  value: "quay.io/pusher/oauth2_proxy:latest"
+                - name: "FS_GROUP_FALLBACK_MAP"
+                  value: "{\"standard-authservice\": 185, \"file-device-registry\":
+                    185, \"broker\": 185}"
+                - name: ENABLE_MONITORING
+                  value: "false"
+                - name: CONSOLE_LINK_SECTION_NAME
+                  value: "Red Hat Integration"
+                - name: CONSOLE_LINK_NAME
+                  value: "Messaging Console"
+                - name: CONSOLE_LINK_IMAGE_URL
+                  value: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAQAAAAEACAYAAABccqhmAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAIj5JREFUeNrsnX1wVOW9x5/dBBIgLxvAKFFkGape0Zo4tFNfppLcueKlRQlzi0A7HRKsdG5va5Iy3r96b7Ktf9w71Ztgp+OI1Sx3Wt/wDol2ZLRqFjuibaEktmClRQJULOElGxKSAHm553dyTrpJNpvz9pzzPOd8vzPbDUKzZ3fP5/v8fr/neX5PiEHS6qPrWUR5KtP+WK49L1EeUe3n1L+3qnblkdR+7lQex7WfE/rf33xi/O8hyRTCRyAF6GUa1PRcqoFdLthlJjSj6NBMo1MxhnZ8ezAAyDzs5RroZQ6M4J6qcMOW9qJvfqd94MC+jv7f/jpx3VO7YAowACgF+HIN+JUCjur24P9aFVv0RPOE/3bpsML/rNmJ4XNde/s/2Ju4qq4hgbsABhDEEX6t34CfCf50uvLXTjYy0J8Y+vR4a/LlZkQIMABfQl+pjfCV7O8FOhZ0+NPpcudfOofPn2np2RXfu+i/drTg7oEByAz9Wg36SFDetx34p0QHJz5JhnLntPS99Vpr0Te+DTOAAUgR3tcEDXoe8Kczg0t/PtwyOjiwvWDNg0gTYADCQE+gV2ngR4P6OfCEf7IG2n/TmRVZsP2TlTfEsQYBBuAV+OXK02YN/kDLTfhTNXIhyUYGB+LJ53fsxGwCDMAt8An4+iCP9iLAP1lUPLx06GBMSQ/i+FZgADzC/FotzI/gExEL/lQN93QnL33Usf3EhoompAcwALvgRzXoqwC++PBPNoLR/ovx5EvPblfSg058YzAAs+DXI7+XE/7JdYLLx4/G+97+ZQxGAAMwGurX49OQH/7JRhAuiMT+tCSE1AAGgBw/SPCjRgADyAR/FUNVPxDwTzCC5PnO/vfeDvysQSjA4NOqvUbm4w05gN+AEZw7k+j/IFEX1NWFoQCCH9FG/FqgHWz4dfV3/Y31dp1u6v5qWSxoaUEoYPDTGv1m5PmAX9fg4CDr7e1Vfx69kEwOf3q8umTlvS0wAH+BH9XAR7gP+NPCPyEt+OTjxOW3Xq1e8oMfd8IA5Idfn9bDqM8ZfiWXVqfbBg93TPjvWQWFLGd5GctVHuGCiNDwpyh5Zd/bsWsrNzXBAOTN9Xdj1OcHP7X36n2zlfW90aJAb6yGNuu6KJt7RznLv28ty1tVKSr84xrpPpcIFy1YV1xcnIQBINcH/Ip6Xomz7me3G4Z+OmUp0UDRQ7Vs/pYa1yIDM/Dr8nNtIOQz8FHh5wh/35st7HSsTu3j56TcMgIr8E+IBk6f8t1MQchH8Jdpo34ZcHYWfsrrP9tWrYT7fAdASg/oOihFEA3+FLVTgfC6r3+rHQaAkN/38FNh79OH17HhC+4NegvrGtjC2noR4ddFH0Z1cXGx9ClB2Afw02q+3YDfefgp1z+xocJV+ElnGxvUiENQ+Jl2r+3+2x/aG2W/B7Ilz/dR5ecIv1MQWhG9PsnOWgRO8I/ryu/erdVSz3Wy1gXCksJPH3ob4Pcn/E5cB2/4L/3yRdbX8AjT7sE27Z6UTlkSwk8f+B6G3Xtc4Ke5/VPf3cRGLw0Kcb3qUWKhkKnCoIvw67pGeWz8biH7zU971BOUpVFIMvir2FixD+IAP1X7Kee3O7/PQ9e/1GbIBDyAf7KqlXQgjhTAefgbAD8/+Ennn9suJPwkI6mAAPCTmrV7FSmAg/DTnYvFPRzhp8U9NN0nqig6yZQKCAK/rnIlHYgq6UArIgBn4K8CxvzgJ51tjAn/XrqfbRozArHh11Wl3bswAMAvNvw0+uvTbiKL1iNMvk5B4ZfGBMKCgh9RHgcBP3/4ST2v7JTmfZ1/drss8KeawEFt3QoMwAj8bGyOH2v6XYBfNYBdcWneG0UrNDUoCfy6ynpHWNu7JeKZgIgRAOB3EX6Cyendfbx15tWXZIKfKfCzwZGxxWuimYBQBqDlS4DfJfhJtNlHNl367a9lg388EmBjy9dhANPAj5zfRfhVA3h/r3Tv9cqB92SEX1e5EgU0wwAAv+fwk9ze6eeUho78UUb4dVWJYgJhAeBvAPzewC9rCkAa7b0gK/ypJtAYaANIOZYL8gB+mTXy2QmZ4ddVq5hAVSANQNvVh7X9gN+aAZw6KTv8upoVE6gMlAFoe6d3A2PA75UEgT/VBMoCYQDaQh/07wP8tpR1461+gZ9d/WBV5M5D53aPjo5GfG8A2siPuX5B4KdOvDIqlF/oF/jZjY3NLDsyPzpw9OM2XxuA1sCzHCiLM/LLagDZN97iG/h1zVl2U1lvx/5mXxqA1robe/oFC/vn3imfH9PobzYCEB1+XXm3rai6+PGhKl8ZQMqhHZBgOX/u8lLpPpNZK+7yJfzjpnzj8sYzr71c5gsDQNFPXPjVEWdVpXSfy+zy1b6FX1Nk4Zr1zW5sHHIjAqCFPij6CQh/6mtJZQArV/sZfl1lX/r9qUapDQB5v/jwq6+3frM0n03O/RsN5f+Swz9mdFcvqurt2F8ppQGkhP6QwPCrOecd5dLMBuSs2RgI+MdTtNtWNB9/oiEqnQEwnNcnBfy6FtaJvyVj1oq7ZywA+gl+vR6waPN3mqUyAGX0p7C/HEjLAb/++jyO5XY0Utn2o6DBP2Z8C64qP//O67VSGIACP4Ur2OEnEfzjN2y9uIfd5m7ayrIzLP/1K/y6iipW1/NIBXhEAJjykxB+Nb9eXiakCRD487Y9Flj4eaYCjp4NqFX9scvPZfipqWffmy3sysnjaY/2otV+tOCHQvxwwczeTMdwiXJOAFX8C57ePe3oHxD4x9V/5HD1vJtuiQtnAFrV/xhGf3fgH9EOyaA++Wa6+pIJ0LTfTHP/natv9/ycQMCfVtTDbWkoFEqKZgAUO2LOnzP8BD4d4knHZNnp50fTflT5n84IvD4pGPBPr8unP4vnXFNSLYwBaGv9DwJtvvBTD/+/PrzO0T7+FBFc98zuaVMDL9IBwD+zet5PVETuqkjY/T1OFQEbgTZf+AnCY0pY7vQhHtQU9OjdS1VzSSe6XioMZhW4k9nRXH/Rq/sB/0zGfdOtjjBnOwLQGntixR9n+Gkk5ikC/PqX2tSZgHQi46Fr4NVFmEb9edt+lHGlH+CfoupQKBT3zAC0wh+F/lEgLi/8Rk1AjxjoKHGnjIDAn7NpqzrPn2mNP+CfqqGe7mR2YZGtgqBdA2hgWPTDDX6CjApxbopMYNl7x2acLqSUgWYg6BqtpCW0pVd9rFw94+YewJ9RMcUAGlw3AEz78YWfqvA8cn4jyl9Vya59xthyjoGBAZb8/Qds6MA+9bQeatc9/NmJCW27Ka8fe75LbeZJz0Y7+gD+GWVrWjDbxgvXAn4+8JMozPbq1N7eN1vUkX2mvQF0RHdfX59asMu20aUX8NtSpO/DA1QQtJQnWooAtPX+x4A5H/gJfKrMeylaJ0CpQCb4JTyi22/wp4qiANMjhtVpQOT9nOAn9byy0/P3QSY0XaEP8IunkZERS0yaNgBt9K8C6nzgVw1gV1yI99OzayfglwD+oaEhdvZ4Z9XhHz4adSMCqAHq/OCn6rpXuf9k0QYjwC8+/MlkkoXy8lnePavquRqAVvnH6M8JfvWmfbNVmPdFew30NADwiwv/6Oio+ufZi6NVXV1dEW4GwFD55wo/qf/9hFDvjyISwC8+/CrMY1OrpjbkmZ0GRPjPEX7SyIWkUO/xYtdpNgT4uYiiq/4P9k74b0b6NqSDPyVqq3m3hDXdc4oZupEMTwNizT9/+El/WhIS6n3SIh7amQf4nTN4I9u56f6i7dqTuzVngj9F1cXFxXGnUwBM/XGGP0gKIvxUVKX1HWcbG2bs5UB7QNR/2xQzCz8b7uk2zKohA1BG/3KGDT+AH/BbFgFNvRzMNnEhs6DNYEbhJ2UVFkU7X28pdzIC2Izb1h34c5eLdYqa2YM4AX96+O3s6FTN4wf/Zgh+XbOX3lDjiAFg6s/dkT9cINYki9ljuAH/RNGajq5Yne3fM/jCDnblwD7D/z57wVWVRhYGGYkAAL+LYT918BVJWQ5t8glqtZ9G/mGHZnb6Yt8zd98+sLHKCQOoAfzu5fz5q9YKNfo7kQIEFf5M+ymsiLZY05Zrw9HkvLzNtgxAa/YZBfzuibrxiHJQJzXsAPx2cn/nN3Vdeu1F49GbgWLgTBFADeD34LXXi5F1GTmJF/BPLx6rOoePHDJn4kuWbbZjAJWA34vX937SJVyy2Fb4j+W9jMumLuq2ZCqNy8mptGQA2jFfEcDvvsYO7Wjw9Bry6n8C+AU0gNRWa4bSgIJI5ETiV5VWIoC1gN87zd9S41ktgHJ/q6M/4J9o5I7/Tq2/ohnlLi9da8UAKgG/hyF4QcST66HKf179k4BfUAOg1MyCzEUAQQv/RV3eS7vC3Lwu/UguK4t/AH+a74/Dmg6LkVnkyFOPV5qJAFYC/mBd30zn8QF+K9/dZse/IzpHwYry7rlvrRkDqAT8wblOwM8vBZiptboZzZnh9KRMyr7q6nJDBhCUxT+y7eqj612656DjeeVMh3ECfnuie8yJg1Xp+6Hj02woevQXPyszEgGUA34xRasEqVc/TRHavamomJTX8CRyfheigOJ6ewf5qgenKt+V3Y1Z+fc+MIXtUJoIoM3PJuCX/fzUWYa2iVLr7sFpjvaebsTPuX+DrVV+gN+8zr/0HOv694dcTc8ma7j7XGLRTTdXzGQAo4BfLumbTi4d6mC9Hb9LA/1d6ohv5CBOwO+89GYel/e/p+7oM7qYh9Zj0JSsU1uyR3p72DXLbghNawBa5582wC+n0L1XXPhTm3nQ53jptZfYlQPvpR3xCXyK0JxuxkLq37+vIvqVysR4bSEI+T/gB/xeiKC/cOHClE4+BLeegqU2+QjlF3A5ZHVCNFiymBif1gBWAn7AD/idgZ9G/uHh4RlqMne5el3hOXMnMB72cwQA+AG/l/BT+C+aQtnZ5WkNQJv/B/yAH/D7FH71O2jbw94t+TvrYT+O/oAf8AP+qep59UX22X8+MoH1VAMoBfyAH/D7Hv4JrKcaQBngB/yA3/fwT2DdNwYA+AE/4DcE/1QDkL0ACPgBP+A3DL8qvRCoRwBRwA/4AX8w4E+NAsIyh/+AH/ADfkvwjw/6ugGUAn7AD/gDA/848/pS4AjgH9tVR2e4977Ryi4dbp9wpluudmJP3n1rWf6qSu6HeAJ+wM8R/vEIQN0NKNMWYB7w01bas40xU+e40XUsrKvn0vkV8AN+zvCruucUC4W047+7gwg/NdWg01t7lVHfqqg7z8LaesAP+KWCX1MR1QDKggg/hfjHVt9uC37S2cYG9unD61QzAfyAXyL4SWXhoMJ/YkOFY0c3kYnQ77NjAoAf8LsMPylCRcDyoIX9BOuwAyP2BIAVU6F04tpndgN+j+Cn75bMuP/9vaq505/pmZqpkuigjvxVa8f/HHD41QiAagANyg/1QYCfRPCbKfaZvrnrG1nRllrA7yL8BDkVcalJqhFR4Xb+QzXTfk8BgZ8UoxRgSVDgpxuEJ/xjNYGY4VQA8Nsf8btidezo3UsNw68bxmnt/zf5fggQ/KRSMoBoEODX4eQtSi2MvA7gd6aOc/65JluRA/0OMpEAwq/WAMJBgZ8W+PA4r326SAPw84ffzHkImUQmcur7m4MGvyoygIjf4Vdv4jdaXXsfFAX0TTO9CPjth/08irgX/u9/2cWWnwcKfor+hVkHwHttP+/cf8rrvb8X8HMo+P314XWOwz8eJSqf3dCRPwYF/nED8D38er7npiaHp4DfmdSKt5FfbHgkKPCPpwC+h9/t0X+y4QB+Z+RGEZciAPo8gwC/5wbg5y29ugEAfofCcxeLuIPP7wgE/J4aAPbzA35T1+ZiEZeigJHPTvoefs8MwG34c5e7X+ekY7gBv7MRgJu6nNjje/g9MQAvRn5q3sFj337G1yxZDPgdTKd4Vf4zRQF+h991A/Ay7J97R7nLEcBdgN9BA3BbI6dO+h5+Vw3A65w//761rqcAgB8SGX7XDECEgl/eqkrX0oCc+zey8KLFgB8SGn5XDECkaj/18HMl3dj6KOCXXKH8At/Dz90ARJvqo+vhPSOQu2mro6M/4He/fkPKvvFW38PP1QBEneenjj1ZnFp6003j5OgP+FOM1eWp3GwONRzR4OdmACIv8qE6wPUvtTluAqH8Qpb/xE71GfBzuKfWb3Yx/C/kMosjGvxcDECGFX7UE85JE6CRP/L8O46F/oB/qqiI65bmKGlcEOB33ABkWt5LJhDdc9B2fjm7fDUreHo34HchcqP7y43RP9dhAxAVft0A2oMG/+R0gK7b7BQhzfMXPN3C8h9H2O+WqOFqFucj2aiG49T3KTr8ijqpK3Abs9ka3C8be2jbcN8brepzunZTFOpnK7khzfM7XSUG/MZEewKoKQiXAUE19d1BgZ+UsG0AQdjVNzAwwPr6+rj9fsBvEqxX4uoZDE6KDJ3gd2r0lwB+1QAoBegE/NOLtvQCfrFU8C+bWeEPfwr47StJBnAc8E8PP7b0iiW9dXf2V9azQpp5sbnrkgp+AYWf1BEG/IBfNvj11t3q9Osv3rFUuNOLuPO2PRZU+FVRDYDy/zbAD/hlgn/K3/f2sMt796iNPK4c2Kf+OV2oz6uIKyP8itaZMgDAD/hFhD+dqKXXcMqefl79GSSGn1RBBkATq92AH/D7BX43JTH8pKIQ/a9iAqOAH/AD/kDBz+45xUJ6ETAB+AE/4A8O/ExbAawbQBLwA37AHxj4SZ2pBtAB+AE/4A8M/OPMh1PDAcAP+AF/IOCfEgF0An7AD/gDA//4oB/S/0QzAYAf8AP+QMCvzgCkRgCscMOWdsAP+AG//+FPTfnHDaDom99pB/yAH/D7Hv70BjBwYF8H4Af8gN/38JM6phhA/29/nXDr1emsN+q6Q48Rzoc+An7AD/inaJz10ARYDh0czeHUf51aOfXs2qlCP/mkV+rHl7+qkhU9VOPo8V2A375RpzuYk3r0hy325gP83ksvAE41gCOH2nJuWF7uKCSH29npWJ0KvhHRTAQ1fwzbbP4I+M2LorFexaj1voiZjuQmo6aOynToqtGW3YBfjNFfMYCKtAZw8f22BuVLdewAPau92+jmuu6Z3cxqNAL4zYN/tjGmfl/DFlIy+r7o3MVMbbsBvzCKKQbQMKUGoNYBPtib8Bp+PfQ8saFCjR4AP1/4u59rYkfvXsrOK8/DFusx9H3Rd02/J12kB/jFzP+nRACkyyePjdrNwwncY6tvt32ludoJPkbTAcBvbtSn9tpGUzMzWljXwBbW1gN+wfP/KRGAemMM9Nu+I5xq2Uy9+c8/tx3wOwy/btA84CedbWxQ7wHAL/bon9YAhj493mo39B887Nyaou5nm2acKgT85tOrdNV9R+FS7oOjq25jV7rPAX5x1DqjASRfbrY1LFAF2UkNa5VpwO9M2P+pEvYPc157MT6YHPkj64s9AvhligCue2pX++XOv1geHjLB6rSpAH7zqZmT0ZkRUZfewRd2AH7v1ank/+0zGoA66p4/Y4niS5xurnQ3LeA3aaKKMfMwZyPq3/FjtUsv4Bdr9J/WAHp2xfdaDdd5aHK+CvjNixZjeSXq0U8mAPjFyv+nNYBF/7Wj5cqJT5IivgvAb+HmfyXOveg34+f62oueRQGAnyWV8L/FsAGQQrlzTMeLTq7jTxUtOQX81tX97HYh7sKB558G/N5oWpanNYC+t15rtWIAWTbX8KcTLQgC/NbTJ7cLf9OJju4C/OKE/xkNoOgb37aUBhjdGGJGI5//AuC3qD6PCn9pv8dTJ9WpQcAvRvif0QBUMP582PTdU7h+s6NXT8c/Z315FeC3WjM5JFafl2EXDADwGwv/ZzSA0cEB08mjukXUwShg3vcfA/w2UwCRNHLqJOB3VzstG0DBmgfbB9p/Y/oOouaiTtQCZpevVh+A37p4rfe3bEgH9gF+90SLfxKWDYCUFVlgOgqg3Xu0i8+OCdD57Xn1TwJ+CPBzGv0NGcAnK2+IW+nbl6Nt5bUyNUijfsHTu1kovxDwQ4DfuuK2DeDmEyw5MjgQt/LqZAJL9xxk87fUGoscShaz/Md3qg/A70+F8gsAvztqUcL/TtsGQEo+v2On1augdKC4vpEte++Y2uuPioSpqQHN8VMrqUjjz1nRqweQ8zssfRGVKKLUDvC7IkOpe8gwQMf+fGx29HNRHleKRT78RDsAaSmwKMpreJLlrNkI+PmKin9LDQ3QhiE6dDAG+OUL++feuVKoO3PWirsBP38ZZtWwARSseTA+3NOdBPxy5fwipQAU/ocXLQb8fEWMtjhuACpQH3VsB/zywK+OuFr/fhGUc/9GwO9C7q+E/0kuBnBiQ0WTE1EA4HdXTi/PtiKa1clZswHw81eTmX9sygBoSnC0/2Ic8MsDv2oAX6vitlXbqOZs2mp5ahfwG1bczOivGrPZVzjT2BCdv6XmmJWjuwD/zKKlu9RabfhCD+t/PzHh72j6NOeWMgXmJWpYbwZq+r3UDdir0b/o1f2WDADwm9JSI3P/tgyANPDh/ubcz6+oAvz24U89j89szz79UFUK8Y0co+bVlCAt7LKyvgPwmx79TR/IYckAzEYBgD89+HbO45ssWlBFpytnOp+PXpOiADcbhOQqof+8bY8BfgFHf8sGQBodHW1QnuoBv3n4zzbF1ANPeDRRJSMo1lZcem0CVPW3sqEL8Lsz+tsygI+uZ5EbPjx/LKuwKAL4jcFPub1bvflp/wWd2Ds5SqPjurpPHmfnH7qfa3cewO+aktrob2k0CVt9VZoRyLQuAPBPurGVUJ/O43Mr/KbTficfAaaf1Tc8Zx4rfP4dNTznIQr5Ab9r2m4VflsRwHgU0HHuYFZkfhTwN2cM+enATC+UpfVmmH1zadqDOqlBR1/se4506qFlvnO3/cjShh/A7/7ob9sASBd++XJV/lfXNwP+9OqK1amjsZciEyjc0cpCn7s54+eqnuBjwQgI/DlbH1We77J0fYDfsqoV+ON2fkHIiasYOtvVlrXgqnLAPzXsd+qodLsyOhdPdQE6xGNIiQwy1QgIer1lm531/YDfstoV+G+3fV84cSVKFFCW9cUvH7wYygL8+vUquT7l/CKJQnPK/c2ITvMZTokKsm+8xbFmLYDflipm6vfnmgGQ/vaH9sbw1SW1gH9sqo3gF60jL2muEqpTuO61AL8tWZ72m6ywU1fU/dWy2OiFZDLo8JNogY+I8JMoz3frcA7Az0XEmGMnvTpmADQtOPzp8eqgw0/ge130m9EEnvgPwC+v6uxU/bkZAKlk5b0tw598nAgq/ProL7quHHiPa39+wM9NCbtVf64GQLr81qvVWpgSOPhp9Bep/14mDb7wNOCXL/R3fErJcQNY8oMfd17Z93YsaPCrN/krO6W5my4n9qgVfsAvjWJWNvu4bgCkays3NY10n0sECX71Rt8Vl+qOIhMA/NKE/lwKS2FeVxwuWrDOzKyA7PBT+C9q5T9TLQDwBzP0524AxcXFhmcF/NLJRzbxjAAAv2Oq5hH6czcAEs0KjJw+1eR3+NX3cahDyruLx5oAwO+YaMFPC88XCPN+B7RASHlq9zP8JDe77DgpJ3YBAn4uohuqjveLcDcAWiCUbmrQb917Rzh093FDww5GAIDf2bzfyQU/nhkA6bqvf6s9tZDhx9bdskYAgF9I0Wo/V26osFvvqLi4WK0HoG8/4IdmzPvjbr1Ytpvv7JrPl9V9dD2j/tXlgB/wQ1Pzfqd2+QkXAaRoHWP2wxvR4M810Jcf8EMZ1Kk8XD+5xXUDoKKgVg9I+gV+9YO0cFKSCMq2eFw34HdUxMI6N4p+IkQAZALtWiTgm7Bf1ggglF8A+L1XtVtFPyEMQDOBBDO5xFHknD/nllI5IwCTHXwBPxf4W7x68bCX71wxgbjyFJMdftJ0J/GILLPn9QF+x9XkZsVfOAPQTKBBeYrLDD+JDuqULQ2YZSL/B/yOi6b76ry+iLAIn4RiAtXTmYBMU310Sq9MylmzAfB7B78Q/eLDonwi6UxAtnn+vFWVUoX/Rtp7A37HlRAFfqEMIMUE2mWEX08DMh3PLZJyN30b8Lsvy7NfgTAATRUK/O2yrvCjE3llyP1nOsYL8HOBv8KLuX6pDIAWCinwVzCLqwW9Xt5LUcDCugah78S8hicBP+AXNgJg2gdFJpCQCX5d87fUqEYgouhkoExn+QF+53N+UeEnhUT/9N4tYUR0lSzw6xLxbEAK/Que3g343VNcpIKfNBHApGhg2ilCUeEn5SwvY4ueEOeawiWLWf7jccAP+CcoS4ZPsrmXtVbnM9ptc4cM8OuihUGzFkdZ35ut3oZ5+YWs4CcvsqyS6wG/O6IVfv8qw4VmyfKJKibwhmICx5UfK2WAfzwSuLmUDc0vZpfaXvcOfiXsn27NP+B3XLS2/79ludgsmT5ZxQTaFROg9rv/rMCfKzr8o6OjLElHIyy7WRl9F4+dx3f5kmuvT9BHnn8HI787oiLfJgX+F2W66JCMn/S7JazszkPndmdH5kdFh39oaGj8v1EL7osNj7hyPHfupq1s3rbHkPO7o042tp9fusaQIVk/cQWwyMDRj9vmLLupTAb4UzWw48ds4IUdbLS3x/HXpkr/nK2PZlzoA/gdlbBz/L42AF29Hfub825bUSUL/OP/ToF/UDEBp4yAwM+5fwPLWbMx478D/I5Kikq/rw2AdPHjQ1Vzb1zeqPwYkQH+yaJOyXRMF9UIzJgBTe3NXrlaAX+jocYegN/RfL/O6738MIAUnXnt5bKFa9ZTVbBMJvgni0yADusgIxhSny9MAD5rkfJQYM++6daMK/oAP9eQv1rGfN/XBkB6t4RFvvT7U42zr15UJSP8vAT4nQv5tZE/6Zc3FPLjt9Tbsb8y77YVzW6kBIA/MCG/p737eCnsx28rv/QLLSf+J3b7lXNnEoAf8NsU3UO3+xF+30YAqTr/zuu1RRWr652OBgB/IEb9mAJ+k5/fZNjv3+L8f/xKk9PRAOAPzKjf5Pc3GgrSt0rThbOvXtSYXVgUAfzQNKO+L6b3YADTAxzp+/BAo5XFQ4Df14ozn1X4kQKkc7xQKJlf+oVqJS2ouHL+bDvgD7z0pbzVQYM/kBGAlbQA8CPchwH4WLSA6IsfHKvNXRytYZNmCwC/L8HfzsaadiSD/mHAANLUB3Kjy6qyCyKAH3k+DCCIOv5EQ3T+P62pH4wsqBqdMw/w+wN8mtPvxEcBAzCswz98NJp3z6r62YujVWEDx2gBfoAPA/Churq6qC5QO3whWZNVEIkAfuT4MIAAioqF/9DeVTnc012fVVgUBfxCiUb5mPJoAfgwAP532+st5bOX3lCTveCqSsDvqWiTznYF+gQ+ChiAJ3WCwgc2VoXn5W3mFRUA/rSj/U421pIL+T0MQKCoYMmyzaGcnEqnagWAf0JuT6P9Toz2MADhdSLxq8rc5aVr2dhBJhHAbwv6Vr/ux4cBBEBHnnq8Mu+e+9ZmX3V1ufLHKOCfMbxPAHoYgC919Bc/K8u/94Hy4e5za0PZ2eXp1hcEEH4VeHr2S7NNGABkuG4wq2RxeXjO3JVkCL1te4IAPwG/VwMe+TwMANJFx54pT5QqlLKxFudlkr+ldu3RgREeBgBZN4UyrX5Qqj2XCQh6pwY6PbcDdhgAxNcYIpoRRFIMoZT9fdYhygwWHTNlKdqDlNQA14FPaqBj5Z2k+n8BBgCYs/pPRyOn1wAAAABJRU5ErkJggg=="
+  customresourcedefinitions:
+    owned:
+    - group: user.enmasse.io
+      version: v1beta1
+      kind: MessagingUser
+      name: messagingusers.user.enmasse.io
+      displayName: Messaging User
+      description: A messaging user that can connect to an Address Space
+      specDescriptors:
+      - description: The user name.
+        displayName: Username
+        path: username
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The authentication type
+        displayName: Authentication type
+        path: authentication.type
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The password
+        displayName: Password
+        path: authentication.password
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpaceSchema
+      name: addressspaceschemas.enmasse.io
+      displayName: AddressSpaceSchema
+      description: A resource representing the available schema of plans and authentication
+        services
+    - group: enmasse.io
+      version: v1beta1
+      kind: AddressSpace
+      name: addressspaces.enmasse.io
+      displayName: Address Space
+      description: A group of messaging addresses that can be accessed via the same
+        endpoint
+      specDescriptors:
+      - description: The address space type.
+        displayName: Type
+        path: type
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The address space plan.
+        displayName: Plan
+        path: plan
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: Address space ready.
+        displayName: Ready
+        path: isReady
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+    - group: enmasse.io
+      version: v1beta1
+      kind: Address
+      name: addresses.enmasse.io
+      displayName: Address
+      description: A messaging address that can be used to send/receive messages to/from
+      specDescriptors:
+      - description: The address type.
+        displayName: Type
+        path: type
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The address plan.
+        displayName: Plan
+        path: plan
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      statusDescriptors:
+      - description: Address ready.
+        displayName: Ready
+        path: isReady
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Address phase
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+    - group: admin.enmasse.io
+      version: v1beta1
+      kind: StandardInfraConfig
+      name: standardinfraconfigs.admin.enmasse.io
+      displayName: Standard Infra Config
+      description: Infrastructure configuration template for the standard address
+        space type
+      specDescriptors:
+      - description: The minimal number of AMQP router replicas to create.
+        displayName: Minimum Router Replicas
+        path: router.minReplicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The link capacity of AMQP producer links attached to the routers.
+        displayName: Link capacity
+        path: router.linkCapacity
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of memory to configure for AMQP router pods.
+        displayName: Router Memory
+        path: router.resources.memory
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of memory to configure for message brokers.
+        displayName: Broker Memory
+        path: broker.resources.memory
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of storage to configure for message brokers.
+        displayName: Broker Storage
+        path: broker.resources.storage
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The storage class name to use for message broker persistent volumes.
+        displayName: Broker Storage Class
+        path: broker.storageClassName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The policy to apply when message queues are full.
+        displayName: Broker Address Full Policy
+        path: broker.addressFullPolicy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of memory to configure for the admin operator.
+        displayName: Admin Memory
+        path: admin.resources.memory
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: admin.enmasse.io
+      version: v1beta1
+      kind: BrokeredInfraConfig
+      name: brokeredinfraconfigs.admin.enmasse.io
+      displayName: Brokered Infra Config
+      description: Infrastructure configuration template for the brokered address
+        space type
+      specDescriptors:
+      - description: The amount of memory to configure for message brokers.
+        displayName: Broker Memory
+        path: broker.resources.memory
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of storage to configure for message brokers.
+        displayName: Broker Storage
+        path: broker.resources.storage
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The storage class name to use for message broker persistent volumes.
+        displayName: Broker Storage Class
+        path: broker.storageClassName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The policy to apply when message queues are full.
+        displayName: Broker Address Full Policy
+        path: broker.addressFullPolicy
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The amount of memory to configure for the admin operator.
+        displayName: Admin Memory
+        path: admin.resources.memory
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: admin.enmasse.io
+      version: v1beta2
+      kind: AddressPlan
+      name: addressplans.admin.enmasse.io
+      displayName: Address Plan
+      description: Plan describing the resource usage of a given address type
+      specDescriptors:
+      - description: The name to be displayed in the console UI.
+        displayName: Display Name
+        path: displayName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The description to be shown in the console UI.
+        displayName: Short Description
+        path: shortDescription
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The broker resource usage.
+        displayName: Broker Usage
+        path: resources.broker
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The router resource usage.
+        displayName: Router Usage
+        path: resources.router
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: admin.enmasse.io
+      version: v1beta2
+      kind: AddressSpacePlan
+      name: addressspaceplans.admin.enmasse.io
+      displayName: Address Space Plan
+      description: Plan describing the capabilities and resource limits of a given
+        address space type
+      specDescriptors:
+      - description: The name to be displayed in the console UI.
+        displayName: Display Name
+        path: displayName
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The reference to the infrastructure config used by this plan.
+        displayName: InfraConfig Reference
+        path: infraConfigRef
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The description to be shown in the console UI.
+        displayName: Short Description
+        path: shortDescription
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The quota for broker resources
+        displayName: Broker Quota
+        path: resourceLimits.broker
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The quota for router resources
+        displayName: Router Quota
+        path: resourceLimits.router
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: The aggregate quota for all resources
+        displayName: Aggregate Quota
+        path: resourceLimits.aggregate
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: admin.enmasse.io
+      version: v1beta1
+      kind: AuthenticationService
+      name: authenticationservices.admin.enmasse.io
+      displayName: Authentication Service
+      description: Authentication service configuration available to address spaces.
+      specDescriptors:
+      - description: The type of authentication service
+        displayName: Type
+        path: type
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: admin.enmasse.io
+      version: v1beta1
+      kind: ConsoleService
+      name: consoleservices.admin.enmasse.io
+      displayName: Console Service
+      description: Console Service Singleton for deploying global console.
+      specDescriptors:
+      - description: The discovery Metadata URL
+        displayName: Discovery Metadata URL
+        path: discoveryMetadataUrl
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Console certificate secret name
+        displayName: Console certificate secret name
+        path: certificateSecret.name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: OAUTH Client Secret Name
+        displayName: OAUTH Client Secret Name
+        path: oauthClientSecret.name
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Scope
+        displayName: Scope
+        path: scope
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+      - description: Host to use for ingress
+        displayName: Host
+        path: host
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:text'
+    - group: iot.enmasse.io
+      version: v1alpha1
+      kind: IoTConfig
+      name: iotconfigs.iot.enmasse.io
+      displayName: IoT Config
+      description: IoT Infrastructure Configuration Singleton
+      specDescriptors:
+      - description: The number of replicas for the HTTP protocol adapter # HTTP adapter
+        displayName: HTTP adapter replicas
+        path: adapters.http.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the MQTT protocol adapter # MQTT adapter
+        displayName: MQTT adapter replicas
+        path: adapters.mqtt.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the Sigfox protocol adapter # Sigfox adapter
+        displayName: Sigfox adapter replicas
+        path: adapters.sigfox.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the LoRaWAN protocol adapter # LoRaWAN adapter
+        displayName: LoRaWAN adapter replicas
+        path: adapters.lorawan.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the device registry # Services
+        displayName: Device registry replicas
+        path: services.deviceRegistry.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the tenant service
+        displayName: Tenant service replicas
+        path: services.tenant.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      - description: The number of replicas for the authentication service
+        displayName: Authentication service replicas
+        path: services.authentication.replicas
+        x-descriptors:
+        - 'urn:alm:descriptor:com.tectonic.ui:podCount'
+      statusDescriptors:
+      - description: State of the IoT infrastructure.
+        displayName: State
+        path: state
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.phase'
+      - description: URL of the Device registry endpoint.
+        displayName: Device Registry Endpoint
+        path: services.deviceRegistry.endpoint.uri
+        x-descriptors:
+        - 'urn:alm:descriptor:org.w3:link'
+      - description: URL of the HTTP Protocol adapter endpoint.
+        displayName: HTTP Adapter endpoint
+        path: adapters.http.endpoint.uri
+        x-descriptors:
+        - 'urn:alm:descriptor:org.w3:link'
+      - description: URL of the LoRaWAN Protocol adapter endpoint.
+        displayName: LoRaWAN Adapter endpoint
+        path: adapters.lorawan.endpoint.uri
+        x-descriptors:
+        - 'urn:alm:descriptor:org.w3:link'
+      - description: URL of the Sigfox Protocol adapter endpoint.
+        displayName: Sigfox Adapter endpoint
+        path: adapters.sigfox.endpoint.uri
+        x-descriptors:
+        - 'urn:alm:descriptor:org.w3:link'
+      - description: URL of the MQTT Protocol adapter endpoint.
+        displayName: MQTT Adapter endpoint
+        path: adapters.mqtt.endpoint.uri
+        x-descriptors:
+        - 'urn:alm:descriptor:org.w3:link'
+    - group: iot.enmasse.io
+      version: v1alpha1
+      kind: IoTProject
+      name: iotprojects.iot.enmasse.io
+      displayName: IoT Project
+      description: An IoT project instance
+      statusDescriptors:
+      - description: The name of the tenant, when used in context of IoT functionality.
+        displayName: IoT tenant name
+        path: tenantName
+        x-descriptors:
+        - 'urn:alm:descriptor:text'
+      - description: Conditions
+        displayName: Conditions
+        path: conditions
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.conditions'
+      - description: The phase of the project.
+        displayName: Phase
+        path: phase
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.phase'
+      - description: Description of the project phase.
+        displayName: Reason
+        path: phaseReason
+        x-descriptors:
+        - 'urn:alm:descriptor:io.kubernetes.phase:reason'

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/authenticationservices.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/authenticationservices.crd.yaml
@@ -1,0 +1,217 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: authenticationservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: AuthenticationService
+    listKind: AuthenticationServiceList
+    singular: authenticationservice
+    plural: authenticationservices
+    categories:
+    - enmasse
+  additionalPrinterColumns:
+  - name: Phase
+    type: string
+    priority: 0
+    description: The phase of the authentication service
+    JSONPath: .status.phase
+  - name: Status
+    type: string
+    priority: 1
+    description: The status of the authentication service
+    JSONPath: .status.message
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: AuthenticationService describes a service that can be used for authenticating messaging clients for one or more address spaces. This resource is created by the service administrator.
+      properties:
+        spec:
+          type: object
+          properties:
+            type:
+              type: string
+              enum:
+              - none
+              - standard
+              - external
+            realm:
+              type: string
+            none:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+            standard:
+              type: object
+              properties:
+                certificateSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                credentialsSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                initImage:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                jvmOptions:
+                  type: string
+                image:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    pullPolicy:
+                      type: string
+                deploymentName:
+                  type: string
+                serviceName:
+                  type: string
+                routeName:
+                  type: string
+                storage:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                      enum:
+                      - ephemeral
+                      - persistent-claim
+                    class:
+                      type: string
+                    size:
+                      type: string
+                    claimName:
+                      type: string
+                    deleteClaim:
+                      type: boolean
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                datasource:
+                  type: object
+                  required:
+                  - type
+                  properties:
+                    type:
+                      type: string
+                    host:
+                      type: string
+                    port:
+                      type: integer
+                    database:
+                      type: string
+                    credentialsSecret:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                        namespace:
+                          type: string
+                securityContext:
+                  type: object
+            external:
+              type: object
+              required:
+              - host
+              - port
+              properties:
+                allowOverride:
+                  type: boolean
+                host:
+                  type: string
+                port:
+                  type: integer
+                caCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+                clientCertSecret:
+                  type: object
+                  properties:
+                    name:
+                      type: string
+                    namespace:
+                      type: string
+        status:
+          type: object
+          properties:
+            phase:
+              type: string
+              description: "Phase of the authentication service."
+            message:
+              type: string
+              description: "Status and error messages for the authentication service."
+            host:
+              type: string
+            port:
+              type: integer

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/brokeredinfraconfigs.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/brokeredinfraconfigs.crd.yaml
@@ -1,0 +1,121 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: brokeredinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: BrokeredInfraConfig
+    listKind: BrokeredInfraConfigList
+    singular: brokeredinfraconfig
+    plural: brokeredinfraconfigs
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: BrokeredInfraConfig defines configuration applied to brokers for an instance of the brokered address space type. This resource is created by the service administrator.
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        securityContext:
+                          type: object
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+            broker:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        securityContext:
+                          type: object
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                javaOpts:
+                  type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/consoleservices.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/consoleservices.crd.yaml
@@ -1,0 +1,164 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: consoleservices.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: ConsoleService
+    listKind: ConsoleServiceList
+    singular: consoleservice
+    plural: consoleservices
+    categories:
+    - enmasse
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: ConsoleService creates a console that can be used by messaging tenants to manage EnMasse. This resource is created by the service administrator.
+      properties:
+        metadata:
+          type: object
+          properties:
+            name:
+              type: string
+              pattern: "console"
+        spec:
+          type: object
+          properties:
+            replicas:
+              type: integer
+            discoveryMetadataURL:
+              type: string
+            certificateSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            oauthClientSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            ssoCookieDomain:
+              type: string
+            scope:
+              type: string
+            host:
+              type: string
+            consoleServer:
+              type: object
+              properties:
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                livenessProbe:
+                  type: object
+                  description: Overrides for the periodic probe of container liveness.
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      description: Number of seconds after the container has started before liveness probes are initiated.
+                    timeoutSeconds:
+                      type: integer
+                      description: Number of seconds after which the probe times out.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                readinessProbe:
+                  type: object
+                  description: Overrides for the periodic probe of container liveness.
+                  properties:
+                    initialDelaySeconds:
+                      type: integer
+                      description: Number of seconds after the container has started before liveness probes are initiated.
+                    timeoutSeconds:
+                      type: integer
+                      description: Number of seconds after which the probe times out.
+                    periodSeconds:
+                      type: integer
+                      description: How often (in seconds) to perform the probe.
+                    successThreshold:
+                      type: integer
+                      description: Minimum consecutive successes for the probe to be considered successful after having failed.
+                    failureThreshold:
+                      type: integer
+                      description: Minimum consecutive failures for the probe to be considered failed after having succeeded.
+                session:
+                  type: object
+                  properties:
+                    lifetime:
+                      type: string
+                      description: Lifetime controls the maximum length of time that a session is valid for before it expires. Defaults to 30m.
+                      pattern: '^[-+]?([0-9]*(\.[0-9]*)?(ns|us|µs|μs|ms|s|m|h))+$'
+                    idleTimeout:
+                      type: string
+                      description: IdleTimeout controls the maximum length of time a session can be inactive before it expires. Defaults to 5m.
+                      pattern: '^[-+]?([0-9]*(\.[0-9]*)?(ns|us|µs|μs|ms|s|m|h))+$'
+            oauthProxy:
+              type: object
+              properties:
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+        status:
+          type: object
+          properties:
+            host:
+              type: string
+            port:
+              type: integer
+            caCertSecret:
+              type: object
+              properties:
+                name:
+                  type: string
+

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/iotconfigs.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/iotconfigs.crd.yaml
@@ -1,0 +1,33 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: iotconfigs.iot.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: iot.enmasse.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: IoTConfig
+    plural: iotconfigs
+    singular: iotconfig
+    shortNames:
+    - icfg
+    categories:
+    - enmasse
+  additionalPrinterColumns:
+  - name: Phase
+    type: string
+    description: Phase of the IoT config
+    JSONPath: .status.phase
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: IoTConfig deploys the IoT protocol adapters, device registry and tenant management services. This resource is created by the service administrator.
+      properties:
+        spec:
+          type: object
+        status:
+          type: object

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/iotprojects.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/iotprojects.crd.yaml
@@ -1,0 +1,50 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: iotprojects.iot.enmasse.io
+  labels:
+    app: enmasse
+    enmasse-component: iot
+spec:
+  group: iot.enmasse.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    kind: IoTProject
+    plural: iotprojects
+    singular: iotproject
+    shortNames:
+    - itp
+    categories:
+    - enmasse
+  additionalPrinterColumns:
+  - name: IoT tenant
+    type: string
+    description: The name of the IoT tenant
+    JSONPath: .status.tenantName
+  - name: Downstream Host
+    type: string
+    description: The endpoint host name
+    JSONPath: .status.downstreamEndpoint.host
+  - name: Downstream Port
+    type: integer
+    description: The endpoint port number
+    JSONPath: .status.downstreamEndpoint.port
+  - name: TLS
+    type: boolean
+    description: If TLS is enabled
+    JSONPath: .status.downstreamEndpoint.tls
+  - name: Phase
+    type: string
+    description: Phase of the IoT project
+    JSONPath: .status.phase
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: IoTProject creates a new isolated space for IoT related messsaging. This resource is created by the messaging tenant and is also sometimes called an "IoT Tenant".
+      properties:
+        spec:
+          type: object
+        status:
+          type: object

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/messagingusers.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/messagingusers.crd.yaml
@@ -1,0 +1,123 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: messagingusers.user.enmasse.io
+  labels:
+    app: enmasse
+    enmasse-component: tenant-api
+spec:
+  group: user.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: MessagingUser
+    listKind: MessagingUserList
+    singular: messaginguser
+    plural: messagingusers
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+  additionalPrinterColumns:
+  - name: Username
+    type: string
+    description: The user name used by clients
+    priority: 0
+    JSONPath: .spec.username
+  - name: Type
+    type: string
+    description: Authentication type of the user
+    priority: 0
+    JSONPath: .spec.authentication.type
+  - name: Phase
+    priority: 0
+    type: string
+    description: Phase of the Messaging User
+    JSONPath: .status.phase
+  - name: Message
+    priority: 1
+    type: string
+    description: Message of the Messaging User
+    JSONPath: .status.message
+  - name: Age
+    priority: 0
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: MessagingUser is a user that can be used to authenticate and authorize a messaging application. This resource is created by messaging tenants.
+      properties:
+        status:
+          type: object
+          properties:
+            phase:
+              description: "The lifecycle phase of the messaging user"
+              type: string
+            message:
+              description: "Message describing the current state"
+              type: string
+            generation:
+              description: "Applied generation"
+              type: integer
+        spec:
+          type: object
+          required:
+            - username
+            - authentication
+          properties:
+            username:
+              type: string
+              description: "The username used by messaging clients."
+              pattern: "^[a-z0-9]+([a-z0-9_@.:\\-]*[a-z0-9]+|[a-z0-9]*)$"
+            authentication:
+              type: object
+              description: "The authentication specification."
+              required:
+                - type
+              properties:
+                type:
+                  type: string
+                  description: "The type of authentication."
+                  enum:
+                  - password
+                  - federated
+                  - serviceaccount
+                password:
+                  type: string
+                  description: "Base64-encoded password for the 'password' authentication type."
+                provider:
+                  type: string
+                  description: "Federated identity provider for the 'federated' authentication type."
+                federatedUserid:
+                  type: string
+                  description: "Federated user id for the 'federated' authentication type."
+                federatedUsername:
+                  type: string
+                  description: "Federated user name for the 'federated' authentication type."
+            authorization:
+              type: array
+              description: "The authorization rules for the user."
+              items:
+                type: object
+                properties:
+                  operations:
+                    type: array
+                    description: "The operations that should apply to addresses matched by this rule."
+                    items:
+                      type: string
+                      enum:
+                      - send
+                      - recv
+                      - view
+                      - manage
+                  addresses:
+                    type: array
+                    description: "The addresses the rule should apply to."
+                    items:
+                      type: string
+                      description: "Pattern used to match addresses. The pattern will be prefixed by the connector name and a forward slash ('myconnector/'). A pattern consists of one or more tokens separated by a forward slash /. A token can be one of the following: a * character, a # character, or a sequence of characters that do not include /, *, or #. The * token matches any single token. The # token matches zero or more tokens. * has higher precedence than #, and exact match has the highest precedence."
+                      pattern: "([^/#*]+|\\*|#)(/([^/#*]+|\\*|#))*"

--- a/manifests/integreatly-amq-online/amq-online-1.4.0/standardinfraconfigs.crd.yaml
+++ b/manifests/integreatly-amq-online/amq-online-1.4.0/standardinfraconfigs.crd.yaml
@@ -1,0 +1,193 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: standardinfraconfigs.admin.enmasse.io
+  labels:
+    app: enmasse
+spec:
+  group: admin.enmasse.io
+  version: v1beta1
+  scope: Namespaced
+  names:
+    kind: StandardInfraConfig
+    listKind: StandardInfraConfigList
+    singular: standardinfraconfig
+    plural: standardinfraconfigs
+    categories:
+    - enmasse
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  validation:
+    openAPIV3Schema:
+      type: object
+      description: StandardInfraConfig defines configuration applied to routers and brokers for an instance of the standard address space type. This resource is created by the service administrator.
+      properties:
+        spec:
+          type: object
+          properties:
+            version:
+              type: string
+            networkPolicy:
+              type: object
+              properties:
+                ingress:
+                  type: array
+                egress:
+                  type: array
+            admin:
+              type: object
+              properties:
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                          items:
+                            type: object
+                        priorityClassName:
+                          type: string
+                        securityContext:
+                          type: object
+                        containers:
+                          type: array
+                          items:
+                            type: object
+                            properties:
+                              resources:
+                                type: object
+            broker:
+              type: object
+              properties:
+                minAvailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        securityContext:
+                          type: object
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                    storage:
+                      type: string
+                javaOpts:
+                  type: string
+                addressFullPolicy:
+                  type: string
+                  enum:
+                  - PAGE
+                  - BLOCK
+                  - FAIL
+                  - DROP
+                storageClassName:
+                  type: string
+                updatePersistentVolumeClaim:
+                  type: boolean
+                connectorIdleTimeout:
+                  type: integer
+                connectorWorkerThreads:
+                  type: integer
+            router:
+              type: object
+              properties:
+                podTemplate:
+                  type: object
+                  properties:
+                    metadata:
+                      type: object
+                      properties:
+                        labels:
+                          type: object
+                    spec:
+                      type: object
+                      properties:
+                        affinity:
+                          type: object
+                        tolerations:
+                          type: array
+                        priorityClassName:
+                          type: string
+                        securityContext:
+                          type: object
+                        resources:
+                          type: object
+                resources:
+                  type: object
+                  properties:
+                    memory:
+                      type: string
+                minReplicas:
+                  type: integer
+                minAvailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                maxUnavailable:
+                  anyOf:
+                  - type: integer
+                  - type: string
+                linkCapacity:
+                  type: integer
+                idleTimeout:
+                  type: integer
+                workerThreads:
+                  type: integer
+                policy:
+                  type: object
+                  properties:
+                    maxConnections:
+                      type: integer
+                    maxConnectionsPerUser:
+                      type: integer
+                    maxConnectionsPerHost:
+                      type: integer
+                    maxSessionsPerConnection:
+                      type: integer
+                    maxSendersPerConnection:
+                      type: integer
+                    maxReceiversPerConnection:
+                      type: integer

--- a/manifests/integreatly-amq-online/amq-online.package.yaml
+++ b/manifests/integreatly-amq-online/amq-online.package.yaml
@@ -1,4 +1,4 @@
 packageName: rhmi-amq-online
 channels:
 - name: rhmi
-  currentCSV: amqonline.1.3.1
+  currentCSV: amq-online.1.4.0

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -53,7 +53,7 @@ var (
 	// Could not find a way to determine these versions dynamically, so they are hard-coded
 	// It is preferable to determine the version of a product dynamically (from a CR, or configmap, etc)
 	// Follow up Jira: https://issues.redhat.com/browse/INTLY-5946
-	VersionAMQOnline           ProductVersion = "1.3"
+	VersionAMQOnline           ProductVersion = "1.4"
 	VersionApicurito           ProductVersion = "7.5"
 	VersionAMQStreams          ProductVersion = "1.1.0"
 	VersionCodeReadyWorkspaces ProductVersion = "2.0.0"
@@ -73,7 +73,7 @@ var (
 
 	// Operator image tags
 	OperatorVersionAMQStreams          OperatorVersion = "1.1.0"
-	OperatorVersionAMQOnline           OperatorVersion = "1.3"
+	OperatorVersionAMQOnline           OperatorVersion = "1.4"
 	OperatorVersionMonitoring          OperatorVersion = "1.1.4"
 	OperatorVersionSolutionExplorer    OperatorVersion = "0.0.46"
 	OperatorVersionRHSSO               OperatorVersion = "8.0.1"

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -613,7 +613,7 @@ func (r *Reconciler) reconcilePrometheusRule(ctx context.Context, client k8sclie
 				"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md",
 				"message": fmt.Sprintf("AMQ-SLO-1.1: AMQ Online console is not available in namespace '%s'", r.Config.GetNamespace()),
 			},
-			Expr:   intstr.FromString(fmt.Sprintf("absent(kube_endpoint_address_available{endpoint='console',namespace='%s'}==1)", r.Config.GetNamespace())),
+			Expr:   intstr.FromString(fmt.Sprintf("absent(kube_endpoint_address_available{endpoint='console',namespace='%s'}==2)", r.Config.GetNamespace())),
 			For:    "300s",
 			Labels: map[string]string{"severity": "critical"},
 		},

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -221,6 +221,10 @@ var expectedRules = []alertsTestRule{
 			"UnifiedPushOperatorDown",
 		},
 	},
+	{
+		File:  "redhat-rhmi-amq-online-enmasse-console-rules.yaml",
+		Rules: []string{},
+	},
 }
 
 var expectedAWSRules = []alertsTestRule{
@@ -355,8 +359,7 @@ func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 		for _, promRule := range group.Rules {
 			switch v := promRule.(type) {
 			case prometheusv1.RecordingRule:
-				recRule := promRule.(prometheusv1.RecordingRule)
-				rule.Rules = append(rule.Rules, recRule.Name)
+				fmt.Print("got a recording rule")
 			case prometheusv1.AlertingRule:
 				alertRule := promRule.(prometheusv1.AlertingRule)
 				rule.Rules = append(rule.Rules, alertRule.Name)

--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -23,12 +23,10 @@ var (
 			Name: "redhat-rhmi-amq-online",
 			Products: []Product{
 				Product{Name: "address-space-controller", ExpectedReplicas: 1},
-				Product{Name: "api-server", ExpectedReplicas: 1},
 				Product{Name: "console", ExpectedReplicas: 1},
 				Product{Name: "enmasse-operator", ExpectedReplicas: 1},
 				Product{Name: "none-authservice", ExpectedReplicas: 1},
 				Product{Name: "standard-authservice", ExpectedReplicas: 1},
-				Product{Name: "user-api-server", ExpectedReplicas: 1},
 			},
 		},
 		{


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-5516

Upgrading AMQ Online to version 1.4. I have tested both install and upgrade using the steps in the JIRA. This has caused an issue with the first walkthrough in solution explorer which I have created a follow on JIRA for.

Unfortunately, it is still not possible to include the Enmasse operator as a dependency in Go mod due to this issue - https://github.com/EnMasseProject/enmasse/issues/4156

## Verification
1. Get login details for both fresh install and upgrade cluster from me directly
2. Test using AMQ Online, creating address spaces, addresses etc.

## Type of change
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer