### PR TITLE
INTLY-7158 Semantic validation for RHMIConfig

### DIFF
--- a/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
@@ -34,11 +34,15 @@ spec:
             backup:
               properties:
                 applyOn:
+                  description: 'apply-on: string, day time. Format: "DDD hh:mm" >
+                    "wed 20:00". UTC time'
                   type: string
               type: object
             maintenance:
               properties:
                 applyFrom:
+                  description: 'apply-from: string, day time. Currently this is a
+                    6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
                   type: string
               type: object
             upgrade:
@@ -48,14 +52,30 @@ spec:
                 https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
               properties:
                 alwaysImmediately:
+                  description: 'always-immediately: boolean value, if set to true
+                    an upgrade will be applied as soon as it is available, whether
+                    service affecting or not. This takes precedences over all other
+                    options'
                   type: boolean
                 applyOn:
+                  description: 'apply-on: string date value. If ''always-immediately''
+                    or ''during-next-maintenance'' is not set the customer is required
+                    to pick a time for the upgrade. Time value will be validated by
+                    a webhook and reset to blank after upgrade has completed. Format:
+                    "dd MMM YYYY hh:mm" > "12 Jan 1980 23:00". UTC time'
                   type: string
                 contacts:
+                  description: 'contacts: list of contacts which are comma separated
+                    "user1@example.com,user2@example.com"'
                   type: string
                 duringNextMaintenance:
+                  description: 'during-next-maintenance: boolean value, if set to
+                    true an upgrade will be applied within the next maintenance window.
+                    Takes precedence over apply-on'
                   type: boolean
               required:
+              - alwaysImmediately
+              - duringNextMaintenance
               type: object
           type: object
         status:

--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -70,19 +70,19 @@ type Upgrade struct {
 	DuringNextMaintenance bool `json:"duringNextMaintenance"`
 	// apply-on: string date value. If 'always-immediately' or 'during-next-maintenance' is not set the customer is
 	// required to pick a time for the upgrade. Time value will be validated by a webhook and reset to blank after
-	// upgrade has completed. Format: "dd MMM YYYY hh:mm" > "12 Jan 1980 23:00". Timezone local to cluster.
+	// upgrade has completed. Format: "dd MMM YYYY hh:mm" > "12 Jan 1980 23:00". UTC time
 	ApplyOn string `json:"applyOn,omitempty"`
 }
 
 type Maintenance struct {
 	// apply-from: string, day time. Currently this is a 6 hour window.
-	// Format: "DDD hh:mm" > "sun 23:00". Timezone local to cluster.
+	// Format: "DDD hh:mm" > "sun 23:00". UTC time
 	ApplyFrom string `json:"applyFrom,omitempty"`
 }
 
 type Backup struct {
 	// apply-on: string, day time.
-	// Format: "DDD hh:mm" > "wed 20:00". Timezone local to cluster.
+	// Format: "DDD hh:mm" > "wed 20:00". UTC time
 	ApplyOn string `json:"applyOn,omitempty"`
 }
 

--- a/test/common/rhmi_config.go
+++ b/test/common/rhmi_config.go
@@ -1,10 +1,17 @@
 package common
 
 import (
+	"fmt"
+	"testing"
+	"time"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"k8s.io/api/admissionregistration/v1beta1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"testing"
+	"k8s.io/apimachinery/pkg/util/wait"
+	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	goctx "context"
 )
@@ -13,7 +20,52 @@ const (
 	RHMIConfigCRName = "rhmi-config-test"
 )
 
-// TestIntegreatlyRoutesExist tests that the routes for all the products are created
+var upgradeSectionStates = map[v1alpha1.Upgrade]func(*testing.T) func(error){
+	{}: assertNoError,
+
+	{
+		ApplyOn:               "",
+		AlwaysImmediately:     true,
+		DuringNextMaintenance: true,
+	}: assertNoError,
+
+	{
+		ApplyOn:               "malformed date!",
+		AlwaysImmediately:     false,
+		DuringNextMaintenance: false,
+	}: assertValidationError,
+
+	// Valid: future date
+	{
+		ApplyOn:               time.Now().Add(time.Hour).UTC().Format("2 Jan 2006 15:04"),
+		AlwaysImmediately:     false,
+		DuringNextMaintenance: false,
+	}: assertNoError,
+
+	// Invalid: past date
+	{
+		ApplyOn:               time.Now().Add(-time.Hour).UTC().Format("2 Jan 2006 15:04"),
+		AlwaysImmediately:     false,
+		DuringNextMaintenance: false,
+	}: assertValidationError,
+
+	// Invalid: valid date, but `duringNextmaintenance` is set
+	{
+		ApplyOn:               time.Now().Add(time.Hour).UTC().Format("2 Jan 2006 15:04"),
+		AlwaysImmediately:     false,
+		DuringNextMaintenance: true,
+	}: assertValidationError,
+
+	// Invalid: valid date, but `alwaysImmediately` is set
+	{
+		ApplyOn:               time.Now().Add(time.Hour).UTC().Format("2 Jan 2006 15:04"),
+		AlwaysImmediately:     true,
+		DuringNextMaintenance: false,
+	}: assertValidationError,
+}
+
+// TestRHMIConfigCRs tests that the RHMIConfig CR is created successfuly and
+// validated.
 func TestRHMIConfigCRs(t *testing.T, ctx *TestingContext) {
 	t.Log("Test rhmi config cr creation")
 
@@ -28,7 +80,28 @@ func TestRHMIConfigCRs(t *testing.T, ctx *TestingContext) {
 	if err := ctx.Client.Create(goctx.TODO(), rhmiConfig); err != nil {
 		t.Fatalf("Failed to create RHMI Config resource %v", err)
 	}
+
+	// Clean up after testing
+	defer deleteRHMIConfigCR(t, ctx.Client, rhmiConfig)
+
+	// Test the CR is created with default values
 	verifyCr(t, ctx)
+
+	// Wait for the ValidatingWebhookConfiguration to be reconciled. In the edge
+	// case that this test is run so fast that the operator mightn't have had
+	// time to reconcile it.
+	if err := waitForValidatingWebhook(ctx.Client); err != nil {
+		t.Fatalf("Error waiting for ValidatingWebhookConfiguration: %v", err)
+	}
+
+	// Test each possible state for the Upgrade section
+	for state, assertion := range upgradeSectionStates {
+		t.Logf("Testing the RHMIConfig state: %s", logUpgrade(state))
+
+		verifyRHMIConfigValidation(ctx.Client, assertion(t), func(cr *v1alpha1.RHMIConfig) {
+			cr.Spec.Upgrade = state
+		})
+	}
 }
 
 func verifyCr(t *testing.T, ctx *TestingContext) {
@@ -48,8 +121,76 @@ func verifyCr(t *testing.T, ctx *TestingContext) {
 	if rhmiConfig.Spec.Upgrade.DuringNextMaintenance != false {
 		t.Errorf("DuringNextMaintenance should be set to false")
 	}
+}
 
-	if err := ctx.Client.Delete(goctx.TODO(), rhmiConfig); err != nil {
+func deleteRHMIConfigCR(t *testing.T, client dynclient.Client, cr *v1alpha1.RHMIConfig) {
+	if err := client.Delete(goctx.TODO(), cr); err != nil {
 		t.Errorf("Failed to delete the rhmi config")
 	}
+}
+
+func verifyRHMIConfigValidation(client dynclient.Client, validateError func(error), mutateRHMIConfig func(*v1alpha1.RHMIConfig)) error {
+	rhmiConfig := &v1alpha1.RHMIConfig{}
+
+	if err := client.Get(
+		goctx.TODO(),
+		types.NamespacedName{Name: RHMIConfigCRName, Namespace: RHMIOperatorNamespace},
+		rhmiConfig,
+	); err != nil {
+		return err
+	}
+
+	// Perform the update and validate the error object
+	mutateRHMIConfig(rhmiConfig)
+	validateError(client.Update(goctx.TODO(), rhmiConfig))
+
+	return nil
+}
+
+func waitForValidatingWebhook(client dynclient.Client) error {
+	return wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
+		vwc := &v1beta1.ValidatingWebhookConfiguration{}
+		err := client.Get(goctx.TODO(),
+			dynclient.ObjectKey{Name: "rhmiconfig.integreatly.org"},
+			vwc,
+		)
+		if err == nil {
+			return true, nil
+		}
+		if errors.IsNotFound(err) {
+			return false, nil
+		}
+
+		return false, err
+	})
+}
+
+func assertNoError(t *testing.T) func(error) {
+	return func(err error) {
+		if err != nil {
+			t.Errorf("Expected error to be nil. Got %v", err)
+		}
+	}
+}
+
+func assertValidationError(t *testing.T) func(error) {
+	return func(err error) {
+		switch e := err.(type) {
+		case errors.APIStatus:
+			if e.Status().Code != 403 {
+				t.Errorf("Expected error to be \"Forbidden\", but got: %s", e.Status().Reason)
+			}
+		default:
+			t.Errorf("Expected error type to be APIStatus type. Got %v", e)
+		}
+	}
+}
+
+func logUpgrade(upgrade v1alpha1.Upgrade) string {
+	return fmt.Sprintf(
+		"{ applyOn: %s, alwaysImmediately: %t, duringNextMaintenance: %t }",
+		upgrade.ApplyOn,
+		upgrade.AlwaysImmediately,
+		upgrade.DuringNextMaintenance,
+	)
 }

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -12,7 +12,7 @@ var (
 
 	HAPPY_PATH_TESTS = []TestCase{
 		// Add all happy path tests to be executed after RHMI installation is completed here
-		{"Verify RHMI Config CRs Successful", TestRHMIConfigCRs},
+		{"A18 - Verify RHMI Config CRs Successful", TestRHMIConfigCRs},
 		{"B03 - Verify RHMI Developer User Permissions are Correct", TestRHMIDeveloperUserPermissions},
 		{"B04 - Verify Dedicated Admin User Permissions are Correct", TestDedicatedAdminUserPermissions},
 		{"A13 - Verify Deployment resources have the expected replicas", TestDeploymentExpectedReplicas},


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/INTLY-7158

Following the implementation of the webhooks server, implement validation for the RHMIConfig.Spec.Upgrade section, and add logic to e2e tests to verify that the validation
is being performed successfully via the `ValidatingWebhookConfiguration` reconciled by
the operator

## Verification steps

1. Follow the verification steps of #652 
2. On the console, find the RHMIConfig CR and attempt to perform the following changes:

| Change | Expected result after save |
| ----------- | ----------------------------------- |
| Set the `applyOn` value to an invalid date format | Error |
| Set the `applyOn` value to a past date (example `2 Jan 2006 15:04`) | Error |
| Set the `applyOn` value to a future date and leave the other values as `false` | Success |
| Set the `applyOn` value to a future date and leave any (or both) values for `applyImmediately` and `duringNextMaintenance` as `true` | Error |

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer