### PR TITLE
Filter the command for ocm get clusters to only include managed/SRE

### DIFF
--- a/scripts/setup-sso-idp.sh
+++ b/scripts/setup-sso-idp.sh
@@ -77,7 +77,7 @@ echo "Keycloak realm: $REALM"
 
 # If CLUSTER_ID is not passed, find out ID based on currently targeted server
 set +e # ignore errors in environments without ocm command
-CLUSTER_ID="${CLUSTER_ID:-$(ocm get /api/clusters_mgmt/v1/clusters/ 2>/dev/null | jq -r ".items[] | select(.api.url == \"$(oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*')\") | .id ")}"
+CLUSTER_ID="${CLUSTER_ID:-$(ocm get /api/clusters_mgmt/v1/clusters/ --parameter "search=managed='true'" 2>/dev/null | jq -r ".items[] | select(.api.url == \"$(oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*')\") | .id ")}"
 set -e
 
 if [[ ${CLUSTER_ID} ]]; then


### PR DESCRIPTION
# Description
Added parameter on the 'ocm get' command for clusters, to filter by managed clusters only, otherwise all of the clusters in the world are included

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer (Alan Moran)