### PR TITLE
INTLY-7418 - e2e verify dedicated admin permissions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,11 +146,11 @@ test/e2e/prow: test/e2e
 test/e2e:  export SURF_DEBUG_HEADERS=1
 test/e2e:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd cluster/prepare/service deploy/integreatly-rhmi-cr.yml
 	 export SURF_DEBUG_HEADERS=1
-	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
+	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=90m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
 
 .PHONY: test/e2e/local
 test/e2e/local: cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
-	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=60m" --debug --up-local
+	$(OPERATOR_SDK) --verbose test local ./test/e2e --namespace="$(NAMESPACE)" --go-test-flags "-timeout=90m" --debug --up-local
 
 
 .PHONY: test/functional

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -231,11 +231,15 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedListStatusCode {
-		t.Errorf("unexpected response from LIST request : %v", resp)
+		t.Errorf("unexpected response from LIST request, expected %d status but got: %v", expectedPermission.ExpectedListStatusCode, resp)
 	}
 
 	// Perform CREATE Request
 	bodyBytes, err := json.Marshal(expectedPermission.ObjectToCreate)
+
+	if err != nil {
+		t.Errorf("failed to marshal object to json for create request: %s", err)
+	}
 
 	resp, err = openshiftClient.DoOpenshiftPostRequest(expectedPermission.ListPath, bodyBytes)
 
@@ -244,7 +248,7 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedCreateStatusCode {
-		t.Errorf("unexpected response from CREATE request : %v", resp)
+		t.Errorf("unexpected response from CREATE request, expected %d status but got: %v", expectedPermission.ExpectedCreateStatusCode, resp)
 	}
 
 	// Perform GET Request
@@ -255,11 +259,15 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedReadStatusCode {
-		t.Errorf("unexpected response from GET request : %v", resp)
+		t.Errorf("unexpected response from GET request, expected %d status but got: %v", expectedPermission.ExpectedReadStatusCode, resp)
 	}
 
 	// Perform UPDATE Request
 	bodyBytes, err = ioutil.ReadAll(resp.Body) // Use response from GET
+
+	if err != nil {
+		t.Errorf("failed to read response body for update request: %s", err)
+	}
 
 	resp, err = openshiftClient.DoOpenshiftPutRequest(expectedPermission.GetPath, bodyBytes)
 
@@ -268,7 +276,7 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedUpdateStatusCode {
-		t.Errorf("unexpected response from UPDATE request : %v", resp)
+		t.Errorf("unexpected response from UPDATE request, expected %d status but got: %v", expectedPermission.ExpectedUpdateStatusCode, resp)
 	}
 
 	// Perform DELETE Request
@@ -279,6 +287,12 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedDeleteStatusCode {
-		t.Errorf("unexpected response from DELETE request  : %v", resp)
+		t.Errorf("unexpected response from DELETE request, expected %d status but got: %v", expectedPermission.ExpectedDeleteStatusCode, resp)
+	}
+
+	// Close the response body
+	err = resp.Body.Close()
+	if err != nil {
+		t.Errorf("failed to close response body: %s", err)
 	}
 }

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -3,6 +3,7 @@ package common
 import (
 	goctx "context"
 	"fmt"
+	enmasseadminv1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/admin/v1beta1"
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta1"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta2"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
@@ -123,6 +124,9 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 
 	// Verify dedicated admin permissions around AddressPlan
 	verifyDedicatedAdminAddressPlanPermissions(t, openshiftClient)
+
+	// Verify dedicated admin permissions around AuthenticationService
+	verifyDedicatedAdminAuthenticationServicePermissions(t, openshiftClient)
 }
 
 // Verify that a dedicated admin can edit routes in the 3scale namespace
@@ -174,6 +178,8 @@ func verifyDedicatedAdminProjectPermissions(projects []projectv1.Project) bool {
 
 // Verify Dedicated admin permissions for RHMIConfig Resource - CRUDL
 func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for RHMIConfig Resource")
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 403,
 		ExpectedReadStatusCode:   200,
@@ -182,7 +188,16 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListRHMIConfig, RHMIOperatorNamespace),
 		GetPath:                  fmt.Sprintf(resources.PathGetRHMIConfig, RHMIOperatorNamespace, "rhmi-config"),
