### PR TITLE
Fixing login flow issue in E2E tests

### DIFF
--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -150,7 +150,8 @@ func openshiftClientSetup(url, username, password string, client *http.Client, i
 	if strings.Contains(browser.Url().Host, openshiftOauthSubdomain) {
 		permissionsForm, err := browser.Form("[action=approve]")
 		if err != nil {
-			return fmt.Errorf("failed to get permissions form: %w", err)
+			// Permissions were already approved
+			return nil
 		}
 		if err = permissionsForm.Submit(); err != nil {
 			return fmt.Errorf("failed to submit acceptance button for permissions: %w", err)


### PR DESCRIPTION
# Description
Some nightly tests failed on:
`failed to login to openshift: error occurred during oauth login: failed to get permissions form: Form not found matching expr '[action=approve]'.`
Logs: https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Nightly/job/rhmi-install-master/36/console

Fix based on our discussion in GChat: https://chat.google.com/room/AAAAP43TtLA/D1-eUVsomnE

Successful prow/e2e run should verify this change