### PR TITLE
INTLY-6728 Add support for a webhook server running with the operator.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ cluster/deploy/integreatly-rhmi-cr.yml: deploy/integreatly-rhmi-cr.yml
 	$(call wait_command, oc get RHMI $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.solution-explorer.phase}' | grep -q completed, solution-explorer phase, 10m, 30)
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
+cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/service cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
@@ -191,6 +191,10 @@ cluster/prepare/osrc:
 cluster/prepare/crd:
 	- oc create -f deploy/crds/integreatly.org_rhmis_crd.yaml
 	- oc create -f deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+
+.PHONY: cluster/prepare/service
+cluster/prepare/service:
+	- oc create -f deploy/webhook-service.yaml
 
 .PHONY: cluster/prepare/local
 cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean

--- a/Makefile
+++ b/Makefile
@@ -141,7 +141,7 @@ test/e2e/prow: test/e2e
 
 .PHONY: test/e2e
 test/e2e:  export SURF_DEBUG_HEADERS=1
-test/e2e:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
+test/e2e:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd cluster/prepare/service deploy/integreatly-rhmi-cr.yml
 	 export SURF_DEBUG_HEADERS=1
 	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
@@ -171,7 +171,7 @@ cluster/deploy/integreatly-rhmi-cr.yml: deploy/integreatly-rhmi-cr.yml
 	$(call wait_command, oc get RHMI $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.solution-explorer.phase}' | grep -q completed, solution-explorer phase, 10m, 30)
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/service cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
+cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
@@ -197,7 +197,7 @@ cluster/prepare/service:
 	- oc create -f deploy/webhook-service.yaml
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
+cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/service cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 	@oc create -f deploy/service_account.yaml
 	@oc create -f deploy/role.yaml
 	@oc create -f deploy/role_binding.yaml

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -206,9 +206,11 @@ func setupWebhooks(mgr manager.Manager) error {
 	// As reference for adding webhooks. This must be called before `SetupServer`.
 	// It can also be called from the `init()` function of any package
 	//
-	// webhooks.Settings.AddWebhook(webhooks.IntegreatlyWebhook{
-	// 	Name:      "rhmi",
-	// 	Validator: &integreatlyv1alpha1.RHMI{},
+	// webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
+	// 	Name: "rhmi",
+	// 	Register: webhooks.ObjectWebhookRegister{
+	// 		Object: &integreatlyv1alpha1.RHMI{},
+	// 	},
 	// 	Rule: webhooks.NewRule().
 	// 		OneResource("integreatly.org", "v1alpha1", "rhmis").
 	// 		ForCreate().

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -19,6 +19,7 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/controller"
 	integreatlymetrics "github.com/integr8ly/integreatly-operator/pkg/metrics"
+	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
 	"github.com/integr8ly/integreatly-operator/version"
 
 	corev1 "k8s.io/api/core/v1"
@@ -166,6 +167,11 @@ func main() {
 		}
 	}
 
+	// Start up the wehook server
+	if err := setupWebhooks(mgr); err != nil {
+		log.Error(err, "Error setting up webhook server")
+	}
+
 	log.Info("Starting the Cmd.")
 
 	// Start the Cmd
