### PR TITLE
change the alert name to include what redis is being alerted on using the cr name

### DIFF
--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -30,7 +30,8 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 	}
 
 	productName := cr.Labels["productName"]
-	alertName := productName + "PostgresInstanceUnavailable"
+	postgresCRName := strings.Title(strings.Replace(cr.Name, "postgres-example-rhmi", "", -1))
+	alertName := postgresCRName + "PostgresInstanceUnavailable"
 	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
@@ -58,7 +59,8 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		return nil, nil
 	}
 	productName := cr.Labels["productName"]
-	alertName := productName + "PostgresConnectionFailed"
+	postgresCRName := strings.Title(strings.Replace(cr.Name, "postgres-example-rhmi", "", -1))
+	alertName := postgresCRName + "PostgresConnectionFailed"
 	ruleName := fmt.Sprintf("connectivity-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -85,9 +85,10 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		logrus.Info("skipping redis alert creation, useClusterStorage is true")
 		return nil, nil
 	}
-
 	productName := cr.Labels["productName"]
-	alertName := productName + "RedisCacheUnavailable"
+	// remove hyphen as prometheus rules have difficulty with them
+	redisCRName := strings.Replace(cr.Name, "-", "", -1)
+	alertName := redisCRName + "RedisCacheUnavailable"
 	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
@@ -115,7 +116,9 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		return nil, nil
 	}
 	productName := cr.Labels["productName"]
-	alertName := productName + "RedisCacheConnectionFailed"
+	// remove hyphen as prometheus rules have difficulty with them
+	redisCRName := strings.Replace(cr.Name, "-", "", -1)
+	alertName := redisCRName + "RedisCacheConnectionFailed"
 	ruleName := fmt.Sprintf("connectivity-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/INTLY-6613
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

## Type of change
There are Duplicate Alert names for system and backend redis in 3scale , This pr is to generate unique names 
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
## Verification

- Confirm that the alert rules are updated as follow

![image](https://user-images.githubusercontent.com/16667688/78363953-9144f500-75b4-11ea-8287-9108b01c174f.png)
