### PR TITLE
Errors in RHMI prometheus logs related to non-RHMI namespaces

### DIFF
--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -210,7 +210,7 @@ func reconcileCronjob(ctx context.Context, serverClient k8sclient.Client, config
 					Template: corev1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Name:   config.Name,
-							Labels: map[string]string{"integreatly": "yes", "cronjob-name": component.Name},
+							Labels: map[string]string{"integreatly": "yes", "cronjob-name": component.Name,"monitoring_key": "middleware"},
 						},
 						Spec: corev1.PodSpec{
 							ServiceAccountName: BackupServiceAccountName,

--- a/templates/monitoring/backup-monitoring-alerts.yaml
+++ b/templates/monitoring/backup-monitoring-alerts.yaml
@@ -38,13 +38,13 @@ spec:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: CronJob {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.label_cronjob_name {{ "}}" }} has not started a Job in 25 hours
         expr: |
-          (time() - (max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
+          (time() - (max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job_name, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (label_cronjob_name))) > 60*60*25
       - alert: CronJobsFailed
         annotations:
           sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md
           message: 'Job {{ "{{" }} $labels.namespace {{ "}}" }}/{{ "{{" }} $labels.job {{ "}}" }} has failed'
         expr: >
-          clamp_max(max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""} ) BY (job, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job) GROUP_RIGHT() kube_job_labels{label_cronjob_name!=""}) BY (label_cronjob_name), 1) * ON(job) GROUP_LEFT() kube_job_status_failed > 0
+          clamp_max(max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"} ) BY (job_name, label_cronjob_name, namespace) == ON(label_cronjob_name) GROUP_LEFT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key="middleware"}) BY (label_cronjob_name), 1) * ON(job_name) GROUP_LEFT() kube_job_status_failed > 0
         for: 5m
         labels:
           severity: critical


### PR DESCRIPTION
# Description
Solving the following issue [Jira](https://issues.redhat.com/browse/INTLY-6772)

#Verification
1. Deploy integreatly from this branch
2. check the prometheus pod logs to ensure the following error is not coming up
```
level=warn ts=2020-04-14T21:35:25.221Z caller=manager.go:513 component="rule manager" group=general.rules msg="Evaluating rule failed" rule="alert: CronJobNotRunInThreshold\nexpr: (time() - (max by(job, label_cronjob_name) (kube_job_status_start_time * on(job)\n  group_right() kube_job_labels{label_monitoring_key=\"middleware\"}) == on(label_cronjob_name)\n  group_left() max by(label_cronjob_name) (kube_job_status_start_time * on(job) group_right()\n  kube_job_labels{label_monitoring_key=\"middleware\"}))) > 60 * 60 * 25\nannotations:\n  message: CronJob {{ $labels.namespace }}/{{ $labels.label_cronjob_name }} has not\n    started a Job in 25 hours\n  sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md\n" err="found duplicate series for the match group {job=\"kube-state-metrics\"} on the left hand-side of the operation: [{__name__=\"kube_job_status_start_time\", endpoint=\"https-main\", instance=\"10.131.2.4:8443\", job=\"kube-state-metrics\", job_name=\"builds-pruner-1586894400\", namespace=\"openshift-sre-pruning\", pod=\"kube-state-metrics-67bcd5775b-jc4tr\", prometheus=\"openshift-monitoring/k8s\", service=\"kube-state-metrics\"}, {__name__=\"kube_job_status_start_time\", endpoint=\"https-main\", instance=\"10.131.2.4:8443\", job=\"kube-state-metrics\", job_name=\"builds-pruner-1586890800\", namespace=\"openshift-sre-pruning\", pod=\"kube-state-metrics-67bcd5775b-jc4tr\", prometheus=\"openshift-monitoring/k8s\", service=\"kube-state-metrics\"}];many-to-many matching not allowed: matching labels must be unique on one side"
level=warn ts=2020-04-14T21:35:25.221Z caller=manager.go:513 component="rule manager" group=general.rules msg="Evaluating rule failed" rule="alert: CronJobsFailed\nexpr: clamp_max(max by(job, label_cronjob_name, namespace) (kube_job_status_start_time\n  * on(job) group_right() kube_job_labels{label_cronjob_name!=\"\"}) == on(label_cronjob_name)\n  group_left() max by(label_cronjob_name) (kube_job_status_start_time * on(job) group_right()\n  kube_job_labels{label_cronjob_name!=\"\"}), 1) * on(job) group_left() kube_job_status_failed\n  > 0\nfor: 5m\nlabels:\n  severity: critical\nannotations:\n  message: Job {{ $labels.namespace }}/{{ $labels.job }} has failed\n  sop_url: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md\n" err="found duplicate series for the match group {job=\"kube-state-metrics\"} on the left hand-side of the operation: [{__name__=\"kube_job_status_start_time\", endpoint=\"https-main\", instance=\"10.131.2.4:8443\", job=\"kube-state-metrics\", job_name=\"builds-pruner-1586894400\", namespace=\"openshift-sre-pruning\", pod=\"kube-state-metrics-67bcd5775b-jc4tr\", prometheus=\"openshift-monitoring/k8s\", service=\"kube-state-metrics\"}, {__name__=\"kube_job_status_start_time\", endpoint=\"https-main\", instance=\"10.131.2.4:8443\", job=\"kube-state-metrics\", job_name=\"builds-pruner-1586890800\", namespace=\"openshift-sre-pruning\", pod=\"kube-state-metrics-67bcd5775b-jc4tr\", prometheus=\"openshift-monitoring/k8s\", service=\"kube-state-metrics\"}];many-to-many matching not allowed: matching labels must be unique on one side"
```
