### PR TITLE
Revert "add resource limit to operator deployment"

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -26,13 +26,6 @@ spec:
           command:
           - rhmi-operator
           imagePullPolicy: Always
-          resources:
-            limits:
-              cpu: 60m
-              memory: 128Mi
-            requests:
-              cpu: 40m
-              memory: 64Mi
           volumeMounts:
           - name: webhook-certs
             mountPath: "/etc/ssl/certs/webhook"


### PR DESCRIPTION
This reverts commit 7137c6c338229e70c4d34508272331f76cb2ed25.

Reverts this PR - https://github.com/integr8ly/integreatly-operator/pull/648