@@ -193,5 +199,26 @@ func serveCRMetrics(cfg *rest.Config) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+func setupWebhooks(mgr manager.Manager) error {
+	// As reference for adding webhooks. This must be called before `SetupServer`.
+	// It can also be called from the `init()` function of any package
+	//
+	// webhooks.Settings.AddWebhook(webhooks.IntegreatlyWebhook{
+	// 	Name:      "rhmi",
+	// 	Validator: &integreatlyv1alpha1.RHMI{},
+	// 	Rule: webhooks.NewRule().
+	// 		OneResource("integreatly.org", "v1alpha1", "rhmis").
+	// 		ForCreate().
+	// 		ForUpdate().
+	// 		NamespacedScope(),
+	// })
+
+	if err := webhooks.Config.SetupServer(mgr); err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -203,20 +203,20 @@ func serveCRMetrics(cfg *rest.Config) error {
 }
 
 func setupWebhooks(mgr manager.Manager) error {
-	// As reference for adding webhooks. This must be called before `SetupServer`.
-	// It can also be called from the `init()` function of any package
-	//
-	// webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
-	// 	Name: "rhmi",
-	// 	Register: webhooks.ObjectWebhookRegister{
-	// 		Object: &integreatlyv1alpha1.RHMI{},
-	// 	},
-	// 	Rule: webhooks.NewRule().
-	// 		OneResource("integreatly.org", "v1alpha1", "rhmis").
-	// 		ForCreate().
-	// 		ForUpdate().
-	// 		NamespacedScope(),
-	// })
+	rhmiConfigRegister, err := webhooks.WebhookRegisterFor(&integreatlyv1alpha1.RHMIConfig{})
+	if err != nil {
+		return err
+	}
+
+	webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
+		Name:     "rhmiconfig",
+		Register: rhmiConfigRegister,
+		Rule: webhooks.NewRule().
+			OneResource("integreatly.org", "v1alpha1", "rhmiconfigs").
+			ForCreate().
+			ForUpdate().
+			NamespacedScope(),
+	})
 
 	if err := webhooks.Config.SetupServer(mgr); err != nil {
 		return err

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -13,10 +13,16 @@ spec:
         name: rhmi-operator
     spec:
       serviceAccountName: rhmi-operator
+      volumes:
+      - name: webhook-certs
+        secret:
+          secretName: rhmi-webhook-cert
       containers:
         - name: rhmi-operator
           # Replace this with the built image name
           image: quay.io/integreatly/integreatly-operator:master
+          ports:
+            - containerPort: 8090
           command:
           - rhmi-operator
           imagePullPolicy: Always
@@ -27,6 +33,10 @@ spec:
             requests:
               cpu: 40m
               memory: 64Mi
+          volumeMounts:
+          - name: webhook-certs
+            mountPath: "/etc/ssl/certs/webhook"
+            readOnly: true
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -348,3 +348,16 @@ rules:
     verbs:
       - get
   # END Permission to fetch identity to get email for created Keycloak users in openshift realm
+
+  # Permission to manage ValidatingWebhookConfiguration CRs pointing to the webhook server
+  - apiGroups:
+      - admissionregistration.k8s.io
+    resources:
+      - validatingwebhookconfigurations
+    verbs:
+      - get
+      - watch
+      - list
+      - create
+      - update
+  # END Permission to manage ValidatingWebhookConfiguration CRs pointing to the webhook server

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -354,6 +354,7 @@ rules:
       - admissionregistration.k8s.io
     resources:
       - validatingwebhookconfigurations
+      - mutatingwebhookconfigurations
     verbs:
       - get
       - watch

--- a/deploy/webhook-service.yaml
+++ b/deploy/webhook-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: rhmi-webhooks
+  namespace: redhat-rhmi-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: rhmi-webhook-cert
+spec:
+  selector:
+    name: rhmi-operator
+  ports:
+    - protocol: TCP
+      port: 443
+      targetPort: 8090

--- a/go.sum
+++ b/go.sum
@@ -749,6 +749,7 @@ github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c h1:nXxl5PrvVm2L/wCy8d
 github.com/morikuni/aec v0.0.0-20170113033406-39771216ff4c/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mrunalp/fileutils v0.0.0-20160930181131-4ee1cc9a8058/go.mod h1:x8F1gnqOkIEiO4rqoeEEEqQbo7HjGMTvyoq3gej4iT0=
 github.com/munnerz/goautoneg v0.0.0-20120707110453-a547fc61f48d/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
+github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30 h1:10VrZWOtDSvWhgViCi2J6VUp4p/B3pOA/efiMH3KjjI=
 github.com/munnerz/goautoneg v0.0.0-20190414153302-2ae31c8b6b30/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mvdan/xurls v0.0.0-20160110113200-1b768d7c393a/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=
 github.com/mvdan/xurls v1.1.0/go.mod h1:tQlNn3BED8bE/15hnSL2HLkDeLWpNPAwtw7wkEq44oU=

--- a/go.sum
+++ b/go.sum
@@ -207,6 +207,7 @@ github.com/coreos/go-systemd v0.0.0-20181031085051-9002847aa142/go.mod h1:F5haX7
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180108230652-97fdf19511ea/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/prometheus-operator v0.26.0/go.mod h1:SO+r5yZUacDFPKHfPoUjI3hMsH+ZUdiuNNhuSq3WoSg=
 github.com/coreos/prometheus-operator v0.29.0/go.mod h1:SO+r5yZUacDFPKHfPoUjI3hMsH+ZUdiuNNhuSq3WoSg=

--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -18,6 +18,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
 // EDIT THIS FILE!  THIS IS SCAFFOLDING FOR YOU TO OWN!
@@ -99,6 +100,18 @@ type RHMIConfigList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 	Items           []RHMIConfig `json:"items"`
+}
+
+func (c *RHMIConfig) ValidateCreate() error {
+	return nil
+}
+
+func (c *RHMIConfig) ValidateUpdate(old runtime.Object) error {
+	return nil
+}
+
+func (c *RHMIConfig) ValidateDelete() error {
+	return nil
 }
 
 func init() {

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -22,6 +22,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/products"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
 
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -239,6 +240,11 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 
 	if installation.Status.Stages == nil {
 		installation.Status.Stages = map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus{}
+	}
+
+	// Reconcile the webhooks
+	if err := webhooks.Config.Reconcile(r.context, r.client); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// either not checked, or rechecking preflight checks

--- a/pkg/webhooks/operator_webhooks.go
+++ b/pkg/webhooks/operator_webhooks.go
@@ -15,7 +15,7 @@ import (
 )
 
 // IntegreatlyWebhookConfig contains the data and logic to setup the webhooks
-// server of a given Manager implementation, and to reconcile ValidatingWebhookConfiguration
+// server of a given Manager implementation, and to reconcile webhook configuration
 // CRs pointing to the server.
 type IntegreatlyWebhookConfig struct {
 	scheme *runtime.Scheme

--- a/pkg/webhooks/operator_webhooks.go
+++ b/pkg/webhooks/operator_webhooks.go
@@ -1,0 +1,256 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// IntegreatlyWebhookConfig contains the data and logic to setup the webhooks
+// server of a given Manager implementation, and to reconcile ValidatingWebhookConfiguration
+// CRs pointing to the server.
+type IntegreatlyWebhookConfig struct {
+	scheme *runtime.Scheme
+
+	Port        int
+	CertDir     string
+	CAConfigMap string
+
+	Webhooks []IntegreatlyWebhook
+}
+
+// IntegreatlyWebhook acts as a single source of truth for validating webhooks
+// managed by the operator. It's data are used both for registering the
+// endpoing to the webhook server and to reconcile the ValidatingWebhookConfiguration
+// that points to the server.
+type IntegreatlyWebhook struct {
+	// Name of the webhook. Used to generate a name for the ValidatingWebhookConfiguration
+	Name string
+
+	// Rule for the webhook to be triggered
+	Rule RuleWithOperations
+
+	// Implementation of the `Validator` interface that performs the validation
+	Validator admission.Validator
+}
+
+const (
+	operatorPodServiceName = "rhmi-webhooks"
+	operatorPodPort        = 8090
+	servicePort            = 443
+	mountedCertDir         = "/etc/ssl/certs/webhook"
+	caConfigMap            = "rhmi-operator-ca"
+	caConfigMapAnnotation  = "service.beta.openshift.io/inject-cabundle"
+)
+
+// Config is a global instance. The same instance is needed in order to use the
+// same configuration for the webhooks server that's run at startup and the
+// reconcilliation of the ValidatingWebhookConfiguration CRs
+var Config *IntegreatlyWebhookConfig = &IntegreatlyWebhookConfig{
+	// Port that the webhook service is pointing to
+	Port: operatorPodPort,
+
+	// Mounted as a volume from the secret generated from Openshift
+	CertDir: mountedCertDir,
+
+	// Name of the config map where the CA certificate is injected
+	CAConfigMap: caConfigMap,
+
+	// List of webhooks to configure
+	Webhooks: []IntegreatlyWebhook{},
+}
+
+// SetupServer sets up the webhook server managed by mgr with the settings from
+// webhookConfig. It sets the port and cert dir based on the settings and
+// registers the Validator implementations from each webhook from webhookConfig.Webhooks
+func (webhookConfig *IntegreatlyWebhookConfig) SetupServer(mgr manager.Manager) error {
+	webhookServer := mgr.GetWebhookServer()
+	webhookServer.Port = webhookConfig.Port
+	webhookServer.CertDir = webhookConfig.CertDir
+
+	webhookConfig.scheme = mgr.GetScheme()
+
+	bldr := builder.WebhookManagedBy(mgr)
+
+	for _, webhook := range webhookConfig.Webhooks {
+		bldr = bldr.For(webhook.Validator)
+	}
+
+	bldr.Complete()
+
+	return nil
+}
+
+// Reconcile reconciles a `ValidationWebhookConfiguration` object for each webhook
+// in `webhookConfig.Webhooks`, using the rules and the path as it's generated
+// by controler-runtime webhook builder.
+// It assumes the injection of the CA that signs the TLS certificates into a ConfigMap
+// to be stored in the `ValidationWebhookConfiguration`
+func (webhookConfig *IntegreatlyWebhookConfig) Reconcile(ctx context.Context, client k8sclient.Client) error {
+	// Create (if it doesn't exist) the config map where the CA certificate is
+	// injected
+	caConfigMap := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      webhookConfig.CAConfigMap,
+			Namespace: "redhat-rhmi-operator",
+			Annotations: map[string]string{
+				caConfigMapAnnotation: "true",
+			},
+		},
+	}
+
+	err := client.Create(ctx, caConfigMap)
+	if err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+
+	// Wait for the config map to be injected with the CA
+	caBundle, err := webhookConfig.waitForCAInConfigMap(ctx, client)
+	if err != nil {
+		return err
+	}
+
+	// Reconcile the webhooks
+	for _, webhook := range webhookConfig.Webhooks {
+		err := webhookConfig.reconcileValidationWebhook(ctx, client, caBundle, webhook)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (webhookConfig *IntegreatlyWebhookConfig) reconcileValidationWebhook(ctx context.Context, client k8sclient.Client, caBundle []byte, webhook IntegreatlyWebhook) error {
+	// We need to declare some parameters of the CR before as it expects pointers
+	var (
+		sideEffects    = v1beta1.SideEffectClassNone
+		port           = int32(servicePort)
+		matchPolicy    = v1beta1.Exact
+		failurePolicy  = v1beta1.Fail
+		timeoutSeconds = int32(30)
+		path, err      = webhookConfig.getPath(webhook)
+	)
+
+	if err != nil {
+		return err
+	}
+
+	// Get the ConfigMap where the CA certificate is injected
+	caConfigMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx,
+		k8sclient.ObjectKey{Name: webhookConfig.CAConfigMap, Namespace: "redhat-rhmi-operator"},
+		caConfigMap,
+	); err != nil {
+		return err
+	}
+
+	// Create ValidatingWebhookConfiguration CR pointing to the webhook server
+	cr := &v1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: fmt.Sprintf("%s.integreatly.org", webhook.Name),
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, client, cr, func() error {
+		cr.Webhooks = []v1beta1.ValidatingWebhook{
+			{
+				Name:        fmt.Sprintf("%s-validating-config.integreatly.org", webhook.Name),
+				SideEffects: &sideEffects,
+				ClientConfig: v1beta1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &v1beta1.ServiceReference{
+						Namespace: "redhat-rhmi-operator",
+						Name:      operatorPodServiceName,
+						Path:      &path,
+						Port:      &port,
+					},
+				},
+				Rules: []v1beta1.RuleWithOperations{
+					{
+						Operations: webhook.Rule.Operations,
+						Rule: v1beta1.Rule{
+							APIGroups:   webhook.Rule.APIGroups,
+							APIVersions: webhook.Rule.APIVersions,
+							Resources:   webhook.Rule.Resources,
+							Scope:       &webhook.Rule.Scope,
+						},
+					},
+				},
+				MatchPolicy:             &matchPolicy,
+				AdmissionReviewVersions: []string{"v1beta1"},
+				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &timeoutSeconds,
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (webhookConfig *IntegreatlyWebhookConfig) waitForCAInConfigMap(ctx context.Context, client k8sclient.Client) ([]byte, error) {
+	var caBundle []byte
+
+	err := wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
+		caConfigMap := &corev1.ConfigMap{}
+		if err := client.Get(ctx,
+			k8sclient.ObjectKey{Name: webhookConfig.CAConfigMap, Namespace: "redhat-rhmi-operator"},
+			caConfigMap,
+		); err != nil {
+			if errors.IsNotFound(err) {
+				return false, nil
+			}
+
+			return false, err
+		}
+
+		result, ok := caConfigMap.Data["service-ca.crt"]
+
+		if !ok {
+			return false, nil
+		}
+
+		caBundle = []byte(result)
+		return true, nil
+	})
+
+	return caBundle, err
+}
+
+// AddWebhook adds a webhook configuration to a webhookSettings. This must be done before
+// starting the server as it registers the endpoints for the validation
+func (webhookConfig *IntegreatlyWebhookConfig) AddWebhook(webhook IntegreatlyWebhook) {
+	webhookConfig.Webhooks = append(webhookConfig.Webhooks, webhook)
+}
+
+// Copied from unexported implementation on controller-runtime/pkg/builder/webhook.go
+func (webhookConfig *IntegreatlyWebhookConfig) getPath(webhook IntegreatlyWebhook) (string, error) {
+	gvk, err := apiutil.GVKForObject(webhook.Validator, webhookConfig.scheme)
+	if err != nil {
+		return "", err
+	}
+
+	path := "/validate-" + strings.Replace(gvk.Group, ".", "-", -1) + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+
+	return path, nil
+}

--- a/pkg/webhooks/operator_webhooks_test.go
+++ b/pkg/webhooks/operator_webhooks_test.go
@@ -36,7 +36,9 @@ func TestReconcile(t *testing.T) {
 					ForCreate().
 					ForUpdate().
 					NamespacedScope(),
-				Validator: &mockValidator{},
+				Register: ObjectWebhookRegister{
+					&mockValidator{},
+				},
 			},
 		},
 	}

