### PR TITLE
federate alert metrics to cluster monitoring

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -314,7 +314,19 @@ rules:
       - create
       - update
       - delete
-      
+
+  # Adding a rolebinding to the monitoring federation namespace
+  - apiGroups:
+      - rbac.authorization.k8s.io
+    resources:
+      - rolebindings
+    verbs:
+      - get
+      - list
+      - create
+      - update
+      - delete
+
   # END Permissions needed for our namespaces, but not given by "admin" role
 
   # Permission to fetch identity to get email for created Keycloak users in openshift realm

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71
 	github.com/operator-framework/operator-lifecycle-manager v0.0.0-20191115003340-16619cd27fa5
 	github.com/operator-framework/operator-marketplace v0.0.0-20191105191618-530c85d41ce7
+	github.com/operator-framework/operator-registry v1.5.7-0.20200121213444-d8e2ec52c19a
 	github.com/operator-framework/operator-sdk v0.15.1
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.3.0

--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -43,6 +43,14 @@ func (m *Monitoring) SetNamespace(newNamespace string) {
 	m.Config["NAMESPACE"] = newNamespace
 }
 
+func (m *Monitoring) GetFederationNamespace() string {
+	return m.Config["FEDERATION_NAMESPACE"]
+}
+
+func (m *Monitoring) SetFederationNamespace(newNamespace string) {
+	m.Config["FEDERATION_NAMESPACE"] = newNamespace
+}
+
 func (m *Monitoring) GetOperatorNamespace() string {
 	return m.Config["OPERATOR_NAMESPACE"]
 }

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -174,7 +174,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			}
 			return integreatlyv1alpha1.PhaseInProgress, nil
 		}
+
 		phase, err := resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetOperatorNamespace())
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			return phase, err
+		}
+
+		phase, err = resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetFederationNamespace())
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}


### PR DESCRIPTION
# Description

Federate metrics about alerts to the cluster monitoring stack

## Type of change

Adds a new service monitor in a new namespace to be scraped by the cluster monitoring stack (exposing metrics about rhmi alerts).

## Verification steps

1. Install RHMI using this branch
2. Make sure a namespace `redhat-rhmi-middleware-monitoring-federate` is created
3. Make sure the namespace contains a service monitor named `rhmi-alerts-federate`
4. Check the config of the prometheus instance in `openshift-monitoring`: a job to scrape the `rhmi-alerts-federate` service monitor should be present

The cluster prometheus should now have a target for the federated endpoint:

![federation](https://user-images.githubusercontent.com/1851198/79222602-228b5580-7e58-11ea-83e9-18ded3d50f19.png)
