### PR TITLE
INTLY-3686 Perform backup of products before upgrade

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975 // indirect
 	golang.org/x/lint v0.0.0-20200130185559-910be7a94367 // indirect
 	golang.org/x/net v0.0.0-20200202094626-16171245cfb2
+	golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
 	golang.org/x/tools v0.0.0-20200207224406-61798d64f025 // indirect
 	gopkg.in/headzoo/surf.v1 v1.0.0
 	gopkg.in/yaml.v2 v2.2.4

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -3,7 +3,9 @@ package amqstreams
 import (
 	"context"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -15,6 +17,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -116,7 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Namespace: r.Config.GetOperatorNamespace(), Channel: marketplace.IntegreatlyChannel, Pkg: constants.AMQStreamsSubscriptionName, ManifestPackage: manifestPackage}, []string{ns}, serverClient)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Namespace: r.Config.GetOperatorNamespace(), Channel: marketplace.IntegreatlyChannel, Pkg: constants.AMQStreamsSubscriptionName, ManifestPackage: manifestPackage}, []string{ns}, backup.NewNoopBackupExecutor(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.AMQStreamsSubscriptionName), err)
 		return phase, err

--- a/pkg/products/apicurito/reconciler.go
+++ b/pkg/products/apicurito/reconciler.go
@@ -3,8 +3,9 @@ package apicurito
 import (
 	"context"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	"strings"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
 	v1 "k8s.io/api/apps/v1"
 
@@ -23,6 +24,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -145,7 +147,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.ApicuritoSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, serverClient)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.ApicuritoSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, backup.NewNoopBackupExecutor(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.ApicuritoSubscriptionName), err)
 		return phase, err

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -3,6 +3,7 @@ package cloudresources
 import (
 	"context"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
 	"github.com/sirupsen/logrus"
@@ -13,6 +14,7 @@ import (
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -108,7 +110,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.CloudResourceSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{installation.Namespace}, client)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.CloudResourceSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{installation.Namespace}, backup.NewNoopBackupExecutor(), client)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.CloudResourceSubscriptionName), err)
 		return phase, err

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -503,6 +503,7 @@ func (r *Reconciler) preUpgradeBackupExecutor() backup.BackupExecutor {
 	return backup.NewConcurrentBackupExecutor(
 		pvBackup,
 		backup.NewAWSBackupExecutor(
+			r.installation.Namespace,
 			"codeready-postgres-rhmi",
 			backup.PostgresSnapshotType,
 		),

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -333,6 +333,7 @@ func preUpgradeBackupExecutor(installation *integreatlyv1alpha1.RHMI) backup.Bac
 	// }
 
 	// return backup.NewAWSBackupExecutor(
+	// 	installation.Namespace,
 	// 	"fuse-online-postgres-rhmi",
 	// 	backup.PostgresSnapshotType,
 	// )

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -3,8 +3,10 @@ package fuse
 import (
 	"context"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
@@ -145,7 +147,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.FuseSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, serverClient)
+	preUpgradeBackups := preUpgradeBackupExecutor(installation)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.FuseSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, preUpgradeBackups, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.FuseSubscriptionName), err)
 		return phase, err
@@ -318,4 +321,19 @@ func (r *Reconciler) reconcileCustomResource(ctx context.Context, installation *
 
 	// if there are no errors, the phase is complete
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func preUpgradeBackupExecutor(installation *integreatlyv1alpha1.RHMI) backup.BackupExecutor {
+	return backup.NewNoopBackupExecutor()
+
+	// Holding off until Fuse 7.6 GA, that allows for external databases:
+	//
+	// if installation.Spec.UseClusterStorage != "false" {
+	// 	return backup.NewNoopBackupExecutor()
+	// }
+
+	// return backup.NewAWSBackupExecutor(
+	// 	"fuse-online-postgres-rhmi",
+	// 	backup.PostgresSnapshotType,
+	// )
 }

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -11,6 +11,7 @@ import (
 	v1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/types"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
@@ -185,7 +186,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.MonitoringSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackagae}, []string{r.Config.GetOperatorNamespace()}, serverClient)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.MonitoringSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackagae}, []string{r.Config.GetOperatorNamespace()}, backup.NewNoopBackupExecutor(), serverClient)
 	logrus.Infof("Phase: %s ReconcileSubscription", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.MonitoringSubscriptionName), err)

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -745,6 +745,7 @@ func (r *Reconciler) preUpgradeBackupsExecutor() backup.BackupExecutor {
 	}
 
 	return backup.NewAWSBackupExecutor(
+		r.installation.Namespace,
 		"rhsso-postgres-rhmi",
 		backup.PostgresSnapshotType,
 	)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -491,6 +491,7 @@ func (r *Reconciler) preUpgradeBackupsExecutor() backup.BackupExecutor {
 	}
 
 	return backup.NewAWSBackupExecutor(
+		r.installation.Namespace,
 		"rhssouser-postgres-rhmi",
 		backup.PostgresSnapshotType,
 	)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 
 	routev1 "github.com/openshift/api/route/v1"
@@ -204,7 +205,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.RHSSOUserSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, serverClient)
+	preUpgradeBackupsExecutor := r.preUpgradeBackupsExecutor()
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.RHSSOUserSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, preUpgradeBackupsExecutor, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.RHSSOUserSubscriptionName), err)
 		return phase, err
