### PR TITLE
Adding 3scale PDB creation

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -419,7 +419,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 			Namespace: r.Config.GetNamespace(),
 		},
 		Spec: threescalev1.APIManagerSpec{
-			HighAvailability: &threescalev1.HighAvailabilitySpec{},
+			HighAvailability:    &threescalev1.HighAvailabilitySpec{},
+			PodDisruptionBudget: &threescalev1.PodDisruptionBudgetSpec{},
 			APIManagerCommonSpec: threescalev1.APIManagerCommonSpec{
 				ResourceRequirementsEnabled: &resourceRequirements,
 			},
@@ -455,6 +456,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		apim.Spec.APIManagerCommonSpec.ResourceRequirementsEnabled = &resourceRequirements
 		apim.Spec.APIManagerCommonSpec.WildcardDomain = r.installation.Spec.RoutingSubdomain
 		apim.Spec.System.FileStorageSpec = fss
+		apim.Spec.PodDisruptionBudget = &threescalev1.PodDisruptionBudgetSpec{Enabled: true}
 
 		if *apim.Spec.System.AppSpec.Replicas < numberOfReplicas {
 			*apim.Spec.System.AppSpec.Replicas = numberOfReplicas


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-6843

With the inclusion of 3scale 2.8, PDBs will now be created if you enable in the API Manager CR

This change will also allow us to delete this SOP - https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/create_cluster_3scale_pod_disruption_budget.md

## Verification
1. Verify 3scale PDBs exist on cluster https://console-openshift-console.apps.dffrench.h8q1.s1.devshift.org/search/ns/redhat-rhmi-3scale?kind=policy%7Ev1beta1%7EPodDisruptionBudget

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Verified independently on a cluster by reviewer