### PR TITLE
Allow integreatly operator to approve its own install plan

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -51,7 +51,7 @@ rules:
     verbs:
       - update
   # END For monitoring functions by operator-sdk
-      
+
   # Our own Subscription needs to be switched into Manual mode after initial installation
   - apiGroups:
       - operators.coreos.com
@@ -88,6 +88,17 @@ rules:
       - update
       - delete
 
+  # Allow operator to approve its own install plan
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - installplans
+    verbs:
+      - get
+      - update
+      - list
+      - watch
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -113,13 +124,13 @@ rules:
       - delete
   # We are using ProjectRequests API to create namespaces where we automatically become admins
   - apiGroups:
-      - ''
+      - ""
       - project.openshift.io
     resources:
       - projectrequests
     verbs:
       - create
-  
+
   # Preflights check for existing installations of products
   - apiGroups:
       - ""
@@ -152,7 +163,7 @@ rules:
       - route.openshift.io
     resources:
       - routes
-    resourceNames: 
+    resourceNames:
       - console
     verbs:
       - get
@@ -177,13 +188,13 @@ rules:
       - delete
       - update
   # END Reconciling Fuse templates and image streams
-  
+
   # Registry pull secret needs to be read to be then copied into some RHMI namespaces
   - apiGroups:
       - ""
     resources:
       - secrets
-    resourceNames: 
+    resourceNames:
       - samples-registry-credentials
     verbs:
       - get
@@ -193,12 +204,12 @@ rules:
       - ""
     resources:
       - secrets
-    resourceNames: 
+    resourceNames:
       - grafana-datasources
     verbs:
       - get
 
-  # OAuthClients are used for login into products with OpenShift User identity 
+  # OAuthClients are used for login into products with OpenShift User identity
   - apiGroups:
       - oauth.openshift.io
     resources:
@@ -230,7 +241,7 @@ rules:
       - user.openshift.io
     resources:
       - groups
-    resourceNames: 
+    resourceNames:
       - rhmi-developers
     verbs:
       - update
@@ -250,7 +261,7 @@ rules:
       - samples.operator.openshift.io
     resources:
       - configs
