### PR TITLE
INTLY-6399 Add missing test ID

### DIFF
--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -29,6 +29,6 @@ var (
 		{"C01 - Verify Alerts are not firing apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
 		{"B05 - Verify Codeready CRUDL permissions", TestCodereadyCrudlPermisssions},
 		{"A09 - Verify Subscription Install Plan Strategy", TestSubscriptionInstallPlanType},
-		{"Verify users with no email get default email", TestDefaultUserEmail},
+		{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
 	}
 )


### PR DESCRIPTION
Add missing test ID `B06` to automated test for default email address

* [Link to JIRA](https://issues.redhat.com/browse/INTLY-6399)
* [Link to test PR](https://github.com/integr8ly/integreatly-operator/pull/546)
* [Link to MR in `integreatly-test-cases` repo](https://gitlab.cee.redhat.com/integreatly-qe/integreatly-test-cases/merge_requests/107)