### PR TITLE
INTLY-7626 Fix RHMI Config dedicated admin permission test

### DIFF
--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -4,14 +4,16 @@ import (
 	goctx "context"
 	"encoding/json"
 	"fmt"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"io/ioutil"
 	"strings"
 	"testing"
 
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+
 	"github.com/integr8ly/integreatly-operator/test/resources"
 	projectv1 "github.com/openshift/api/project/v1"
 	v1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -154,7 +156,12 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 	}
 
 	// Dedicate admin can not CREATE new RHMI config
-	rhmiConfig := &integreatlyv1alpha1.RHMIConfig{}
+	rhmiConfig := &integreatlyv1alpha1.RHMIConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1alpha1",
+			Kind:       "RHMIConfig",
+		},
+	}
 	bodyBytes, err = json.Marshal(rhmiConfig)
 
 	resp, err = openshiftClient.DoOpenshiftPostRequest(path, bodyBytes)

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -227,7 +227,7 @@ func (oc *OpenshiftClient) DoOpenshiftPutRequest(path string, data []byte) (*htt
 
 // make a delete request, expects a path
 func (oc *OpenshiftClient) DoOpenshiftDeleteRequest(path string) (*http.Response, error) {
-	req, err := http.NewRequest("Delete", fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
+	req, err := http.NewRequest(http.MethodDelete, fmt.Sprintf("https://%s%s", oc.ApiUrl, path), nil)
 	if err != nil {
 		return nil, fmt.Errorf("error occurred while creating new http request : %w", err)
 	}


### PR DESCRIPTION
# Description

> Link to JIRA of bug this PR fixes: https://issues.redhat.com/browse/INTLY-7626

Add missing `TypeMeta` field to `RHMIConfig` that is marshalled and sent directly
to the Openshift API. This field is not required when using the Kubernetes client,
but when performing requests directly to the API it might fail if not provided.

Use `http.MethodDelete` to perform DELETE requests to Openshift API, as opposed to
hardcoded `"Delete"`, which can be rejected with "405 Method Not Allowed"

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer