### PR TITLE
Functional test:  Code ready login - Add more logging information

### DIFF
--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -120,7 +120,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// login to codeready
-	token, err := loginClient.CodereadyLogin(keycloakHost, redirectUrl)
+	token, err := loginClient.CodereadyLogin(keycloakHost, redirectUrl, t)
 	if err != nil {
 		t.Fatalf("failed to login to codeready: %v", err)
 	}

--- a/test/resources/codeready_login.go
+++ b/test/resources/codeready_login.go
@@ -10,9 +10,9 @@ import (
 	"net/http/httputil"
 	"net/url"
 	"strings"
+	"testing"
 
 	"github.com/PuerkitoBio/goquery"
-	"github.com/sirupsen/logrus"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -57,9 +57,10 @@ func (c *CodereadyLoginClient) OpenshiftLogin(namespacePrefix string) error {
 }
 
 // Log user into codeready. Returns an access token to be used for codeready API calls
-func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string) (string, error) {
+func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string, t *testing.T) (string, error) {
 	u := fmt.Sprintf(codereadySSOAuthEndpoint, keycloakHost, clientId, redirectUrl)
-	logrus.Debugf("SSO Auth endpoint url: %s", u)
+	t.Logf("SSO Auth endpoint url: %s", u)
+
 	response, err := c.HttpClient.Get(u)
 	if err != nil {
 		return "", fmt.Errorf("failed to get %v: %v", u, err)
@@ -90,7 +91,7 @@ func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string) 
 	if err != nil {
 		return "", err
 	}
-	logrus.Debugf("Resolved relative url: %s", u)
+	t.Logf("Resolved relative url: %s", u)
 	response, err = c.HttpClient.Get(u)
 	if err != nil {
 		return "", fmt.Errorf("failed to get %v: %v", u, err)
@@ -98,11 +99,11 @@ func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string) 
 	if response.StatusCode != http.StatusOK {
 		return "", errorWithResponseDump(response, fmt.Errorf("the request to %s failed with code %d", u, response.StatusCode))
 	}
-	logrus.Infof("Response: raw query = %s", response.Request.URL.RawQuery)
+	t.Logf("Response: raw query = %s", response.Request.URL.RawQuery)
 	code := strings.Split(response.Request.URL.RawQuery, "&")[1]
 	tokenUrl := fmt.Sprintf(codereadySSOTokenEndpoint, keycloakHost)
-	logrus.Infof("Received code: %s", code)
-	logrus.Infof("Token url: %s", tokenUrl)
+	t.Logf("Received code: %s", code)
+	t.Logf("Token url: %s", tokenUrl)
 
 	formValues := url.Values{
 		"grant_type":   []string{"authorization_code"},


### PR DESCRIPTION
# Description
Jira link: https://issues.redhat.com/browse/INTLY-6679
Added more logging information for the code ready login flow flake. Theoratical understanding is
the code received from oauth is not valid or expired. One possible reason could be username in IDP
is not yet synced correctly (fixed in: https://issues.redhat.com/browse/INTLY-6766).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Verified independently on a cluster by reviewer