### PR TITLE
Removing amq-online-enmasse-console-rules alert test

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -213,10 +213,6 @@ var expectedRules = []alertsTestRule{
 			"UnifiedPushOperatorDown",
 		},
 	},
-	{
-		File:  "redhat-rhmi-amq-online-enmasse-console-rules.yaml",
-		Rules: []string{},
-	},
 }
 
 var expectedAWSRules = []alertsTestRule{


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-7157

Removal of the `redhat-rhmi-amq-online-enmasse-console-rules.yaml` alerts exist test

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Verification
- Execute the functional tests against a cluster using this branch - you may have to comment out some of the other test cases in order to solely test the `alerts_exist` test case (please ask if unsure) 
- Confirm that the test **does not** fail with the following message:
```
File Name: redhat-rhmi-amq-online-enmasse-console-rules.yaml
Missing Rules: []
Unexpected Rules: []
Status: File expected but not found
```