--- a/pkg/webhooks/operator_webhooks_test.go
+++ b/pkg/webhooks/operator_webhooks_test.go
@@ -1,0 +1,177 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"k8s.io/api/admissionregistration/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/scheme"
+)
+
+func TestReconcile(t *testing.T) {
+	// Set up testing scheme
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	v1beta1.AddToScheme(scheme)
+	schemeBuilder.AddToScheme(scheme)
+	scheme.AddKnownTypes(schemeBuilder.GroupVersion, &mockValidator{})
+
+	// Create testing webhook config
+	settings := IntegreatlyWebhookConfig{
+		scheme:      scheme,
+		Port:        8090,
+		CAConfigMap: "test-configmap",
+		Webhooks: []IntegreatlyWebhook{
+			{
+				Name: "test",
+				Rule: NewRule().
+					OneResource("example.org", "v1", "mockvalidator").
+					ForCreate().
+					ForUpdate().
+					NamespacedScope(),
+				Validator: &mockValidator{},
+			},
+		},
+	}
+
+	client := fake.NewFakeClientWithScheme(scheme)
+
+	// Start mock of CA controller
+	done := make(chan struct{})
+	defer close(done)
+	go mockCAController(context.TODO(), client, done)
+
+	// Perform one reconcilliation. After this, the ValidatingWebhookConfiguration
+	// must have been created with the specification of the testing webhook
+	if err := settings.Reconcile(context.TODO(), client); err != nil {
+		t.Fatalf("Error reconciling webhook objects: %v", err)
+	}
+
+	vwc, err := findValidatingWebhookConfig(client)
+	if err != nil {
+		t.Fatalf("Error finding ValidatingWebhookConfig: %v", err)
+	}
+
+	if len(vwc.Webhooks) != 1 {
+		t.Fatalf("Expected one webhook to be registered, found %d", len(vwc.Webhooks))
+	}
+
+	webhook := vwc.Webhooks[0]
+
+	if string(webhook.ClientConfig.CABundle) != "TEST" {
+		t.Errorf("Expected CABundle field to be obtained from ConfigMap, but got %s", string(webhook.ClientConfig.CABundle))
+	}
+
+	if len(webhook.Rules) != 1 {
+		t.Fatalf("Expected one rule to be registered, found %d", len(webhook.Rules))
+	}
+
+	rule := webhook.Rules[0]
+
+	if rule.APIGroups[0] != "example.org" {
+		t.Errorf("Expected rule.APIGroups to be [\"example.org\"], got %s", rule.APIGroups[0])
+	}
+	if rule.APIVersions[0] != "v1" {
+		t.Errorf("Expected rule.APIVersions to be [\"v1\"], got %s", rule.APIVersions[0])
+	}
+	if rule.Resources[0] != "mockvalidator" {
+		t.Errorf("Expected rule.Resources to be [\"mockvalidator\"], got %s", rule.Resources[0])
+	}
+}
+
+type mockValidator struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Value string
+}
+
+func (m *mockValidator) ValidateCreate() error {
+	if m.Value == "correct" {
+		return nil
+	}
+
+	return fmt.Errorf("Unexpected value. Expected correct, got %s", m.Value)
+}
+
+func (m *mockValidator) ValidateUpdate(old runtime.Object) error {
+	if m.Value == "correct" {
+		return nil
+	}
+
+	return fmt.Errorf("Unexpected value. Expected correct, got %s", m.Value)
+}
+
+func (m *mockValidator) ValidateDelete() error {
+	return fmt.Errorf("Delete not allowed")
+}
+
+func (m *mockValidator) DeepCopyObject() runtime.Object {
+	return &mockValidator{
+		Value: m.Value,
+	}
+}
+
+var schemeBuilder = &scheme.Builder{
+	GroupVersion: schema.GroupVersion{
+		Group:   "example.org",
+		Version: "v1",
+	},
+}
+
+// Mock the behaviour of the CA controller, that injects a `service-ca.crt` field
+// on ConfigMaps that are annotated with a specific annotation. This is used
+// to obtain the CA that signs the certificates used by the webhook server and
+// reference it in the ValidatingWebhookConfig CR
+func mockCAController(ctx context.Context, client k8sclient.Client, stop <-chan struct{}) {
+	for {
+		// Stop if the channel was closed
+		select {
+		case <-stop:
+			break
+		default:
+		}
+
+		// Get the list of config maps
+		configMaps := &corev1.ConfigMapList{}
+		err := client.List(ctx, configMaps,
+			k8sclient.InNamespace("redhat-rhmi-operator"))
+		if err != nil {
+			continue
+		}
+
+		for _, configMap := range configMaps.Items {
+			annotation, ok := configMap.Annotations[caConfigMapAnnotation]
+			if !ok || annotation != "true" {
+				continue
+			}
+
+			configMap.Data = map[string]string{
+				"service-ca.crt": "TEST",
+			}
+
+			client.Update(ctx, &configMap)
+		}
+	}
+}
+
+func findValidatingWebhookConfig(client k8sclient.Client) (*v1beta1.ValidatingWebhookConfiguration, error) {
+	vwc := &v1beta1.ValidatingWebhookConfiguration{}
+	err := client.Get(
+		context.TODO(),
+		k8sclient.ObjectKey{Name: "test.integreatly.org"},
+		vwc,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return vwc, nil
+}

--- a/pkg/webhooks/reconciller.go
+++ b/pkg/webhooks/reconciller.go
@@ -1,0 +1,174 @@
+package webhooks
+
+import (
+	"context"
+	"fmt"
+
+	"k8s.io/api/admissionregistration/v1beta1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// WebhookReconciler knows how to reconcile webhook configuration CRs
+type WebhookReconciler interface {
+	SetName(name string)
+	SetRule(rule RuleWithOperations)
+	Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error
+}
+
+type CompositeWebhookReconciler struct {
+	Reconcilers []WebhookReconciler
+}
+
+func (reconciler *CompositeWebhookReconciler) SetName(name string) {
+	for _, innerReconciler := range reconciler.Reconcilers {
+		innerReconciler.SetName(name)
+	}
+}
+
+func (reconciler *CompositeWebhookReconciler) SetRule(rule RuleWithOperations) {
+	for _, innerReconciler := range reconciler.Reconcilers {
+		innerReconciler.SetRule(rule)
+	}
+}
+
+func (reconciler *CompositeWebhookReconciler) Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error {
+	for _, innerReconciler := range reconciler.Reconcilers {
+		if err := innerReconciler.Reconcile(ctx, client, caBundle); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+type ValidatingWebhookReconciler struct {
+	Path string
+	name string
+	rule RuleWithOperations
+}
+
+type MutatingWebhookReconciler struct {
+	Path string
+	name string
+	rule RuleWithOperations
+}
+
+func (reconciler *MutatingWebhookReconciler) Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error {
+	var (
+		sideEffects    = v1beta1.SideEffectClassNone
+		port           = int32(servicePort)
+		matchPolicy    = v1beta1.Exact
+		failurePolicy  = v1beta1.Fail
+		timeoutSeconds = int32(30)
+	)
+
+	cr := &v1beta1.MutatingWebhookConfiguration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: fmt.Sprintf("%s.integreatly.org", reconciler.name),
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, cr, func() error {
+		cr.Webhooks = []v1beta1.MutatingWebhook{
+			{
+				Name:        fmt.Sprintf("%s-mutating-config.integreatly.org", reconciler.name),
+				SideEffects: &sideEffects,
+				ClientConfig: v1beta1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &v1beta1.ServiceReference{
+						Namespace: "redhat-rhmi-operator",
+						Name:      operatorPodServiceName,
+						Path:      &reconciler.Path,
+						Port:      &port,
+					},
+				},
+				Rules: []v1beta1.RuleWithOperations{
+					{
+						Operations: reconciler.rule.Operations,
+						Rule: v1beta1.Rule{
+							APIGroups:   reconciler.rule.APIGroups,
+							APIVersions: reconciler.rule.APIVersions,
+							Resources:   reconciler.rule.Resources,
+							Scope:       &reconciler.rule.Scope,
+						},
+					},
+				},
+				MatchPolicy:             &matchPolicy,
+				AdmissionReviewVersions: []string{"v1beta1"},
+				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &timeoutSeconds,
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+func (reconciler *ValidatingWebhookReconciler) Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error {
+	var (
+		sideEffects    = v1beta1.SideEffectClassNone
+		port           = int32(servicePort)
+		matchPolicy    = v1beta1.Exact
+		failurePolicy  = v1beta1.Fail
+		timeoutSeconds = int32(30)
+	)
+
+	cr := &v1beta1.ValidatingWebhookConfiguration{
+		ObjectMeta: v1.ObjectMeta{
+			Name: fmt.Sprintf("%s.integreatly.org", reconciler.name),
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, cr, func() error {
+		cr.Webhooks = []v1beta1.ValidatingWebhook{
+			{
+				Name:        fmt.Sprintf("%s-validating-config.integreatly.org", reconciler.name),
+				SideEffects: &sideEffects,
+				ClientConfig: v1beta1.WebhookClientConfig{
+					CABundle: caBundle,
+					Service: &v1beta1.ServiceReference{
+						Namespace: "redhat-rhmi-operator",
+						Name:      operatorPodServiceName,
+						Path:      &reconciler.Path,
+						Port:      &port,
+					},
+				},
+				Rules: []v1beta1.RuleWithOperations{
+					{
+						Operations: reconciler.rule.Operations,
+						Rule: v1beta1.Rule{
+							APIGroups:   reconciler.rule.APIGroups,
+							APIVersions: reconciler.rule.APIVersions,
+							Resources:   reconciler.rule.Resources,
+							Scope:       &reconciler.rule.Scope,
+						},
+					},
+				},
+				MatchPolicy:             &matchPolicy,
+				AdmissionReviewVersions: []string{"v1beta1"},
+				FailurePolicy:           &failurePolicy,
+				TimeoutSeconds:          &timeoutSeconds,
+			},
+		}
+		return nil
+	})
+	return err
+}
+
+func (reconciler *ValidatingWebhookReconciler) SetName(name string) {
+	reconciler.name = name
+}
+
+func (reconciler *MutatingWebhookReconciler) SetName(name string) {
+	reconciler.name = name
+}
+
+func (reconciler *ValidatingWebhookReconciler) SetRule(rule RuleWithOperations) {
+	reconciler.rule = rule
+}
+
+func (reconciler *MutatingWebhookReconciler) SetRule(rule RuleWithOperations) {
+	reconciler.rule = rule
+}

--- a/pkg/webhooks/rules.go
+++ b/pkg/webhooks/rules.go
@@ -1,0 +1,57 @@
+package webhooks
+
+import "k8s.io/api/admissionregistration/v1beta1"
+
+// The `RuleWithOperations` and `Rule` types redefine the original ones from
+// k8s.io/api/admissionregistration/v1beta1 in order to allow to define methods
+// to build the rule as a fluent interface.
+
+type RuleWithOperations struct {
+	Operations []v1beta1.OperationType
+	Rule
+}
+
+type Rule struct {
+	APIGroups   []string
+	APIVersions []string
+	Resources   []string
+	Scope       v1beta1.ScopeType
+}
+
+func NewRule() RuleWithOperations {
+	return RuleWithOperations{}
+}
+
+func (rule RuleWithOperations) OneResource(apiGroup, apiVersion, resource string) RuleWithOperations {
+	rule.APIGroups = []string{apiGroup}
+	rule.APIVersions = []string{apiVersion}
+	rule.Resources = []string{resource}
+
+	return rule
+}
+
+func (rule RuleWithOperations) NamespacedScope() RuleWithOperations {
+	rule.Scope = v1beta1.NamespacedScope
+
+	return rule
+}
+
+func (rule RuleWithOperations) ForCreate() RuleWithOperations {
+	rule.Operations = append(rule.Operations, v1beta1.Create)
+	return rule
+}
+
+func (rule RuleWithOperations) ForUpdate() RuleWithOperations {
+	rule.Operations = append(rule.Operations, v1beta1.Update)
+	return rule
+}
+
+func (rule RuleWithOperations) ForDelete() RuleWithOperations {
+	rule.Operations = append(rule.Operations, v1beta1.Delete)
+	return rule
+}
+
+func (rule RuleWithOperations) ForAll() RuleWithOperations {
+	rule.Operations = append(rule.Operations, v1beta1.OperationAll)
+	return rule
+}

--- a/pkg/webhooks/webhook_register.go
+++ b/pkg/webhooks/webhook_register.go
@@ -1,0 +1,73 @@
+package webhooks
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// WebhookRegister knows how the register a webhoop into the server. Either by
+// regstering to the WebhookBuilder or directly to the webhook server.
+type WebhookRegister interface {
+	GetPath(scheme *runtime.Scheme) (string, error)
+
+	RegisterToBuilder(blrd *builder.WebhookBuilder) *builder.WebhookBuilder
+	RegisterToServer(scheme *runtime.Scheme, srv *webhook.Server)
+}
+
+// ObjectWebhookRegister registers objects that implement either the `Validator`
+// interface or the `Defaulting` interface into the WebhookBuilder
+type ObjectWebhookRegister struct {
+	Object runtime.Object
+}
+
+// GetPath creates the path for the webhook as implemented at controller-runtime/pkg/builder/webhook.go
+// in order to match the path registered under the hood by the WebhookBuilder
+func (vwr ObjectWebhookRegister) GetPath(scheme *runtime.Scheme) (string, error) {
+	gvk, err := apiutil.GVKForObject(vwr.Object, scheme)
+	if err != nil {
+		return "", err
+	}
+
+	path := "/validate-" + strings.Replace(gvk.Group, ".", "-", -1) + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+
+	return path, nil
+}
+
+// RegisterToBuilder adds the object into the builder, which registers the webhook
+// for the object into the webhook server
+func (vwr ObjectWebhookRegister) RegisterToBuilder(bldr *builder.WebhookBuilder) *builder.WebhookBuilder {
+	return bldr.For(vwr.Object)
+}
+
+// RegisterToServer does nothing, as the register is done by the builder
+func (vwr ObjectWebhookRegister) RegisterToServer(_ *runtime.Scheme, _ *webhook.Server) {}
+
+// AdmissionWebhookRegister registers a given webhook into a specific path.
+// This allows a more low level alternative to the WebhookBuilder, as it can
+// directly get access the the AdmissionReview object sent to the webhook.
+type AdmissionWebhookRegister struct {
+	Hook *admission.Webhook
+	Path string
+}
+
+// GetPath simply returns the path of `awr`
+func (awr AdmissionWebhookRegister) GetPath(_ *runtime.Scheme) (string, error) {
+	return awr.Path, nil
+}
+
+// RegisterToBuilder does not mutate the WebhookBuilder
+func (awr AdmissionWebhookRegister) RegisterToBuilder(bldr *builder.WebhookBuilder) *builder.WebhookBuilder {
+	return bldr
+}
+
+// RegisterToServer regsiters the webhook to the path of `awr`
+func (awr AdmissionWebhookRegister) RegisterToServer(scheme *runtime.Scheme, srv *webhook.Server) {
+	awr.Hook.InjectScheme(scheme)
+	srv.Register(awr.Path, awr.Hook)
+}

--- a/pkg/webhooks/webhook_register.go
+++ b/pkg/webhooks/webhook_register.go
@@ -146,7 +146,7 @@ func (awr AdmissionWebhookRegister) RegisterToServer(scheme *runtime.Scheme, srv
 }
 
 // GetReconciler creates a reconciler for awr's given Path and Type
-func (awr AdmissionWebhookRegister) GetReconciler() (WebhookReconciler, error) {
+func (awr AdmissionWebhookRegister) GetReconciler(_ *runtime.Scheme) (WebhookReconciler, error) {
 	switch awr.Type {
 	case ValidatingType:
 		return &ValidatingWebhookReconciler{

--- a/pkg/webhooks/webhook_register.go
+++ b/pkg/webhooks/webhook_register.go
@@ -1,22 +1,24 @@
 package webhooks
 
 import (
+	"fmt"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// WebhookRegister knows how the register a webhoop into the server. Either by
+// WebhookRegister knows how the register a webhook into the server. Either by
 // regstering to the WebhookBuilder or directly to the webhook server.
 type WebhookRegister interface {
-	GetPath(scheme *runtime.Scheme) (string, error)
-
 	RegisterToBuilder(blrd *builder.WebhookBuilder) *builder.WebhookBuilder
 	RegisterToServer(scheme *runtime.Scheme, srv *webhook.Server)
+
+	GetReconciler(scheme *runtime.Scheme) (WebhookReconciler, error)
 }
 
 // ObjectWebhookRegister registers objects that implement either the `Validator`
@@ -25,18 +27,23 @@ type ObjectWebhookRegister struct {
 	Object runtime.Object
 }
 
-// GetPath creates the path for the webhook as implemented at controller-runtime/pkg/builder/webhook.go
-// in order to match the path registered under the hood by the WebhookBuilder
-func (vwr ObjectWebhookRegister) GetPath(scheme *runtime.Scheme) (string, error) {
-	gvk, err := apiutil.GVKForObject(vwr.Object, scheme)
-	if err != nil {
-		return "", err
+type valueForType struct {
+	validating string
+	mutating   string
+}
+
+// WebhookRegisterFor creates a WebhookRegister for a given object, validating
+// beforehand that the object implements either the `Defaulter` of `Validator`
+// interfaces
+func WebhookRegisterFor(object runtime.Object) (*ObjectWebhookRegister, error) {
+	_, isDefaulter := object.(admission.Defaulter)
+	_, isValidator := object.(admission.Validator)
+
+	if isDefaulter || isValidator {
+		return &ObjectWebhookRegister{object}, nil
 	}
 
-	path := "/validate-" + strings.Replace(gvk.Group, ".", "-", -1) + "-" +
-		gvk.Version + "-" + strings.ToLower(gvk.Kind)
-
-	return path, nil
+	return nil, fmt.Errorf("Object %v does not implement Defaulter or Validator interface", object)
 }
 
 // RegisterToBuilder adds the object into the builder, which registers the webhook
@@ -48,17 +55,83 @@ func (vwr ObjectWebhookRegister) RegisterToBuilder(bldr *builder.WebhookBuilder)
 // RegisterToServer does nothing, as the register is done by the builder
 func (vwr ObjectWebhookRegister) RegisterToServer(_ *runtime.Scheme, _ *webhook.Server) {}
 
+// GetReconciler creates a reconciler according to the implementation of vwr.Object.
+// The object can implement the `Validator` or `Defaulter` interfaces, and if both
+// interfaces are implemented, two webhook configurations must be reconciled, as
+// two endpoints will be registered in the webhook server
+func (vwr ObjectWebhookRegister) GetReconciler(scheme *runtime.Scheme) (WebhookReconciler, error) {
+	paths, err := vwr.getPaths(scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	reconcilers := []WebhookReconciler{}
+
+	if paths.mutating != "" {
+		reconcilers = append(reconcilers, &MutatingWebhookReconciler{
+			Path: paths.mutating,
+		})
+	}
+
+	if paths.validating != "" {
+		reconcilers = append(reconcilers, &ValidatingWebhookReconciler{
+			Path: paths.validating,
+		})
+	}
+
+	return &CompositeWebhookReconciler{
+		Reconcilers: reconcilers,
+	}, nil
+}
+
+// getPaths retrieves the paths for the webhook as implemented at controller-runtime/pkg/builder/webhook.go
+// in order to match the path registered under the hood by the WebhookBuilder
+func (vwr ObjectWebhookRegister) getPaths(scheme *runtime.Scheme) (*valueForType, error) {
+	gvk, err := apiutil.GVKForObject(vwr.Object, scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &valueForType{}
+
+	_, isDefaulter := vwr.Object.(admission.Defaulter)
+	if isDefaulter {
+		result.mutating = generatePath("mutate", gvk)
+	}
+
+	_, isValidator := vwr.Object.(admission.Validator)
+	if isValidator {
+		result.validating = generatePath("validate", gvk)
+	}
+
+	return result, nil
+}
+
+func generatePath(prefix string, gvk schema.GroupVersionKind) string {
+	path := fmt.Sprintf("/%s-", prefix) + strings.Replace(gvk.Group, ".", "-", -1) + "-" +
+		gvk.Version + "-" + strings.ToLower(gvk.Kind)
+
+	return path
+}
+
+// WebhookType represents the type of webhook configuration to reconcile. Can
+// be ValidatingType or MutatingType
+type WebhookType string
+
+// ValidatingType indicates that a ValidatingWebhookConfiguration must be
+// reconciled
+const ValidatingType = "Validating"
+
+// MutatingType indicates that a MutatingWebhookConfiguration must be reconciled
+const MutatingType = "Mutating"
+
 // AdmissionWebhookRegister registers a given webhook into a specific path.
 // This allows a more low level alternative to the WebhookBuilder, as it can
 // directly get access the the AdmissionReview object sent to the webhook.
 type AdmissionWebhookRegister struct {
+	Type WebhookType
 	Hook *admission.Webhook
 	Path string
-}
-
-// GetPath simply returns the path of `awr`
-func (awr AdmissionWebhookRegister) GetPath(_ *runtime.Scheme) (string, error) {
-	return awr.Path, nil
 }
 
 // RegisterToBuilder does not mutate the WebhookBuilder
@@ -70,4 +143,20 @@ func (awr AdmissionWebhookRegister) RegisterToBuilder(bldr *builder.WebhookBuild
 func (awr AdmissionWebhookRegister) RegisterToServer(scheme *runtime.Scheme, srv *webhook.Server) {
 	awr.Hook.InjectScheme(scheme)
 	srv.Register(awr.Path, awr.Hook)
+}
+
+// GetReconciler creates a reconciler for awr's given Path and Type
+func (awr AdmissionWebhookRegister) GetReconciler() (WebhookReconciler, error) {
+	switch awr.Type {
+	case ValidatingType:
+		return &ValidatingWebhookReconciler{
+			Path: awr.Path,
+		}, nil
+	case MutatingType:
+		return &MutatingWebhookReconciler{
+			Path: awr.Path,
+		}, nil
+	}
+
+	return nil, fmt.Errorf("Unsupported type for AdmissionWebhookRegister: %s", awr.Type)
 }

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -39,4 +39,9 @@ if [[ "$VERSION" != "$PREVIOUS_VERSION" ]]; then
   set_version
 fi
 
+# Include the webhook service in the bundle (temporal solution as OLM will soon
+# support webhooks as part of the CSV:
+# https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/contributors/design-proposals/webhooks.md
+cp deploy/webhook-service.yaml deploy/olm-catalog/integreatly-operator/$VERSION/webhook-service.yaml
+
 set_images

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -27,6 +27,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/remotecommand"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -536,6 +537,32 @@ func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	installationPrefix, found := os.LookupEnv("INSTALLATION_PREFIX")
 	if !found {
 		t.Fatal("INSTALLATION_PREFIX env var is not set")
+	}
+
+	var service = &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhmi-webhooks",
+			Namespace: namespace,
+			Annotations: map[string]string{
+				"service.beta.openshift.io/serving-cert-secret-name": "rhmi-webhook-cert",
+			},
+		},
+		Spec: corev1.ServiceSpec{
+			Selector: map[string]string{
+				"name": "rhmi-operator",
+			},
+			Ports: []corev1.ServicePort{
+				{
+					Protocol:   corev1.ProtocolTCP,
+					Port:       443,
+					TargetPort: intstr.FromInt(8090),
+				},
+			},
+		},
+	}
+	err = f.Client.Create(context.TODO(), service, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatal(err)
 	}
 
 	var smtpSec = &corev1.Secret{


### PR DESCRIPTION
# Description
In order to add the ability to implement custom validation for the new customer config CR, set up a Webhook server running with the operator.

Kubernetes allows to create validation webhooks pointing to a service in the cluster. The `controller-runtime` library contains the logic to register webhooks in the server provided by the `Manager` interface, but in order to set up the webhook a `ValidatingWebhookConfiguration` CR must be created pointing to the webhook service. 

These changes create a single source of truth for both the Webhooks endpoint and the CRs that are reconciled, therefore there's no need for manual synchronization between the webhook server and the `ValidatingWebhookConfiguration` CRs.

The webhook server requires TLS certificates to run. The following changes were made to allow the operator to use the certificates following [1]:

* Create a Service pointing to the operator, with an annotation `service.beta.openshift.io/serving-cert-secret-name` that triggers the creation of a secret with a key-pair that can be injected as a volume to the Pod.
* Update the operator Deployment to listen to the `8090` port and mount the certificates.
* Reconcile a ConfigMap where the CA certificate is injected, and obtain it from the operator in order to validate the certificates via the `CABundle` field of `ValidatingWebhookConfiguration`

[1] https://docs.openshift.com/container-platform/4.1/authentication/certificates/service-serving-certificate.html

## Adding webhooks

A singleton instance of the webhook configuration is defined and contains a list of the webhooks to be registered and managed. Adding elements to the list before the startup of the server will guarantee that the webhook will be created and the CR will be reconciled. In order to add a webhook, an implementation of the `WebhookRegister` interface is required. This manages the registration of the webhook against the server. This PR includes two implementations:

1. `ObjectWebhookRegister`, encapsules a webhook that implements the `Validator` or `Defaulter` interface.
2. `AdmissionWebhookRegister` to register webhooks directly to the webhook server with a custom function and path (as opposed to the auto-generated path and validation logic for `ObjectWebhookRegister`)

The following is an example of adding a webhook for the `RHMI` CR (provided that it implements the `Validator` interface):

```go
webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
	Name:      "rhmi",
	Register: webhooks.ObjectWebhookRegister{
		Object: &integreatlyv1alpha1.RHMI{},
	},
	Rule: webhooks.NewRule().
		OneResource("integreatly.org", "v1alpha1", "rhmis").
		ForCreate().
		ForUpdate().
		NamespacedScope(),
})
```

## Verification

In order to verify this, you'll need to run the operator as a Pod. Build your own image and edit the `Deployment` to point to the image.

Create the webhooks service that points to the operator pod:

```sh
make cluster/prepare/service
```

Run the operator

```sh
oc create -f deploy/operator.yaml
```

The operator pod will be created. Verify that:

1. The operator starts successfully and triggers the installation.
2. A `ValidatingWebhookConfiguration` CR is reconciled referencing the `RHMIConfig` CR and the webhooks service that points to the operator pod.
3. Modify the RHMIConfig CR and verify that no error occurs and no error is displayed in the operator log.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] This change requires a documentation update
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer