### PR TITLE
update csv generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@ else
 	OPERATOR_SDK ?= go run github.com/operator-framework/operator-sdk/cmd/operator-sdk
 endif
 
+# Set sed -i as it's different for mac vs gnu
+ifeq ($(shell uname -s | tr A-Z a-z), darwin)
+	SED_INLINE ?= sed -i ''
+else
+ 	SED_INLINE ?= sed -i
+endif
+
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
 export INSTALLATION_NAME   ?= rhmi
@@ -269,14 +276,14 @@ endif
 gen/csv:
 	@mv deploy/olm-catalog/integreatly-operator/integreatly-operator-$(PREVIOUS_TAG) deploy/olm-catalog/integreatly-operator/$(PREVIOUS_TAG)
 	@rm -rf deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)
-	@sed -i 's/image:.*/image: quay\.io\/integreatly\/integreatly-operator:v$(TAG)/g' deploy/operator.yaml
+	@$(SED_INLINE) 's/image:.*/image: quay\.io\/integreatly\/integreatly-operator:v$(TAG)/g' deploy/operator.yaml
 	$(OPERATOR_SDK) generate csv --csv-version $(TAG) --default-channel --csv-channel=rhmi --update-crds --from-version $(PREVIOUS_TAG)
 	@echo Updating package file
-	@sed -i 's/$(PREVIOUS_TAG)/$(TAG)/g' version/version.go
-	@sed -i 's/$(PREVIOUS_TAG)/$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml
+	@$(SED_INLINE) 's/$(PREVIOUS_TAG)/$(TAG)/g' version/version.go
+	@$(SED_INLINE) 's/$(PREVIOUS_TAG)/$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml
 	@mv deploy/olm-catalog/integreatly-operator/$(PREVIOUS_TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(PREVIOUS_TAG)
 	@mv deploy/olm-catalog/integreatly-operator/$(TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)
-	@sed -i 's/integreatly-operator:v$(PREVIOUS_TAG).*/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
+	@$(SED_INLINE) 's/integreatly-operator:v$(PREVIOUS_TAG).*/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
 
 .PHONY: push/csv
 push/csv:

--- a/Makefile
+++ b/Makefile
@@ -276,7 +276,7 @@ gen/csv:
 	@sed -i 's/$(PREVIOUS_TAG)/$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml
 	@mv deploy/olm-catalog/integreatly-operator/$(PREVIOUS_TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(PREVIOUS_TAG)
 	@mv deploy/olm-catalog/integreatly-operator/$(TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)
-	@sed -i 's/integreatly-operator:v$(PREVIOUS_TAG)/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
+	@sed -i 's/integreatly-operator:v$(PREVIOUS_TAG).*/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
 
 .PHONY: push/csv
 push/csv:

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 include ./make/*.mk
 
-ORG=integreatly
+ORG ?= integreatly
 NAMESPACE=redhat-rhmi-operator
 PROJECT=integreatly-operator
 REG=quay.io
 SHELL=/bin/bash
-PREVIOUS_TAG=1.19.0
-TAG=2.0.0
+PREVIOUS_TAG ?=1.19.0
+TAG ?= 2.0.0
 PKG=github.com/integr8ly/integreatly-operator
 TEST_DIRS?=$(shell sh -c "find $(TOP_SRC_DIRS) -name \\*_test.go -exec dirname {} \\; | sort | uniq")
 TEST_POD_NAME=integreatly-operator-test

--- a/Makefile
+++ b/Makefile
@@ -269,14 +269,14 @@ endif
 gen/csv:
 	@mv deploy/olm-catalog/integreatly-operator/integreatly-operator-$(PREVIOUS_TAG) deploy/olm-catalog/integreatly-operator/$(PREVIOUS_TAG)
 	@rm -rf deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)
-	@sed -i '' 's/image:.*/image: quay\.io\/integreatly\/integreatly-operator:v$(TAG)/g' deploy/operator.yaml
+	@sed -i 's/image:.*/image: quay\.io\/integreatly\/integreatly-operator:v$(TAG)/g' deploy/operator.yaml
 	$(OPERATOR_SDK) generate csv --csv-version $(TAG) --default-channel --csv-channel=rhmi --update-crds --from-version $(PREVIOUS_TAG)
 	@echo Updating package file
-	@sed -i '' 's/$(PREVIOUS_TAG)/$(TAG)/g' version/version.go
-	@sed -i '' 's/$(PREVIOUS_TAG)/$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml
+	@sed -i 's/$(PREVIOUS_TAG)/$(TAG)/g' version/version.go
+	@sed -i 's/$(PREVIOUS_TAG)/$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml
 	@mv deploy/olm-catalog/integreatly-operator/$(PREVIOUS_TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(PREVIOUS_TAG)
 	@mv deploy/olm-catalog/integreatly-operator/$(TAG) deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)
-	@sed -i '' 's/integreatly-operator:v$(PREVIOUS_TAG)/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
+	@sed -i 's/integreatly-operator:v$(PREVIOUS_TAG)/integreatly-operator:v$(TAG)/g' deploy/olm-catalog/integreatly-operator/integreatly-operator-$(TAG)/integreatly-operator.v${TAG}.clusterserviceversion.yaml
 
 .PHONY: push/csv
 push/csv:

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -191,6 +191,7 @@ type RHMIProductStatus struct {
 // +k8s:openapi-gen=true
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=rhmis,scope=Namespaced
+// +operator-sdk:gen-csv:customresourcedefinitions.displayName="RHMI Installation"
 type RHMI struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
`make gen/csv` command crashes on fedora system as there is differences in using the `sed -i` command for mac vs gnu systems.

A csv annotation was also added to include the custom resource display name as it was previously missing when generating a new csv which would prevent installation via OLM

Also made changes to allow setting the `ORG`, `PREVIOUS_TAG` and `TAG` makefile arguments by passing them through command line so that these do not need changed in the makefile when testing

## Verification
* Checkout this branch
* Generate a new csv via
  ```
    PREVIOUS_TAG=2.0.0 TAG=2.0.1 make gen/csv
  ```
* Verify new csv has `RHMI Installation` as the `displayName` of `customresourcedefinitions`
* Verify the operator image tag in the new csv  is `v2.0.1`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Verified independently on a cluster by reviewer