### PR TITLE
INTLY-6778-Add new BlackboxTargets for Apicurito, RHSSOUser and Syndesis

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
 	github.com/matryer/moq v0.0.0-20200310130814-7721994d1b54
+	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/pkg/config/apicurito.go
+++ b/pkg/config/apicurito.go
@@ -10,11 +10,11 @@ import (
 )
 
 type Apicurito struct {
-	Config ProductConfig
+	config ProductConfig
 }
 
 func NewApicurito(config ProductConfig) *Apicurito {
-	return &Apicurito{Config: config}
+	return &Apicurito{config: config}
 }
 
 //GetWatchableCRDs to trigger a reconcile of the integreatly installation when these are updated
@@ -30,19 +30,29 @@ func (r *Apicurito) GetWatchableCRDs() []runtime.Object {
 }
 
 func (r *Apicurito) GetNamespace() string {
-	return r.Config["NAMESPACE"]
+	return r.config["NAMESPACE"]
 }
 
 func (r *Apicurito) SetNamespace(newNamespace string) {
-	r.Config["NAMESPACE"] = newNamespace
+	r.config["NAMESPACE"] = newNamespace
+}
+func (r *Apicurito) GetBlackboxTargetPath() string {
+	return r.config["BLACKBOX_TARGET_PATH"]
+}
+func (r *Apicurito) SetBlackboxTargetPath(newBlackboxTargetPath string) {
+	r.config["BLACKBOX_TARGET_PATH"] = newBlackboxTargetPath
 }
 
 func (r *Apicurito) GetOperatorNamespace() string {
-	return r.Config["NAMESPACE"] + "-operator"
+	return r.config["NAMESPACE"] + "-operator"
+}
+
+func (r *Apicurito) SetOperatorNamespace(newNamespace string) {
+	r.config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (r *Apicurito) Read() ProductConfig {
-	return r.Config
+	return r.config
 }
 
 func (r *Apicurito) GetProductName() integreatlyv1alpha1.ProductName {
@@ -58,11 +68,11 @@ func (r *Apicurito) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
 }
 
 func (c *Apicurito) GetHost() string {
-	return c.Config["HOST"]
+	return c.config["HOST"]
 }
 
 func (c *Apicurito) SetHost(newHost string) {
-	c.Config["HOST"] = newHost
+	c.config["HOST"] = newHost
 }
 
 func (r *Apicurito) Validate() error {

--- a/pkg/config/fuse.go
+++ b/pkg/config/fuse.go
@@ -44,6 +44,12 @@ func (f *Fuse) GetOperatorNamespace() string {
 func (f *Fuse) SetOperatorNamespace(newNamespace string) {
 	f.config["OPERATOR_NAMESPACE"] = newNamespace
 }
+func (f *Fuse) GetBlackboxTargetPath() string {
+	return f.config["BLACKBOX_TARGET_PATH"]
+}
+func (f *Fuse) SetBlackboxTargetPath(newBlackboxTargetPath string) {
+	f.config["BLACKBOX_TARGET_PATH"] = newBlackboxTargetPath
+}
 
 func (f *Fuse) GetHost() string {
 	return f.config["HOST"]

--- a/pkg/config/rhssouser.go
+++ b/pkg/config/rhssouser.go
@@ -120,6 +120,13 @@ func (r *RHSSOUser) GetDevelopersGroupConfigured() (bool, error) {
 	return strconv.ParseBool(r.Config["DEVELOPERS_GROUP_CONFIGURED"])
 }
 
+func (r *RHSSOUser) GetBlackboxTargetPath() string {
+	return r.Config["BLACKBOX_TARGET_PATH"]
+}
+func (r *RHSSOUser) SetBlackboxTargetPath(newBlackboxTargetPath string) {
+	r.Config["BLACKBOX_TARGET_PATH"] = newBlackboxTargetPath
+}
+
 func (r *RHSSOUser) Validate() error {
 	if r.GetProductName() == "" {
 		return errors.New("config product name is not defined")

--- a/pkg/products/apicurito/reconciler_test.go
+++ b/pkg/products/apicurito/reconciler_test.go
@@ -333,6 +333,11 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 		WriteConfigFunc: func(config config.ConfigReadable) error {
 			return nil
 		},
+		ReadMonitoringFunc: func() (*config.Monitoring, error) {
+			return config.NewMonitoring(config.ProductConfig{
+				"NAMESPACE": "middleware-monitoring",
+			}), nil
+		},
 	}
 }
 

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -65,6 +65,11 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 		WriteConfigFunc: func(config config.ConfigReadable) error {
 			return nil
 		},
+		ReadMonitoringFunc: func() (*config.Monitoring, error) {
+			return config.NewMonitoring(config.ProductConfig{
+				"NAMESPACE": "middleware-monitoring",
+			}), nil
+		},
 	}
 }
 

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -71,6 +71,11 @@ func basicConfigMock() *config.ConfigReadWriterMock {
 		GetOauthClientsSecretNameFunc: func() string {
 			return "oauth-client-secrets"
 		},
+		ReadMonitoringFunc: func() (*config.Monitoring, error) {
+			return config.NewMonitoring(config.ProductConfig{
+				"NAMESPACE": "middleware-monitoring",
+			}), nil
+		},
 	}
 }
 


### PR DESCRIPTION
# Description
This PR will create new Blackbox targets for Apicurito, RHSSOUser and Syndesis which are currently missing from the Operator

## Type of change

<!-- Please delete options that are not relevant. -->

- [:heavy_check_mark:  ] Bug fix (non-breaking change which fixes an issue)
## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer
## Verification
- Set up OSD cluster and login through cli
- Checkout this branch locally
- Run `make cluster/prepare/local` and `make code/run`
- After Integreatly has finished installation ensure that Integreatly-apicurito, Integreatly-RHSSOUser, Integreatly-Syndesis exist in Prometheus under `Probe_success` query
- Ensure that Integreatly-apicurito, Integreatly-RHSSOUser, Integreatly-Syndesis exist in grafana, under detailed summary