@@ -481,6 +483,17 @@ func (r *Reconciler) createOrUpdateKeycloakAdmin(user keycloak.KeycloakAPIUser, 
 
 		return nil
 	})
+}
+
+func (r *Reconciler) preUpgradeBackupsExecutor() backup.BackupExecutor {
+	if r.installation.Spec.UseClusterStorage != "false" {
+		return backup.NewNoopBackupExecutor()
+	}
+
+	return backup.NewAWSBackupExecutor(
+		"rhssouser-postgres-rhmi",
+		backup.PostgresSnapshotType,
+	)
 }
 
 func GetKeycloakUsers(ctx context.Context, serverClient k8sclient.Client, ns string) ([]keycloak.KeycloakAPIUser, error) {

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	"strings"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
 	"github.com/integr8ly/integreatly-operator/version"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
@@ -177,7 +179,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.SolutionExplorerSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, serverClient)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.SolutionExplorerSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, backup.NewNoopBackupExecutor(), serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.SolutionExplorerSubscriptionName), err)
 		return phase, err

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
@@ -171,7 +172,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.ThreeScaleSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, serverClient)
+	preUpgradeBackups := r.preUpgradeBackupExecutor()
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.ThreeScaleSubscriptionName, Channel: marketplace.IntegreatlyChannel, Namespace: r.Config.GetOperatorNamespace(), ManifestPackage: manifestPackage}, []string{r.Config.GetNamespace()}, preUpgradeBackups, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.ThreeScaleSubscriptionName), err)
 		return phase, err
@@ -843,6 +845,27 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) preUpgradeBackupExecutor() backup.BackupExecutor {
+	if r.installation.Spec.UseClusterStorage != "false" {
+		return backup.NewNoopBackupExecutor()
+	}
+
+	return backup.NewConcurrentBackupExecutor(
+		backup.NewAWSBackupExecutor(
+			"threescale-postgres-rhmi",
+			backup.PostgresSnapshotType,
+		),
+		backup.NewAWSBackupExecutor(
+			"threescale-backend-redis-rhmi",
+			backup.RedisSnapshotType,
+		),
+		backup.NewAWSBackupExecutor(
+			"threescale-redis-rhmi",
+			backup.RedisSnapshotType,
+		),
+	)
 }
 
 func syncOpenshiftAdminMembership(openshiftAdminGroup *usersv1.Group, newTsUsers *Users, systemAdminUsername string, isWorkshop bool, tsClient ThreeScaleInterface, accessToken string) error {

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -854,14 +854,17 @@ func (r *Reconciler) preUpgradeBackupExecutor() backup.BackupExecutor {
 
 	return backup.NewConcurrentBackupExecutor(
 		backup.NewAWSBackupExecutor(
+			r.installation.Namespace,
 			"threescale-postgres-rhmi",
 			backup.PostgresSnapshotType,
 		),
 		backup.NewAWSBackupExecutor(
+			r.installation.Namespace,
 			"threescale-backend-redis-rhmi",
 			backup.RedisSnapshotType,
 		),
 		backup.NewAWSBackupExecutor(
+			r.installation.Namespace,
 			"threescale-redis-rhmi",
 			backup.RedisSnapshotType,
 		),

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -307,6 +307,7 @@ func preUpgradeBackupExecutor(installation *integreatlyv1alpha1.RHMI) backup.Bac
 	}
 
 	return backup.NewAWSBackupExecutor(
+		installation.Namespace,
 		"ups-postgres-rhmi",
 		backup.PostgresSnapshotType,
 	)

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -8,6 +8,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
@@ -133,7 +134,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.UPSSubscriptionName, Namespace: r.Config.GetOperatorNamespace(), Channel: marketplace.IntegreatlyChannel, ManifestPackage: manifestPackage}, []string{ns}, serverClient)
+	preUpgradeBackups := preUpgradeBackupExecutor(installation)
+	phase, err = r.ReconcileSubscription(ctx, namespace, marketplace.Target{Pkg: constants.UPSSubscriptionName, Namespace: r.Config.GetOperatorNamespace(), Channel: marketplace.IntegreatlyChannel, ManifestPackage: manifestPackage}, []string{ns}, preUpgradeBackups, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.UPSSubscriptionName), err)
 
