### PR TITLE
Add build description to weekly jobs report

### DIFF
--- a/scripts/jenkins/nightly-report.sh
+++ b/scripts/jenkins/nightly-report.sh
@@ -64,7 +64,12 @@ do
       buildUrl=$(cat build.json | jq -r .url)
       getDateString
       buildResult=$(cat build.json | jq -r .result)
-      echo -e "\t#$buildNumber\t$buildDate\tResult: $buildResult\tUrl: $buildUrl\n" >> report.txt
+      echo -e "\n\t#$buildNumber\t$buildDate\tResult: $buildResult\tUrl: $buildUrl" >> report.txt
+
+      description=$(cat build.json | jq -r .description)
+      if [[ $description != "null" ]] ; then
+        echo -e "\t\tNote: $description" >> report.txt
+      fi
     fi
   done
 done


### PR DESCRIPTION
# Description
@psturc @pawelpaszki Wdyt?

I decided to improve weekly report generated based on the results of nightly jobs.
Now the "Build information" text is added as a "Note" in the weekly report.
This way we can communicate additional information about the particular build.

Output of the script now looks like this: https://gist.github.com/matskiv/1d2e16d9300ac01fe210e9bc43571b1d

I started adding "Build information" into the results of failed builds this week. It can be seen in Jenkins as well:
<img width="413" alt="Screenshot 2020-04-08 at 18 17 50" src="https://user-images.githubusercontent.com/1605799/78801661-a1e6d800-79c5-11ea-84c7-8703556d7cdf.png">


## Type of change
Script for pipeline. No impact on product.