### PR TITLE
add delorean pullsecrets script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -222,6 +222,10 @@ ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
 	@ oc apply -f integreatly-delorean-secret.yml --namespace=$(NAMESPACE)
 endif
 
+.PHONY: cluster/prepare/delorean/pullsecret
+cluster/prepare/delorean/pullsecret:
+	@./scripts/setup-delorean-pullsecret.sh
+
 .PHONY: cluster/cleanup
 cluster/cleanup:
 	@-oc delete -f deploy/integreatly-rhmi-cr.yml --timeout=240s --wait

--- a/scripts/setup-delorean-pullsecret.sh
+++ b/scripts/setup-delorean-pullsecret.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -e
+set -o pipefail
+
+CONFIG_PULLSECRET="$(pwd)/config-pullsecret"
+DECODED_PULLSECRET="$(pwd)/config-pullsecret-decoded"
+DELOREAN_PULLSECRET="$(pwd)/integreatly-delorean-auth.json"
+STAGED_PULLSECRET="$(pwd)/staged-pullsecret"
+COMBINED_PULLSECRET="$(pwd)/combined-pullsecret"
+
+if [ ! -f ${DELOREAN_PULLSECRET} ]; then
+  echo "Error: integreatly-delorean-auth.json not found at ${DELOREAN_PULLSECRET}"
+  echo "Download the integreatly-delorean-auth.json file from https://quay.io/organization/integreatly?tab=robots Docker Configuration tab"
+  exit 1
+fi
+
+oc get secret pull-secret -n openshift-config -o yaml > "$CONFIG_PULLSECRET"
+sed -i 's+quay.io+quay.io/integreatly/delorean+g' $DELOREAN_PULLSECRET
+yq r $CONFIG_PULLSECRET 'data' | awk '{print $2}' | base64 -d > $DECODED_PULLSECRET
+jq -s -c '{auths: map(.auths) | add}' $DECODED_PULLSECRET $DELOREAN_PULLSECRET | base64 > $STAGED_PULLSECRET
+awk '{ printf "%s", $0 }' $STAGED_PULLSECRET  > $COMBINED_PULLSECRET
+oc patch secret pull-secret -n openshift-config -p='{"data": {".dockerconfigjson": "'$(cat ${COMBINED_PULLSECRET})'"}}'
+rm $CONFIG_PULLSECRET $STAGED_PULLSECRET $COMBINED_PULLSECRET $DECODED_PULLSECRET


### PR DESCRIPTION
# Description
As part of the delorean setup to ensure pods can pull from the private delorean repo we can edit the pull-secret secret in the openshift-config namespace to include our secret. The operator will then deploy this to each node and they can then by default pull from the private repo.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer

## Verification

1. Download token from `docker configuration` tab here https://quay.io/organization/integreatly?tab=robots and place it in the integreatly-operator root directory
2. Run `make cluster/prepare/delorean/pullsecret`
3. Run `make code/run/delorean`
4. Verify that the delorean pull secret is in the pull-secret secret in the openshift-config namespace
5. Verify that the installation completes