### PR TITLE
INTLY-6748 disable 3scale resource requirements for pds

### DIFF
--- a/pkg/controller/installation/types.go
+++ b/pkg/controller/installation/types.go
@@ -96,7 +96,6 @@ var (
 				integreatlyv1alpha1.ProductCodeReadyWorkspaces: {Name: integreatlyv1alpha1.ProductCodeReadyWorkspaces},
 				integreatlyv1alpha1.ProductAMQOnline:           {Name: integreatlyv1alpha1.ProductAMQOnline},
 				integreatlyv1alpha1.Product3Scale:              {Name: integreatlyv1alpha1.Product3Scale},
-				integreatlyv1alpha1.ProductAMQStreams:          {Name: integreatlyv1alpha1.ProductAMQStreams},
 				integreatlyv1alpha1.ProductRHSSOUser:           {Name: integreatlyv1alpha1.ProductRHSSOUser},
 				integreatlyv1alpha1.ProductUps:                 {Name: integreatlyv1alpha1.ProductUps},
 				integreatlyv1alpha1.ProductApicurito:           {Name: integreatlyv1alpha1.ProductApicurito},

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -413,7 +413,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 	}
 
 	// create the 3scale api manager
-	resourceRequirements := true
+	resourceRequirements := r.installation.Spec.Type != string(integreatlyv1alpha1.InstallationTypeWorkshop)
 	apim := &threescalev1.APIManager{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      apiManagerName,

--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -33,7 +33,7 @@ func lookup3ScaleClientSecret(client dynclient.Client, clientId string) (string,
 // Tests that a user in group rhmi-developers can log into fuse and
 // create an integration
 func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -54,7 +54,7 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	keycloakHost := rhmi.Status.Stages[v1alpha1.AuthenticationStage].Products[v1alpha1.ProductRHSSO].Host
 	redirectUrl := fmt.Sprintf("%v/p/admin/dashboard", host)
 
-	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, ctx.HttpClient, ctx.Client)
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, ctx.HttpClient, ctx.Client, t)
 
 	// First login to OpenShift
 	err = tsClient.LoginOpenshift(masterURL, threescaleLoginUser, DefaultPassword, rhmi.Spec.NamespacePrefix)

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -97,7 +97,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	t.Log("Test codeready workspace creation")
 
 	// Ensure testing-idp is available
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("failed to create testing idp: %v", err)
 	}
 
@@ -114,7 +114,7 @@ func TestCodereadyCrudlPermisssions(t *testing.T, ctx *TestingContext) {
 	redirectUrl := fmt.Sprintf("%v/dashboard/", cheHost)
 
 	// login to openshift
-	loginClient := resources.NewCodereadyLoginClient(ctx.HttpClient, ctx.Client, masterURL, TestingIDPRealm, username, password)
+	loginClient := resources.NewCodereadyLoginClient(ctx.HttpClient, ctx.Client, masterURL, TestingIDPRealm, username, password, t)
 	if err := loginClient.OpenshiftLogin(rhmi.Spec.NamespacePrefix); err != nil {
 		t.Fatalf("failed to login to openshift: %v", err)
 	}

--- a/test/common/default_email.go
+++ b/test/common/default_email.go
@@ -1,10 +1,7 @@
 package common
 
 import (
-	"crypto/tls"
 	"fmt"
-	"net/http"
-	"net/http/cookiejar"
 	"testing"
 	"time"
 
@@ -12,7 +9,6 @@ import (
 
 	keycloakv1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	userv1 "github.com/openshift/api/user/v1"
-	"golang.org/x/net/publicsuffix"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,21 +25,7 @@ const (
 //
 // Verify that the email address is generated as <username>@rhmi.io
 func TestDefaultUserEmail(t *testing.T, ctx *TestingContext) {
-	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: ctx.SelfSignedCerts},
-	}
-
-	jar, err := cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
-	if err != nil {
-		t.Fatalf("error occurred creating a new cookie jar: %v", err)
-	}
-
-	httpClient := &http.Client{
-		Transport: tr,
-		Jar:       jar,
-	}
-
-	err = createTestingIDP(t, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts)
+	err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts)
 	if err != nil {
 		t.Fatalf("Error occurred creating testing IDP: %v", err)
 	}

--- a/test/common/fuse_crudl.go
+++ b/test/common/fuse_crudl.go
@@ -13,10 +13,10 @@ var (
 	fuseLoginPassword = DefaultPassword
 )
 
-func loginOpenshift(ctx *TestingContext, masterUrl, username, password, namespacePrefix string) error {
+func loginOpenshift(t *testing.T, ctx *TestingContext, masterUrl, username, password, namespacePrefix string) error {
 	authUrl := fmt.Sprintf("%s/auth/login", masterUrl)
 
-	if err := resources.DoAuthOpenshiftUser(authUrl, username, password, ctx.HttpClient, "testing-idp"); err != nil {
+	if err := resources.DoAuthOpenshiftUser(authUrl, username, password, ctx.HttpClient, "testing-idp", t); err != nil {
 		return err
 	}
 
@@ -30,7 +30,7 @@ func loginOpenshift(ctx *TestingContext, masterUrl, username, password, namespac
 // Tests that a user in group rhmi-developers can log into fuse and
 // create an integration
 func TestFuseCrudlPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -44,7 +44,7 @@ func TestFuseCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	// Get the fuse host url from the rhmi status
 	fuseHost := rhmi.Status.Stages[v1alpha1.ProductsStage].Products[v1alpha1.ProductFuse].Host
 
-	err = loginOpenshift(ctx, masterURL, fuseLoginUser, fuseLoginPassword, rhmi.Spec.NamespacePrefix)
+	err = loginOpenshift(t, ctx, masterURL, fuseLoginUser, fuseLoginPassword, rhmi.Spec.NamespacePrefix)
 	if err != nil {
 		t.Fatalf("error logging into openshift: %v", err)
 	}

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -20,7 +20,7 @@ const (
 
 func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
@@ -37,7 +37,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	}
 	//retrieve an openshift oauth proxy cookie
 	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
-	if err := resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm); err != nil {
+	if err := resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatal("failed to login through openshift oauth proxy", err)
 	}
 
@@ -57,14 +57,13 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 		dumpResp, _ := httputil.DumpResponse(successResp, true)
 		t.Logf("dumpResp: %q", dumpResp)
 
-		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-6738")
-		//t.Fatalf("unexpected status code on success request, got=%+v", successResp)
+		t.Fatalf("unexpected status code on success request, got=%+v", successResp)
 	}
 }
 
 func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	//reconcile idp setup
-	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, context.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatal("failed to reconcile testing idp", err)
 	}
 	grafanaRootHostname, err := getGrafanaRoute(ctx.Client)
@@ -73,9 +72,8 @@ func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	}
 	//retrieve an openshift oauth proxy cookie
 	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
-	if err = resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm); err != nil {
-		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-7267", err)
-		// t.Fatal("failed to login through openshift oauth proxy", err)
+	if err = resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+		t.Fatal("failed to login through openshift oauth proxy", err)
 	}
 	//get dashboards for grafana from the external route
 	grafanaDashboardsUrl := fmt.Sprintf("%s/api/search", grafanaRootHostname)

--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -50,7 +50,7 @@ func TestNetworkPolicyAccessNSToSVC(t *testing.T, ctx *TestingContext) {
 		Jar:       jar,
 	}
 
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, httpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -63,7 +63,7 @@ func TestNetworkPolicyAccessNSToSVC(t *testing.T, ctx *TestingContext) {
 	masterURL := rhmi.Spec.MasterURL
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, httpClient, TestingIDPRealm); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, httpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -38,7 +38,7 @@ var productNamespaces = []string{
 }
 
 func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -56,7 +56,7 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -27,7 +27,7 @@ type LogOptions struct {
 }
 
 func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
-	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.HttpClient, ctx.SelfSignedCerts); err != nil {
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
 
@@ -47,7 +47,7 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	t.Log("retrieved openshift-Oauth route")
 
 	// get rhmi developer user tokens
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "test-user-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "test-user-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 	t.Log("retrieved rhmi developer user tokens")

--- a/test/resources/3scale_api.go
+++ b/test/resources/3scale_api.go
@@ -31,15 +31,17 @@ type ThreeScaleAPIClientImpl struct {
 	token        string
 	keycloakHost string
 	redirectUrl  string
+	logger       SimpleLogger
 }
 
-func NewThreeScaleAPIClient(host, keycloakHost, redirectUrl string, client *http.Client, kubeClient k8sclient.Client) ThreeScaleAPIClient {
+func NewThreeScaleAPIClient(host, keycloakHost, redirectUrl string, client *http.Client, kubeClient k8sclient.Client, logger SimpleLogger) ThreeScaleAPIClient {
 	return &ThreeScaleAPIClientImpl{
 		host:         host,
 		client:       client,
 		kubeClient:   kubeClient,
 		keycloakHost: keycloakHost,
 		redirectUrl:  redirectUrl,
+		logger:       logger,
 	}
 }
 
@@ -79,7 +81,7 @@ func (r *ThreeScaleAPIClientImpl) Login3Scale(clientSecret string) error {
 
 func (r *ThreeScaleAPIClientImpl) LoginOpenshift(masterUrl, username, password, namespacePrefix string) error {
 	authUrl := fmt.Sprintf("%s/auth/login", masterUrl)
-	if err := DoAuthOpenshiftUser(authUrl, username, password, r.client, "testing-idp"); err != nil {
+	if err := DoAuthOpenshiftUser(authUrl, username, password, r.client, "testing-idp", r.logger); err != nil {
 		return err
 	}
 

--- a/test/resources/codeready_login.go
+++ b/test/resources/codeready_login.go
@@ -28,9 +28,10 @@ type CodereadyLoginClient struct {
 	IdpName    string
 	Username   string
 	Password   string
+	Logger     SimpleLogger
 }
 
-func NewCodereadyLoginClient(httpClient *http.Client, client k8sclient.Client, masterUrl, idp, username, password string) *CodereadyLoginClient {
+func NewCodereadyLoginClient(httpClient *http.Client, client k8sclient.Client, masterUrl, idp, username, password string, logger SimpleLogger) *CodereadyLoginClient {
 	return &CodereadyLoginClient{
 		HttpClient: httpClient,
 		Client:     client,
@@ -38,13 +39,14 @@ func NewCodereadyLoginClient(httpClient *http.Client, client k8sclient.Client, m
 		IdpName:    idp,
 		Username:   username,
 		Password:   password,
+		Logger:     logger,
 	}
 }
 
 // Login user to openshift and wait for the user to be reconciled to the openshift realm in keycloak
 func (c *CodereadyLoginClient) OpenshiftLogin(namespacePrefix string) error {
 	authUrl := fmt.Sprintf("%s/auth/login", c.MasterUrl)
-	if err := DoAuthOpenshiftUser(authUrl, c.Username, c.Password, c.HttpClient, c.IdpName); err != nil {
+	if err := DoAuthOpenshiftUser(authUrl, c.Username, c.Password, c.HttpClient, c.IdpName, c.Logger); err != nil {
 		return err
 	}
 

--- a/test/resources/types.go
+++ b/test/resources/types.go
@@ -1,0 +1,5 @@
+package resources
+
+type SimpleLogger interface {
+	Log(...interface{})
+}


### PR DESCRIPTION
Copy of https://github.com/integr8ly/integreatly-operator/pull/650 so I can see the OpenShift cluster the e2e tests are running on, for debugging