-		ObjectToCreate:           &integreatlyv1alpha1.RHMIConfig{},
+		ObjectToCreate:           &integreatlyv1alpha1.RHMIConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-rhmi-config",
+				Namespace: RHMIOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1alpha1",
+				Kind:       "RHMIConfig",
+			},
+		},
 	}
 
 	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
@@ -190,6 +205,8 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 
 // Verify Dedicated admin permissions for StandardInfraConfig Resource - CRUDL
 func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for StandardInfraConfig Resource")
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -220,6 +237,8 @@ func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftC
 
 // Verify Dedicated admin permissions for BrokeredInfraConfig Resource - CRUDL
 func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for BrokeredInfraConfig Resource")
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -248,8 +267,10 @@ func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftC
 	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
 }
 
-// Verify Dedicated admin permissions for BrokeredInfraConfig Resource - CRUDL
+// Verify Dedicated admin permissions for AddressSpacePlan Resource - CRUDL
 func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AddressSpacePlan Resource")
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -285,6 +306,8 @@ func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClie
 
 // Verify Dedicated admin permissions for AddressPlan Resource - CRUDL
 func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AddressPlan Resource")
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -308,6 +331,36 @@ func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *r
 					Router: 0.01,
 					Broker: 0.001,
 				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for AuthenticationService Resource - CRUDL
+func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	t.Log("Verifying Dedicated admin permissions for AuthenticationService Resource")
+
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListAuthenticationService, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetAuthenticationService, AMQOnlineOperatorNamespace, "test-authentication-service"),
+		ObjectToCreate: enmasseadminv1beta1.AuthenticationService{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-authentication-service",
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AuthenticationService",
+				APIVersion: "admin.enmasse.io/v1beta1",
+			},
+			Spec: enmasseadminv1beta1.AuthenticationServiceSpec{
+				Type: "none",
 			},
 		},
 	}

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -113,6 +113,9 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 
 	// Verify dedicated admin permissions around StandardInfraConfig
 	verifyDedicatedAdminStandardInfraConfigPermissions(t, openshiftClient)
+
+	// Verify dedicated admin permissions around BrokeredInfraConfig
+	verifyDedicatedAdminBrokeredInfraConfigPermissions(t, openshiftClient)
 }
 
 // Verify that a dedicated admin can edit routes in the 3scale namespace
@@ -198,6 +201,36 @@ func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftC
 				APIVersion: "admin.enmasse.io/v1beta1",
 			},
 			Spec: enmassev1beta1.StandardInfraConfigSpec{
+				Broker: enmassev1beta1.InfraConfigBroker{
+					AddressFullPolicy: "FAIL",
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for BrokeredInfraConfig Resource - CRUDL
+func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListBrokeredInfraConfig, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetBrokeredInfraConfig, AMQOnlineOperatorNamespace, "test-brokered-infra-config"),
+		ObjectToCreate: enmassev1beta1.BrokeredInfraConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-brokered-infra-config",
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "BrokeredInfraConfig",
+				APIVersion: "admin.enmasse.io/v1beta1",
+			},
+			Spec: enmassev1beta1.BrokeredInfraConfigSpec{
 				Broker: enmassev1beta1.InfraConfigBroker{
 					AddressFullPolicy: "FAIL",
 				},

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -7,6 +7,7 @@ import (
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta1"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta2"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"io/ioutil"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"reflect"
@@ -392,7 +393,7 @@ func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshif
 				APIVersion: "admin.enmasse.io/v1beta1",
 			},
 			Spec: enmasseadminv1beta1.AuthenticationServiceSpec{
-				Type: enmasseadminv1beta1.None,
+				Type: enmasseadminv1beta1.External,
 			},
 		},
 	}
@@ -418,7 +419,7 @@ func verifyDedicatedAdminAMQOnlineRolePermissions(t *testing.T, ctx *TestingCont
 	}
 
 	if !found {
-		t.Fatalf("Did not dedicated admin group in %s rolebinding in %s namespace", roleBinding.Name, roleBinding.Namespace)
+		t.Fatalf("Did not find dedicated admin group in %s rolebinding in %s namespace", roleBinding.Name, roleBinding.Namespace)
 	}
 
 	// Verify permissions given by the role

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -119,7 +119,10 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	verifyDedicatedAdminBrokeredInfraConfigPermissions(t, openshiftClient)
 
 	// Verify dedicated admin permissions around AddressSpacePlan
