### PR TITLE
set additional secret keys for 3scale s3

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -563,10 +563,21 @@ func (r *Reconciler) getBlobStorageFileStorageSpec(ctx context.Context, serverCl
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, credSec, func() error {
-		credSec.Data["AWS_ACCESS_KEY_ID"] = blobStorageSec.Data["credentialKeyID"]
-		credSec.Data["AWS_SECRET_ACCESS_KEY"] = blobStorageSec.Data["credentialSecretKey"]
-		credSec.Data["AWS_BUCKET"] = blobStorageSec.Data["bucketName"]
-		credSec.Data["AWS_REGION"] = blobStorageSec.Data["bucketRegion"]
+		// Map known key names from CRO, and append any additional values that may be used for Minio
+		for key, value := range blobStorageSec.Data {
+			switch key {
+			case "credentialKeyID":
+				credSec.Data["AWS_ACCESS_KEY_ID"] = blobStorageSec.Data["credentialKeyID"]
+			case "credentialSecretKey":
+				credSec.Data["AWS_SECRET_ACCESS_KEY"] = blobStorageSec.Data["credentialSecretKey"]
+			case "bucketName":
+				credSec.Data["AWS_BUCKET"] = blobStorageSec.Data["bucketName"]
+			case "bucketRegion":
+				credSec.Data["AWS_REGION"] = blobStorageSec.Data["bucketRegion"]
+			default:
+				credSec.Data[key] = value
+			}
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
allow additional keys to be appended to 3scale S3 secret. allows 3scale to be used with Minio

verification:
- run the operator against a cluster
- wait for the installation to complete
- update the cro blobstorage secret in the `redhat-rhmi-operator` namespace with some additional keys
- wait for threescale to reconcile
- ensure the `s3-credentials` secret in the threescale namespace contains additional keys