### PR TITLE
Installation of AMQ monitoring resources

### DIFF
--- a/manifests/integreatly-amq-online/1.4.1/amq-online.1.4.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-amq-online/1.4.1/amq-online.1.4.1.clusterserviceversion.yaml
@@ -688,7 +688,7 @@ spec:
                 - name: "FS_GROUP_FALLBACK_MAP"
                   value: "{}"
                 - name: ENABLE_MONITORING
-                  value: "false"
+                  value: "true"
                 - name: CONSOLE_LINK_SECTION_NAME
                   value: "Red Hat Integration"
                 - name: CONSOLE_LINK_NAME

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -214,6 +214,30 @@ var expectedRules = []alertsTestRule{
 			"UnifiedPushOperatorDown",
 		},
 	},
+	{
+		File: "redhat-rhmi-amq-online-kube-metrics.yaml",
+		Rules: []string{
+			"TerminatingPods",
+			"RestartingPods",
+			"RestartingPods",
+			"PendingPods",
+		},
+	},
+	{
+		File: "redhat-rhmi-amq-online-enmasse.yaml",
+		Rules: []string{
+			"ComponentHealth",
+			"AuthenticationService",
+			"AddressSpaceHealth",
+			"AddressHealth",
+			"RouterMeshConnectivityHealth",
+			"RouterMeshUndeliveredHealth",
+		},
+	},
+	{
+		File:  "redhat-rhmi-amq-online-enmasse-console-rules.yaml",
+		Rules: []string{},
+	},
 }
 
 var expectedAWSRules = []alertsTestRule{

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -64,6 +64,18 @@ var expectedDashboards = []dashboardsTestRule{
 	{
 		Title: "Critical SLO summary",
 	},
+	{
+		Title: "AMQ Online",
+	},
+	{
+		Title: "EnMasse Brokers",
+	},
+	{
+		Title: "EnMasse Console",
+	},
+	{
+		Title: "EnMasse Routers",
+	},
 }
 
 func TestIntegreatlyDashboardsExist(t *testing.T, ctx *TestingContext) {


### PR DESCRIPTION
# Description
- Successful installation of monitoring resources using this branch
- Successful installation of monitoring resources when upgrading from `2.1.0` -> `2.2.0` via OLM
- Tests updated to account for the new dashboards/alerts

## JIRA
https://issues.redhat.com/browse/INTLY-5111

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Verification

Verification requires both an install (which can be done locally), and an install and upgrade (via OLM) to test that the upgrade works as expected

## Installation
- `oc login` to your OS4 cluster
- Using this branch, run a local install
- Ensure the following alerts are created, and are not triggering:
```
/etc/prometheus/rules/prometheus-application-monitoring-rulefiles-0/redhat-rhmi-amq-online-enmasse.yaml
ComponentHealth
AddressHealth
AddressSpaceHealth
AuthenticationService
RouterMeshConnectivityHealth
RouterMeshUndeliveredHealth

/etc/prometheus/rules/prometheus-application-monitoring-rulefiles-0/redhat-rhmi-amq-online-kube-metrics.yaml
PendingPods
RestartingPods
RestartingPods
TerminatingPods
```
- Remove the `RHMI` installation once complete

## Upgrade

### Installing 2.1.0 via OLM
- `oc login` to your OS4 cluster
- Login to `quay.io`
- Push the `integreatly-operator 2.1.0` CSV to your own quay.io application registry. From master, run: 
  `QUAY_USERNAME=<your user> QUAY_PASSWORD=<your password> REPO=<your quay name> make push/csv` (requires operator courier)
- Within `quay.io`, make the application public (applications -> settings -> make public)
- Create an operator source on the cluster:
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: rhmi
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: RHMI Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: <The REPO you used above>
  type: appregistry
```
- Run: `make cluster/prepare/project && make cluster/prepare/smtp && make cluster/prepare/dms && make cluster/prepare/pagerduty`
- Manually create an automatic subscription for RHMI on  the cluster through OLM, in the `redhat-rhmi-operator` namespace (operator-hub -> RHMI-Integreation -> RHMI -> install)
- Wait for `RHMI` to install

### Upgrading to this branch
- Checkout this branch
- `make release/prepare SEMVER=2.2.0`
- Within the newly created CSV file, update the `image` value to point to your `quay.io` repositiory, i.e ` quay.io/robrien/integreatly-operator:v2.2.0`
- Update the `ORG` in the makefile to point to your quay `ORG`
- `make image/build`
- Push the new CSV to quay: `QUAY_USERNAME=<your user> QUAY_PASSWORD=<your password> REPO=<your quay name> make push/csv`
- Push the new image to quay: `make image/push`
- Make the `integreatly-operator` repository public in quay, if it isn't already (repositories -> settings -> make public)
- Delete the `rhmi-x` pod in the `openshift-marketplace` namespace
- In the `redhat-rhmi-operator` namespace, navigate to Installed-Operators -> RHMI -> subscription and approve the upgrade
- Ensure the upgrade was successful, the following alerts exist in Prometheus and none of the alerts are in a triggered state (you may have to wait a few minutes for the upgrade to take affect):

```
/etc/prometheus/rules/prometheus-application-monitoring-rulefiles-0/redhat-rhmi-amq-online-enmasse.yaml
ComponentHealth
AddressHealth
AddressSpaceHealth
AuthenticationService
RouterMeshConnectivityHealth
RouterMeshUndeliveredHealth

/etc/prometheus/rules/prometheus-application-monitoring-rulefiles-0/redhat-rhmi-amq-online-kube-metrics.yaml
PendingPods
RestartingPods
RestartingPods
TerminatingPods
```