### PR TITLE
update 3scale provider route selector to be more specific

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -251,6 +251,7 @@ var threescaleRoute1 = &v1.Route{
 	},
 }
 
+// Have two system-developer routes, the reconcile should pick up on 3scale.
 var threescaleRoute2 = &v1.Route{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "3scale-system-developer-route",
@@ -266,6 +267,20 @@ var threescaleRoute2 = &v1.Route{
 
 var threescaleRoute3 = &v1.Route{
 	ObjectMeta: metav1.ObjectMeta{
+		Name:      "3scale-system-developer-route-2",
+		Namespace: "3scale",
+		Labels: map[string]string{
+			"zync.3scale.net/route-to": "system-developer",
+		},
+	},
+	Spec: v1.RouteSpec{
+		Host: "3scale.system-developer",
+	},
+}
+
+// Have two system-provider routes, the reconcile should pick up on 3scale-admin.
+var threescaleRoute4 = &v1.Route{
+	ObjectMeta: metav1.ObjectMeta{
 		Name:      "3scale-system-provider-route",
 		Namespace: "3scale",
 		Labels: map[string]string{
@@ -274,6 +289,19 @@ var threescaleRoute3 = &v1.Route{
 	},
 	Spec: v1.RouteSpec{
 		Host: "system-provider",
+	},
+}
+
+var threescaleRoute5 = &v1.Route{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "3scale-system-provider-route-2",
+		Namespace: "3scale",
+		Labels: map[string]string{
+			"zync.3scale.net/route-to": "system-provider",
+		},
+	},
+	Spec: v1.RouteSpec{
+		Host: "3scale-admin.system-provider",
 	},
 }
 
@@ -415,6 +443,8 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		threescaleRoute1,
 		threescaleRoute2,
 		threescaleRoute3,
+		threescaleRoute4,
+		threescaleRoute5,
 		postgres,
 		postgresSec,
 		redis,


### PR DESCRIPTION
when multiple tenants are in the 3scale namespace, the current
approach to selecting routes will return the first route found.
this may not be the managed tenant.

verification:
- run an installation
- create an additional 3scale tenant 'evals'
- ensure the 3scale hostname provided to the solution explorer is
  the correct hostname
- ensure blackbox targets for 3scale are pointed at the main
  developer route