### PR TITLE
Certain 3scale alerts not firing when pods are down

### DIFF
--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -13,7 +13,7 @@ spec:
           message: >-
             3Scale apicast-staging has no pods in a ready state.
         expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"apicast-staging.*"})
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -23,7 +23,7 @@ spec:
           message: >-
             3Scale apicast-production has no pods in a ready state.
         expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"apicast-production.*"})
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -33,7 +33,7 @@ spec:
           message: >-
             3Scale backend-worker has no pods in a ready state.
         expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-worker.*"})
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -43,7 +43,7 @@ spec:
           message: >-
             3Scale backend-listener has no pods in a ready state.
         expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"backend-listener.*"})
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -53,7 +53,7 @@ spec:
           message: >-
             3Scale system-app has no pods in a ready state.
         expr: |
-          absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"system-app-.*"})
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-listener",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -53,7 +53,7 @@ spec:
           message: >-
             3Scale system-app has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-listener",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"}) < 1
         for: 5m
         labels:
           severity: critical

--- a/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_3scale_alerts.yaml
@@ -13,7 +13,7 @@ spec:
           message: >-
             3Scale apicast-staging has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-staging",namespace="{{ index .Params "Namespace" }}"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -23,7 +23,7 @@ spec:
           message: >-
             3Scale apicast-production has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="apicast-production",namespace="{{ index .Params "Namespace" }}"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -33,7 +33,7 @@ spec:
           message: >-
             3Scale backend-worker has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-worker",namespace="{{ index .Params "Namespace" }}"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -43,7 +43,7 @@ spec:
           message: >-
             3Scale backend-listener has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="backend-listener",namespace="{{ index .Params "Namespace" }}"}) < 1
         for: 5m
         labels:
           severity: critical
@@ -53,7 +53,7 @@ spec:
           message: >-
             3Scale system-app has no pods in a ready state.
         expr: |
-          (1 - absent(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"})) or count(kube_pod_status_ready{condition="true",namespace="redhat-rhmi-3scale"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="redhat-rhmi-3scale"}) < 1
+          (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="{{ index .Params "Namespace" }}"})) or count(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on(pod, namespace) kube_pod_labels{label_deploymentconfig="system-app",namespace="{{ index .Params "Namespace" }}"}) < 1
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
# Description
[JIRA](https://issues.redhat.com/browse/INTLY-6769) the following PR is to fix certain alerts that are counting deploy pods which have already completed and are not running which stops the alerts from triggering.

#Verifcation 
1. install integreatly from this branch
2. Run the following command to bring the relevant pods down 
```
while true; do
  if oc get deployment -n redhat-rhmi-3scale-operator -o json | jq '.items[0].spec.replicas' | grep 1; then
    oc scale deployment 3scale-operator --replicas=0 -n redhat-rhmi-3scale-operator
  fi
  if oc get dc apicast-production -n redhat-rhmi-3scale -o json | jq '.spec.replicas' | grep 2; then
    oc scale dc apicast-production --replicas=0 -n redhat-rhmi-3scale
  fi
  sleep 5
done
```
Substituting apicast-production with a deployment config from below:

- apicast-production
- apicast-staging
- backend-listener
- backend-worker
- system-app
3.  Ensure the following rules fire when the relevant pods are down
- ThreeScaleApicastProductionPod
- ThreeScaleApicastStagingPod
- ThreeScaleBackendListenerPod
- ThreeScaleBackendWorkerPod
- ThreeScaleSystemAppPod
![Screenshot from 2020-04-16 10-46-01](https://user-images.githubusercontent.com/53817495/79441740-85532d00-7fcf-11ea-9e18-db3701b540d2.png)