-    resourceNames: 
+    resourceNames:
       - cluster
     verbs:
       - get

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -96,6 +96,7 @@ var (
 	EventProcessingError       string = "ProcessingError"
 	EventInstallationCompleted string = "InstallationCompleted"
 	EventPreflightCheckPassed  string = "PreflightCheckPassed"
+	EventUpgradeApproved       string = "UpgradeApproved"
 
 	DefaultOriginPullSecretName      = "samples-registry-credentials"
 	DefaultOriginPullSecretNamespace = "openshift"

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -2,6 +2,7 @@ package installation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -12,6 +13,8 @@ import (
 	usersv1 "github.com/openshift/api/user/v1"
 
 	"github.com/sirupsen/logrus"
+
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
@@ -193,6 +196,11 @@ type ReconcileInstallation struct {
 // Reconcile reads that state of the cluster for a Installation object and makes changes based on the state read
 // and what is in the Installation.Spec
 func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	retryRequeue := reconcile.Result{
+		Requeue:      true,
+		RequeueAfter: 10 * time.Second,
+	}
+
 	installInProgress := false
 	installation := &integreatlyv1alpha1.RHMI{}
 	err := r.client.Get(context.TODO(), request.NamespacedName, installation)
@@ -203,15 +211,42 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
-	retryRequeue := reconcile.Result{
-		Requeue:      true,
-		RequeueAfter: 10 * time.Second,
-	}
-
 	//context is cancelled on delete of an installation, so if context is cancelled but there is no deletion timestamp
 	//the installation must be created after one was deleted, so recreate a context to use for the new installation.
 	if r.context.Err() == context.Canceled && installation.DeletionTimestamp == nil {
 		r.context, r.cancel = context.WithCancel(context.Background())
+	}
+
+	rhmiSubscription, err := r.getIntegreatlyOperatorSubscription(request.NamespacedName.Namespace)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+
+	if r.isRHMIUpgradeAvailable(rhmiSubscription) {
+		//TODO expose event since RHMI operator will be redeployed and logs will likely get lost
+		//TODO Setup secondary watch on subscription resources in the rhmi operator namespace
+		logrus.Infof("RHMI upgrade available")
+
+		latestRHMIInstallPlan, err := r.getIntegreatlyOperatorInstallPlan(rhmiSubscription)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		latestRHMICSV, err := r.getIntegreatlyOperatorCSV(latestRHMIInstallPlan)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		if !r.isRHMIUpgradeServiceAffecting(latestRHMICSV) {
+			err = r.approveRHMIUpgrade(latestRHMIInstallPlan)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+
+			// Requeue the reconciler until the RHMI subscription upgrade is complete
+			return retryRequeue, nil
+		}
+		logrus.Infof("Not automatically upgrading - Service Affecting Release")
 	}
 
 	installType, err := TypeFactory(installation.Spec.Type, r.productsToInstall)
@@ -634,6 +669,88 @@ func (r *ReconcileInstallation) addCustomInformer(crd runtime.Object, namespace 
 	}
 
 	logrus.Infof("Cache synced. A %s watch in %s namespace successfully initialized.", gvk, namespace)
+	return nil
+}
+
+func (r *ReconcileInstallation) getIntegreatlyOperatorSubscription(namespace string) (*olmv1alpha1.Subscription, error) {
+	subscriptions := olmv1alpha1.SubscriptionList{}
+	opts := k8sclient.ListOptions{
+		Namespace: namespace,
+	}
+	err := r.client.List(r.context, &subscriptions, &opts)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, subscription := range subscriptions.Items {
+		if strings.Contains(subscription.Name, "rhmi") || strings.Contains(subscription.Name, "integreatly") {
+			return &subscription, nil
+		}
+	}
+
+	// Don't fail the reconciler if no subsciption is found, it will default to not approve the install plan
+	logrus.Infof("No RHMI subscription found containing the text rhmi or integreatly")
+	return &olmv1alpha1.Subscription{}, nil
+}
+
+func (r *ReconcileInstallation) isRHMIUpgradeAvailable(subscription *olmv1alpha1.Subscription) bool {
+	// How to tell an upgrade is available - https://operator-framework.github.io/olm-book/docs/subscriptions.html#how-do-i-know-when-an-update-is-available-for-an-operator
+	return subscription.Status.CurrentCSV != subscription.Status.InstalledCSV
+}
+
+func (r *ReconcileInstallation) getIntegreatlyOperatorInstallPlan(subscription *olmv1alpha1.Subscription) (*olmv1alpha1.InstallPlan, error) {
+	rhmiLatestInstallPlan := &olmv1alpha1.InstallPlan{}
+	// Get the latest installPlan associated with the currentCSV (newest known to OLM)
+	installPlanName := subscription.Status.InstallPlanRef.Name
+	installPlanNamespace := subscription.Status.InstallPlanRef.Namespace
+	err := r.client.Get(r.context, k8sclient.ObjectKey{Name: installPlanName, Namespace: installPlanNamespace}, rhmiLatestInstallPlan)
+	if err != nil {
+		logrus.Infof("Error getting installPlan %s in ns: %s", installPlanName, installPlanNamespace)
+		return nil, err
+	}
+
+	return rhmiLatestInstallPlan, nil
+}
+
+func (r *ReconcileInstallation) getIntegreatlyOperatorCSV(rhmiInstallPlan *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error) {
+	rhmiCSV := &olmv1alpha1.ClusterServiceVersion{}
+
+	// The latest CSV is only represented in the new install plan while the upgrade is pending approval
+	for _, installPlanResources := range rhmiInstallPlan.Status.Plan {
+		if installPlanResources.Resource.Kind == olmv1alpha1.ClusterServiceVersionKind {
+			err := json.Unmarshal([]byte(installPlanResources.Resource.Manifest), &rhmiCSV)
+			if err != nil {
+				return rhmiCSV, fmt.Errorf("failed to unmarshal json: %w", err)
+			}
+		}
+	}
+
+	return rhmiCSV, nil
+}
+
+func (r *ReconcileInstallation) isRHMIUpgradeServiceAffecting(rhmiCSV *olmv1alpha1.ClusterServiceVersion) bool {
+	// Always default to the release being service affecting and requiring manual upgrade approval
+	serviceAffectingUpgrade := true
+	if val, ok := rhmiCSV.ObjectMeta.Annotations["serviceAffecting"]; ok && val == "false" {
+		serviceAffectingUpgrade = false
+	}
+	return serviceAffectingUpgrade
+}
+
+func (r *ReconcileInstallation) approveRHMIUpgrade(rhmilatestInstallPlan *olmv1alpha1.InstallPlan) error {
+	if rhmilatestInstallPlan.Status.Phase == olmv1alpha1.InstallPlanPhaseInstalling {
+		logrus.Infof("RHMI Upgrade in progress.")
+		return nil
+	}
+
+	logrus.Infof("Approving %s install plan: %s", rhmilatestInstallPlan.Name, rhmilatestInstallPlan.Spec.ClusterServiceVersionNames[0])
+
+	rhmilatestInstallPlan.Spec.Approved = true
+	err := r.client.Update(r.context, rhmilatestInstallPlan)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/installation/installation_controller_test.go
+++ b/pkg/controller/installation/installation_controller_test.go
@@ -3,12 +3,17 @@ package installation
 import (
 	"context"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
@@ -17,13 +22,292 @@ func buildScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 
 	integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme)
+	olmv1alpha1.SchemeBuilder.AddToScheme(scheme)
 
 	return scheme
+}
+
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
 }
 
 const (
 	defaultNamespace = "redhat-rhmi-operator"
 )
+
+func TestGetIntegreatlyOperatorSubscription(t *testing.T) {
+	nonRhmiSubscriptionMock := &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "another-subscription",
+			Namespace: defaultNamespace,
+		},
+	}
+
+	rhmiSubscriptionMock := &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redhat-rhmi-subscription",
+			Namespace: defaultNamespace,
+		},
+	}
+
+	subscriptionListMock := &olmv1alpha1.SubscriptionList{
+		Items: []olmv1alpha1.Subscription{
+			*nonRhmiSubscriptionMock,
+			*rhmiSubscriptionMock,
+		},
+	}
+
+	scenarios := []struct {
+		Name       string
+		FakeClient k8sclient.Client
+		Context    context.Context
+		Verify     func(rhmiSubscription *olmv1alpha1.Subscription, err error)
+	}{
+		{
+			Name:       "Test rhmi subscription not retrieved",
+			FakeClient: fake.NewFakeClientWithScheme(buildScheme()),
+			Context:    context.TODO(),
+			Verify: func(rhmiSubscription *olmv1alpha1.Subscription, err error) {
+				// Should return a not found error with no rhmi subscription present
+				if !k8serr.IsNotFound(err) {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			},
+		},
+		{
+			Name:       "Test rhmi subscription not retrieved with other subscriptions in namespace",
+			FakeClient: fake.NewFakeClientWithScheme(buildScheme(), nonRhmiSubscriptionMock),
+			Verify: func(rhmiSubscription *olmv1alpha1.Subscription, err error) {
+				// Should return a not found error with no rhmi subscription present
+				if !k8serr.IsNotFound(err) {
+					t.Fatalf("Unexpected error %v", err)
+				}
+			},
+		},
+		{
+			Name:       "Test rhmi subscription retrieved",
+			FakeClient: fake.NewFakeClientWithScheme(buildScheme(), rhmiSubscriptionMock),
+			Verify: func(rhmiSubscription *olmv1alpha1.Subscription, err error) {
+				// No errors return when RHMI subscription found
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+
+				if !reflect.DeepEqual(rhmiSubscription, rhmiSubscriptionMock) {
+					t.Fatalf("Non RHMI subscription returned %v", err)
+				}
+			},
+		},
+		{
+			Name:       "Test rhmi subscription retrieved with other subscriptions in namespace",
+			FakeClient: fake.NewFakeClientWithScheme(buildScheme(), subscriptionListMock),
+			Verify: func(rhmiSubscription *olmv1alpha1.Subscription, err error) {
+				// No errors return when RHMI subscription found
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+
+				if !reflect.DeepEqual(rhmiSubscription, rhmiSubscriptionMock) {
+					t.Fatalf("Non RHMI subscription returned %v", err)
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			r := &ReconcileInstallation{client: scenario.FakeClient, context: scenario.Context}
+			rhmiSubscription, err := r.getIntegreatlyOperatorSubscription(defaultNamespace)
+
+			scenario.Verify(rhmiSubscription, err)
+		})
+	}
+}
+
+func TestIsRhmiUpgradeAvailable(t *testing.T) {
+	scenarios := []struct {
+		Name                           string
+		RhmiSubscription               *olmv1alpha1.Subscription
+		ExpectedUpgradeAvailableResult bool
+	}{
+		{
+			Name:                           "Test no subscription found",
+			RhmiSubscription:               nil,
+			ExpectedUpgradeAvailableResult: false,
+		},
+		{
+			Name: "Test same RHMI CSV version in subscription",
+			RhmiSubscription: &olmv1alpha1.Subscription{
+				Status: olmv1alpha1.SubscriptionStatus{
+					CurrentCSV:   "1.0.0",
+					InstalledCSV: "1.0.0",
+				},
+			},
+			ExpectedUpgradeAvailableResult: false,
+		},
+		{
+			Name: "Test new RHMI CSV version in subscription",
+			RhmiSubscription: &olmv1alpha1.Subscription{
+				Status: olmv1alpha1.SubscriptionStatus{
+					CurrentCSV:   "1.0.1",
+					InstalledCSV: "1.0.0",
+				},
+			},
+			ExpectedUpgradeAvailableResult: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			r := &ReconcileInstallation{}
+
+			upgradeAvailable := r.isRHMIUpgradeAvailable(scenario.RhmiSubscription)
+			if upgradeAvailable != scenario.ExpectedUpgradeAvailableResult {
+				t.Fatalf("Expected upgradeAvailable to be %v but got %v", scenario.ExpectedUpgradeAvailableResult, upgradeAvailable)
+			}
+		})
+	}
+}
+
+func TestIsRhmiUpgradeServiceAffecting(t *testing.T) {
+	scenarios := []struct {
+		Name                           string
+		RhmiCSV                        *olmv1alpha1.ClusterServiceVersion
+		ExpectedServiceAffectingResult bool
+	}{
+		{
+			Name:                           "Test no CSV",
+			RhmiCSV:                        nil,
+			ExpectedServiceAffectingResult: true,
+		},
+		{
+			Name: "Test CSV with no service_affecting annotation",
+			RhmiCSV: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{},
+				},
+			},
+			ExpectedServiceAffectingResult: true,
+		},
+		{
+			Name: "Test CSV with service_affecting annotation true",
+			RhmiCSV: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"serviceAffecting": "true",
+					},
+				},
+			},
+			ExpectedServiceAffectingResult: true,
+		},
+		{
+			Name: "Test CSV with service_affecting annotation false",
+			RhmiCSV: &olmv1alpha1.ClusterServiceVersion{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						"serviceAffecting": "false",
+					},
+				},
+			},
+			ExpectedServiceAffectingResult: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			r := &ReconcileInstallation{}
+
+			isServiceAffecting := r.isRHMIUpgradeServiceAffecting(scenario.RhmiCSV)
+			if isServiceAffecting != scenario.ExpectedServiceAffectingResult {
+				t.Fatalf("Expected isServiceAffecting to be %v but got %v", scenario.ExpectedServiceAffectingResult, isServiceAffecting)
+			}
+		})
+	}
+}
+
+func TestApproveRHMIUpgrade(t *testing.T) {
+	installPlanObjectMeta := metav1.ObjectMeta{
+		Name:      "rhmi-ip",
+		Namespace: defaultNamespace,
+	}
+
+	installPlanReadyForApproval := &olmv1alpha1.InstallPlan{
+		ObjectMeta: installPlanObjectMeta,
+		Spec: olmv1alpha1.InstallPlanSpec{
+			Approved: false,
+			ClusterServiceVersionNames: []string{
+				"RHMI-v1.0.0",
+			},
+		},
+	}
+
+	installPlanAlreadyUpgrading := &olmv1alpha1.InstallPlan{
+		ObjectMeta: installPlanObjectMeta,
+		Spec: olmv1alpha1.InstallPlanSpec{
+			Approved: false,
+		},
+		Status: olmv1alpha1.InstallPlanStatus{
+			Phase: olmv1alpha1.InstallPlanPhaseInstalling,
+		},
+	}
+
+	scenarios := []struct {
+		Name            string
+		FakeClient      k8sclient.Client
+		Context         context.Context
+		EventRecorder   record.EventRecorder
+		RhmiInstallPlan *olmv1alpha1.InstallPlan
+		Verify          func(rhmiInstallPlan *olmv1alpha1.InstallPlan, err error)
+	}{
+		{
+			Name:            "Test install plan already upgrading",
+			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanAlreadyUpgrading),
+			Context:         context.TODO(),
+			EventRecorder:   setupRecorder(),
+			RhmiInstallPlan: installPlanAlreadyUpgrading,
+			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, err error) {
+				// Should not return an error
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+
+				if updatedRhmiInstallPlan.Spec.Approved != false {
+					t.Fatalf("Expected installPlan to not be upgraded")
+				}
+			},
+		},
+		{
+			Name:            "Test install plan ready to upgrade",
+			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanReadyForApproval),
+			Context:         context.TODO(),
+			EventRecorder:   setupRecorder(),
+			RhmiInstallPlan: installPlanReadyForApproval,
+			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, err error) {
+				// Should not return an error
+				if err != nil {
+					t.Fatalf("Unexpected error %v", err)
+				}
+
+				if updatedRhmiInstallPlan.Spec.Approved != true {
+					t.Fatalf("Expected installplan.Spec.Approved to be true")
+				}
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			r := &ReconcileInstallation{client: scenario.FakeClient, context: scenario.Context}
+
+			r.approveRHMIUpgrade(scenario.RhmiInstallPlan, scenario.EventRecorder)
+
+			retrievedInstallPlan := &olmv1alpha1.InstallPlan{}
+			err := r.client.Get(scenario.Context, k8sclient.ObjectKey{Name: scenario.RhmiInstallPlan.Name, Namespace: scenario.RhmiInstallPlan.Namespace}, retrievedInstallPlan)
+
+			scenario.Verify(retrievedInstallPlan, err)
+		})
+	}
+}
 
 // Test that the installation CR spec value for UseClusterStorage is true when the
 // USE_CLUSTER_STORAGE environment variable is set to true


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-6170