-	verifyDedicatedAddressSpacePlanPermissions(t, openshiftClient)
+	verifyDedicatedAdminAddressSpacePlanPermissions(t, openshiftClient)
+
+	// Verify dedicated admin permissions around AddressPlan
+	verifyDedicatedAdminAddressPlanPermissions(t, openshiftClient)
 }
 
 // Verify that a dedicated admin can edit routes in the 3scale namespace
@@ -246,7 +249,7 @@ func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftC
 }
 
 // Verify Dedicated admin permissions for BrokeredInfraConfig Resource - CRUDL
-func verifyDedicatedAddressSpacePlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -272,6 +275,38 @@ func verifyDedicatedAddressSpacePlanPermissions(t *testing.T, openshiftClient *r
 					Router:    1,
 					Broker:    1,
 					Aggregate: 1,
+				},
+			},
+		},
+	}
+
+	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+// Verify Dedicated admin permissions for AddressPlan Resource - CRUDL
+func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
+	expectedPermission := ExpectedPermissions{
+		ExpectedCreateStatusCode: 201,
+		ExpectedReadStatusCode:   200,
+		ExpectedUpdateStatusCode: 200,
+		ExpectedDeleteStatusCode: 200,
+		ExpectedListStatusCode:   200,
+		ListPath:                 fmt.Sprintf(resources.PathListAddressPlan, AMQOnlineOperatorNamespace),
+		GetPath:                  fmt.Sprintf(resources.PathGetAddressPlan, AMQOnlineOperatorNamespace, "test-address-plan"),
+		ObjectToCreate: enmassev1beta2.AddressPlan{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-address-plan",
+				Namespace: AMQOnlineOperatorNamespace,
+			},
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "AddressPlan",
+				APIVersion: "admin.enmasse.io/v1beta2",
+			},
+			Spec: enmassev1beta2.AddressPlanSpec{
+				AddressType: "queue",
+				Resources: enmassev1beta2.AddressPlanResources{
+					Router: 0.01,
+					Broker: 0.001,
 				},
 			},
 		},

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -7,8 +7,10 @@ import (
 	enmassev1beta1 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta1"
 	enmassev1beta2 "github.com/integr8ly/integreatly-operator/pkg/apis-products/enmasse/v1beta2"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
+	"reflect"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"testing"
 
@@ -112,6 +114,9 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 
 	// Verify dedicated admin permissions around AuthenticationService
 	verifyDedicatedAdminAuthenticationServicePermissions(t, openshiftClient)
+
+	// Verify dedicated admin Role / Role binding for AMQ Online resources
+	verifyDedicatedAdminAMQOnlineRolePermissions(t, ctx)
 }
 
 // Verify that a dedicated admin can edit routes in the 3scale namespace
@@ -225,6 +230,8 @@ func verifyDedicatedAdminRHMIConfigPermissions(t *testing.T, openshiftClient *re
 func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	t.Log("Verifying Dedicated admin permissions for StandardInfraConfig Resource")
 
+	resourceName := "test-standard-infra-config"
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -232,7 +239,7 @@ func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftC
 		ExpectedDeleteStatusCode: 200,
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListStandardInfraConfig, AMQOnlineOperatorNamespace),
-		GetPath:                  fmt.Sprintf(resources.PathGetStandardInfraConfig, AMQOnlineOperatorNamespace, "test-standard-infra-config"),
+		GetPath:                  fmt.Sprintf(resources.PathGetStandardInfraConfig, AMQOnlineOperatorNamespace, resourceName),
 		ObjectToCreate: enmassev1beta1.StandardInfraConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "test-standard-infra-config",
