### PR TITLE
always regenerate the csv files

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -8,6 +8,10 @@ create_new_csv() {
   operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name integreatly-operator --csv-channel=rhmi --update-crds --from-version "$PREVIOUS_VERSION"
 }
 
+update_csv() {
+  operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name integreatly-operator --csv-channel=rhmi --update-crds
+}
+
 set_version() {
   "${SED_INLINE[@]}" "s/$PREVIOUS_VERSION/$VERSION/g" Makefile
   "${SED_INLINE[@]}" "s/$PREVIOUS_VERSION/$VERSION/g" version/version.go
@@ -45,6 +49,8 @@ fi
 if [[ "$VERSION" != "$PREVIOUS_VERSION" ]]; then
   create_new_csv
   set_version
+else
+  update_csv
 fi
 
 # Include the webhook service in the bundle (temporal solution as OLM will soon


### PR DESCRIPTION
# Description

At the moment, when the pre-release script is executed, it will only regenerate the csv files when the minor versions are changed. This means if there are changes made to the `operator.yaml` file between RC releases, these changes are not reflected in the csv files.

The changes here will make sure the CSV file will always be regenerated.
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer