### PR TITLE
INTLY-7398 allow dedicated admins modify 3scale routes

### DIFF
--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	projectv1 "github.com/openshift/api/project/v1"
@@ -48,6 +49,7 @@ var (
 func getBuildScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
 	err := threescalev1.SchemeBuilder.AddToScheme(scheme)
+	err = rbacv1.SchemeBuilder.AddToScheme(scheme)
 	err = keycloak.SchemeBuilder.AddToScheme(scheme)
 	err = integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme)
 	err = operatorsv1alpha1.AddToScheme(scheme)

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -98,6 +98,38 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 
 	// Verify Dedicated admin permissions around RHMI Config
 	verifyDedicatedAdminRHMIConfigPermissions(t, openshiftClient)
+
+	verifyDedicatedAdmin3ScaleRoutePermissions(t, openshiftClient)
+}
+
+// Verify that a dedicated admin can edit routes in the 3scale namespace
+func verifyDedicatedAdmin3ScaleRoutePermissions(t *testing.T, client *resources.OpenshiftClient) {
+	ns := "redhat-rhmi-3scale"
+	route := "backend"
+
+	path := fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err := client.DoOpenshiftGetRequest(path)
+	if err != nil {
+		t.Errorf("Failed to get route : %s", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Unable to get 3scale route as dedicated admin : %v", resp)
+	}
+
+	bodyBytes, err := ioutil.ReadAll(resp.Body) // Use response from GET
+	if err != nil {
+		t.Errorf("failed to read response body from get route request : %s", err)
+	}
+
+	path = fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err = client.DoOpenshiftPutRequest(path, bodyBytes)
+
+	if err != nil {
+		t.Errorf("Failed to update route : %s", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("Failed to update route as dedicated admin : %v", resp)
+	}
 }
 
 // verifies that there is at least 1 project with a prefix `openshift` , `redhat` and `kube`

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -102,6 +102,23 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 
 	// Verify RHMI Developer permissions around RHMI Config
 	verifyRHMIDeveloperRHMIConfigPermissions(t, openshiftClient)
+
+	verifyRHMIDeveloper3ScaleRoutePermissions(t, openshiftClient)
+}
+
+// Verify that a dedicated admin can edit routes in the 3scale namespace
+func verifyRHMIDeveloper3ScaleRoutePermissions(t *testing.T, client *resources.OpenshiftClient) {
+	ns := "redhat-rhmi-3scale"
+	route := "backend"
+
+	path := fmt.Sprintf(resources.PathGetRoute, ns, route)
+	resp, err := client.DoOpenshiftGetRequest(path)
+	if err != nil {
+		t.Errorf("Failed to get route : %s", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("RHMI Developer was incorrectly able to get route : %v", resp)
+	}
 }
 
 func testRHMIDeveloperProjects(masterURL, fuseNamespace string, openshiftClient *resources.OpenshiftClient) error {

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -21,6 +21,7 @@ const (
 	OpenshiftPathGetSecret    = "/api/kubernetes/api/v1/namespaces/%s/secrets"
 	PathListRHMIConfig        = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs"
 	PathGetRHMIConfig         = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
+	PathGetRoute              = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
 )
 
 type OpenshiftClient struct {


### PR DESCRIPTION
# Description
Add a new Role that allows the dedicated admin group edit routes in the rhmi 3scale namespace

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## Verify
**Verification1** 
Patch the route as dedicated admin and verify success:
Patch the route as rhmi developer and verify permission denied error:
`oc patch route backend -p '{"metadata":{"labels":{"test":"version1"}}}' -n redhat-rhmi-3scale`

**Verification2**
Wait a period of time to verify that the rhmi reconciler does not revert the patch change

**Verification3**
Check that zync:domains:resync command won't case the changes to be reverted (run the following command within the system-app pod - bundle exec rake zync:resync:domains ).