@@ -257,6 +264,8 @@ func verifyDedicatedAdminStandardInfraConfigPermissions(t *testing.T, openshiftC
 func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	t.Log("Verifying Dedicated admin permissions for BrokeredInfraConfig Resource")
 
+	resourceName := "test-brokered-infra-config"
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -264,10 +273,10 @@ func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftC
 		ExpectedDeleteStatusCode: 200,
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListBrokeredInfraConfig, AMQOnlineOperatorNamespace),
-		GetPath:                  fmt.Sprintf(resources.PathGetBrokeredInfraConfig, AMQOnlineOperatorNamespace, "test-brokered-infra-config"),
+		GetPath:                  fmt.Sprintf(resources.PathGetBrokeredInfraConfig, AMQOnlineOperatorNamespace, resourceName),
 		ObjectToCreate: enmassev1beta1.BrokeredInfraConfig{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-brokered-infra-config",
+				Name:      resourceName,
 				Namespace: AMQOnlineOperatorNamespace,
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -289,6 +298,8 @@ func verifyDedicatedAdminBrokeredInfraConfigPermissions(t *testing.T, openshiftC
 func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	t.Log("Verifying Dedicated admin permissions for AddressSpacePlan Resource")
 
+	resourceName := "test-address-plan-space"
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -296,10 +307,10 @@ func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClie
 		ExpectedDeleteStatusCode: 200,
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListAddressSpacePlan, AMQOnlineOperatorNamespace),
-		GetPath:                  fmt.Sprintf(resources.PathGetAddressSpacePlan, AMQOnlineOperatorNamespace, "test-address-plan-space"),
+		GetPath:                  fmt.Sprintf(resources.PathGetAddressSpacePlan, AMQOnlineOperatorNamespace, resourceName),
 		ObjectToCreate: enmassev1beta2.AddressSpacePlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-address-plan-space",
+				Name:      resourceName,
 				Namespace: AMQOnlineOperatorNamespace,
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -326,6 +337,8 @@ func verifyDedicatedAdminAddressSpacePlanPermissions(t *testing.T, openshiftClie
 func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	t.Log("Verifying Dedicated admin permissions for AddressPlan Resource")
 
+	resourceName := "test-address-plan"
+
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -333,10 +346,10 @@ func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *r
 		ExpectedDeleteStatusCode: 200,
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListAddressPlan, AMQOnlineOperatorNamespace),
-		GetPath:                  fmt.Sprintf(resources.PathGetAddressPlan, AMQOnlineOperatorNamespace, "test-address-plan"),
+		GetPath:                  fmt.Sprintf(resources.PathGetAddressPlan, AMQOnlineOperatorNamespace, resourceName),
 		ObjectToCreate: enmassev1beta2.AddressPlan{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-address-plan",
+				Name:      resourceName,
 				Namespace: AMQOnlineOperatorNamespace,
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -360,6 +373,7 @@ func verifyDedicatedAdminAddressPlanPermissions(t *testing.T, openshiftClient *r
 func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshiftClient *resources.OpenshiftClient) {
 	t.Log("Verifying Dedicated admin permissions for AuthenticationService Resource")
 
+	resourceName := "test-authentication-service"
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 201,
 		ExpectedReadStatusCode:   200,
@@ -367,10 +381,10 @@ func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshif
 		ExpectedDeleteStatusCode: 200,
 		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListAuthenticationService, AMQOnlineOperatorNamespace),
-		GetPath:                  fmt.Sprintf(resources.PathGetAuthenticationService, AMQOnlineOperatorNamespace, "test-authentication-service"),
+		GetPath:                  fmt.Sprintf(resources.PathGetAuthenticationService, AMQOnlineOperatorNamespace, resourceName),
 		ObjectToCreate: enmasseadminv1beta1.AuthenticationService{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-authentication-service",
+				Name:      resourceName,
 				Namespace: AMQOnlineOperatorNamespace,
 			},
 			TypeMeta: metav1.TypeMeta{
@@ -378,10 +392,56 @@ func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshif
 				APIVersion: "admin.enmasse.io/v1beta1",
 			},
 			Spec: enmasseadminv1beta1.AuthenticationServiceSpec{
-				Type: "none",
+				Type: enmasseadminv1beta1.None,
 			},
 		},
 	}
 
 	verifyCRUDLPermissions(t, openshiftClient, expectedPermission)
+}
+
+func verifyDedicatedAdminAMQOnlineRolePermissions(t *testing.T, ctx *TestingContext) {
+	t.Log("Verifying Dedicated admin AMQ Online resource role / role binding")
+
+	roleBinding := &rbacv1.RoleBinding{}
+	if err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: "dedicated-admins-service-admin", Namespace: AMQOnlineOperatorNamespace}, roleBinding); err != nil {
+		t.Fatalf("error getting dedicated-admins-service-admin role binding in %s namespace: %s", AMQOnlineOperatorNamespace, err)
+	}
+
+	// Verify dedicated admin group is in role binding
+	found := false
+	for _, subject := range roleBinding.Subjects {
+		if subject.Name == "dedicated-admins" && subject.Kind == "Group" {
+			found = true
+			break
+		}
+	}
+
+	if !found {
+		t.Fatalf("Did not dedicated admin group in %s rolebinding in %s namespace", roleBinding.Name, roleBinding.Namespace)
+	}
+
+	// Verify permissions given by the role
+	role := &rbacv1.Role{}
+	if err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: roleBinding.RoleRef.Name, Namespace: AMQOnlineOperatorNamespace}, role); err != nil {
+		t.Fatalf("error %s role in %s namespace: %s", roleBinding.RoleRef.Name, AMQOnlineOperatorNamespace, err)
+	}
+
+	haveCorrectPermission := false
+	expectedRule := rbacv1.PolicyRule{
+		Verbs:     []string{"create", "get", "update", "delete", "list", "watch", "patch"},
+		APIGroups: []string{"admin.enmasse.io"},
+		Resources: []string{"addressplans", "addressspaceplans", "brokeredinfraconfigs", "standardinfraconfigs", "authenticationservices"},
+	}
+
+	for _, rule := range role.Rules {
+		if reflect.DeepEqual(rule, expectedRule) {
+			haveCorrectPermission = true
+			break
+		}
+	}
+
+	if !haveCorrectPermission {
+		t.Fatalf("Incorrect permissions found for %s role in %s namespace. Excpected %s as a policy rule ", role.Name, role.Namespace, expectedRule)
+	}
 }

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -43,12 +43,12 @@ func TestIntegreatly(t *testing.T) {
 		}
 	})
 
-	// Do not execute these tests unless DESTRUCTIVE is set to true
-	if os.Getenv("DESTRUCTIVE") != "true" {
-		t.Skip("Skipping Destructive tests as DESTRUCTIVE env var is not set to true")
-	}
-
 	t.Run("Integreatly Destructive Tests", func(t *testing.T) {
+		// Do not execute these tests unless DESTRUCTIVE is set to true
+		if os.Getenv("DESTRUCTIVE") != "true" {
+			t.Skip("Skipping Destructive tests as DESTRUCTIVE env var is not set to true")
+		}
+
 		for _, test := range common.DESTRUCTIVE_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
 				testingContext, err := common.NewTestingContext(config)

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -28,6 +28,8 @@ const (
 	PathGetBrokeredInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
 	PathListAddressSpacePlan    = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans"
 	PathGetAddressSpacePlan     = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans/%s"
+	PathListAddressPlan         = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans"
+	PathGetAddressPlan          = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans/%s"
 )
 
 type OpenshiftClient struct {

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -26,6 +26,8 @@ const (
 	PathGetStandardInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
 	PathListBrokeredInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs"
 	PathGetBrokeredInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
+	PathListAddressSpacePlan    = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans"
+	PathGetAddressSpacePlan     = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans/%s"
 )
 
 type OpenshiftClient struct {

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -15,13 +15,15 @@ import (
 )
 
 const (
-	OpenshiftPathListProjects = "/api/kubernetes/apis/project.openshift.io/v1/projects"
-	OpenshiftPathGetProject   = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
-	OpenshiftPathListPods     = "/api/kubernetes/api/v1/namespaces/%v/pods"
-	OpenshiftPathGetSecret    = "/api/kubernetes/api/v1/namespaces/%s/secrets"
-	PathListRHMIConfig        = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs"
-	PathGetRHMIConfig         = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
+	OpenshiftPathListProjects   = "/api/kubernetes/apis/project.openshift.io/v1/projects"
+	OpenshiftPathGetProject     = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
+	OpenshiftPathListPods       = "/api/kubernetes/api/v1/namespaces/%v/pods"
+	OpenshiftPathGetSecret      = "/api/kubernetes/api/v1/namespaces/%s/secrets"
+	PathListRHMIConfig          = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs"
+	PathGetRHMIConfig           = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
 	PathGetRoute              = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
+	PathListStandardInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/"
+	PathGetStandardInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
 )
 
 type OpenshiftClient struct {

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -24,6 +24,8 @@ const (
 	PathGetRoute                = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
 	PathListStandardInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/"
 	PathGetStandardInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
+	PathListBrokeredInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs"
+	PathGetBrokeredInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
 )
 
 type OpenshiftClient struct {

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -19,9 +19,9 @@ const (
 	OpenshiftPathGetProject     = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
 	OpenshiftPathListPods       = "/api/kubernetes/api/v1/namespaces/%v/pods"
 	OpenshiftPathGetSecret      = "/api/kubernetes/api/v1/namespaces/%s/secrets"
-	PathListRHMIConfig          = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs"
-	PathGetRHMIConfig           = "/apis/integreatly.org/v1alpha1/namespaces/redhat-rhmi-operator/rhmiconfigs/%s"
-	PathGetRoute              = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
+	PathListRHMIConfig          = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs"
+	PathGetRHMIConfig           = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs/%s"
+	PathGetRoute                = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
 	PathListStandardInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/"
 	PathGetStandardInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
 )

--- a/test/resources/openshift_api.go
+++ b/test/resources/openshift_api.go
@@ -15,21 +15,23 @@ import (
 )
 
 const (
-	OpenshiftPathListProjects   = "/api/kubernetes/apis/project.openshift.io/v1/projects"
-	OpenshiftPathGetProject     = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
-	OpenshiftPathListPods       = "/api/kubernetes/api/v1/namespaces/%v/pods"
-	OpenshiftPathGetSecret      = "/api/kubernetes/api/v1/namespaces/%s/secrets"
-	PathListRHMIConfig          = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs"
-	PathGetRHMIConfig           = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs/%s"
-	PathGetRoute                = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
-	PathListStandardInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/"
-	PathGetStandardInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
-	PathListBrokeredInfraConfig = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs"
-	PathGetBrokeredInfraConfig  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
-	PathListAddressSpacePlan    = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans"
-	PathGetAddressSpacePlan     = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans/%s"
-	PathListAddressPlan         = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans"
-	PathGetAddressPlan          = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans/%s"
+	OpenshiftPathListProjects     = "/api/kubernetes/apis/project.openshift.io/v1/projects"
+	OpenshiftPathGetProject       = "/api/kubernetes/apis/project.openshift.io/v1/projects/%v"
+	OpenshiftPathListPods         = "/api/kubernetes/api/v1/namespaces/%v/pods"
+	OpenshiftPathGetSecret        = "/api/kubernetes/api/v1/namespaces/%s/secrets"
+	PathListRHMIConfig            = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs"
+	PathGetRHMIConfig             = "/apis/integreatly.org/v1alpha1/namespaces/%s/rhmiconfigs/%s"
+	PathGetRoute                  = "/apis/route.openshift.io/v1/namespaces/%s/routes/%s"
+	PathListStandardInfraConfig   = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs"
+	PathGetStandardInfraConfig    = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/standardinfraconfigs/%s"
+	PathListBrokeredInfraConfig   = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs"
+	PathGetBrokeredInfraConfig    = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/brokeredinfraconfigs/%s"
+	PathListAddressSpacePlan      = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans"
+	PathGetAddressSpacePlan       = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressspaceplans/%s"
+	PathListAddressPlan           = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans"
+	PathGetAddressPlan            = "/apis/admin.enmasse.io/v1beta2/namespaces/%s/addressplans/%s"
+	PathListAuthenticationService = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/authenticationservices"
+	PathGetAuthenticationService  = "/apis/admin.enmasse.io/v1beta1/namespaces/%s/authenticationservices/%s"
 )
 
 type OpenshiftClient struct {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

* Verifies CRUDL Dedicated Admin Permissions for in `redhat-rhmi-amq-online`nNamespace:
  * StandardInfraConfig
  * BrokeredInfraConfig
  * AddressSpacePlan
  * AddressPlan
  * AuthenticationService
* Verifies `github-oauth secret` access in `redhat-rhmi-operator` namespace
* Verifies role binding / role vebs and resources for amq online resourcs in `
redhat-rhmi-amq-online` namespace

Test cases:
* https://gitlab.cee.redhat.com/integreatly-qe/integreatly-test-cases/blob/master/tests/authorization/b04-verify-dedicated-admin-user-permissions-are-correct.md
* https://gitlab.cee.redhat.com/integreatly-qe/integreatly-test-cases/blob/master/tests/authorization/b02-verify-the-permissions-of-the-users.md#check-dedicated-admin-permissions

Jira:
* https://issues.redhat.com/browse/INTLY-7418
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Test Automation

## Checklist
- [x] Verified independently on a cluster by reviewer