### PR TITLE
resources backup for AMQ Online

### DIFF
--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -583,6 +583,11 @@ func (r *Reconciler) reconcileBackup(ctx context.Context, serverClient k8sclient
 				Type:     "enmasse_pv",
 				Schedule: r.Config.GetBackupSchedule(),
 			},
+			{
+				Name:     "resources-backup",
+				Type:     "amq_online_resources",
+				Schedule: r.Config.GetBackupSchedule(),
+			},
 		},
 	}
 

--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -129,6 +129,16 @@ func reconcileRole(ctx context.Context, serverClient k8sclient.Client, config Ba
 				APIGroups: []string{""},
 				Resources: []string{"pods", "secrets"},
 				Verbs:     []string{"get", "list"},
+			}, {
+				APIGroups: []string{"admin.enmasse.io"},
+				Resources: []string{
+					"addressplans",
+					"addressspaceplans",
+					"authenticationservices",
+					"brokeredinfraconfigs",
+					"standardinfraconfigs",
+				},
+				Verbs: []string{"get", "list"},
 			},
 			{
 				APIGroups: []string{""},
@@ -218,7 +228,7 @@ func reconcileCronjob(ctx context.Context, serverClient k8sclient.Client, config
 							Containers: []corev1.Container{
 								{
 									Name:            "backup-cronjob",
-									Image:           "quay.io/integreatly/backup-container:1.0.13",
+									Image:           "quay.io/integreatly/backup-container:1.0.14",
 									ImagePullPolicy: "Always",
 									Command: []string{
 										"/opt/intly/tools/entrypoint.sh",

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -518,6 +518,9 @@ func waitForInstallationStageCompletion(t *testing.T, f *framework.Framework, na
 		}
 
 		t.Logf("Waiting for completion of %s\n", phase)
+		if installation.Status.LastError != "" {
+			t.Logf("Last Error: %s\n", installation.Status.LastError)
+		}
 		return false, nil
 	})
 	if err != nil {


### PR DESCRIPTION
# Description
AMQ Online resources are not backed up. This adds a cronjob to back them up to s3.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Verified independently on a cluster by reviewer