### PR TITLE
Refactored threescale external resource metric creation

### DIFF
--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -73,7 +73,7 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 }
 
 // CreateRedisAvailabilityAlert creates a PrometheusRule alert to watch for the availability
-// of a Redis cacheu
+// of a Redis cache
 func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, inst *v1alpha1.RHMI, cr *crov1.Redis) (*prometheusv1.PrometheusRule, error) {
 	if strings.ToLower(inst.Spec.UseClusterStorage) == "true" {
 		logrus.Info("skipping redis alert creation, useClusterStorage is true")


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/INTLY-6490

This PR addresses 2 issues:

1. When installing RHMI using external AWS resources resources, the Threescale Postgres/Redis alerts would trigger initially, and then resolve when the resources were in an available state. This PR refactors the existing Threescale alert creation flow to ensure that the alerts are created only when the resources are in an available state.

![threescale_alerts](https://user-images.githubusercontent.com/47980969/77921309-7feba800-7297-11ea-96ea-8c88caf8df5a.png)

2. AWS Postgres and Redis alerts were noticed to be firing continuously, on what looked to be every hour. Any AWS resource related Prometheus alerts are now created with `for = '5m'`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
- Using this branch, run an install using external Postgres/Redis AWS resources
- Ensure the Postgres/Redis Threescale alerts are created only once the accompanying AWS resources are in an available state, and that they are **not** firing.
- Verify that the alerts are not firing every hour.