### PR TITLE
Automate configuration of ews branches

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ export INSTALLATION_NAME   ?= rhmi
 export INSTALLATION_PREFIX ?= redhat-rhmi
 export USE_CLUSTER_STORAGE ?= true
 export OPERATORS_IN_PRODUCT_NAMESPACE ?= false # e2e tests and createInstallationCR() need to be updated when default is changed
+export DELOREAN_PULL_SECRET_NAME ?= integreatly-delorean-pull-secret
 
 define wait_command
 	@echo Waiting for $(2) for $(3)...
@@ -69,6 +70,9 @@ code/run: code/gen cluster/prepare/smtp cluster/prepare/dms cluster/prepare/page
 code/run/service_account: setup/service_account
 	@oc login --token=$(shell oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE})
 	$(MAKE) code/run
+
+.PHONY: code/run/delorean
+code/run/delorean: cluster/cleanup cluster/prepare cluster/prepare/local deploy/integreatly-rhmi-cr.yml code/run/service_account
 
 .PHONY: code/compile
 code/compile: code/gen
@@ -165,7 +169,7 @@ cluster/deploy/integreatly-rhmi-cr.yml: deploy/integreatly-rhmi-cr.yml
 	$(call wait_command, oc get RHMI $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.solution-explorer.phase}' | grep -q completed, solution-explorer phase, 10m, 30)
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty
+cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
@@ -186,7 +190,7 @@ cluster/prepare/crd:
 	- oc create -f deploy/crds/*_crd.yaml
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty
+cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 	@oc create -f deploy/service_account.yaml
 	@oc create -f deploy/role.yaml
 	@oc create -f deploy/role_binding.yaml
@@ -222,6 +226,15 @@ cluster/prepare/dms:
 	@-oc create secret generic $(INSTALLATION_PREFIX)-deadmanssnitch -n $(NAMESPACE) \
 		--from-literal=url=https://dms.example.com
 
+.PHONY: cluster/prepare/delorean
+cluster/prepare/delorean:
+ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
+	@echo Detected a delorean ews branch. The integreatly-delorean-secret.yml is required.
+	@echo Please contact the delorean team to get this if you do not already have it.
+	@echo Add it to the root dir of this repo and rerun the desired target if the target fails on it not existing
+	@ oc apply -f integreatly-delorean-secret.yml --namespace=$(NAMESPACE)
+endif
+
 .PHONY: cluster/cleanup
 cluster/cleanup:
 	@-oc delete -f deploy/integreatly-rhmi-cr.yml --timeout=240s --wait
@@ -254,6 +267,15 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
 	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > deploy/integreatly-rhmi-cr.yml
+ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
+	@sed -i.bak "s/DELOREAN_PULL_SECRET_NAMESPACE/$(NAMESPACE)/g" deploy/integreatly-rhmi-cr.yml
+	@sed -i.bak "s/DELOREAN_PULL_SECRET_NAME/$(DELOREAN_PULL_SECRET_NAME)/g" deploy/integreatly-rhmi-cr.yml
+	rm deploy/integreatly-rhmi-cr.yml.bak
+else
+	@sed -i.bak "s/DELOREAN_PULL_SECRET_NAMESPACE//g" deploy/integreatly-rhmi-cr.yml
+	@sed -i.bak "s/DELOREAN_PULL_SECRET_NAME//g" deploy/integreatly-rhmi-cr.yml
+	rm deploy/integreatly-rhmi-cr.yml.bak
+endif
 	@-oc create -f deploy/integreatly-rhmi-cr.yml
 
 .PHONY: gen/csv

--- a/deploy/crds/examples/integreatly-rhmi-cr.yaml
+++ b/deploy/crds/examples/integreatly-rhmi-cr.yaml
@@ -11,3 +11,6 @@ spec:
   smtpSecret: INSTALLATION_PREFIX-smtp
   deadMansSnitchSecret: INSTALLATION_PREFIX-deadmanssnitch
   pagerDutySecret: INSTALLATION_PREFIX-pagerduty
+  pullSecret:
+    name: 'DELOREAN_PULL_SECRET_NAME'
+    namespace: 'DELOREAN_PULL_SECRET_NAMESPACE'


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/DEL-208

## Pre-req
- A copy of the delorean pull secret downloaded from quay in the root dir of the operator.
- An openshift cluster to run it against and logged in with a user with cluster-admin privileges

NOTE: The verification can be done very early on in the install. You can kill it by deleting the cr but keep the operator running locally until you see `INFO[xxxx] uninstall completed`

## Verify that... 

### A)..the delorean pre-config is done

1. Checkout this branch
2. `git rebase fuse-online-next-del195 `
3. oc login with kubeadmin user to OSD cluster (I can provide one if needed) 
#### for local Delorean code run
Run steps 1-3 above (if not done already)
4.  make code/run/delorean 
#### for e2e-test
Run steps 1-3 above (if not done already)
4. sed 's/TAG=2.0.0/TAG=2.0.0-rc1/g' Makefile
5. -make test/e2e

In both cases, verify that the entry 

1. `pullSecret` is populated with this value: ```    name: integreatly-delorean-pull-secret
    namespace: redhat-rhmi-operator``` in rhmi ci in `redhat-rhmi-operator` namespace

2. integreatly-delorean-pull-secret is created in `redhat-rhmi-operator` namespace

### B).. the delorean pre-config **not** added in cases where no image_mirror_mapping
Repeat steps 1.3. (if not done already) and 4 above. 
- the configuration should not be added in the rhmi cr.
- the integreatly-delorean-pull-secret is **not** in `redhat-rhmi-operator` namespace

## Type of change

- [x] Automation 

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer