### PR TITLE
INTLY-6742 - Add realm display name parameter to idp setup script

### DIFF
--- a/scripts/setup-sso-idp.sh
+++ b/scripts/setup-sso-idp.sh
@@ -4,6 +4,7 @@ set -o pipefail
 
 PASSWORD="${PASSWORD:-$(openssl rand -base64 12)}"
 REALM="${REALM:-testing-idp}"
+REALM_DISPLAY_NAME="${REALM_DISPLAY_NAME:-Testing IDP}"
 INSTALLATION_PREFIX="${INSTALLATION_PREFIX:-$(oc get RHMIs --all-namespaces -o json | jq -r .items[0].spec.namespacePrefix)}"
 INSTALLATION_PREFIX=${INSTALLATION_PREFIX%-} # remove trailing dash
 ADMIN_USERNAME="${ADMIN_USERNAME:-customer-admin}"
@@ -91,7 +92,7 @@ if [[ ${CLUSTER_ID} ]]; then
     echo "To delete IDP execute: ocm delete \"/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers/$IDP_ID\""
   else
 
-    oc process -p OAUTH_URL="$OAUTH_URL" -p NAMESPACE="$INSTALLATION_PREFIX-rhsso" -p REALM="$REALM" -p CLIENT_SECRET="$CLIENT_SECRET" -f "${BASH_SOURCE%/*}/testing-idp-template.yml" | oc apply -f -
+    oc process -p OAUTH_URL="$OAUTH_URL" -p NAMESPACE="$INSTALLATION_PREFIX-rhsso" -p REALM="$REALM" -p REALM_DISPLAY_NAME="$REALM_DISPLAY_NAME" -p CLIENT_SECRET="$CLIENT_SECRET" -f "${BASH_SOURCE%/*}/testing-idp-template.yml" | oc apply -f -
 
     sed "s|REALM|$REALM|g; s|KEYCLOAK_URL|$KEYCLOAK_URL|g; s|CLIENT_SECRET|$CLIENT_SECRET|g" "${BASH_SOURCE%/*}/ocm-idp-template.json" | ocm post "/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers"
     echo "$REALM IDP added into OCM configuration"
@@ -115,7 +116,7 @@ else
   fi
 
   # apply KeycloakRealm and KeycloakClient from a template
-  oc process -p OAUTH_URL="$OAUTH_URL" -p NAMESPACE="$INSTALLATION_PREFIX-rhsso" -p REALM="$REALM" -p CLIENT_SECRET="$CLIENT_SECRET" -f "${BASH_SOURCE%/*}/testing-idp-template.yml" | oc apply -f -
+  oc process -p OAUTH_URL="$OAUTH_URL" -p NAMESPACE="$INSTALLATION_PREFIX-rhsso" -p REALM="$REALM" -p REALM_DISPLAY_NAME="$REALM_DISPLAY_NAME" -p CLIENT_SECRET="$CLIENT_SECRET" -f "${BASH_SOURCE%/*}/testing-idp-template.yml" | oc apply -f -
   # create KeycloakUsers
   create_users
 

--- a/scripts/testing-idp-template.yml
+++ b/scripts/testing-idp-template.yml
@@ -15,7 +15,7 @@ objects:
         matchLabels:
           sso: integreatly
       realm:
-        displayName: Testing IDP
+        displayName: ${REALM_DISPLAY_NAME}
         enabled: true
         id: ${REALM}
         realm: ${REALM}
@@ -124,6 +124,9 @@ parameters:
   - description: Realm name
     name: REALM
     value: testing-idp
+  - description: Realm display name
+    name: REALM_DISPLAY_NAME
+    value: Testing IDP
   - description: IDP client client
     name: CLIENT_SECRET
     generate: expression


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Realm display name was previously hardcoded to `Testing IDP` in the realm template used by the idp-script. This change adds an additional optional `REALM_DISPLAY_NAME` parameter to the IDP script to allow specifying the display name of the realm created

Jira:
* https://issues.redhat.com/browse/INTLY-6724

Assoicated SOP update PR:
* https://github.com/RHCloudServices/integreatly-help/pull/450

## Verification
* Install RHMI from this branch
  * Should only need up till RHSSO is install
* Run the IDP script, passing the `REALM_DISPLAY_NAME` parameter
  ```
   REALM_DISPLAY_NAME=RHSSO NUM_ADMIN=1 NUM_REGULAR_USER=0 ./scripts/setup-sso-idp.sh
  ```
* In an incognito tab, select the created idp in the openshift sign in page, and verify the display is in the one passed in via the script

![Screenshot from 2020-04-09 10-05-59](https://user-images.githubusercontent.com/24636860/78878273-0481b780-7a4a-11ea-97f6-f25b7384f8ab.png)
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Verified independently on a cluster by reviewer