Adding ability for RHMI operator to approve its own manual approval install plan when the release is non-service affecting. Currently, the detection for service affecting or not is based on an annotation for the new integreatly-operator CSV.

## Verification
Verification is a little complicated since this is dealing with OLM and upgrades.

1. Run `PREVIOUS_TAG=2.0.0 TAG=2.0.1 make gen/csv`
2. Manually modify new CSV
-- Change containerImage and operator deployment image field to my image `quay.io/davidffrench/integreatly-operator:vINTLY-6170`
-- Add `displayName: RHMI Installation` to spec.customresourcedefinitions.owned
3. Push the CSV to your application registry. `QUAY_USERNAME=<your username> QUAY_PASSWORD=<your password> REPO=<your repo name, I used my username> make push/csv`
4. Setup OperatorSource on cluster
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: RHMI
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: RHMI Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: <YOUR QUAY REPO>
  type: appregistry
```
5. Run `make cluster/prepare/project && make cluster/prepare/smtp && make cluster/prepare/dms && make cluster/prepare/pagerduty`
6. Go through cluster OLM UI to install operator in `redhat-rhmi-operator` namespace with manual approval.
7. Manually approve Install Plan on cluster
8. Rerun steps 1 & 2 but with `PREVIOUS_TAG=2.0.1 TAG=2.0.2 ` set
9. Add  `serviceAffecting: "false"` to CSV metadata.annotations
10. Rerun step 3
11. On cluster, in the openshift-marketplace namespace, delete the rhmi-<> pod.
-- Note: This will allow the new CSV to be picked up from your application registry immediately
12. Verify the integreatly-operator automatically approves its own new install plan.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer