### PR TITLE
INTLY-6744 - Role for RHMI Config

### DIFF
--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -314,14 +314,14 @@ func (r *Reconciler) reconcileRHMIConfigPermissions(ctx context.Context, serverC
 	if _, err := controllerutil.CreateOrUpdate(ctx, serverClient, configRole, func() error {
 		configRole.Rules = []rbacv1.PolicyRule{
 			{
-				APIGroups:     []string{"integreatly.org"},
-				Resources:     []string{"rhmiconfigs"},
-				Verbs:         []string{"update", "get", "list"},
+				APIGroups: []string{"integreatly.org"},
+				Resources: []string{"rhmiconfigs"},
+				Verbs:     []string{"update", "get", "list"},
 			},
 		}
 		return nil
 	}); err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error creating Github OAuth secrets role: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error creating RHMI Config dedicated admin role: %w", err)
 	}
 
 	configRoleBinding := &rbacv1.RoleBinding{

--- a/pkg/controller/installation/bootstrapReconciler_test.go
+++ b/pkg/controller/installation/bootstrapReconciler_test.go
@@ -1,0 +1,81 @@
+package installation
+
+import (
+	"context"
+	"errors"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = rbacv1.SchemeBuilder.AddToScheme(scheme)
+
+	tests := []struct {
+		Name    string
+		ExpectedStatus integreatlyv1alpha1.StatusPhase
+		FakeConfig     *config.ConfigReadWriterMock
+		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Installation   *integreatlyv1alpha1.RHMI
+		Recorder       record.EventRecorder
+		FakeClient     k8sclient.Client
+	}{
+		{
+			Name: "Test Role and Role Binding is created",
+			FakeConfig: &config.ConfigReadWriterMock{
+				GetOperatorNamespaceFunc: func() string {
+					return "test-namespace"
+				},
+			},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
+			Installation: &integreatlyv1alpha1.RHMI{},
+			Recorder: record.NewFakeRecorder(50),
+			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme),
+		},
+		{
+			Name: "Test - error in creating role and role binding",
+			FakeConfig: &config.ConfigReadWriterMock{
+				GetOperatorNamespaceFunc: func() string {
+					return "test-namespace"
+				},
+			},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
+			Installation: &integreatlyv1alpha1.RHMI{},
+			Recorder: record.NewFakeRecorder(50),
+			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
+			FakeClient: &moqclient.SigsClientInterfaceMock{
+				GetFunc: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return errors.New("dummy get error")
+				},
+				CreateFunc: func(ctx context.Context, obj runtime.Object, opts ...k8sclient.CreateOption) error {
+					return errors.New("dummy create error")
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			reconciler, err := NewBootstrapReconciler(tt.FakeConfig, tt.Installation, tt.FakeMPM, tt.Recorder)
+			if err != nil {
+				t.Fatalf("Error creating bootstrap reconciler: %s", err)
+			}
+
+			phase, err := reconciler.reconcileRHMIConfigPermissions(context.TODO(), tt.FakeClient)
+
+			if phase != tt.ExpectedStatus {
+				t.Fatalf("Expected %s phase but got %s", tt.ExpectedStatus, phase)
+			}
+
+		})
+	}
+}

--- a/pkg/controller/installation/bootstrapReconciler_test.go
+++ b/pkg/controller/installation/bootstrapReconciler_test.go
@@ -21,7 +21,7 @@ func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
 	_ = rbacv1.SchemeBuilder.AddToScheme(scheme)
 
 	tests := []struct {
-		Name    string
+		Name           string
 		ExpectedStatus integreatlyv1alpha1.StatusPhase
 		FakeConfig     *config.ConfigReadWriterMock
 		FakeMPM        *marketplace.MarketplaceInterfaceMock
@@ -36,11 +36,11 @@ func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
 					return "test-namespace"
 				},
 			},
-			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
-			Installation: &integreatlyv1alpha1.RHMI{},
-			Recorder: record.NewFakeRecorder(50),
+			FakeMPM:        &marketplace.MarketplaceInterfaceMock{},
+			Installation:   &integreatlyv1alpha1.RHMI{},
+			Recorder:       record.NewFakeRecorder(50),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient: fakeclient.NewFakeClientWithScheme(scheme),
+			FakeClient:     fakeclient.NewFakeClientWithScheme(scheme),
 		},
 		{
 			Name: "Test - error in creating role and role binding",
@@ -49,9 +49,9 @@ func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
 					return "test-namespace"
 				},
 			},
-			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
-			Installation: &integreatlyv1alpha1.RHMI{},
-			Recorder: record.NewFakeRecorder(50),
+			FakeMPM:        &marketplace.MarketplaceInterfaceMock{},
+			Installation:   &integreatlyv1alpha1.RHMI{},
+			Recorder:       record.NewFakeRecorder(50),
 			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
 			FakeClient: &moqclient.SigsClientInterfaceMock{
 				GetFunc: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -95,7 +95,7 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// Verify Dedicated admin permissions around RHMI Config
-	verifyDedicatedAdminRHMIConfigPermissions(t, openshiftClient, masterURL)
+	verifyDedicatedAdminRHMIConfigPermissions(t, openshiftClient)
 }
 
 // verifies that there is at least 1 project with a prefix `openshift` , `redhat` and `kube`
@@ -115,9 +115,9 @@ func verifyDedicatedAdminProjectPermissions(projects []projectv1.Project) bool {
 	return hasKubePrefix && hasRedhatPrefix && hasOpenshiftPrefix
 }
 
-func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient, masterURL string) {
+func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	// Dedicated admin can LIST RHMI Config CR
-	resp, err := openshiftClient.DoOpenshiftGetRequest(masterURL, resources.PathListRHMIConfig)
+	resp, err := openshiftClient.DoOpenshiftGetRequest(resources.PathListRHMIConfig)
 
 	if err != nil {
 		t.Errorf("failed to perform LIST request for rhmi config with error : %s", err)
@@ -130,7 +130,7 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 	// Dedicated admin can GET RHMI Config CR
 	path := fmt.Sprintf(resources.PathGetRHMIConfig, "rhmi-config")
 
-	resp, err = openshiftClient.DoOpenshiftGetRequest(masterURL, path)
+	resp, err = openshiftClient.DoOpenshiftGetRequest(path)
 
 	if err != nil {
 		t.Errorf("failed to perform GET request for rhmi config with error : %s", err)
@@ -143,7 +143,7 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 	// Dedicated admin can UPDATE RHMI Config CR
 	bodyBytes, err := ioutil.ReadAll(resp.Body) // Use response from GET
 
-	resp, err = openshiftClient.DoOpenshiftPutRequest(masterURL, path, bodyBytes)
+	resp, err = openshiftClient.DoOpenshiftPutRequest(path, bodyBytes)
 
 	if err != nil {
 		t.Errorf("failed to perform UPDATE request for rhmi config with error : %s", err)
@@ -157,7 +157,7 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 	rhmiConfig := &integreatlyv1alpha1.RHMIConfig{}
 	bodyBytes, err = json.Marshal(rhmiConfig)
 
-	resp, err = openshiftClient.DoOpenshiftPostRequest(masterURL, path, bodyBytes)
+	resp, err = openshiftClient.DoOpenshiftPostRequest(path, bodyBytes)
 
 	if err != nil {
 		t.Errorf("failed to perform CREATE request for rhmi config with error : %s", err)
@@ -168,7 +168,7 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 	}
 
 	// Dedicate admin can not DELETE RHMI config
-	resp, err = openshiftClient.DoOpenshiftDeleteRequest(masterURL, path)
+	resp, err = openshiftClient.DoOpenshiftDeleteRequest(path)
 
 	if err != nil {
 		t.Errorf("failed to perform DELETE request for rhmi config with error : %s", err)

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -101,7 +101,7 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// Verify RHMI Developer permissions around RHMI Config
-	verifyRHMIDeveloperRHMIConfigPermissions(t, openshiftClient, masterURL)
+	verifyRHMIDeveloperRHMIConfigPermissions(t, openshiftClient)
 }
 
 func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient *resources.OpenshiftClient) error {
@@ -137,9 +137,9 @@ func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient 
 	return nil
 }
 
-func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient, masterURL string) {
+func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	// RHMI Developer can not LIST RHMI Config CR
-	resp, err := openshiftClient.DoOpenshiftGetRequest(masterURL, resources.PathListRHMIConfig)
+	resp, err := openshiftClient.DoOpenshiftGetRequest(resources.PathListRHMIConfig)
 
 	if err != nil {
 		t.Errorf("failed to perform LIST request for rhmi config with error : %s", err)
@@ -152,7 +152,7 @@ func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *res
 	// RHMI Developer can not GET RHMI Config CR
 	path := fmt.Sprintf(resources.PathGetRHMIConfig, "rhmi-config")
 
-	resp, err = openshiftClient.DoOpenshiftGetRequest(masterURL, path)
+	resp, err = openshiftClient.DoOpenshiftGetRequest(path)
 
 	if err != nil {
 		t.Errorf("failed to perform GET request for rhmi config with error : %s", err)
@@ -165,7 +165,7 @@ func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *res
 	// RHMI Developer can not UPDATE RHMI Config CR
 	bodyBytes, err := ioutil.ReadAll(resp.Body) // Use response from GET
 
-	resp, err = openshiftClient.DoOpenshiftPutRequest(masterURL, path, bodyBytes)
+	resp, err = openshiftClient.DoOpenshiftPutRequest(path, bodyBytes)
 
 	if err != nil {
 		t.Errorf("failed to perform UPDATE request for rhmi config with error : %s", err)
@@ -179,7 +179,7 @@ func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *res
 	rhmiConfig := &integreatlyv1alpha1.RHMIConfig{}
 	bodyBytes, err = json.Marshal(rhmiConfig)
 
-	resp, err = openshiftClient.DoOpenshiftPostRequest(masterURL, path, bodyBytes)
+	resp, err = openshiftClient.DoOpenshiftPostRequest(path, bodyBytes)
 
 	if err != nil {
 		t.Errorf("failed to perform CREATE request for rhmi config with error : %s", err)
@@ -190,7 +190,7 @@ func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *res
 	}
 
 	// RHMI Developer can not DELETE RHMI config
-	resp, err = openshiftClient.DoOpenshiftDeleteRequest(masterURL, path)
+	resp, err = openshiftClient.DoOpenshiftDeleteRequest(path)
 
 	if err != nil {
 		t.Errorf("failed to perform DELETE request for rhmi config with error : %s", err)

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -2,7 +2,10 @@ package common
 
 import (
 	goctx "context"
+	"encoding/json"
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"io/ioutil"
 	"testing"
 	"time"
 
@@ -96,6 +99,9 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 			}
 		}
 	}
+
+	// Verify RHMI Developer permissions around RHMI Config
+	verifyRHMIDeveloperRHMIConfigPermissions(t, openshiftClient, masterURL)
 }
 
 func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient *resources.OpenshiftClient) error {
@@ -129,4 +135,68 @@ func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient 
 	}
 
 	return nil
+}
+
+func verifyRHMIDeveloperRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient, masterURL string) {
+	// RHMI Developer can not LIST RHMI Config CR
+	resp, err := openshiftClient.DoOpenshiftGetRequest(masterURL, resources.PathListRHMIConfig)
+
+	if err != nil {
+		t.Errorf("failed to perform LIST request for rhmi config with error : %s", err)
+	}
+
+	if resp.StatusCode != 403 {
+		t.Errorf("unexpected response from LIST request for rhmi config : %v", resp)
+	}
+
+	// RHMI Developer can not GET RHMI Config CR
+	path := fmt.Sprintf(resources.PathGetRHMIConfig, "rhmi-config")
+
+	resp, err = openshiftClient.DoOpenshiftGetRequest(masterURL, path)
+
+	if err != nil {
+		t.Errorf("failed to perform GET request for rhmi config with error : %s", err)
+	}
+
+	if resp.StatusCode != 403 {
+		t.Errorf("unexpected response from GET request for rhmi config : %v", resp)
+	}
+
+	// RHMI Developer can not UPDATE RHMI Config CR
+	bodyBytes, err := ioutil.ReadAll(resp.Body) // Use response from GET
+
+	resp, err = openshiftClient.DoOpenshiftPutRequest(masterURL, path, bodyBytes)
+
+	if err != nil {
+		t.Errorf("failed to perform UPDATE request for rhmi config with error : %s", err)
+	}
+
+	if resp.StatusCode != 403 {
+		t.Errorf("unexpected response from UPDATE request for rhmi config : %v", resp)
+	}
+
+	// RHMI Developer can not CREATE new RHMI config
+	rhmiConfig := &integreatlyv1alpha1.RHMIConfig{}
+	bodyBytes, err = json.Marshal(rhmiConfig)
+
+	resp, err = openshiftClient.DoOpenshiftPostRequest(masterURL, path, bodyBytes)
+
+	if err != nil {
+		t.Errorf("failed to perform CREATE request for rhmi config with error : %s", err)
+	}
+
+	if resp.StatusCode != 403 {
+		t.Errorf("unexpected response from CREATE request for rhmi config : %v", resp)
+	}
+
+	// RHMI Developer can not DELETE RHMI config
+	resp, err = openshiftClient.DoOpenshiftDeleteRequest(masterURL, path)
+
+	if err != nil {
+		t.Errorf("failed to perform DELETE request for rhmi config with error : %s", err)
+	}
+
+	if resp.StatusCode != 403 {
+		t.Errorf("unexpected response from DELETE request for rhmi config : %v", resp)
+	}
 }

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -32,15 +32,15 @@ func TestIntegreatly(t *testing.T) {
 				test.Test(t, testingContext)
 			})
 		}
-		for _, test := range FUNCTIONAL_TESTS {
-			t.Run(test.Description, func(t *testing.T) {
-				testingContext, err := common.NewTestingContext(config)
-				if err != nil {
-					t.Fatal("failed to create testing context", err)
-				}
-				test.Test(t, testingContext)
-			})
-		}
+		//for _, test := range FUNCTIONAL_TESTS {
+		//	t.Run(test.Description, func(t *testing.T) {
+		//		testingContext, err := common.NewTestingContext(config)
+		//		if err != nil {
+		//			t.Fatal("failed to create testing context", err)
+		//		}
+		//		test.Test(t, testingContext)
+		//	})
+		//}
 	})
 
 	// Do not execute these tests unless DESTRUCTIVE is set to true

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -32,15 +32,15 @@ func TestIntegreatly(t *testing.T) {
 				test.Test(t, testingContext)
 			})
 		}
-		//for _, test := range FUNCTIONAL_TESTS {
-		//	t.Run(test.Description, func(t *testing.T) {
-		//		testingContext, err := common.NewTestingContext(config)
-		//		if err != nil {
-		//			t.Fatal("failed to create testing context", err)
-		//		}
-		//		test.Test(t, testingContext)
-		//	})
-		//}
+		for _, test := range FUNCTIONAL_TESTS {
+			t.Run(test.Description, func(t *testing.T) {
+				testingContext, err := common.NewTestingContext(config)
+				if err != nil {
+					t.Fatal("failed to create testing context", err)
+				}
+				test.Test(t, testingContext)
+			})
+		}
 	})
 
 	// Do not execute these tests unless DESTRUCTIVE is set to true

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -20,18 +20,22 @@ const (
 	OpenshiftPathListPods     = "/api/kubernetes/api/v1/namespaces/%v/pods"
 	OpenshiftPathGetSecret    = "/api/kubernetes/api/v1/namespaces/%s/secrets"
 	PathListRHMIConfig        = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs"
-	PathGetRHMIConfig       = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
+	PathGetRHMIConfig         = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
 )
 
 type OpenshiftClient struct {
 	HTTPClient *http.Client
 	MasterUrl  string
+	ApiUrl     string
 }
 
 func NewOpenshiftClient(httpClient *http.Client, masterUrl string) *OpenshiftClient {
+	openshiftAPIURL := strings.Replace(masterUrl, "console-openshift-console.apps.", "api.", 1) + ":6443"
+
 	return &OpenshiftClient{
 		MasterUrl:  masterUrl,
 		HTTPClient: httpClient,
+		ApiUrl:     openshiftAPIURL,
 	}
 }
 
@@ -108,14 +112,14 @@ func (oc *OpenshiftClient) GetRequest(path string) (*http.Response, error) {
 	return resp, nil
 }
 
-func (oc *OpenshiftClient) DoOpenshiftCreateProject(apiURL string, projectCR *projectv1.ProjectRequest) error {
+func (oc *OpenshiftClient) DoOpenshiftCreateProject(projectCR *projectv1.ProjectRequest) error {
 
 	projectJson, err := json.Marshal(projectCR)
 	if err != nil {
 		return fmt.Errorf("failed to marshal projectCR: %w", err)
 	}
 
-	response, err := oc.DoOpenshiftPostRequest(apiURL, PathProjectRequests, projectJson)
+	response, err := oc.DoOpenshiftPostRequest(PathProjectRequests, projectJson)
 	if err != nil {
 		return fmt.Errorf("error occured durning oc request : %w", err)
 	}
@@ -128,14 +132,14 @@ func (oc *OpenshiftClient) DoOpenshiftCreateProject(apiURL string, projectCR *pr
 	return nil
 }
 
-func (oc *OpenshiftClient) DoOpenshiftCreateServiceInANamespace(openshiftAPIURL string, namespace string, serviceCR *corev1.Service) error {
+func (oc *OpenshiftClient) DoOpenshiftCreateServiceInANamespace(namespace string, serviceCR *corev1.Service) error {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/services", namespace)
 	serviceJSON, err := json.Marshal(serviceCR)
 	if err != nil {
 		return fmt.Errorf("failed to marshal serviceCR: %w", err)
 	}
 
-	response, err := oc.DoOpenshiftPostRequest(openshiftAPIURL, path, serviceJSON)
+	response, err := oc.DoOpenshiftPostRequest(path, serviceJSON)
 	if err != nil {
 		return fmt.Errorf("error occured durning oc request : %w", err)
 	}
@@ -148,14 +152,14 @@ func (oc *OpenshiftClient) DoOpenshiftCreateServiceInANamespace(openshiftAPIURL 
 	return nil
 }
 
-func (oc *OpenshiftClient) DoOpenshiftCreatePodInANamespace(apiURL string, namespace string, podCR *corev1.Pod) error {
+func (oc *OpenshiftClient) DoOpenshiftCreatePodInANamespace(namespace string, podCR *corev1.Pod) error {
 	path := fmt.Sprintf("/api/v1/namespaces/%s/pods", namespace)
 	podJSON, err := json.Marshal(podCR)
 	if err != nil {
 		return fmt.Errorf("failed to marshal serviceCR: %w", err)
 	}
 
-	response, err := oc.DoOpenshiftPostRequest(apiURL, path, podJSON)
+	response, err := oc.DoOpenshiftPostRequest(path, podJSON)
 	if err != nil {
 		return fmt.Errorf("error occured durning oc request : %w", err)
 	}
@@ -167,29 +171,14 @@ func (oc *OpenshiftClient) DoOpenshiftCreatePodInANamespace(apiURL string, names
 	return nil
 }
 
-// makes a get request, expects master url, a path and a token
-func (oc *OpenshiftClient) DoOpenshiftGetRequest(masterUrl string, path string) (*http.Response, error) {
-	// use openshift api url instead
-	openshiftAPIURL := strings.Replace(masterUrl, "console-openshift-console.apps.", "api.", 1) + ":6443"
-
-	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", openshiftAPIURL, path), nil)
+// makes a get request, expects a path
+func (oc *OpenshiftClient) DoOpenshiftGetRequest(path string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
 	}
 
-	// Set auth headers from current user session
-	token, err := getOauthTokenFromCookie(masterUrl, oc.HTTPClient)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting the oauth token client: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-	resp, err := oc.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
-	}
-	return resp, nil
+	return oc.PerformRequest(req)
 }
 
 // get Oauth token from cookie
@@ -214,78 +203,54 @@ func getOauthTokenFromCookie(masterURL string, client *http.Client) (string, err
 	return token, nil
 }
 
-// makes a post request, expects master url, a path and the body
-func (oc *OpenshiftClient) DoOpenshiftPostRequest(masterURL string, path string, data []byte) (*http.Response, error) {
-	openshiftAPIURL := strings.Replace(masterURL, "console-openshift-console.apps.", "api.", 1) + ":6443"
-
-	// openshift api url required for POST requests
-	url := fmt.Sprintf("https://%s%s", openshiftAPIURL, path)
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewBuffer(data))
+// makes a post request, expects a path and the body
+func (oc *OpenshiftClient) DoOpenshiftPostRequest(path string, data []byte) (*http.Response, error) {
+	requestUrl := fmt.Sprintf("https://%s%s", oc.ApiUrl, path)
+	req, err := http.NewRequest(http.MethodPost, requestUrl, bytes.NewBuffer(data))
 	if err != nil {
 		return nil, fmt.Errorf("Error reading request: %w", err)
 	}
 
-	token, err := getOauthTokenFromCookie(masterURL, oc.HTTPClient)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting the oauth token client: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-	resp, err := oc.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
-	}
-	return resp, nil
+	return oc.PerformRequest(req)
 }
 
-// makes a post request, expects master url, a path and the body
-func (oc *OpenshiftClient) DoOpenshiftPutRequest(masterURL string, path string, data []byte) (*http.Response, error) {
-	openshiftAPIURL := strings.Replace(masterURL, "console-openshift-console.apps.", "api.", 1) + ":6443"
-
-	// openshift api url required for POST requests
-	url := fmt.Sprintf("https://%s%s", openshiftAPIURL, path)
-	req, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(data))
+// makes a put request, expects a path and the body
+func (oc *OpenshiftClient) DoOpenshiftPutRequest(path string, data []byte) (*http.Response, error) {
+	requestUrl := fmt.Sprintf("https://%s%s", oc.ApiUrl, path)
+	req, err := http.NewRequest(http.MethodPut, requestUrl, bytes.NewBuffer(data))
 	if err != nil {
-		return nil, fmt.Errorf("Error reading request: %w", err)
+		return nil, fmt.Errorf("error reading request: %w", err)
 	}
 
-	token, err := getOauthTokenFromCookie(masterURL, oc.HTTPClient)
-	if err != nil {
-		return nil, fmt.Errorf("Error getting the oauth token client: %w", err)
-	}
-
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-	resp, err := oc.HTTPClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
-	}
-	return resp, nil
+	return oc.PerformRequest(req)
 }
 
-func (oc *OpenshiftClient) DoOpenshiftDeleteRequest(masterUrl string, path string) (*http.Response, error) {
-	// use openshift api url instead
-	openshiftAPIURL := strings.Replace(masterUrl, "console-openshift-console.apps.", "api.", 1) + ":6443"
-
-	req, err := http.NewRequest("Delete", fmt.Sprintf("https://%s%s", openshiftAPIURL, path), nil)
+// make a delete request, expects a path
+func (oc *OpenshiftClient) DoOpenshiftDeleteRequest(path string) (*http.Response, error) {
+	req, err := http.NewRequest("Delete", fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
 	}
 
+	return oc.PerformRequest(req)
+}
+
+// Common function for setting auth headers on request and performing the request
+func (oc *OpenshiftClient) PerformRequest(req *http.Request) (*http.Response, error) {
 	// Set auth headers from current user session
-	token, err := getOauthTokenFromCookie(masterUrl, oc.HTTPClient)
+	token, err := getOauthTokenFromCookie(oc.MasterUrl, oc.HTTPClient)
 	if err != nil {
-		return nil, fmt.Errorf("Error getting the oauth token client: %w", err)
+		return nil, fmt.Errorf("error getting the oauth token client: %w", err)
 	}
+
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
 
+	// Perform http request
 	resp, err := oc.HTTPClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while performing http request : %w", err)
 	}
+
 	return resp, nil
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Dedicated admins should have view and update access to RHMI Config resource

Jira:
* https://issues.redhat.com/browse/INTLY-6744

## Verification
(Already covered as part of e2e test)
* Install RHMI from this branch 
  * Should only need to wait till the `bootstrap` phase is complete
* Verify `rhmiconfig-dedicated-admins-role` Role is created
* Verify `rhmiconfig-dedicated-admins-role-binding` Role Binding is created
* Install testing IDP
  ```
  PASSWORD=Password1 ./scripts/setup-sso-idp.sh
  ```
* Login as a dedicated admin (e.g `customer-admin01`)
* Verify dedicated admin **can** view and update RHMI Config in only the `redhat-rhmi-operator` namespace
* Verify dedicated admin **cannot** delete or create RHMI config resource
* Login as developer user (e.g `test-user01`)
* Verify test user has no access to the RHMI Config resource at all

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Verified independently on a cluster by reviewer