### PR TITLE
Allowing rhsso and user sso replicas to be scaled

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -48,6 +48,7 @@ var (
 	githubIdpAlias            = "github"
 	manifestPackage           = "integreatly-rhsso"
 	adminCredentialSecretName = "credential-" + keycloakName
+	numberOfReplicas          = 2
 )
 
 const (
@@ -434,7 +435,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
 		}
 		kc.Labels = GetInstanceLabels()
-		kc.Spec.Instances = 2
+		if kc.Spec.Instances < numberOfReplicas {
+			kc.Spec.Instances = numberOfReplicas
+		}
 		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{
 			Enabled: true,

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -48,6 +48,7 @@ var (
 	manifestPackage           = "integreatly-rhsso"
 	masterRealmName           = "master"
 	adminCredentialSecretName = "credential-" + keycloakName
+	numberOfReplicas          = 2
 )
 
 const (
@@ -291,7 +292,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		}
 		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Labels = getMasterLabels()
-		kc.Spec.Instances = 2
+		if kc.Spec.Instances < numberOfReplicas {
+			kc.Spec.Instances = numberOfReplicas
+		}
 		kc.Spec.ExternalAccess = keycloak.KeycloakExternalAccess{Enabled: true}
 		kc.Spec.Profile = rhsso.RHSSOProfile
 		kc.Spec.PodDisruptionBudget = keycloak.PodDisruptionBudgetConfig{Enabled: true}

--- a/test/common/scale_up_replicas_rhsso.go
+++ b/test/common/scale_up_replicas_rhsso.go
@@ -1,0 +1,119 @@
+package common
+
+import (
+	goctx "context"
+	"testing"
+	"time"
+
+	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	numberOfRhssoReplicas  int = 2
+	scaleUpRhssoReplicas   int = 3
+	scaleDownRhssoReplicas int = 1
+	rhssoName                  = "rhsso"
+	rhssoNamespace             = "redhat-rhmi-rhsso"
+	userSSOName                = "rhssouser"
+	userSSONamespace           = "redhat-rhmi-user-sso"
+)
+
+func TestReplicasInRHSSOAndUserSSO(t *testing.T, ctx *TestingContext) {
+	checkScalingOfKeycloakReplicas(t, ctx, rhssoName, rhssoNamespace)
+	checkScalingOfKeycloakReplicas(t, ctx, userSSOName, userSSONamespace)
+}
+
+func checkScalingOfKeycloakReplicas(t *testing.T, ctx *TestingContext, keycloakCRName string, keycloakCRNamespace string) {
+	keycloakCR, err := getKeycloakCR(ctx.Client, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("failed to get KeycloakCR : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, numberOfRhssoReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas to start : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx.Client, scaleUpRhssoReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, scaleUpRhssoReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx.Client, scaleDownRhssoReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of updated replicas are set")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, numberOfRhssoReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+
+	keycloakCR, err = updateKeycloakCR(ctx.Client, numberOfRhssoReplicas, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		t.Fatalf("Unable to update : %v", err)
+	}
+
+	t.Log("Checking correct number of replicas has been reset")
+	if err := checkNumberOfReplicasAgainstValueRhsso(keycloakCR, ctx, numberOfRhssoReplicas, retryInterval, timeout, t); err != nil {
+		t.Fatalf("Incorrect number of replicas : %v", err)
+	}
+}
+
+func getKeycloakCR(dynClient k8sclient.Client, keycloakCRName string, keycloakCRNamespace string) (keycloakv1alpha1.Keycloak, error) {
+	keycloakCR := &keycloakv1alpha1.Keycloak{}
+
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: keycloakCRName, Namespace: keycloakCRNamespace}, keycloakCR); err != nil {
+		return *keycloakCR, err
+	}
+
+	return *keycloakCR, nil
+}
+
+func updateKeycloakCR(dynClient k8sclient.Client, replicas int, keycloakCRName string, keycloakCRNamespace string) (keycloakv1alpha1.Keycloak, error) {
+
+	keycloakCR, err := getKeycloakCR(dynClient, keycloakCRName, keycloakCRNamespace)
+	if err != nil {
+		return keycloakCR, err
+	}
+	keycloakCR = keycloakv1alpha1.Keycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            keycloakCRName,
+			Namespace:       keycloakCRNamespace,
+			ResourceVersion: keycloakCR.GetResourceVersion(),
+		},
+		Spec: keycloakv1alpha1.KeycloakSpec{
+			Instances: replicas,
+		},
+	}
+
+	if err := dynClient.Update(goctx.TODO(), keycloakCR.DeepCopy(), &k8sclient.UpdateOptions{}); err != nil {
+		return keycloakCR, err
+	}
+
+	return keycloakCR, nil
+}
+
+func checkNumberOfReplicasAgainstValueRhsso(keycloakCR keycloakv1alpha1.Keycloak, ctx *TestingContext, numberOfRequiredReplicas int, retryInterval, timeout time.Duration, t *testing.T) error {
+	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
+		keycloakCR, err = getKeycloakCR(ctx.Client, keycloakCR.Name, keycloakCR.Namespace)
+		if err != nil {
+			t.Fatalf("failed to get KeycloakCR : %v", err)
+		}
+		if keycloakCR.Spec.Instances != numberOfRequiredReplicas {
+			t.Logf("Number of replicas for keycloakCR.Spec.Instances is not correct : Replicas - %v, Expected - %v", keycloakCR.Spec.Instances, numberOfRequiredReplicas)
+			t.Logf("retrying in : %v seconds", retryInterval)
+			return false, nil
+		}
+		return true, nil
+	})
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -31,5 +31,6 @@ var (
 		{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
 		{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},
 		{"F06 - Verify Replicas Scale correctly in Apicurito", TestReplicasInApicurito},
+		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
 	}
 )


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-7054

Allowing RHSSO and user SSO replicas to be scaled beyond the default of 2. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer