### PR TITLE
Adding AMQ Online PDB creation for brokers and routers

### DIFF
--- a/pkg/apis-products/enmasse/v1beta1/brokeredinfraconfig_types.go
+++ b/pkg/apis-products/enmasse/v1beta1/brokeredinfraconfig_types.go
@@ -22,12 +22,14 @@ type InfraConfigAdmin struct {
 type InfraConfigBroker struct {
 	Resources         InfraConfigResources `json:"resources"`
 	AddressFullPolicy string               `json:"addressFullPolicy"`
+	MaxUnavailable    int                  `json:"maxUnavailable,omitempty"`
 }
 
 type InfraConfigRouter struct {
-	MinReplicas  int                  `json:"minReplicas"`
-	Resources    InfraConfigResources `json:"resources"`
-	LinkCapacity int                  `json:"linkCapacity"`
+	MinReplicas    int                  `json:"minReplicas"`
+	Resources      InfraConfigResources `json:"resources"`
+	LinkCapacity   int                  `json:"linkCapacity"`
+	MaxUnavailable int                  `json:"maxUnavailable,omitempty"`
 }
 
 type InfraConfigResources struct {

--- a/pkg/products/amqonline/infraconfigs.go
+++ b/pkg/products/amqonline/infraconfigs.go
@@ -78,13 +78,15 @@ func GetDefaultStandardInfraConfigs(ns string) []*v1beta1.StandardInfraConfig {
 						Storage: "2Gi",
 					},
 					AddressFullPolicy: "FAIL",
+					MaxUnavailable:    1,
 				},
 				Router: v1beta1.InfraConfigRouter{
 					MinReplicas: 2,
 					Resources: v1beta1.InfraConfigResources{
 						Memory: "512Mi",
 					},
-					LinkCapacity: 250,
+					LinkCapacity:   250,
+					MaxUnavailable: 1,
 				},
 			},
 		},
@@ -104,13 +106,15 @@ func GetDefaultStandardInfraConfigs(ns string) []*v1beta1.StandardInfraConfig {
 						Storage: "2Gi",
 					},
 					AddressFullPolicy: "FAIL",
+					MaxUnavailable:    1,
 				},
 				Router: v1beta1.InfraConfigRouter{
 					MinReplicas: 2,
 					Resources: v1beta1.InfraConfigResources{
 						Memory: "512Mi",
 					},
-					LinkCapacity: 250,
+					LinkCapacity:   250,
+					MaxUnavailable: 1,
 				},
 			},
 		},


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-6837

With the inclusion of AMQ Online 1.4, PDBs will now be created if you specify a particular value in the standardInfraConfig.

This change will also allow us to delete this SOP - https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/on_request_amqonline_addressspace_pod_disruption_budget.md

## Verification
Out of 4 InfraConfigs, only 2 should create PDBs for its brokers and routers. The brokered and minimal standard addressspace will not have PDBs created for them.
1. Login to https://console-openshift-console.apps.dffrench.h8q1.s1.devshift.org/
2. Verify 4 PDBs exist. 1 router and 1 broker PDBs for 2 different address spaces
-- https://console-openshift-console.apps.dffrench.h8q1.s1.devshift.org/search/ns/redhat-rhmi-amq-online?kind=policy%7Ev1beta1%7EPodDisruptionBudget
3. Verify 4 different addressspaces have been created
-- https://console-redhat-rhmi-amq-online.apps.dffrench.h8q1.s1.devshift.org/#/address-spaces

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Verified independently on a cluster by reviewer