### PR TITLE
Removed fuseonlinepodcount alert and updated server and ui queries

### DIFF
--- a/templates/monitoring/kube_state_metrics_fuse_online_alerts.yaml
+++ b/templates/monitoring/kube_state_metrics_fuse_online_alerts.yaml
@@ -12,8 +12,8 @@ spec:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
             message: >-
               Fuse Online Syndesis Server instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
-          expr: >
-            absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"syndesis-server-.*"})
+          expr: |
+            (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{label_deploymentconfig="syndesis-server"})) or sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{label_deploymentconfig="syndesis-server"}) < 1
           for: 5m
           labels:
             severity: critical
@@ -22,17 +22,8 @@ spec:
             sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
             message: >-
               Fuse Online Syndesis UI instance {{ "{{" }}$labels.pod{{ "}}" }} in namespace {{ "{{" }}$labels.namespace{{ "}}" }} is down.
-          expr: >
-            absent(kube_pod_status_ready{namespace="{{ index .Params "Namespace" }}", condition="true", pod=~"syndesis-ui-.*"})
-          for: 5m
-          labels:
-            severity: critical
-        - alert: FuseOnlinePodCount
-          annotations:
-            sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
-            message: Pod count for namespace {{ "{{" }} $labels.namespace {{ "}}" }} is {{ "{{" }} printf "%.0f" $value {{ "}}" }}. Expected at least 6 pods.
           expr: |
-            (1-absent(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"})) or sum(kube_pod_status_ready{condition="true", namespace="{{ index .Params "Namespace" }}"}) < 6
+            (1 - absent(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{label_deploymentconfig="syndesis-ui"})) or sum(kube_pod_status_ready{condition="true",namespace="{{ index .Params "Namespace" }}"} * on (pod, namespace) kube_pod_labels{label_deploymentconfig="syndesis-ui"}) < 1
           for: 5m
           labels:
             severity: critical

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -124,7 +124,6 @@ var expectedRules = []alertsTestRule{
 		Rules: []string{
 			"FuseOnlineSyndesisServerInstanceDown",
 			"FuseOnlineSyndesisUIInstanceDown",
-			"FuseOnlinePodCount",
 		},
 	},
 	{


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-6839

This change also includes the removal of the `FuseOnlinePodCount` alerting rule.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verfication
- Install via this branch
- Use the below command to bring the relevant pods down - this needs to be done for both the `syndesis-server` and `syndesis-ui` pods:

**Syndesis-UI**
```
while true; do
  if oc get deployment syndesis-operator -n redhat-rhmi-fuse-operator -o json | jq '.items[0].spec.replicas' | grep 1; then
    oc scale deployment syndesis-operator --replicas=0 -n redhat-rhmi-fuse-operator
  fi
  if oc get dc syndesis-ui  -n redhat-rhmi-fuse -o json | jq '.spec.replicas' | grep 1; then
    oc scale dc syndesis-ui --replicas=0 -n redhat-rhmi-fuse
  fi
  sleep 5gp
done
```

**Syndesis-Server**
```
while true; do
  if oc get deployment syndesis-operator -n redhat-rhmi-fuse-operator -o json | jq '.items[0].spec.replicas' | grep 1; then
    oc scale deployment syndesis-operator --replicas=0 -n redhat-rhmi-fuse-operator
  fi
  if oc get dc syndesis-server  -n redhat-rhmi-fuse -o json | jq '.spec.replicas' | grep 1; then
    oc scale dc syndesis-server --replicas=0 -n redhat-rhmi-fuse
  fi
  sleep 5gp
done
```
- Navigate to the Prometheus instance in the `middleware-monitoring` namespace and ensure that the following alerts are firing:

`FuseOnlineSyndesisServerInstanceDown`
`FuseOnlineSyndesisUIInstanceDown`