### PR TITLE
DEL-243 Add a new make target to integreatly-operator to run the test…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ tmp/_output/bin/integreatly-operator
 cmd/manager/debug
 build/_output
 build/_test
+test-results
 # Created by https://www.gitignore.io/api/go,vim,emacs,visualstudiocode
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
 CONTAINER_ENGINE ?= docker
+TEST_RESULTS_DIR ?= "test-results"
 
 # If openapi-gen is available on the path, use that; otherwise use it through
 # "go run" (slower)
@@ -159,6 +160,21 @@ test/functional:  export SURF_DEBUG_HEADERS=1
 test/functional:
 	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
 	go clean -testcache && go test -v ./test/functional -timeout=80m
+
+.PHONY: test/products/local
+test/products/local:
+	# Running the products tests against an existing cluster inside a container. Make sure you have logged in to the cluster.
+	# Using 'test-containers.yaml' as config and 'test-results' as output dir
+	mkdir -p "test-results"
+	$(CONTAINER_ENGINE) pull quay.io/integreatly/delorean-cli:master
+	$(CONTAINER_ENGINE) run --rm -e KUBECONFIG=/kube.config -v "${HOME}/.kube/config":/kube.config:z -v $(shell pwd)/test-containers.yaml:/test-containers.yaml -v $(shell pwd)/test-results:/test-results quay.io/integreatly/delorean-cli:master delorean tests run --test-config ./test-containers.yaml --output /test-results --namespace test-products
+
+.PHONY: test/products
+test/products:
+	# Running the products tests against an existing cluster. Make sure you have logged in to the cluster.
+	# Using "test-containers.yaml" as config and $(TEST_RESULTS_DIR) as output dir
+	mkdir -p $(TEST_RESULTS_DIR)
+	delorean tests run --test-config ./test-containers.yaml --output $(TEST_RESULTS_DIR) --namespace test-products
 
 .PHONY: install/olm
 install/olm: cluster/cleanup/olm cluster/cleanup/crds cluster/prepare cluster/prepare/olm/subscription deploy/integreatly-rhmi-cr.yml cluster/check/operator/deployment cluster/prepare/dms cluster/prepare/pagerduty

--- a/README.md
+++ b/README.md
@@ -178,6 +178,13 @@ To run E2E tests against an existing RHMI cluster:
 make test/functional
 ```
 
+### Products tests
+
+To run products tests against an existing RHMI cluster
+```
+make test/products/local
+```
+
 ## Using `ocm` for installation of RHMI
 
 If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using `ocm`. If you want to spin up a cluster using BYOC (your own AWS credentials), follow the additional steps marked as **BYOC**.

--- a/test-containers.yaml
+++ b/test-containers.yaml
@@ -1,0 +1,14 @@
+---
+tests:
+  - name: codeready-test
+    image: quay.io/crw/osd-e2e
+    timeout: 3600
+    envVars:
+      - name: CODEREADY_NAMESPACE
+        value: redhat-rhmi-codeready-workspaces
+  - name: 3scale-test
+    image: quay.io/integreatly/3scale-py-testsuite:0.1.0
+    timeout: 3600
+    envVars:
+      - name: NAMESPACE
+        value: redhat-rhmi-3scale


### PR DESCRIPTION
To verify:

- Make sure a RHMI cluster is available and running, and you have access to the kubeconfig file and it is saved locally somewhere.

- Check out the branch and build it. Run the following command:
`make test/products`