@@ -297,4 +299,15 @@ func (r *Reconciler) reconcileBlackboxTargets(ctx context.Context, installation 
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func preUpgradeBackupExecutor(installation *integreatlyv1alpha1.RHMI) backup.BackupExecutor {
+	if installation.Spec.UseClusterStorage != "false" {
+		return backup.NewNoopBackupExecutor()
+	}
+
+	return backup.NewAWSBackupExecutor(
+		"ups-postgres-rhmi",
+		backup.PostgresSnapshotType,
+	)
 }

--- a/pkg/resources/backup/aws.go
+++ b/pkg/resources/backup/aws.go
@@ -1,0 +1,134 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	crotypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// AWSBackupExecutor knows how to perform backups by creating snapshot CRs
+// and waiting for their completion
+type AWSBackupExecutor struct {
+	ResourceName string          // AWS Resource name
+	SnapshotType AWSSnapshotType // Type of snapshot CR to create
+}
+
+func NewAWSBackupExecutor(resourceName string, snapshotType AWSSnapshotType) BackupExecutor {
+	return &AWSBackupExecutor{
+		ResourceName: resourceName,
+		SnapshotType: snapshotType,
+	}
+}
+
+// AWSSnapshotType represents the type of snapshot to create
+type AWSSnapshotType string
+
+const (
+	// PostgresSnapshotType creates PostgresSnapshot CRs
+	PostgresSnapshotType AWSSnapshotType = "PostgresSnapshot"
+	// RedisSnapshotType creates RedisSnapshot CRs
+	RedisSnapshotType AWSSnapshotType = "RedisSnapshot"
+)
+
+// PerformBackup creates a snapshot CR and waits until the status of the CR
+// is `complete`
+func (e *AWSBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.Duration) error {
+	logrus.Infof("Performing backup by creating %s for AWS resource %s", e.SnapshotType, e.ResourceName)
+
+	snapshotName := fmt.Sprintf("%s-preupgrade-snapshot-%s", e.ResourceName, time.Now().Format("2006-01-02-150405"))
+
+	// Initialize the snapshot CR based on the snapshot type
+	var snapshotCR runtime.Object
+	commonObjectMeta := v1.ObjectMeta{
+		Namespace: "redhat-rhmi-operator",
+		Name:      snapshotName,
+	}
+
+	switch e.SnapshotType {
+	case PostgresSnapshotType:
+		snapshotCR = &v1alpha1.PostgresSnapshot{
+			ObjectMeta: commonObjectMeta,
+			Spec: v1alpha1.PostgresSnapshotSpec{
+				ResourceName: e.ResourceName,
+			},
+		}
+	case RedisSnapshotType:
+		snapshotCR = &v1alpha1.RedisSnapshot{
+			ObjectMeta: commonObjectMeta,
+			Spec: v1alpha1.RedisSnapshotSpec{
+				ResourceName: e.ResourceName,
+			},
+		}
+	default:
+		return fmt.Errorf("Unsupported value for AWSShapshotType. Expected %s or %s, got %s",
+			PostgresSnapshotType, RedisSnapshotType, e.SnapshotType)
+	}
+
+	// Create the CR
+	err := client.Create(context.TODO(), snapshotCR)
+	if err != nil {
+		return fmt.Errorf("Error creating %s for backup of resource %s: %v",
+			e.SnapshotType, e.ResourceName, err)
+	}
+
+	// Initialize the CR to query it's completion
+	var queryCR runtime.Object
+	switch e.SnapshotType {
+	case PostgresSnapshotType:
+		queryCR = &v1alpha1.PostgresSnapshot{}
+	case RedisSnapshotType:
+		queryCR = &v1alpha1.RedisSnapshot{}
+	}
+
+	// Request the CR status until it's complete or it times out
+	started := time.Now()
+	for {
+		// If it times out, return an error
+		if time.Now().After(started.Add(timeout)) {
+			return fmt.Errorf("Snapshot of %s %s timed out", e.ResourceName, e.SnapshotType)
+		}
+
+		// Get the CR
+		err = client.Get(context.TODO(), types.NamespacedName{
+			Name:      snapshotName,
+			Namespace: "redhat-rhmi-operator",
+		}, queryCR)
+		if err != nil {
+			return fmt.Errorf("Error occurred querying snapshot for backup %s", e.ResourceName)
+		}
+
+		// Get the phase
+		var phase crotypes.StatusPhase
+		var message crotypes.StatusMessage
+		switch e.SnapshotType {
+		case PostgresSnapshotType:
+			typedSnapshotCR := queryCR.(*v1alpha1.PostgresSnapshot)
+			phase = typedSnapshotCR.Status.Phase
+			message = typedSnapshotCR.Status.Message
+		case RedisSnapshotType:
+			typedSnapshotCR := queryCR.(*v1alpha1.RedisSnapshot)
+			phase = typedSnapshotCR.Status.Phase
+			message = typedSnapshotCR.Status.Message
+		}
+
+		// If the snapshot failed, return an error with the message
+		if phase == crotypes.PhaseFailed {
+			return fmt.Errorf("Snapshot failed: %s", message)
+		}
+
+		// If it's complete, break the loop
+		if phase == crotypes.PhaseComplete {
+			break
+		}
+	}
+
+	return nil
+}

--- a/pkg/resources/backup/aws.go
+++ b/pkg/resources/backup/aws.go
@@ -17,14 +17,16 @@ import (
 // AWSBackupExecutor knows how to perform backups by creating snapshot CRs
 // and waiting for their completion
 type AWSBackupExecutor struct {
-	ResourceName string          // AWS Resource name
-	SnapshotType AWSSnapshotType // Type of snapshot CR to create
+	SnapshotNamespace string          // Namespace where the snapshot CR is created
+	ResourceName      string          // AWS Resource name
+	SnapshotType      AWSSnapshotType // Type of snapshot CR to create
 }
 
-func NewAWSBackupExecutor(resourceName string, snapshotType AWSSnapshotType) BackupExecutor {
+func NewAWSBackupExecutor(snapshotNamespace, resourceName string, snapshotType AWSSnapshotType) BackupExecutor {
 	return &AWSBackupExecutor{
-		ResourceName: resourceName,
-		SnapshotType: snapshotType,
+		SnapshotNamespace: snapshotNamespace,
+		ResourceName:      resourceName,
+		SnapshotType:      snapshotType,
 	}
 }
 
@@ -48,7 +50,7 @@ func (e *AWSBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.
 	// Initialize the snapshot CR based on the snapshot type
 	var snapshotCR runtime.Object
 	commonObjectMeta := v1.ObjectMeta{
-		Namespace: "redhat-rhmi-operator",
+		Namespace: e.SnapshotNamespace,
 		Name:      snapshotName,
 	}
 
@@ -99,7 +101,7 @@ func (e *AWSBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.
 		// Get the CR
 		err = client.Get(context.TODO(), types.NamespacedName{
 			Name:      snapshotName,
-			Namespace: "redhat-rhmi-operator",
+			Namespace: e.SnapshotNamespace,
 		}, queryCR)
 		if err != nil {
 			return fmt.Errorf("Error occurred querying snapshot for backup %s", e.ResourceName)

--- a/pkg/resources/backup/aws_test.go
+++ b/pkg/resources/backup/aws_test.go
@@ -24,16 +24,17 @@ func TestAWSSnapshotPostgres(t *testing.T) {
 		return
 	}
 
+	namespace := "redhat-rhmi-operator"
 	resourceName := "test-rhmi-postgres"
 
 	client := fake.NewFakeClientWithScheme(scheme)
-	executor := NewAWSBackupExecutor(resourceName, PostgresSnapshotType)
+	executor := NewAWSBackupExecutor(namespace, resourceName, PostgresSnapshotType)
 
 	go func() {
 		var postgresSnapshot *v1alpha1.PostgresSnapshot
 		for {
 			existingSnapshots := &v1alpha1.PostgresSnapshotList{}
-			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace(namespace))
 
 			for _, existingSnapshot := range existingSnapshots.Items {
 				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
@@ -71,16 +72,17 @@ func TestAWSSnapshotRedis(t *testing.T) {
 		return
 	}
 
+	namespace := "redhat-rhmi-operator"
 	resourceName := "test-rhmi-redis"
 
 	client := fake.NewFakeClientWithScheme(scheme)
-	executor := NewAWSBackupExecutor(resourceName, RedisSnapshotType)
+	executor := NewAWSBackupExecutor(namespace, resourceName, RedisSnapshotType)
 
 	go func() {
 		var redisSnapshot *v1alpha1.RedisSnapshot
 		for {
 			existingSnapshots := &v1alpha1.RedisSnapshotList{}
-			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace(namespace))
 
 			for _, existingSnapshot := range existingSnapshots.Items {
 				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
@@ -118,16 +120,17 @@ func TestAWSSnapshotPostgres_FailedJob(t *testing.T) {
 		return
 	}
 
+	namespace := "redhat-rhmi-operator"
 	resourceName := "test-rhmi-postgres"
 
 	client := fake.NewFakeClientWithScheme(scheme)
-	executor := NewAWSBackupExecutor(resourceName, PostgresSnapshotType)
+	executor := NewAWSBackupExecutor(namespace, resourceName, PostgresSnapshotType)
 
 	go func() {
 		var postgresSnapshot *v1alpha1.PostgresSnapshot
 		for {
 			existingSnapshots := &v1alpha1.PostgresSnapshotList{}
-			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace(namespace))
 
 			for _, existingSnapshot := range existingSnapshots.Items {
 				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
@@ -173,16 +176,17 @@ func TestAWSSnapshotRedis_FailedJob(t *testing.T) {
 		return
 	}
 
+	namespace := "redhat-rhmi-operator"
 	resourceName := "test-rhmi-redis"
 
 	client := fake.NewFakeClientWithScheme(scheme)
-	executor := NewAWSBackupExecutor(resourceName, RedisSnapshotType)
+	executor := NewAWSBackupExecutor(namespace, resourceName, RedisSnapshotType)
 
 	go func() {
 		var redisSnapshot *v1alpha1.RedisSnapshot
 		for {
 			existingSnapshots := &v1alpha1.RedisSnapshotList{}
-			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace(namespace))
 
 			for _, existingSnapshot := range existingSnapshots.Items {
 				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {

--- a/pkg/resources/backup/aws_test.go
+++ b/pkg/resources/backup/aws_test.go
@@ -1,0 +1,227 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// TestAWSSnapshotPostgres tests that the AWSBackupExecutor succesfully creates
+// a PostgresSnapshot and waits for it's completion
+func TestAWSSnapshotPostgres(t *testing.T) {
+	scheme, err := buildSchemeForAWSBackup()
+	if err != nil {
+		t.Errorf("Error building scheme: %w", err)
+		return
+	}
+
+	resourceName := "test-rhmi-postgres"
+
+	client := fake.NewFakeClientWithScheme(scheme)
+	executor := NewAWSBackupExecutor(resourceName, PostgresSnapshotType)
+
+	go func() {
+		var postgresSnapshot *v1alpha1.PostgresSnapshot
+		for {
+			existingSnapshots := &v1alpha1.PostgresSnapshotList{}
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+
+			for _, existingSnapshot := range existingSnapshots.Items {
+				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
+					continue
+				}
+
+				postgresSnapshot = &existingSnapshot
+				break
+			}
+
+			if postgresSnapshot != nil {
+				break
+			}
+		}
+
+		// Simulate the time it would take to finish the backup
+		time.Sleep(time.Second * 1)
+
+		postgresSnapshot.Status.Phase = types.PhaseComplete
+		client.Status().Update(context.TODO(), postgresSnapshot)
+	}()
+
+	err = executor.PerformBackup(client, time.Second*10)
+	if err != nil {
+		t.Errorf("Unexpected error performing postgres backup: %w", err)
+	}
+}
+
+// TestAWSSnapshotRedis tests that the AWSBackupExecutor succesfully creates
+// and waits for the completion of a RedisSnapshot
+func TestAWSSnapshotRedis(t *testing.T) {
+	scheme, err := buildSchemeForAWSBackup()
+	if err != nil {
+		t.Errorf("Error building scheme: %w", err)
+		return
+	}
+
+	resourceName := "test-rhmi-redis"
+
+	client := fake.NewFakeClientWithScheme(scheme)
+	executor := NewAWSBackupExecutor(resourceName, RedisSnapshotType)
+
+	go func() {
+		var redisSnapshot *v1alpha1.RedisSnapshot
+		for {
+			existingSnapshots := &v1alpha1.RedisSnapshotList{}
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+
+			for _, existingSnapshot := range existingSnapshots.Items {
+				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
+					continue
+				}
+
+				redisSnapshot = &existingSnapshot
+				break
+			}
+
+			if redisSnapshot != nil {
+				break
+			}
+		}
+
+		// Simulate the time it would take to finish the backup
+		time.Sleep(time.Second * 1)
+
+		redisSnapshot.Status.Phase = types.PhaseComplete
+		client.Status().Update(context.TODO(), redisSnapshot)
+	}()
+
+	err = executor.PerformBackup(client, time.Second*10)
+	if err != nil {
+		t.Errorf("Unexpected error performing postgres backup: %w", err)
+	}
+}
+
+// TestAWSSnapshotPostgres_FailedJob tests that the AWSBackupExecutor returns
+// an error when a PostgresSnapshot backup fails
+func TestAWSSnapshotPostgres_FailedJob(t *testing.T) {
+	scheme, err := buildSchemeForAWSBackup()
+	if err != nil {
+		t.Fatalf("Error building scheme: %v", err)
+		return
+	}
+
+	resourceName := "test-rhmi-postgres"
+
+	client := fake.NewFakeClientWithScheme(scheme)
+	executor := NewAWSBackupExecutor(resourceName, PostgresSnapshotType)
+
+	go func() {
+		var postgresSnapshot *v1alpha1.PostgresSnapshot
+		for {
+			existingSnapshots := &v1alpha1.PostgresSnapshotList{}
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+
+			for _, existingSnapshot := range existingSnapshots.Items {
+				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
+					continue
+				}
+
+				postgresSnapshot = &existingSnapshot
+				break
+			}
+
+			if postgresSnapshot != nil {
+				break
+			}
+		}
+
+		// Simulate the time it would take to finish the backup
+		time.Sleep(time.Second * 1)
+
+		// Set a failed status
+		postgresSnapshot.Status.Phase = types.PhaseFailed
+		postgresSnapshot.Status.Message = "MOCK FAIL"
+		client.Status().Update(context.TODO(), postgresSnapshot)
+	}()
+
+	err = executor.PerformBackup(client, time.Second*10)
+	if err == nil {
+		t.Fatal("Expected error when performing fail backup")
+		return
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "MOCK FAIL") {
+		t.Errorf("Expected error message to contain PostgresSnapshot status message, but got %s", errMsg)
+	}
+}
+
+// TestAWSSnapshotRedis_FailedJob tests that the AWSBackupExecutor returns
+// an error when a RedisSnapshot backup fails
+func TestAWSSnapshotRedis_FailedJob(t *testing.T) {
+	scheme, err := buildSchemeForAWSBackup()
+	if err != nil {
+		t.Fatalf("Error building scheme: %v", err)
+		return
+	}
+
+	resourceName := "test-rhmi-redis"
+
+	client := fake.NewFakeClientWithScheme(scheme)
+	executor := NewAWSBackupExecutor(resourceName, RedisSnapshotType)
+
+	go func() {
+		var redisSnapshot *v1alpha1.RedisSnapshot
+		for {
+			existingSnapshots := &v1alpha1.RedisSnapshotList{}
+			client.List(context.TODO(), existingSnapshots, k8sclient.InNamespace("redhat-rhmi-operator"))
+
+			for _, existingSnapshot := range existingSnapshots.Items {
+				if !strings.HasPrefix(existingSnapshot.Name, fmt.Sprintf("%s-preupgrade-snapshot", resourceName)) {
+					continue
+				}
+
+				redisSnapshot = &existingSnapshot
+				break
+			}
+
+			if redisSnapshot != nil {
+				break
+			}
+		}
+
+		// Simulate the time it would take to finish the backup
+		time.Sleep(time.Second * 1)
+
+		// Set a failed status
+		redisSnapshot.Status.Phase = types.PhaseFailed
+		redisSnapshot.Status.Message = "MOCK FAIL"
+		client.Status().Update(context.TODO(), redisSnapshot)
+	}()
+
+	err = executor.PerformBackup(client, time.Second*10)
+	if err == nil {
+		t.Fatal("Expected error when performing fail backup")
+		return
+	}
+
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "MOCK FAIL") {
+		t.Errorf("Expected error message to contain RedisSnapshot status message, but got %s", errMsg)
+	}
+}
+
+func buildSchemeForAWSBackup() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := v1alpha1.SchemeBuilder.AddToScheme(scheme)
+
+	return scheme, err
+}

--- a/pkg/resources/backup/backup_executor.go
+++ b/pkg/resources/backup/backup_executor.go
@@ -1,0 +1,65 @@
+package backup
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"golang.org/x/sync/errgroup"
+
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// BackupExecutor knows how to perform backups and wait for their successful
+// completion
+type BackupExecutor interface {
+	PerformBackup(client k8sclient.Client, timeout time.Duration) error
+}
+
+// NoopBackupExecutor does nothing. For components that do not require backups
+type NoopBackupExecutor struct{}
+
+func NewNoopBackupExecutor() BackupExecutor {
+	return &NoopBackupExecutor{}
+}
+
+// PerformBackup simply returns a `nil` error
+func (e *NoopBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.Duration) error {
+	logrus.Infof("No backup to perform")
+	return nil
+}
+
+// ConcurrentBackupExecutor performs backups by delegating the operation into
+// a list of `BackupExecutor` that are performed concurrently in separate
+// goroutines
+type ConcurrentBackupExecutor struct {
+	Executors []BackupExecutor
+}
+
+func NewConcurrentBackupExecutor(executors ...BackupExecutor) BackupExecutor {
+	return &ConcurrentBackupExecutor{
+		Executors: executors,
+	}
+}
+
+func (e *ConcurrentBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.Duration) error {
+	logrus.Infof("Concurrently performing %d backups", len(e.Executors))
+
+	var g errgroup.Group
+
+	for _, backup := range e.Executors {
+		// We need to re-assign the BackupExecutor instance in the scope of the
+		// loop, otherwise, as the goroutine might start in another iteration,
+		// the value pointed by the `backup` variable will have changed
+		each := backup
+		g.Go(func() error {
+			return each.PerformBackup(client, timeout)
+		})
+	}
+
+	if err := g.Wait(); err != nil {
+		return fmt.Errorf("Error occurred when performing concurrent backups: %v", err)
+	}
+
+	return nil
+}

--- a/pkg/resources/backup/backup_executor_test.go
+++ b/pkg/resources/backup/backup_executor_test.go
@@ -1,0 +1,55 @@
+package backup
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestConcurrentBackup(t *testing.T) {
+	scheme := runtime.NewScheme()
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	// 7 concurrent backups that take 1 second each. Should still take approximately
+	// 1 second as they're concurrent
+	executor := NewConcurrentBackupExecutor(
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+		mockBackupExecutor{1 * time.Second},
+	)
+
+	timeStarted := time.Now()
+	err := executor.PerformBackup(client, time.Second*3)
+	timeFinished := time.Now()
+
+	if err != nil {
+		t.Errorf("Unexpected error performing concurrent backups: %w", err)
+	}
+
+	elapsed := timeFinished.Sub(timeStarted)
+	// Add 2 seconds threshold (more than enough) for context switching. If it
+	// took more than that the concurrency is not properly implemented
+	if elapsed > time.Second*3 {
+		t.Errorf("Concurrent backups took too long: %v", elapsed)
+	}
+}
+
+type mockBackupExecutor struct {
+	SleepTime time.Duration
+}
+
+func (e mockBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.Duration) error {
+	if e.SleepTime > timeout {
+		return fmt.Errorf("SleepTime %v for mock is greater than given timeout %v", e.SleepTime, timeout)
+	}
+	time.Sleep(e.SleepTime)
+	return nil
+}

--- a/pkg/resources/backup/cronjob.go
+++ b/pkg/resources/backup/cronjob.go
@@ -1,0 +1,96 @@
+package backup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// CronJobBackupExecutor creates backups by creating a Job from a CronJob and
+// waiting for its completion
+type CronJobBackupExecutor struct {
+	CronJobName     string // Name of the CronJob that performs the backup
+	Namespace       string // Namespace where the CronJob is (and the job is created)
+	JobGenerateName string // Base name for the created Job
+}
+
+func NewCronJobBackupExecutor(cronJobName, namespace, jobGenerateName string) BackupExecutor {
+	return &CronJobBackupExecutor{
+		CronJobName:     cronJobName,
+		Namespace:       namespace,
+		JobGenerateName: jobGenerateName,
+	}
+}
+
+func (e *CronJobBackupExecutor) PerformBackup(client k8sclient.Client, timeout time.Duration) error {
+	logrus.Infof("Performing backup by creating Job from CronJob %s in namespace %s", e.CronJobName, e.Namespace)
+
+	// Generate the job name
+	jobName := fmt.Sprintf("%s-%s", e.JobGenerateName, time.Now().Format("2006-01-02-150405"))
+
+	// Get the CronJob to run
+	cronJob := &batchv1beta1.CronJob{}
+	err := client.Get(context.TODO(), types.NamespacedName{
+		Name:      e.CronJobName,
+		Namespace: e.Namespace,
+	}, cronJob)
+	if err != nil {
+		return fmt.Errorf("Error obtaining CronJob %s in namespace %s: %v", e.CronJobName, e.Namespace, err)
+	}
+
+	// Create the Job based on the CronJob spec
+	jobTemplate := cronJob.Spec.JobTemplate
+	job := &batchv1.Job{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: e.Namespace,
+			Name:      jobName,
+		},
+		Spec: jobTemplate.Spec,
+	}
+	if err := client.Create(context.TODO(), job); err != nil {
+		return fmt.Errorf("Error creating Job from CronJob %s in namespace %s: %v",
+			e.CronJobName, e.Namespace, err)
+	}
+
+	// Query the newly created job until either it finishes, or it times out
+	timeStarted := time.Now()
+	for {
+		if time.Now().After(timeStarted.Add(timeout)) {
+			return fmt.Errorf("Timed out when waiting for Job %s to finish", "")
+		}
+
+		queryJob := &batchv1.Job{}
+		err = client.Get(context.TODO(), types.NamespacedName{Name: jobName, Namespace: e.Namespace}, queryJob)
+		if err != nil {
+			return fmt.Errorf("Error querying newly created Job %s in namespace %s: %v", "", e.Namespace, err)
+		}
+
+		// If the completion time field is set, the job finished succesfully
+		if queryJob.Status.CompletionTime != nil {
+			return nil
+		}
+
+		// Check if the job finished with errors, if it did, return the error
+		if err := getJobError(queryJob); err != nil {
+			return fmt.Errorf("Error performing backup job: %w", err)
+		}
+	}
+}
+
+func getJobError(job *batchv1.Job) error {
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobFailed && condition.Status == apiv1.ConditionTrue {
+			return fmt.Errorf("job failed: %v", condition.Message)
+		}
+	}
+
+	return nil
+}

--- a/pkg/resources/backup/cronjob_test.go
+++ b/pkg/resources/backup/cronjob_test.go
@@ -1,0 +1,189 @@
+package backup
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	batchv1 "k8s.io/api/batch/v1"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestCronJob(t *testing.T) {
+	var (
+		cronJobName     = "cronjob-foo"
+		namespace       = "test-namespace"
+		generateJobName = "job-foo"
+	)
+
+	jobTemplate := batchv1beta1.JobTemplateSpec{}
+
+	// Test backup CronJob
+	cronJob := &batchv1beta1.CronJob{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cronJobName,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			JobTemplate: jobTemplate,
+		},
+	}
+
+	client := createMockClientForCronJob(t, cronJob) // Initialize client with mock CronJob
+	executor := NewCronJobBackupExecutor(cronJobName, namespace, generateJobName)
+
+	// In a separate goroutine, wait for the job to be created, and set the
+	// completion time to signal the job finished successfully. The goroutine
+	// must be started before calling `PerformBackup` as it's a blocking call
+	// that waits for the backup to finish
+	go func() {
+		// Get the job created by the backup executor
+		var expectedJob *batchv1.Job
+		for {
+			existingJobs := &batchv1.JobList{}
+			client.List(context.TODO(), existingJobs, k8sclient.InNamespace(namespace))
+
+			for _, existingJob := range existingJobs.Items {
+				if !strings.HasPrefix(existingJob.Name, generateJobName) {
+					continue
+				}
+
+				expectedJob = &existingJob
+				break
+			}
+
+			if expectedJob != nil {
+				break
+			}
+		}
+
+		// Simulate the time it takes to execute the job
+		time.Sleep(time.Second * 1)
+
+		// Set the completion time
+		expectedJob.Status.CompletionTime = &v1.Time{
+			Time: time.Now(),
+		}
+		client.Status().Update(context.TODO(), expectedJob)
+	}()
+
+	// Call `PerformBackup` and assert that no error is returned
+	err := executor.PerformBackup(client, time.Second*10)
+	if err != nil {
+		t.Errorf("Unexpected error running backup from CronJob: %w", err)
+	}
+}
+
+func TestCronJob_NoCronJob(t *testing.T) {
+	var (
+		cronJobName     = "cronjob-foo"
+		namespace       = "test-namespace"
+		generateJobName = "job-foo"
+	)
+
+	client := createMockClientForCronJob(t)
+	executor := NewCronJobBackupExecutor(cronJobName, namespace, generateJobName)
+
+	err := executor.PerformBackup(client, time.Second*1)
+	if err == nil {
+		t.Errorf("Expected backup to fail as no CronJob is found")
+	}
+}
+
+func TestCronJob_FailedJob(t *testing.T) {
+	var (
+		cronJobName     = "cronjob-foo"
+		namespace       = "test-namespace"
+		generateJobName = "job-foo"
+		errorMessage    = "MOCK FAIL"
+	)
+
+	jobTemplate := batchv1beta1.JobTemplateSpec{}
+
+	// Test backup CronJob
+	cronJob := &batchv1beta1.CronJob{
+		ObjectMeta: v1.ObjectMeta{
+			Namespace: namespace,
+			Name:      cronJobName,
+		},
+		Spec: batchv1beta1.CronJobSpec{
+			JobTemplate: jobTemplate,
+		},
+	}
+
+	client := createMockClientForCronJob(t, cronJob) // Initialize client with mock CronJob
+	executor := NewCronJobBackupExecutor(cronJobName, namespace, generateJobName)
+
+	// In a separate goroutine, wait for the job to be created, and set the
+	// completion time to signal the job finished with failure.
+	// The goroutine must be started before calling `PerformBackup` as it's a
+	// blocking call that waits for the backup to finish
+	go func() {
+		// Get the job created by the backup executor
+		var expectedJob *batchv1.Job
+		for {
+			existingJobs := &batchv1.JobList{}
+			client.List(context.TODO(), existingJobs, k8sclient.InNamespace(namespace))
+
+			for _, existingJob := range existingJobs.Items {
+				if !strings.HasPrefix(existingJob.Name, generateJobName) {
+					continue
+				}
+
+				expectedJob = &existingJob
+				break
+			}
+
+			if expectedJob != nil {
+				break
+			}
+		}
+
+		// Simulate the time it takes to execute the job
+		time.Sleep(time.Second * 1)
+
+		// Update the job with a failure status
+		expectedJob.Status.Conditions = []batchv1.JobCondition{
+			batchv1.JobCondition{
+				Type:    batchv1.JobFailed,
+				Status:  apiv1.ConditionTrue,
+				Message: errorMessage,
+			},
+		}
+
+		client.Status().Update(context.TODO(), expectedJob)
+	}()
+
+	// Call `PerformBackup` and assert that no error is returned
+	err := executor.PerformBackup(client, time.Second*10)
+	if err == nil {
+		t.Error("Expected backup to fail as Job failed")
+	}
+
+	// Assert that the error includes the job failure message
+	if !strings.Contains(err.Error(), errorMessage) {
+		t.Errorf("Expected error to contain Job failure message, got: %s", err.Error())
+	}
+}
+
+func buildSchemeForCronJob() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := batchv1.AddToScheme(scheme)
+	err = batchv1beta1.AddToScheme(scheme)
+	return scheme, err
+}
+
+func createMockClientForCronJob(t *testing.T, initObjects ...runtime.Object) k8sclient.Client {
+	scheme, err := buildSchemeForCronJob()
+	if err != nil {
+		t.Errorf("Error creating testing scheme: %w", err)
+	}
+
+	return fake.NewFakeClientWithScheme(scheme, initObjects...)
+}

--- a/pkg/resources/installPlan.go
+++ b/pkg/resources/installPlan.go
@@ -3,7 +3,9 @@ package resources
 import (
 	"context"
 	"fmt"
+	"time"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/sirupsen/logrus"
 
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -11,10 +13,22 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func upgradeApproval(ctx context.Context, client k8sclient.Client, ip *v1alpha1.InstallPlan) error {
+func upgradeApproval(ctx context.Context, preUpgradeBackupExecutor backup.BackupExecutor, client k8sclient.Client, ip *v1alpha1.InstallPlan) error {
 	if ip.Spec.Approved == false && len(ip.Spec.ClusterServiceVersionNames) > 0 {
 		logrus.Infof("Approving %s resource version: %s", ip.Name, ip.Spec.ClusterServiceVersionNames[0])
 		ip.Spec.Approved = true
+
+		// Perform a backup of the product before updating the InstalPlan. We
+		// must check that the product is already installed, as this function
+		// is also called when the product is first installed
+		if ip.Generation > 1 {
+			backupTimeout := time.Minute * 20
+			logrus.Infof("Triggering pre-upgrade backups with timeout of %v", backupTimeout)
+			if err := preUpgradeBackupExecutor.PerformBackup(client, backupTimeout); err != nil {
+				return fmt.Errorf("error performing pre-upgrade backup: %w", err)
+			}
+		}
+
 		err := client.Update(ctx, ip)
 		if err != nil {
 			return fmt.Errorf("error approving installplan: %w", err)

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -10,6 +10,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
@@ -151,7 +152,7 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				tc.FakeMPM,
 			)
 
-			status, err := reconciler.ReconcileSubscription(context.TODO(), tc.Installation, marketplace.Target{Namespace: "test-ns", Channel: "integreatly", Pkg: tc.SubscriptionName}, []string{"test-ns"}, tc.client)
+			status, err := reconciler.ReconcileSubscription(context.TODO(), tc.Installation, marketplace.Target{Namespace: "test-ns", Channel: "integreatly", Pkg: tc.SubscriptionName}, []string{"test-ns"}, backup.NewNoopBackupExecutor(), tc.client)
 			if tc.ExpectErr && err == nil {
 				t.Fatal("expected an error but got none")
 			}


### PR DESCRIPTION
# Description
Implement components to perform and wait for backups on AWS resources or by creating
`Jobs` of backup `CronJobs`.
Add logic to perform the backups required for the different products before approving
an `InstallPlan`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Steps to verify

The behaviour of this feature is different for installations using cluster storage than AWS storage. In order to fully verify this PR, it must be done on both kinds of installations. Repeat the following steps with: 1. `useClusterStorage = true` 2. `useClusterStorage = false`

* In a cluster, install RHMI and verify that the installation is not affected (no backup jobs are created either from CronJobs or PostgresSnapshot/RedisSnapshot)
* For each product listed in the [backup SOP](https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/backup):
  * Simulate a pending upgrade by setting the `approved` flag in the product `InstallPlan` to `false`
  * The operator should trigger the backups for the product (**Note: for installations where `useClusterStorage == true` no AWS backup should be performed**). Verify that:
    i. For AWS Postgres backups -> A `PostgresSnapshot` CR is created in the `redhat-rhmi-operator` namespace
    ii. For AWS Redis backups -> A `RedisSnapshot` CR is created in the `redhat-rhmi-operator` namespace
    iii. For CronJob based backups -> A job is created in the product namespace based on the backup CronJob
  * Verify that the backups successfully finish and the `InstallPlan` is approved
* For each product **not** listed in the backup SOP:
  * Simulate a pending upgrade as done in the previous steps
  * Verify that no backup job is triggered and the upgrade is approved

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer