### PR TITLE
New product in the monitoring stage

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -49,6 +49,7 @@ var (
 	ProductMonitoring          ProductName = "middleware-monitoring"
 	ProductCloudResources      ProductName = "cloud-resources"
 	ProductDataSync            ProductName = "datasync"
+	ProductMonitoringSpec      ProductName = "monitoring-spec"
 
 	// Could not find a way to determine these versions dynamically, so they are hard-coded
 	// It is preferable to determine the version of a product dynamically (from a CR, or configmap, etc)
@@ -66,6 +67,7 @@ var (
 	VersionDataSync            ProductVersion = "0.9.4"
 	VersionRHSSO               ProductVersion = "7.3"
 	VersionRHSSOUser           ProductVersion = "7.3"
+	VersionMonitoringSpec      ProductVersion = "1.0"
 
 	// Versioning for Fuse on OpenShift does not follow a similar pattern to other products.
 	// It is currently implicitly tied to version 7.6 of Fuse, hence the 7.6 value for VersionFuseOnOpenshift above
@@ -91,6 +93,7 @@ var (
 	OperatorVersionCloudResources      OperatorVersion = "0.15.1"
 	OperatorVersionUPS                 OperatorVersion = "0.5.0"
 	OperatorVersionApicurito           OperatorVersion = "1.6.0"
+	OperatorVersionMonitoringSpec      OperatorVersion = "1.0"
 
 	// Event reasons to be used when emitting events
 	EventProcessingError       string = "ProcessingError"

--- a/pkg/config/ConfigReadWriter_moq.go
+++ b/pkg/config/ConfigReadWriter_moq.go
@@ -22,6 +22,7 @@ var (
 	lockConfigReadWriterMockReadFuse                    sync.RWMutex
 	lockConfigReadWriterMockReadFuseOnOpenshift         sync.RWMutex
 	lockConfigReadWriterMockReadMonitoring              sync.RWMutex
+	lockConfigReadWriterMockReadMonitoringSpec          sync.RWMutex
 	lockConfigReadWriterMockReadProduct                 sync.RWMutex
 	lockConfigReadWriterMockReadRHSSO                   sync.RWMutex
 	lockConfigReadWriterMockReadRHSSOUser               sync.RWMutex
@@ -80,6 +81,9 @@ var _ ConfigReadWriter = &ConfigReadWriterMock{}
 //             },
 //             ReadMonitoringFunc: func() (*Monitoring, error) {
 // 	               panic("mock out the ReadMonitoring method")
+//             },
+//             ReadMonitoringSpecFunc: func() (*MonitoringSpec, error) {
+// 	               panic("mock out the ReadMonitoringSpec method")
 //             },
 //             ReadProductFunc: func(product v1alpha1.ProductName) (ConfigReadable, error) {
 // 	               panic("mock out the ReadProduct method")
@@ -151,6 +155,9 @@ type ConfigReadWriterMock struct {
 	// ReadMonitoringFunc mocks the ReadMonitoring method.
 	ReadMonitoringFunc func() (*Monitoring, error)
 
+	// ReadMonitoringSpecFunc mocks the ReadMonitoringSpec method.
+	ReadMonitoringSpecFunc func() (*MonitoringSpec, error)
+
 	// ReadProductFunc mocks the ReadProduct method.
 	ReadProductFunc func(product v1alpha1.ProductName) (ConfigReadable, error)
 
@@ -215,6 +222,9 @@ type ConfigReadWriterMock struct {
 		}
 		// ReadMonitoring holds details about calls to the ReadMonitoring method.
 		ReadMonitoring []struct {
+		}
+		// ReadMonitoringSpec holds details about calls to the ReadMonitoringSpec method.
+		ReadMonitoringSpec []struct {
 		}
 		// ReadProduct holds details about calls to the ReadProduct method.
 		ReadProduct []struct {
@@ -584,6 +594,32 @@ func (mock *ConfigReadWriterMock) ReadMonitoringCalls() []struct {
 	lockConfigReadWriterMockReadMonitoring.RLock()
 	calls = mock.calls.ReadMonitoring
 	lockConfigReadWriterMockReadMonitoring.RUnlock()
+	return calls
+}
+
+// ReadMonitoringSpec calls ReadMonitoringSpecFunc.
+func (mock *ConfigReadWriterMock) ReadMonitoringSpec() (*MonitoringSpec, error) {
+	if mock.ReadMonitoringSpecFunc == nil {
+		panic("ConfigReadWriterMock.ReadMonitoringSpecFunc: method is nil but ConfigReadWriter.ReadMonitoringSpec was just called")
+	}
+	callInfo := struct {
+	}{}
+	lockConfigReadWriterMockReadMonitoringSpec.Lock()
+	mock.calls.ReadMonitoringSpec = append(mock.calls.ReadMonitoringSpec, callInfo)
+	lockConfigReadWriterMockReadMonitoringSpec.Unlock()
+	return mock.ReadMonitoringSpecFunc()
+}
+
+// ReadMonitoringSpecCalls gets all the calls that were made to ReadMonitoringSpec.
+// Check the length with:
+//     len(mockedConfigReadWriter.ReadMonitoringSpecCalls())
+func (mock *ConfigReadWriterMock) ReadMonitoringSpecCalls() []struct {
+} {
+	var calls []struct {
+	}
+	lockConfigReadWriterMockReadMonitoringSpec.RLock()
+	calls = mock.calls.ReadMonitoringSpec
+	lockConfigReadWriterMockReadMonitoringSpec.RUnlock()
 	return calls
 }
 

--- a/pkg/config/manager.go
+++ b/pkg/config/manager.go
@@ -56,6 +56,7 @@ type ConfigReadWriter interface {
 	ReadApicurito() (*Apicurito, error)
 	ReadCloudResources() (*CloudResources, error)
 	ReadDataSync() (*DataSync, error)
+	ReadMonitoringSpec() (*MonitoringSpec, error)
 }
 
 //go:generate moq -out ConfigReadable_moq.go . ConfigReadable
@@ -122,6 +123,8 @@ func (m *Manager) ReadProduct(product integreatlyv1alpha1.ProductName) (ConfigRe
 		return m.ReadMonitoring()
 	case integreatlyv1alpha1.ProductDataSync:
 		return m.ReadDataSync()
+	case integreatlyv1alpha1.ProductMonitoringSpec:
+		return m.ReadMonitoringSpec()
 	}
 
 	return nil, fmt.Errorf("no config found for product %v", product)
@@ -221,6 +224,14 @@ func (m *Manager) ReadMonitoring() (*Monitoring, error) {
 		return nil, err
 	}
 	return NewMonitoring(config), nil
+}
+
+func (m *Manager) ReadMonitoringSpec() (*MonitoringSpec, error) {
+	config, err := m.readConfigForProduct(integreatlyv1alpha1.ProductMonitoringSpec)
+	if err != nil {
+		return nil, err
+	}
+	return NewMonitoringSpec(config), nil
 }
 
 func (m *Manager) ReadApicurito() (*Apicurito, error) {

--- a/pkg/config/monitoringspec.go
+++ b/pkg/config/monitoringspec.go
@@ -3,7 +3,9 @@ package config
 import (
 	"errors"
 
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -16,7 +18,15 @@ func NewMonitoringSpec(config ProductConfig) *MonitoringSpec {
 }
 
 func (m *MonitoringSpec) GetWatchableCRDs() []runtime.Object {
-	return []runtime.Object{}
+
+	return []runtime.Object{
+		&monitoringv1.ServiceMonitor{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: monitoringv1.SchemeGroupVersion.String(),
+				Kind:       monitoringv1.ServiceMonitorsKind,
+			},
+		},
+	}
 }
 
 func (m *MonitoringSpec) GetNamespace() string {

--- a/pkg/config/monitoringspec.go
+++ b/pkg/config/monitoringspec.go
@@ -1,0 +1,80 @@
+package config
+
+import (
+	"errors"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+type MonitoringSpec struct {
+	Config ProductConfig
+}
+
+func NewMonitoringSpec(config ProductConfig) *MonitoringSpec {
+	return &MonitoringSpec{Config: config}
+}
+
+func (m *MonitoringSpec) GetWatchableCRDs() []runtime.Object {
+	return []runtime.Object{}
+}
+
+func (m *MonitoringSpec) GetNamespace() string {
+	return m.Config["NAMESPACE"]
+}
+
+func (m *MonitoringSpec) SetNamespace(newNamespace string) {
+	m.Config["NAMESPACE"] = newNamespace
+}
+
+func (m *MonitoringSpec) GetNamespacePrefix() string {
+	return m.Config["NAMESPACE_PREFIX"]
+}
+
+func (m *MonitoringSpec) SetNamespacePrefix(newNamespacePrefix string) {
+	m.Config["NAMESPACE_PREFIX"] = newNamespacePrefix
+}
+
+func (m *MonitoringSpec) GetHost() string {
+	return m.Config["HOST"]
+}
+
+func (m *MonitoringSpec) SetHost(newHost string) {
+	m.Config["HOST"] = newHost
+}
+
+func (m *MonitoringSpec) Read() ProductConfig {
+	return m.Config
+}
+
+func (m *MonitoringSpec) GetProductName() integreatlyv1alpha1.ProductName {
+	return integreatlyv1alpha1.ProductMonitoringSpec
+}
+
+func (m *MonitoringSpec) GetProductVersion() integreatlyv1alpha1.ProductVersion {
+	return integreatlyv1alpha1.VersionMonitoringSpec
+}
+
+func (m *MonitoringSpec) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
+	return integreatlyv1alpha1.OperatorVersionMonitoringSpec
+}
+
+func (m *MonitoringSpec) SetProductVersion(version string) {
+	m.Config["VERSION"] = version
+}
+
+func (m *MonitoringSpec) Validate() error {
+	if m.GetProductName() == "" {
+		return errors.New("config product name is not defined")
+	}
+
+	if m.GetNamespace() == "" {
+		return errors.New("config namespace is not defined")
+	}
+
+	if m.GetProductVersion() == "" {
+		return errors.New("config product version is not defined")
+	}
+
+	return nil
+}

--- a/pkg/controller/installation/types.go
+++ b/pkg/controller/installation/types.go
@@ -30,7 +30,8 @@ var (
 		{
 			Name: integreatlyv1alpha1.MonitoringStage,
 			Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-				integreatlyv1alpha1.ProductMonitoring: {Name: integreatlyv1alpha1.ProductMonitoring},
+				integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
+				integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 			},
 		},
 		{
@@ -77,7 +78,8 @@ var (
 		{
 			Name: integreatlyv1alpha1.MonitoringStage,
 			Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-				integreatlyv1alpha1.ProductMonitoring: {Name: integreatlyv1alpha1.ProductMonitoring},
+				integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
+				integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 			},
 		},
 		{

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -145,16 +145,15 @@ func (r *Reconciler) createNamespace(ctx context.Context, serverClient k8sclient
 		if !k8serr.IsNotFound(err) {
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
-		//TODO - addClusterMonitoringLabel flipped back to true
 		_, err := resources.CreateNSWithProjectRequest(ctx, r.Config.GetNamespace(),
-			serverClient, installation, false, false)
+			serverClient, installation, false, true)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	}
 
-	resources.PrepareObject(namespace, installation, false, false)
+	resources.PrepareObject(namespace, installation, false, true)
 	err = serverClient.Update(ctx, namespace)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -1,0 +1,390 @@
+package monitoringspec
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+
+	"github.com/sirupsen/logrus"
+	rbac "k8s.io/api/rbac/v1"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	defaultInstallationNamespace              = "monitoring"
+	packageName                               = "monitoringspec"
+	roleBindingName                           = "prometheus-k8s"
+	clusterMonitoringPrometheusServiceAccount = "prometheus-k8s"
+	clusterMonitoringNamespace                = "openshift-monitoring"
+	roleRefAPIGroup                           = "rbac.authorization.k8s.io"
+	roleRefName                               = "view"
+	labelSelector                             = "monitoring-key=middleware"
+	clonedServiceMonitorLabelKey              = "integreatly.org/cloned-servicemonitor"
+	clonedServiceMonitorLabelValue            = "true"
+)
+
+type Reconciler struct {
+	Config        *config.MonitoringSpec
+	extraParams   map[string]string
+	ConfigManager config.ConfigReadWriter
+	Logger        *logrus.Entry
+	mpm           marketplace.MarketplaceInterface
+	installation  *integreatlyv1alpha1.RHMI
+	*resources.Reconciler
+	recorder record.EventRecorder
+}
+
+func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
+	return nil
+}
+
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI,
+	mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {
+	logger := logrus.NewEntry(logrus.StandardLogger())
+	config, err := configManager.ReadMonitoringSpec()
+	if err != nil {
+		return nil, err
+	}
+	config.SetNamespacePrefix(installation.Spec.NamespacePrefix)
+	if config.GetNamespace() == "" {
+		config.SetNamespace(installation.Spec.NamespacePrefix + defaultInstallationNamespace)
+	}
+	return &Reconciler{
+		Config:        config,
+		extraParams:   make(map[string]string),
+		ConfigManager: configManager,
+		Logger:        logger,
+		installation:  installation,
+		mpm:           mpm,
+		Reconciler:    resources.NewReconciler(mpm),
+		recorder:      recorder,
+	}, nil
+}
+
+// Reconcile method for monitorspec
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI,
+	product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()),
+		func() (integreatlyv1alpha1.StatusPhase, error) {
+			logrus.Infof("Phase: Monitoringspec ReconcileFinalizer")
+
+			// Check if namespace is still present before trying to delete it resources
+			_, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
+			if err != nil && k8serr.IsNotFound(err) {
+				logrus.Infof("Spec phase completed")
+				//namespace is gone, return complete
+				return integreatlyv1alpha1.PhaseCompleted, nil
+			}
+			//TODO - Check for other resources clean-up - Rolebindings created in the other namespaces
+
+			phase, err := resources.RemoveNamespace(ctx, installation, serverClient, r.Config.GetNamespace())
+			if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+				logrus.Infof("Spec phase removal failure: %v", err)
+				return phase, err
+			}
+			return integreatlyv1alpha1.PhaseInProgress, nil
+		})
+
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		logrus.Errorf("failed to reconcile finalizer: %v", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile finalizer", err)
+		return phase, err
+	}
+
+	phase, err = r.createNamespace(ctx, serverClient, installation)
+	logrus.Infof("Phase: %s createNamespace", phase)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		logrus.Errorf("failed to create namespace : %v", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to create namespace", err)
+		return phase, err
+	}
+
+	phase, err = r.reconcileMonitoring(ctx, serverClient, installation)
+	logrus.Infof("Phase: %s reconcileMonitoring", phase)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		logrus.Errorf("ailed to reconcile: %v", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile:", err)
+		return phase, err
+	}
+
+	logrus.Infof("\n\n service monitors done!")
+	product.Host = r.Config.GetHost()
+	product.Version = r.Config.GetProductVersion()
+
+	err = r.ConfigManager.WriteConfig(r.Config)
+	if err != nil {
+		logrus.Errorf("failed to write config: %v ", err)
+		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to update monitoring config", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not update monitoring config: %w", err)
+	}
+
+	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.MonitoringStage, r.Config.GetProductName())
+	logrus.Infof("%s installation is reconciled successfully", packageName)
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+// make the federation namespace discoverable by cluster monitoring
+func (r *Reconciler) createNamespace(ctx context.Context, serverClient k8sclient.Client,
+	installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
+	namespace, err := resources.GetNS(ctx, r.Config.GetNamespace(), serverClient)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+		_, err := resources.CreateNSWithProjectRequest(ctx, r.Config.GetNamespace(),
+			serverClient, installation, false, true)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+		return integreatlyv1alpha1.PhaseCompleted, nil
+	}
+
+	resources.PrepareObject(namespace, installation, false, true) //TODO - Cluster monitoring flipped back to true
+	err = serverClient.Update(ctx, namespace)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) reconcileMonitoring(ctx context.Context, serverClient k8sclient.Client,
+	installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
+
+	//Get list of service monitors in the monitoring namespace
+	monSermonMap, err := r.getServiceMonitors(ctx, serverClient, r.Config.GetNamespace())
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	ls, err := labels.Parse(labelSelector)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	opts := &k8sclient.ListOptions{
+		LabelSelector: ls,
+	}
+
+	//Get the list of namespaces with the given label selector
+	namespaces := &corev1.NamespaceList{}
+	err = serverClient.List(ctx, namespaces, opts)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	for _, ns := range namespaces.Items {
+		//Get list of service monitors in each name space
+		listOpts := []k8sclient.ListOption{
+			k8sclient.InNamespace(ns.Name),
+		}
+		serviceMonitors := &v1.ServiceMonitorList{}
+		err := serverClient.List(ctx, serviceMonitors, listOpts...)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+		for _, sm := range serviceMonitors.Items {
+			//Create a copy of service monitors in the monitoring namespace
+			//Create the corresponding rolebindings at each of the service namespace
+			key := sm.Namespace + `-` + sm.Name
+			delete(monSermonMap, key) // Servicemonitor exists, remove it from the local map
+			err := r.reconcileServiceMonitor(ctx, serverClient, sm)
+			if err != nil {
+				return integreatlyv1alpha1.PhaseFailed, err
+			}
+		}
+	}
+
+	//Clean-up the stale service monitors and rolebindings if any
+	if len(monSermonMap) > 0 {
+		for _, sm := range monSermonMap {
+			//Remove servicemonitor
+			err = r.removeServicemonitor(ctx, serverClient, sm.Namespace, sm.Name)
+			if err != nil {
+				return integreatlyv1alpha1.PhaseFailed, err
+			}
+			//Remove rolebindings
+			for _, nameSpace := range sm.Spec.NamespaceSelector.MatchNames {
+				err := r.removeRoleBinding(ctx, serverClient, nameSpace, roleBindingName)
+				if err != nil {
+					return integreatlyv1alpha1.PhaseFailed, err
+				}
+			}
+		}
+	}
+	return integreatlyv1alpha1.PhaseCompleted, err
+}
+
+func (r *Reconciler) reconcileServiceMonitor(ctx context.Context,
+	serverClient k8sclient.Client, serviceMonitor *v1.ServiceMonitor) (err error) {
+
+	if serviceMonitor.Spec.NamespaceSelector.Any {
+		logrus.Warnf("servicemonitor : %s cannot be copied to %s namespace. Namespace selector has been set to any",
+			serviceMonitor.Name, r.Config.GetNamespace())
+		return nil
+	}
+	sm := &v1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      serviceMonitor.Namespace + `-` + serviceMonitor.Name,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+	opRes, err := controllerutil.CreateOrUpdate(ctx, serverClient, sm, func() error {
+		// Check if the servicemonitor has no  namespace selectors defined,
+		// if not add the namespace
+		sm.Spec = serviceMonitor.Spec
+		if len(sm.Spec.NamespaceSelector.MatchNames) == 0 {
+			sm.Spec.NamespaceSelector.MatchNames = []string{serviceMonitor.Namespace}
+		}
+		//Add all the original labels and append cloned servicemonitor label
+		sm.Labels = serviceMonitor.Labels
+		if len(sm.Labels) == 0 {
+			sm.Labels = make(map[string]string)
+		}
+		sm.Labels[clonedServiceMonitorLabelKey] = clonedServiceMonitorLabelValue
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	r.Logger.Infof("operation result of creating servicemonitor %v was %v", sm.Name, opRes)
+
+	//Get the service monitor - that was created/updated
+	sermon := &v1.ServiceMonitor{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: sm.Name, Namespace: r.Config.GetNamespace()}, sermon)
+	if err != nil {
+		return err
+	}
+	//Create role binding for each of the namespace label selectors
+	for _, nameSpace := range sermon.Spec.NamespaceSelector.MatchNames {
+		err := r.reconcileRoleBindings(ctx, serverClient, nameSpace)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (r *Reconciler) reconcileRoleBindings(ctx context.Context,
+	serverClient k8sclient.Client, nameSpace string) (err error) {
+
+	roleBinding := &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: nameSpace,
+		},
+	}
+	opRes, err := controllerutil.CreateOrUpdate(ctx, serverClient, roleBinding, func() error {
+		roleBinding.Subjects = []rbac.Subject{
+			{
+				Kind:      rbac.ServiceAccountKind,
+				Name:      clusterMonitoringPrometheusServiceAccount,
+				Namespace: clusterMonitoringNamespace,
+			},
+		}
+		roleBinding.RoleRef = rbac.RoleRef{
+			APIGroup: roleRefAPIGroup,
+			Kind:     bundle.ClusterRoleKind,
+			Name:     roleRefName,
+		}
+		return nil
+	})
+	r.Logger.Infof("operation result of creating rolebinding: %v was %v", roleBindingName, opRes)
+	return err
+}
+
+func (r *Reconciler) removeServicemonitor(ctx context.Context,
+	serverClient k8sclient.Client, nameSpace, name string) (err error) {
+	//Get the service monitor
+	sm := &v1.ServiceMonitor{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: name, Namespace: nameSpace}, sm)
+	if err != nil && k8serr.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	//Delete the servicemonitor
+	err = serverClient.Delete(ctx, sm)
+	if err != nil && k8serr.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func (r *Reconciler) removeRoleBinding(ctx context.Context,
+	serverClient k8sclient.Client, nameSpace, name string) (err error) {
+
+	// Check if the namespace has service monitors
+	// if so donot delete the rolebinding
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+	}
+	serviceMonitors := &v1.ServiceMonitorList{}
+	err = serverClient.List(ctx, serviceMonitors, listOpts...)
+	if err != nil {
+		return err
+	}
+	if len(serviceMonitors.Items) > 0 {
+		return nil
+	}
+
+	//Get the rolebinding
+	rb := &rbac.RoleBinding{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: name, Namespace: nameSpace}, rb)
+	if err != nil && k8serr.IsNotFound(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	//Delete the rolebinding
+	err = serverClient.Delete(ctx, rb)
+	if err != nil && k8serr.IsNotFound(err) {
+		return nil
+	}
+	return err
+}
+
+func (r *Reconciler) getServiceMonitors(ctx context.Context,
+	serverClient k8sclient.Client,
+	nameSpace string) (serviceMonitorsMap map[string]*v1.ServiceMonitor, err error) {
+	//Get list of service monitors in the namespace that has
+	//label "integreatly.org/cloned-servicemonitor" set to "true"
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+		k8sclient.MatchingLabels(getClonedServiceMonitorLabel()),
+	}
+	serviceMonitors := &v1.ServiceMonitorList{}
+	err = serverClient.List(ctx, serviceMonitors, listOpts...)
+	if err != nil {
+		return serviceMonitorsMap, err
+	}
+	serviceMonitorsMap = make(map[string]*v1.ServiceMonitor)
+	for _, sm := range serviceMonitors.Items {
+		serviceMonitorsMap[sm.Name] = sm
+	}
+	return serviceMonitorsMap, err
+}
+
+func getClonedServiceMonitorLabel() map[string]string {
+	return map[string]string{
+		clonedServiceMonitorLabelKey: clonedServiceMonitorLabelValue,
+	}
+}

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -1,0 +1,516 @@
+package monitoringspec
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+
+	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+
+	monitoringv1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	projectv1 "github.com/openshift/api/project/v1"
+
+	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
+	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
+
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	mockSMTPSecretName      = "test-smtp"
+	mockPagerdutySecretName = "test-pd"
+	mockDMSSecretName       = "test-dms"
+)
+
+func basicInstallation() *integreatlyv1alpha1.RHMI {
+	return &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "installation",
+			Namespace: defaultInstallationNamespace,
+			UID:       types.UID("xyz"),
+		},
+		TypeMeta: metav1.TypeMeta{
+			Kind:       integreatlyv1alpha1.SchemaGroupVersionKind.Kind,
+			APIVersion: integreatlyv1alpha1.SchemeGroupVersion.String(),
+		},
+		Spec: integreatlyv1alpha1.RHMISpec{
+			SMTPSecret:           mockSMTPSecretName,
+			PagerDutySecret:      mockPagerdutySecretName,
+			DeadMansSnitchSecret: mockDMSSecretName,
+		},
+	}
+}
+
+func creatServicemonitor(name, namepsace string) *v1.ServiceMonitor {
+	return &v1.ServiceMonitor{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namepsace,
+		},
+		Spec: v1.ServiceMonitorSpec{
+			Endpoints: []v1.Endpoint{
+				{
+					Port:   "upstream",
+					Path:   "/name",
+					Scheme: "http",
+					Params: map[string][]string{
+						"match[]": []string{"{__name__=\"ALERTS\",alertstate=\"firing\"}"},
+					},
+					Interval:      "30s",
+					ScrapeTimeout: "30s",
+					HonorLabels:   true,
+				},
+			},
+		},
+	}
+}
+
+func createRoleBinding(name, namespace string) *rbac.RoleBinding {
+	roleBinding := &rbac.RoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Subjects: []rbac.Subject{
+			{
+				Kind:      rbac.ServiceAccountKind,
+				Name:      clusterMonitoringPrometheusServiceAccount,
+				Namespace: clusterMonitoringNamespace,
+			},
+		},
+		RoleRef: rbac.RoleRef{
+			APIGroup: roleRefAPIGroup,
+			Kind:     bundle.ClusterRoleKind,
+			Name:     roleRefName,
+		},
+	}
+	return roleBinding
+}
+
+func basicConfigMock() *config.ConfigReadWriterMock {
+	return &config.ConfigReadWriterMock{
+		ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
+			return config.NewMonitoringSpec(config.ProductConfig{}), nil
+		},
+		WriteConfigFunc: func(config config.ConfigReadable) error {
+			return nil
+		},
+	}
+}
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := monitoringv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := operatorsv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := marketplacev1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := corev1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := coreosv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := prometheusmonitoringv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := projectv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := v1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := rbac.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return scheme, nil
+}
+
+func setupRecorder() record.EventRecorder {
+	return record.NewFakeRecorder(50)
+}
+
+func TestReconciler_config(t *testing.T) {
+	cases := []struct {
+		Name           string
+		ExpectError    bool
+		ExpectedStatus integreatlyv1alpha1.StatusPhase
+		ExpectedError  string
+		FakeConfig     *config.ConfigReadWriterMock
+		FakeClient     k8sclient.Client
+		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Installation   *integreatlyv1alpha1.RHMI
+		Recorder       record.EventRecorder
+	}{
+		{
+			Name:           "test error on failed config",
+			ExpectedStatus: integreatlyv1alpha1.PhaseFailed,
+			ExpectError:    true,
+			ExpectedError:  "could not read monitoring config",
+			Installation:   &integreatlyv1alpha1.RHMI{},
+			FakeClient:     fakeclient.NewFakeClient(),
+			FakeConfig: &config.ConfigReadWriterMock{
+				ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
+					return nil, errors.New("could not read monitoring config")
+				},
+			},
+			Recorder: setupRecorder(),
+		},
+		{
+			Name:         "test namespace is set without fail",
+			Installation: &integreatlyv1alpha1.RHMI{},
+			FakeClient:   fakeclient.NewFakeClient(),
+			FakeConfig: &config.ConfigReadWriterMock{
+				ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
+					return config.NewMonitoringSpec(config.ProductConfig{
+						"NAMESPACE": "",
+					}), nil
+				},
+			},
+			Recorder: setupRecorder(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			_, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder)
+			if err != nil && err.Error() != tc.ExpectedError {
+				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
+			}
+			if err == nil && tc.ExpectedError != "" {
+				t.Fatalf("expected error '%v' and got nil", tc.ExpectedError)
+			}
+		})
+	}
+
+}
+
+// Test case - creates a monitoring and fuse namespaces
+// Creates a servicemonitor in  fuse namespace
+// Verifies that the service monitor is cloned in the monitoring namespace
+// Verifies that a rolebinding is created in the fuse namespace
+func TestReconciler_fullReconcile(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// initialise runtime objects
+
+	//Monitoring namespace
+	monitoringns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultInstallationNamespace,
+			Labels: map[string]string{
+				resources.OwnerLabelKey: string(basicInstallation().GetUID()),
+			},
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+	//Fuse namespace
+	fusens := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fuse",
+			Labels: map[string]string{
+				resources.OwnerLabelKey: string(basicInstallation().GetUID()),
+				"monitoring-key":        "middleware",
+			},
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+	//Service monitor inside fuse namespace
+	fusesm := creatServicemonitor("fuse-servicemon", "fuse")
+
+	installation := basicInstallation()
+
+	cases := []struct {
+		Name           string
+		ExpectError    bool
+		ExpectedStatus integreatlyv1alpha1.StatusPhase
+		ExpectedError  string
+		FakeConfig     *config.ConfigReadWriterMock
+		FakeClient     k8sclient.Client
+		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Installation   *integreatlyv1alpha1.RHMI
+		Product        *integreatlyv1alpha1.RHMIProductStatus
+		Recorder       record.EventRecorder
+	}{
+		{
+			Name:           "test successful reconcile",
+			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, installation, monitoringns, fusens, fusesm),
+			FakeConfig: &config.ConfigReadWriterMock{
+				ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
+					return config.NewMonitoringSpec(config.ProductConfig{
+						"NAMESPACE":          "",
+						"OPERATOR_NAMESPACE": defaultInstallationNamespace,
+					}), nil
+				},
+				WriteConfigFunc: func(config config.ConfigReadable) error {
+					return nil
+				},
+			},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{
+				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval) error {
+					return nil
+				},
+				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlanList{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "ApplicationMonitoring",
+								APIVersion: monitoringv1.SchemeGroupVersion.String(),
+							},
+							Items: []operatorsv1alpha1.InstallPlan{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "monitoring-install-plan",
+									},
+									Status: operatorsv1alpha1.InstallPlanStatus{
+										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
+									},
+								},
+							},
+							ListMeta: metav1.ListMeta{},
+						}, &operatorsv1alpha1.Subscription{
+							Status: operatorsv1alpha1.SubscriptionStatus{
+								Install: &operatorsv1alpha1.InstallPlanReference{
+									Name: "monitoring-install-plan",
+								},
+							},
+						}, nil
+				},
+			},
+			Installation: basicInstallation(),
+			Product:      &integreatlyv1alpha1.RHMIProductStatus{},
+			Recorder:     setupRecorder(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder)
+			if err != nil && err.Error() != tc.ExpectedError {
+				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
+			}
+
+			ctx := context.TODO()
+			//Verify that reconcilation was completed successfuly
+			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient)
+			if err != nil && !tc.ExpectError {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+			if err == nil && tc.ExpectError {
+				t.Fatal("expected error but got none")
+			}
+			if status != tc.ExpectedStatus {
+				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
+			}
+			//Verify that a new servicemonitor is created in the namespace
+			sermon := &v1.ServiceMonitor{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: "fuse-fuse-servicemon", Namespace: defaultInstallationNamespace}, sermon)
+			if err != nil {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+			//Verify that a role binding was created in the fuse namespace
+			rb := &rbac.RoleBinding{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: roleBindingName, Namespace: "fuse"}, rb)
+			if err != nil {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+		})
+	}
+}
+
+// Test case - creates a monitoring and fuse namespaces
+// Creates a rolebinding in  fuse namespace - stale
+// Creates a servicemonitor in the monitoring namespace - stale
+// Verifies that the service monitor is removed in the monitoring namespace
+// Verifies that a rolebinding is removed in the fuse namespace
+func TestReconciler_fullReconcileWithCleanUp(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// initialise runtime objects
+
+	//Monitoring namespace
+	monitoringns := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: defaultInstallationNamespace,
+			Labels: map[string]string{
+				resources.OwnerLabelKey: string(basicInstallation().GetUID()),
+			},
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+
+	//Fuse namespace
+	fusens := &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "fuse",
+			Labels: map[string]string{
+				resources.OwnerLabelKey: string(basicInstallation().GetUID()),
+				"monitoring-key":        "middleware",
+			},
+		},
+		Status: corev1.NamespaceStatus{
+			Phase: corev1.NamespaceActive,
+		},
+	}
+	//Create a UPS servicemonitor in just monitoring namespace - stale one
+	upssm := creatServicemonitor("ups-servicemon", defaultInstallationNamespace)
+
+	//Create a rolebinding in fuse namespace
+
+	rb := createRoleBinding(roleBindingName, "fuse")
+	if len(upssm.Labels) == 0 {
+		upssm.Labels = make(map[string]string)
+	}
+	upssm.Labels[clonedServiceMonitorLabelKey] = clonedServiceMonitorLabelValue
+
+	installation := basicInstallation()
+
+	cases := []struct {
+		Name           string
+		ExpectError    bool
+		ExpectedStatus integreatlyv1alpha1.StatusPhase
+		ExpectedError  string
+		FakeConfig     *config.ConfigReadWriterMock
+		FakeClient     k8sclient.Client
+		FakeMPM        *marketplace.MarketplaceInterfaceMock
+		Installation   *integreatlyv1alpha1.RHMI
+		Product        *integreatlyv1alpha1.RHMIProductStatus
+		Recorder       record.EventRecorder
+	}{
+		{
+			Name:           "test successful reconcile with cleanup",
+			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, installation, monitoringns, upssm, fusens, rb),
+			FakeConfig: &config.ConfigReadWriterMock{
+				ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
+					return config.NewMonitoringSpec(config.ProductConfig{
+						"NAMESPACE":          "",
+						"OPERATOR_NAMESPACE": defaultInstallationNamespace,
+					}), nil
+				},
+				WriteConfigFunc: func(config config.ConfigReadable) error {
+					return nil
+				},
+			},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{
+				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, owner ownerutil.Owner, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval) error {
+					return nil
+				},
+				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlanList{
+							TypeMeta: metav1.TypeMeta{
+								Kind:       "ApplicationMonitoring",
+								APIVersion: monitoringv1.SchemeGroupVersion.String(),
+							},
+							Items: []operatorsv1alpha1.InstallPlan{
+								{
+									ObjectMeta: metav1.ObjectMeta{
+										Name: "monitoring-install-plan",
+									},
+									Status: operatorsv1alpha1.InstallPlanStatus{
+										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
+									},
+								},
+							},
+							ListMeta: metav1.ListMeta{},
+						}, &operatorsv1alpha1.Subscription{
+							Status: operatorsv1alpha1.SubscriptionStatus{
+								Install: &operatorsv1alpha1.InstallPlanReference{
+									Name: "monitoring-install-plan",
+								},
+							},
+						}, nil
+				},
+			},
+			Installation: basicInstallation(),
+			Product:      &integreatlyv1alpha1.RHMIProductStatus{},
+			Recorder:     setupRecorder(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder)
+			if err != nil && err.Error() != tc.ExpectedError {
+				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
+			}
+
+			ctx := context.TODO()
+
+			//Verify that the sm exisits in monitoring namespace
+			sermon := &v1.ServiceMonitor{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: "ups-servicemon", Namespace: defaultInstallationNamespace}, sermon)
+			if err != nil {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+
+			//Verify fuse namespace has a stale rolebinding
+			rb := &rbac.RoleBinding{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: roleBindingName, Namespace: "fuse"}, rb)
+			if err != nil {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+
+			//Verify that reconcilation was completed successfuly
+			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient)
+			if err != nil && !tc.ExpectError {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+			if err == nil && tc.ExpectError {
+				t.Fatal("expected error but got none")
+			}
+			if status != tc.ExpectedStatus {
+				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
+			}
+			//Verify that the stale servicemonitor is removed
+			sermon = &v1.ServiceMonitor{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: "ups-servicemon", Namespace: defaultInstallationNamespace}, sermon)
+			if err != nil && !k8serr.IsNotFound(err) {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+			//Verify that the stale rolebinding is removed
+			rb = &rbac.RoleBinding{}
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: roleBindingName, Namespace: "fuse"}, rb)
+			if err != nil && !k8serr.IsNotFound(err) {
+				t.Fatalf("expected no error but got one: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -10,17 +10,14 @@ import (
 
 	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
-	applicationmonitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 
 	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	projectv1 "github.com/openshift/api/project/v1"
 
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
-	marketplacev1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 
 	corev1 "k8s.io/api/core/v1"
@@ -118,25 +115,7 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 
 func getBuildScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
-	if err := applicationmonitoringv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
 	if err := integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := operatorsv1alpha1.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := marketplacev1.SchemeBuilder.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := corev1.SchemeBuilder.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := operatorsv1.SchemeBuilder.AddToScheme(scheme); err != nil {
-		return nil, err
-	}
-	if err := prometheusmonitoringv1.SchemeBuilder.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 	if err := projectv1.AddToScheme(scheme); err != nil {
@@ -284,10 +263,6 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				},
 				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
 					return &operatorsv1alpha1.InstallPlanList{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "ApplicationMonitoring",
-								APIVersion: applicationmonitoringv1alpha1.SchemeGroupVersion.String(),
-							},
 							Items: []operatorsv1alpha1.InstallPlan{
 								{
 									ObjectMeta: metav1.ObjectMeta{
@@ -433,10 +408,6 @@ func TestReconciler_fullReconcileWithCleanUp(t *testing.T) {
 				},
 				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
 					return &operatorsv1alpha1.InstallPlanList{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "ApplicationMonitoring",
-								APIVersion: prometheusmonitoringv1.SchemeGroupVersion.String(),
-							},
 							Items: []operatorsv1alpha1.InstallPlan{
 								{
 									ObjectMeta: metav1.ObjectMeta{

--- a/pkg/products/reconciler.go
+++ b/pkg/products/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/apicurito"
+	"github.com/integr8ly/integreatly-operator/pkg/products/monitoringspec"
 
 	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
 
@@ -132,6 +133,8 @@ func NewReconciler(product integreatlyv1alpha1.ProductName, rc *rest.Config, con
 		}
 	case integreatlyv1alpha1.ProductMonitoring:
 		reconciler, err = monitoring.NewReconciler(configManager, installation, mpm, recorder)
+	case integreatlyv1alpha1.ProductMonitoringSpec:
+		reconciler, err = monitoringspec.NewReconciler(configManager, installation, mpm, recorder)
 	case integreatlyv1alpha1.ProductApicurito:
 		reconciler, err = apicurito.NewReconciler(configManager, installation, mpm, recorder)
 	case integreatlyv1alpha1.Product3Scale:

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -1,0 +1,145 @@
+package common
+
+import (
+	goctx "context"
+	"testing"
+
+	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clonedServiceMonitorLabelKey   = "integreatly.org/cloned-servicemonitor"
+	clonedServiceMonitorLabelValue = "true"
+	labelSelector                  = "monitoring-key=middleware"
+	roleBindingName                = "prometheus-k8s"
+)
+
+//Defines an list of expected service monitor names
+var expectedServicemonitors = []string{
+	"redhat-rhmi-amq-online-enmasse-address-space-controller",
+	"redhat-rhmi-amq-online-enmasse-admin",
+	"redhat-rhmi-amq-online-enmasse-broker",
+	"redhat-rhmi-amq-online-enmasse-console",
+	"redhat-rhmi-amq-online-enmasse-iot",
+	"redhat-rhmi-amq-online-enmasse-operator-metrics",
+	"redhat-rhmi-amq-online-enmasse-router",
+	"redhat-rhmi-cloud-resources-operator-cloud-resource-operator-metrics",
+	"redhat-rhmi-fuse-syndesis-infra",
+	"redhat-rhmi-fuse-syndesis-integrations",
+	"redhat-rhmi-middleware-monitoring-operator-application-monitoring-operator-metrics",
+	"redhat-rhmi-middleware-monitoring-operator-grafana-servicemonitor",
+	"redhat-rhmi-middleware-monitoring-operator-prometheus-servicemonitor",
+	"redhat-rhmi-rhsso-keycloak-service-monitor",
+	"redhat-rhmi-ups-operator-unifiedpush-operator-metrics",
+	"redhat-rhmi-ups-unifiedpush",
+	"redhat-rhmi-user-sso-keycloak-service-monitor",
+}
+
+// TestServiceMonitorsCloneAndRolebindingsExist monitirng spec testcase
+// Verifies the list of servicemonitors that are cloned in monitoring namespace
+// Verifies the rolebindings exist
+// Verifies if there are any stale service monitors in the monitoring namespace
+func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingContext) {
+	//Get list of service monitors in the monitoring namespace
+	monSermonMap, err := getServiceMonitors(ctx, MonitoringSpecNamespace)
+	if err != nil {
+		t.Fatal("failed to list servicemonitors in monitoring namespace:", err, "length is empty")
+	}
+	if len(monSermonMap) == 0 {
+		t.Fatal("No servicemonitors present in monitoring namespace")
+	}
+	//Validate the servicemonitors against the list
+	for _, sm := range expectedServicemonitors {
+		if _, ok := monSermonMap[sm]; !ok {
+			t.Fatal("Error - Servicemonitor(s) not found in monitoring namespace", sm)
+		}
+	}
+	//Check if rolebindings exists
+	for _, sm := range monSermonMap {
+		for _, namespace := range sm.Spec.NamespaceSelector.MatchNames {
+			err := checkRoleBindingExists(ctx, roleBindingName, namespace)
+			if err != nil {
+				t.Fatal("Error retrieving rolebinding: ", err, "in namespace:", namespace)
+			}
+		}
+	}
+	//Get the namespaces
+	ls, err := labels.Parse(labelSelector)
+	if err != nil {
+		t.Fatal("failed to parse label", err)
+	}
+	opts := &k8sclient.ListOptions{
+		LabelSelector: ls,
+	}
+	namespaces := &corev1.NamespaceList{}
+	err = ctx.Client.List(goctx.TODO(), namespaces, opts)
+	if err != nil {
+		t.Fatal("failed to list namespaces", err)
+	}
+	//Get servicemonitors for each namespace and validate them
+	for _, ns := range namespaces.Items {
+		//Get list of service monitors in each name space
+		listOpts := []k8sclient.ListOption{
+			k8sclient.InNamespace(ns.Name),
+		}
+		serviceMonitors := &v1.ServiceMonitorList{}
+		err := ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
+		if err != nil {
+			t.Fatal("failed to list servicemonitors", err)
+		}
+		for _, sm := range serviceMonitors.Items {
+			key := sm.Namespace + `-` + sm.Name
+			if _, ok := monSermonMap[key]; !ok {
+				t.Fatal("Servicemonitor: ", key, "not found in monitoring namespace")
+			}
+			delete(monSermonMap, key) // Servicemonitor exists, remove it from the local map
+		}
+	}
+	// Any values left in the servicemonitors map are stale
+	if len(monSermonMap) > 0 {
+		var staleMonitors string
+		for key := range monSermonMap {
+			staleMonitors = staleMonitors + key + ","
+		}
+		t.Fatal("stale service monitors present: %s", staleMonitors)
+	}
+}
+
+func getServiceMonitors(ctx *TestingContext,
+	nameSpace string) (serviceMonitorsMap map[string]*v1.ServiceMonitor, err error) {
+	//Get list of service monitors in the namespace that has
+	//label "integreatly.org/cloned-servicemonitor" set to "true"
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+		k8sclient.MatchingLabels(getClonedServiceMonitorLabel()),
+	}
+	serviceMonitors := &v1.ServiceMonitorList{}
+	err = ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
+	if err != nil {
+		return serviceMonitorsMap, err
+	}
+	serviceMonitorsMap = make(map[string]*v1.ServiceMonitor)
+	for _, sm := range serviceMonitors.Items {
+		serviceMonitorsMap[sm.Name] = sm
+	}
+	return serviceMonitorsMap, err
+}
+
+func getClonedServiceMonitorLabel() map[string]string {
+	return map[string]string{
+		clonedServiceMonitorLabelKey: clonedServiceMonitorLabelValue,
+	}
+}
+
+func checkRoleBindingExists(ctx *TestingContext, name, namespace string) (err error) {
+	rb := &rbac.RoleBinding{}
+	err = ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, rb)
+	if err != nil {
+		return err
+	}
+	return err
+}

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -105,7 +105,7 @@ func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingCont
 		for key := range monSermonMap {
 			staleMonitors = staleMonitors + key + ","
 		}
-		t.Fatal("stale service monitors present: %s", staleMonitors)
+		t.Fatal("stale service monitors present: ", staleMonitors)
 	}
 }
 

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -4,7 +4,7 @@ import (
 	goctx "context"
 	"testing"
 
-	v1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -39,7 +39,7 @@ var expectedServicemonitors = []string{
 	"redhat-rhmi-user-sso-keycloak-service-monitor",
 }
 
-// TestServiceMonitorsCloneAndRolebindingsExist monitirng spec testcase
+// TestServiceMonitorsCloneAndRolebindingsExist monitoring spec testcase
 // Verifies the list of servicemonitors that are cloned in monitoring namespace
 // Verifies the rolebindings exist
 // Verifies if there are any stale service monitors in the monitoring namespace
@@ -47,7 +47,7 @@ func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingCont
 	//Get list of service monitors in the monitoring namespace
 	monSermonMap, err := getServiceMonitors(ctx, MonitoringSpecNamespace)
 	if err != nil {
-		t.Fatal("failed to list servicemonitors in monitoring namespace:", err, "length is empty")
+		t.Fatal("failed to list servicemonitors in monitoring namespace:", err)
 	}
 	if len(monSermonMap) == 0 {
 		t.Fatal("No servicemonitors present in monitoring namespace")
@@ -86,7 +86,7 @@ func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingCont
 		listOpts := []k8sclient.ListOption{
 			k8sclient.InNamespace(ns.Name),
 		}
-		serviceMonitors := &v1.ServiceMonitorList{}
+		serviceMonitors := &monitoringv1.ServiceMonitorList{}
 		err := ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
 		if err != nil {
 			t.Fatal("failed to list servicemonitors", err)
@@ -110,19 +110,19 @@ func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingCont
 }
 
 func getServiceMonitors(ctx *TestingContext,
-	nameSpace string) (serviceMonitorsMap map[string]*v1.ServiceMonitor, err error) {
+	nameSpace string) (serviceMonitorsMap map[string]*monitoringv1.ServiceMonitor, err error) {
 	//Get list of service monitors in the namespace that has
 	//label "integreatly.org/cloned-servicemonitor" set to "true"
 	listOpts := []k8sclient.ListOption{
 		k8sclient.InNamespace(nameSpace),
 		k8sclient.MatchingLabels(getClonedServiceMonitorLabel()),
 	}
-	serviceMonitors := &v1.ServiceMonitorList{}
+	serviceMonitors := &monitoringv1.ServiceMonitorList{}
 	err = ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
 	if err != nil {
 		return serviceMonitorsMap, err
 	}
-	serviceMonitorsMap = make(map[string]*v1.ServiceMonitor)
+	serviceMonitorsMap = make(map[string]*monitoringv1.ServiceMonitor)
 	for _, sm := range serviceMonitors.Items {
 		serviceMonitorsMap[sm.Name] = sm
 	}
@@ -138,8 +138,5 @@ func getClonedServiceMonitorLabel() map[string]string {
 func checkRoleBindingExists(ctx *TestingContext, name, namespace string) (err error) {
 	rb := &rbac.RoleBinding{}
 	err = ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: namespace}, rb)
-	if err != nil {
-		return err
-	}
 	return err
 }

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -37,11 +37,8 @@ var (
 		{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},
 		{"F06 - Verify Replicas Scale correctly in Apicurito", TestReplicasInApicurito},
 		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
-<<<<<<< HEAD
 		{"A06 - Verify PVC", TestPVClaims},
-=======
 		{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
->>>>>>> Addition of common test which verifies servicemonitors are cloned in monitoring namespace
 	}
 
 	DESTRUCTIVE_TESTS = []TestCase{

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -37,7 +37,11 @@ var (
 		{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},
 		{"F06 - Verify Replicas Scale correctly in Apicurito", TestReplicasInApicurito},
 		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
+<<<<<<< HEAD
 		{"A06 - Verify PVC", TestPVClaims},
+=======
+		{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
+>>>>>>> Addition of common test which verifies servicemonitors are cloned in monitoring namespace
 	}
 
 	DESTRUCTIVE_TESTS = []TestCase{

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -36,6 +36,7 @@ const (
 	ThreeScaleOperatorNamespace       = ThreeScaleProductNamespace + "-operator"
 	UPSProductNamespace               = NamespacePrefix + "ups"
 	UPSOperatorNamespace              = UPSProductNamespace + "-operator"
+	MonitoringSpecNamespace           = NamespacePrefix + "monitoring"
 )
 
 type TestingContext struct {


### PR DESCRIPTION
Jira link:  https://issues.redhat.com/browse/INTLY-7034
Clones service monitors from other namespaces that have "middleware-monitoring=true" in the new
redhat-rhmi-monitoring namespace. Creates rolebindings in the other namespaces (where servicemonitors were cloned)
for prometheus to scrape metrics from the corresponding services.

# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Verified independently on a cluster by reviewer