### PR TITLE
add sop_url to alerts for postgres and redis connectivity and availability alerts

### DIFF
--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -42,9 +42,9 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_postgres_instance_unavailable.asciidoc "
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -71,9 +71,9 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_postgres_connection_failed.asciidoc"
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -100,9 +100,9 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_redis_cache_unavailable.asciidoc"
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -129,9 +129,9 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_redis_connection_failed.asciidoc"
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -139,7 +139,7 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 }
 
 // reconcilePrometheusRule will create a PrometheusRule object
-func reconcilePrometheusRule(ctx context.Context, client k8sclient.Client, ruleName, ns, alertName, desc string, alertExp intstr.IntOrString, labels map[string]string) (*prometheusv1.PrometheusRule, error) {
+func reconcilePrometheusRule(ctx context.Context, client k8sclient.Client, ruleName, ns, alertName, desc string, sopUrl string, alertExp intstr.IntOrString, labels map[string]string) (*prometheusv1.PrometheusRule, error) {
 	alertGroupName := alertName + "Group"
 	groups := []prometheusv1.RuleGroup{
 		{
@@ -152,6 +152,7 @@ func reconcilePrometheusRule(ctx context.Context, client k8sclient.Client, ruleN
 					Labels: labels,
 					Annotations: map[string]string{
 						"description": desc,
+						"sop_url":     sopUrl,
 					},
 				},
 			},
@@ -186,6 +187,7 @@ func reconcilePrometheusRule(ctx context.Context, client k8sclient.Client, ruleN
 						Labels: labels,
 						Annotations: map[string]string{
 							"description": desc,
+							"sop_url":     sopUrl,
 						},
 					},
 				},

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -42,7 +42,7 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_postgres_instance_unavailable.asciidoc "
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc "
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -71,7 +71,7 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_postgres_connection_failed.asciidoc"
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -100,7 +100,7 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_redis_cache_unavailable.asciidoc"
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -129,7 +129,7 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/alert_redis_connection_failed.asciidoc"
+	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -42,7 +42,7 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc "
+	sopUrl := alertPostgresInstanceUnavailable
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -71,7 +71,7 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
+	sopUrl := alertPostgresConnectionFailed
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -100,7 +100,7 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
+	sopUrl := alertRedisCacheUnavailable
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {
@@ -129,7 +129,7 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
+	sopUrl := alertRedisConnectionFailed
 	// create the rule
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
 	if err != nil {

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -42,9 +42,8 @@ func CreatePostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := alertPostgresInstanceUnavailable
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresInstanceUnavailable, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -71,9 +70,8 @@ func CreatePostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := alertPostgresConnectionFailed
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresConnectionFailed, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -100,9 +98,8 @@ func CreateRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := alertRedisCacheUnavailable
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisCacheUnavailable, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -129,9 +126,8 @@ func CreateRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		"severity":    "critical",
 		"productName": cr.Labels["productName"],
 	}
-	sopUrl := alertRedisConnectionFailed
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrl, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisConnectionFailed, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -1,0 +1,9 @@
+package resources
+
+// Add alert strings here
+const(
+	alertPostgresInstanceUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc"
+	alertPostgresConnectionFailed = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
+	alertRedisCacheUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
+	alertRedisConnectionFailed = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
+)

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -2,8 +2,8 @@ package resources
 
 // Add alert strings here
 const (
-	alertPostgresInstanceUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc"
-	alertPostgresConnectionFailed    = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
-	alertRedisCacheUnavailable       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
-	alertRedisConnectionFailed       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
+	sopUrlPostgresInstanceUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc"
+	sopUrlPostgresConnectionFailed    = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
+	sopUrlRedisCacheUnavailable       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
+	sopUrlRedisConnectionFailed       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
 )

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -1,9 +1,9 @@
 package resources
 
 // Add alert strings here
-const(
+const (
 	alertPostgresInstanceUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_instance_unavailable.asciidoc"
-	alertPostgresConnectionFailed = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
-	alertRedisCacheUnavailable = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
-	alertRedisConnectionFailed = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
+	alertPostgresConnectionFailed    = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
+	alertRedisCacheUnavailable       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
+	alertRedisConnectionFailed       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
 )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
New sops been written for 
https://issues.redhat.com/browse/INTLY-6613
https://issues.redhat.com/browse/INTLY-6612
sop_url is not present in the alert at present. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation --> https://github.com/RHCloudServices/integreatly-help/pull/447

## Verification 
- set the  useClusterStorage: 'false' in the rhmi cr
- deploy branch to cluster
- go to the prometheus route
- go to alerts
- check product alerts `-PostgresConnectionFailed` , `-PostgresInstanceUnavailable`, `-RedisCacheUnavailable` and `-RedisCacheConnectionFailed` for the sop_url in annotations

- [ ] Verified independently on a cluster by reviewer
