### PR TITLE
Add test timeout to test/functional target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,7 +145,7 @@ test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/c
 .PHONY: test/functional
 test/functional:
 	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
-	go clean -testcache && go test -v ./test/functional
+	go clean -testcache && go test -v ./test/functional -timeout=80m
 
 .PHONY: install/olm
 install/olm: cluster/cleanup/olm cluster/cleanup/crds cluster/prepare cluster/prepare/olm/subscription deploy/integreatly-rhmi-cr.yml cluster/check/operator/deployment cluster/prepare/dms cluster/prepare/pagerduty


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Currently when running the test/functional target we are defaulting to 10 minutes. We have a number of polls in our functional tests adding up to a combined 57 minute timeout. This change adds the timeout flag to our target, increasing the timeout to 80 minutes to allow for the maximum timeout of the test polls and giving some wiggle room to any additional tests to be added. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
