### PR TITLE
INTLY-6739 - add resource limit to operator deployment

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -20,6 +20,13 @@ spec:
           command:
           - rhmi-operator
           imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: 60m
+              memory: 128Mi
+            requests:
+              cpu: 40m
+              memory: 64Mi
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Adds resource limits to operator deployment

Jira:
* https://issues.redhat.com/browse/INTLY-6739

## Verification
* Generate a new csv
  * ` PREVIOUS_TAG=2.1.0 TAG=2.2.0  make gen/csv`
* Check generated csv that the limits has been added to the container deployment

Optional:
* Install RHMI from this branch
  ```
   make cluster/prepare/local
   oc create -f deploy/operator.yaml -n redhat-rhmi-operator
  ```
* Check the deployment and operator pod for limits
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Verified independently on a cluster by reviewer