### PR TITLE
[WIP]Grafana route e2e test flake 

### DIFF
--- a/test/resources/openshift_auth.go
+++ b/test/resources/openshift_auth.go
@@ -124,7 +124,7 @@ func OpenshiftUserReconcileCheck(openshiftClient *OpenshiftClient, k8sclient dyn
 func openshiftClientSetup(url, username, password string, client *http.Client, idp string) error {
 	//oauth proxy-specific constants
 	const (
-		openshiftConsoleSubdomain = "console-openshift-console.apps."
+		approvalPromptURLElement = "approval_prompt"
 	)
 	//follow the oauth proxy flow
 	browser := surf.NewBrowser()
@@ -153,8 +153,7 @@ func openshiftClientSetup(url, username, password string, client *http.Client, i
 		return fmt.Errorf("failed to submit login form on oauth proxy screen: %w", err)
 	}
 	//sometimes we'll reach an accept permissions page for the user if they haven't accepted these scope requests before.
-	//refactored, this approach assumes that if the redirected page is not the console then it looks for an approve action, previous approach would cause e2e test flakes
-	if !strings.Contains(browser.Url().Host, openshiftConsoleSubdomain) {
+	if strings.Contains(browser.Url().Host, approvalPromptURLElement) {
 		permissionsForm, err := browser.Form("[action=approve]")
 		if err != nil {
 			return fmt.Errorf("failed to get permissions form: %w", err)


### PR DESCRIPTION
# Description
- Altered test logic to make use of `wait.PollImmediate()` to set timeout and wait for status code to change to 200 (During manual testing the status code changed from 403 to 200 after the test had failed)
- Added function to check `responseCode` and return done status for `wait.PollImmediate()`
- Change input element for the section of code where a check is performed to see whether permission approval form exists
## JIRA link
https://issues.redhat.com/browse/INTLY-6738
## Type of change

<!-- Please delete options that are not relevant. -->

- [ :heavy_check_mark: ] Bug fix (non-breaking change which fixes an issue)

## Verification
- PR Prow e2e tests passing on _Verify Grafana Route is accessible_ 
- ***Cannot test locally with `make test/e2e/prow` in a reliable/reproducable way***