### PR TITLE
redhat-rhmi-monitoring-federate namespace not removing when rhmi is uninstalled

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -176,12 +176,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			return integreatlyv1alpha1.PhaseInProgress, nil
 		}
 
-		phase, err := resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetOperatorNamespace())
+		phase, err := resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetFederationNamespace())
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}
 
-		phase, err = resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetFederationNamespace())
+		phase, err = resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetOperatorNamespace())
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}


### PR DESCRIPTION
# Description
[Jira](https://issues.redhat.com/browse/INTLY-6951) This Pr is to ensure that  the redhat-rhmi-monitoring-federate namespace will be removed when rhmi is uninstalled. 

## Verification
1. install the monitoring product
2. uninstall the monitoring product
3. redhat-rhmi-monitoring-federation namespace should be removed without manual interference 