### PR TITLE
INTLY-6766 - fix auth issues affecting nightly tests

### DIFF
--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -324,6 +324,7 @@ func createKeycloakUsers(ctx context.Context, client dynclient.Client, keycloakC
 					},
 				},
 				User: v1alpha1.KeycloakAPIUser{
+					ID:        keycloakUser.Spec.User.ID,
 					FirstName: user.FirstName,
 					LastName:  user.LastName,
 					UserName:  user.UserName,
@@ -499,6 +500,9 @@ func createKeycloakClient(ctx context.Context, client dynclient.Client, oauthURL
 	}
 
 	if _, err := controllerutil.CreateOrUpdate(ctx, client, keycloakClient, func() error {
+		if keycloakClient.Spec.Client != nil && keycloakClient.Spec.Client.Secret != "" {
+			keycloakSpec.Client.Secret = keycloakClient.Spec.Client.Secret
+		}
 		keycloakClient.Spec = keycloakSpec
 		return nil
 	}); err != nil {

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -112,7 +112,12 @@ func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient 
 		return true, nil
 	})
 	if err != nil {
-		return fmt.Errorf("unexpected developer project count : %d expected project count : %d , error occurred - %w", len(rhmiDevfoundProjects.Items), expectedRhmiDeveloperProjectCount, err)
+		if rhmiDevfoundProjects != nil {
+			return fmt.Errorf("unexpected developer project count : %d expected project count : %d , error occurred - %w", len(rhmiDevfoundProjects.Items), expectedRhmiDeveloperProjectCount, err)
+		} else {
+			return fmt.Errorf("unexpected error occurred when retrieving projects list - %w", err)
+		}
+
 	}
 
 	foundNamespace := rhmiDevfoundProjects.Items[0].Name

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -150,8 +150,7 @@ func openshiftClientSetup(url, username, password string, client *http.Client, i
 	if strings.Contains(browser.Url().Host, openshiftOauthSubdomain) {
 		permissionsForm, err := browser.Form("[action=approve]")
 		if err != nil {
-			// Permissions were already approved
-			return nil
+			return fmt.Errorf("failed to get permissions form: %w", err)
 		}
 		if err = permissionsForm.Submit(); err != nil {
 			return fmt.Errorf("failed to submit acceptance button for permissions: %w", err)


### PR DESCRIPTION
# Description
This is a fix for the e2e tests failure we've seen on nightly pipeline
JIRA: https://issues.redhat.com/browse/INTLY-6766

This issue has been caused by the tests code that is adding/updating "testing-idp" related resources. Main problem was with the KeycloakClient CR, which was overridden with a different secret, but OAuth CR was not being updated to use this secret.
Minor bug fixes around error handling and KeycloakUser CR updates.
I also reverted my previous "fix".  

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer