### PR TITLE
[W.I.P]INTLY-6737-e2e-verify-user-permissions-test-flake

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,15 @@ test/unit:
 	@TEMPLATE_PATH=$(TEMPLATE_PATH) ./scripts/ci/unit_test.sh
 
 .PHONY: test/e2e/prow
+test/e2e/prow: export SURF_DEBUG_HEADERS=1
 test/e2e/prow: export component := integreatly-operator
 test/e2e/prow: export INTEGREATLY_OPERATOR_IMAGE := "${IMAGE_FORMAT}"
 test/e2e/prow: test/e2e
 
 .PHONY: test/e2e
-test/e2e: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
+test/e2e:  export SURF_DEBUG_HEADERS=1
+test/e2e:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
+	 export SURF_DEBUG_HEADERS=1
 	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: test/e2e/local

--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -33,7 +33,7 @@ func lookup3ScaleClientSecret(client dynclient.Client, clientId string) (string,
 // Tests that a user in group rhmi-developers can log into fuse and
 // create an integration
 func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -97,7 +97,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	t.Log("Test codeready workspace creation")
 
 	// Ensure testing-idp is available
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
 		t.Fatalf("failed to create testing idp: %v", err)
 	}
 

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -97,7 +97,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	t.Log("Test codeready workspace creation")
 
 	// Ensure testing-idp is available
-	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("failed to create testing idp: %v", err)
 	}
 

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -97,7 +97,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	t.Log("Test codeready workspace creation")
 
 	// Ensure testing-idp is available
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
+	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("failed to create testing idp: %v", err)
 	}
 

--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -43,7 +43,7 @@ func TestDefaultUserEmail(t *testing.T, ctx *TestingContext) {
 		Jar:       jar,
 	}
 
-	err = createTestingIDP(goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
+	err = createTestingIDP(goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts, nil)
 	if err != nil {
 		t.Fatalf("Error occurred creating testing IDP: %v", err)
 	}

--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -43,7 +43,7 @@ func TestDefaultUserEmail(t *testing.T, ctx *TestingContext) {
 		Jar:       jar,
 	}
 
-	err = createTestingIDP(nil, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
+	err = createTestingIDP(t, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
 	if err != nil {
 		t.Fatalf("Error occurred creating testing IDP: %v", err)
 	}

--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -43,7 +43,7 @@ func TestDefaultUserEmail(t *testing.T, ctx *TestingContext) {
 		Jar:       jar,
 	}
 
-	err = createTestingIDP(goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts, nil)
+	err = createTestingIDP(nil, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
 	if err != nil {
 		t.Fatalf("Error occurred creating testing IDP: %v", err)
 	}

--- a/test/common/fuse_crudl.go
+++ b/test/common/fuse_crudl.go
@@ -30,7 +30,7 @@ func loginOpenshift(ctx *TestingContext, masterUrl, username, password, namespac
 // Tests that a user in group rhmi-developers can log into fuse and
 // create an integration
 func TestFuseCrudlPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -20,7 +20,7 @@ const (
 
 func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
+	if err := createTestingIDP(nil, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
@@ -64,7 +64,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 
 func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
+	if err := createTestingIDP(nil, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -20,7 +20,7 @@ const (
 
 func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
@@ -64,7 +64,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 
 func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -20,7 +20,7 @@ const (
 
 func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(nil, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
@@ -64,7 +64,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 
 func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(nil, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)

--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -50,7 +50,7 @@ func TestNetworkPolicyAccessNSToSVC(t *testing.T, ctx *TestingContext) {
 		Jar:       jar,
 	}
 
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -40,7 +40,7 @@ type TestUser struct {
 }
 
 // creates testing idp
-func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *http.Client, hasSelfSignedCerts bool, t *testing.T) error {
+func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client, httpClient *http.Client, hasSelfSignedCerts bool) error {
 	rhmiCR, err := getRHMI(client)
 	if err != nil {
 		return fmt.Errorf("error occurred while getting rhmi cr: %w", err)

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -35,7 +35,7 @@ const (
 
 type TestUser struct {
 	UserName  string
-	FirstName string
+	FirstName stringq
 	LastName  string
 }
 
@@ -49,7 +49,6 @@ func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client
 
 	// create dedicated admins group is it doesnt exist
 	if !hasDedicatedAdminGroup(ctx, client) {
-		t.Log("creating dedicatedAdminGroup")
 		if err := setupDedicatedAdminGroup(ctx, client); err != nil {
 			return fmt.Errorf("error occurred while creating dedicated admin group: %w", err)
 		}

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -2,7 +2,9 @@ package common
 
 import (
 	"fmt"
+	"io"
 	"net/http"
+	"testing"
 	"time"
 
 	"github.com/integr8ly/integreatly-operator/test/resources"
@@ -38,7 +40,7 @@ type TestUser struct {
 }
 
 // creates testing idp
-func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *http.Client, hasSelfSignedCerts bool) error {
+func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *http.Client, hasSelfSignedCerts bool, t *testing.T) error {
 	rhmiCR, err := getRHMI(client)
 	if err != nil {
 		return fmt.Errorf("error occurred while getting rhmi cr: %w", err)
@@ -47,6 +49,7 @@ func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *
 
 	// create dedicated admins group is it doesnt exist
 	if !hasDedicatedAdminGroup(ctx, client) {
+		t.Log("creating dedicatedAdminGroup")
 		if err := setupDedicatedAdminGroup(ctx, client); err != nil {
 			return fmt.Errorf("error occurred while creating dedicated admin group: %w", err)
 		}
@@ -57,7 +60,6 @@ func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *
 	if err := client.Get(ctx, types.NamespacedName{Name: resources.OpenshiftOAuthRouteName, Namespace: resources.OpenshiftAuthenticationNamespace}, oauthRoute); err != nil {
 		return fmt.Errorf("error occurred while getting Openshift Oauth Route: %w ", err)
 	}
-
 	// create keycloak client secret
 	if err := createClientSecret(ctx, client, []byte(defaultSecret)); err != nil {
 		return fmt.Errorf("error occurred while setting up testing idp client secret: %w", err)
@@ -67,7 +69,6 @@ func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *
 	if err := createKeycloakRealm(ctx, client); err != nil {
 		return fmt.Errorf("error occurred while setting up keycloak realm: %w", err)
 	}
-
 	// create keycloak client
 	keycloakClientName := fmt.Sprintf("%s-client", TestingIDPRealm)
 	keycloakClientNamespace := fmt.Sprintf("%srhsso", NamespacePrefix)
@@ -100,10 +101,15 @@ func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *
 	if err := waitForOauthDeployment(ctx, client); err != nil {
 		return fmt.Errorf("error occurred while waiting for oauth deployment: %w", err)
 	}
-
 	// ensure the IDP is available in OpenShift
+
 	err = wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
-		return resources.OpenshiftIDPCheck(fmt.Sprintf("https://%s/auth/login", masterURL), httpClient, TestingIDPRealm)
+		if err == io.EOF {
+			t.Logf("attempted to check OpenshiftIDP, got error: %s, ignoring and retrying", io.EOF)
+			return done, nil
+		}
+		return resources.OpenshiftIDPCheck(t, fmt.Sprintf("https://%s/auth/login", masterURL), httpClient, TestingIDPRealm)
+
 	})
 	if err != nil {
 		return fmt.Errorf("failed to check for openshift idp: %w", err)

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -102,7 +102,7 @@ func createTestingIDP(ctx context.Context, client dynclient.Client, httpClient *
 	}
 
 	// ensure the IDP is available in OpenShift
-	err = wait.PollImmediate(time.Second*10, time.Minute*3, func() (done bool, err error) {
+	err = wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
 		return resources.OpenshiftIDPCheck(fmt.Sprintf("https://%s/auth/login", masterURL), httpClient, TestingIDPRealm)
 	})
 	if err != nil {

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -35,7 +35,7 @@ const (
 
 type TestUser struct {
 	UserName  string
-	FirstName stringq
+	FirstName string
 	LastName  string
 }
 

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -38,7 +38,7 @@ var productNamespaces = []string{
 }
 
 func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -38,7 +38,7 @@ var productNamespaces = []string{
 }
 
 func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -38,7 +38,7 @@ var productNamespaces = []string{
 }
 
 func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
+	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -27,7 +27,7 @@ type LogOptions struct {
 }
 
 func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -27,7 +27,7 @@ type LogOptions struct {
 }
 
 func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
+	if err := createTestingIDP(nil, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -27,7 +27,7 @@ type LogOptions struct {
 }
 
 func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts, nil); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -54,6 +54,7 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
 
 	// test rhmi developer projects are as expected
+	t.Log("testing rhmi developer projects")
 	fuseNamespace := fmt.Sprintf("%sfuse", NamespacePrefix)
 	if err := testRHMIDeveloperProjects(masterURL, fuseNamespace, openshiftClient); err != nil {
 		t.Fatalf("test failed - %v", err)

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -37,18 +37,20 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
 	masterURL := rhmi.Spec.MasterURL
+	t.Logf("retrieved console master URL %v", masterURL)
 
 	// get oauth route
 	oauthRoute := &v1.Route{}
 	if err := ctx.Client.Get(goctx.TODO(), types.NamespacedName{Name: resources.OpenshiftOAuthRouteName, Namespace: resources.OpenshiftAuthenticationNamespace}, oauthRoute); err != nil {
 		t.Fatal("error getting Openshift Oauth Route: ", err)
 	}
+	t.Log("retrieved openshift-Oauth route")
 
 	// get rhmi developer user tokens
 	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "test-user-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
-
+	t.Log("retrieved rhmi developer user tokens")
 	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
 
 	// test rhmi developer projects are as expected

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/url"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
@@ -61,9 +62,10 @@ func DoAuthOpenshiftUser(authPageURL string, username string, password string, h
 	return nil
 }
 
-func OpenshiftIDPCheck(url string, client *http.Client, idp string) (bool, error) {
+func OpenshiftIDPCheck(t *testing.T, url string, client *http.Client, idp string) (bool, error) {
 	browser := surf.NewBrowser()
 	browser.SetTransport(client.Transport)
+	t.Logf("Attempting to open browser with url: %s", url)
 	if err := browser.Open(url); err != nil {
 		return false, fmt.Errorf("failed to open browser url: %w", err)
 	}

--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -122,7 +122,7 @@ func OpenshiftUserReconcileCheck(openshiftClient *OpenshiftClient, k8sclient dyn
 func openshiftClientSetup(url, username, password string, client *http.Client, idp string) error {
 	//oauth proxy-specific constants
 	const (
-		openshiftOauthSubdomain = "oauth-openshift."
+		openshiftConsoleSubdomain = "console-openshift-console.apps."
 	)
 	//follow the oauth proxy flow
 	browser := surf.NewBrowser()
@@ -151,7 +151,8 @@ func openshiftClientSetup(url, username, password string, client *http.Client, i
 		return fmt.Errorf("failed to submit login form on oauth proxy screen: %w", err)
 	}
 	//sometimes we'll reach an accept permissions page for the user if they haven't accepted these scope requests before.
-	if strings.Contains(browser.Url().Host, openshiftOauthSubdomain) {
+	//refactored, this approach assumes that if the redirected page is not the console then it looks for an approve action, previous approach would cause e2e test flakes
+	if !strings.Contains(browser.Url().Host, openshiftConsoleSubdomain) {
 		permissionsForm, err := browser.Form("[action=approve]")
 		if err != nil {
 			return fmt.Errorf("failed to get permissions form: %w", err)


### PR DESCRIPTION
# Description
Fix  *B03 - Verify RHMI Developer User Permissions are Correct* test flake
- Increase timeout to 5 minutes to prevent timeout test flake
- Reverse logic and change subdomain on approval page check function to prevent `Form not found matching expr "[action=approve]" ` test flake
- Add some logging to help troubleshoot if further flakes exist
- Add error handling for io.EOF error returned when checking for openshiftIDP, this error handling is needed to prevent the test flake, the check function will finish and not run again if an error is returned at any stage, this means that in this case the error is returned before the IDP becomes fully available (or such is the theory)
## Type of change
- [:heavy_check_mark: ] Bug fix (non-breaking change which fixes an Issue

## Verification
- Run `make test/e2e/prow` on OSD cluster
- Ensure *B03 - Verify RHMI Developer User Permissions are Correct* passes
- Test flakes may still exists with other tests, this PR only aims to fix B03
- If tests are run more than once in a row on the same cluster with `make test/e2e/prow` be advised of https://issues.redhat.com/browse/INTLY-7026 and ensure that all users are deleted between test runs (Get users by `oc get users` and delete them with `oc delete user xxxxx`)  and  `make cluster/cleanup` has sucessfully cleaned up all resources 
