### PR TITLE
feat: support custom release image version

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -25,7 +25,7 @@ if [[ -z "$SEMVER" ]]; then
 fi
 
 
-if [[ $SEMVER =~ ^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(-(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]]; then
+if [[ $SEMVER =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]]; then
   echo "Valid version string: ${SEMVER}"
 else
   echo "Error: Invalid version string: ${SEMVER}"
@@ -50,6 +50,6 @@ fi
 # Include the webhook service in the bundle (temporal solution as OLM will soon
 # support webhooks as part of the CSV:
 # https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/contributors/design-proposals/webhooks.md
-cp deploy/webhook-service.yaml deploy/olm-catalog/integreatly-operator/$VERSION/webhook-service.yaml
+cp deploy/webhook-service.yaml "deploy/olm-catalog/integreatly-operator/$VERSION/webhook-service.yaml"
 
 set_images


### PR DESCRIPTION
## Description
1. Added an option to specify custom container image tag in CSV (required for upgrade pipeline which runs the upgrade `2.x.x -> master`)
2. Added support for Mac OS (sed)
3. Few fixes based on recommendations from [shellcheck](https://github.com/koalaman/shellcheck)
4. Fixed semver regex (replaced `\d` by `[0-9]`, since `\d` is not supported in bash - try out the fixed regex [here](https://regexr.com/53u9s))
5. Used in [RHMI upgrade pipeline](https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/merge_requests/135)

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Verification

```
export SEMVER=2.9.9 IMAGE_TAG=master
make release/prepare
grep ":master" deploy/olm-catalog/integreatly-operator/$SEMVER/integreatly-operator.v$SEMVER.clusterserviceversion.yaml
```
You should get the following output:
```
    containerImage: quay.io/integreatly/integreatly-operator:master
                image: quay.io/integreatly/integreatly-operator:master
```
