### PR TITLE
use headless service to ensure clusterIP is never empty for webhook s…

### DIFF
--- a/deploy/webhook-service.yaml
+++ b/deploy/webhook-service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     service.beta.openshift.io/serving-cert-secret-name: rhmi-webhook-cert
 spec:
+  clusterIP: "None"
   selector:
     name: rhmi-operator
   ports:


### PR DESCRIPTION
We always have to provide a cluster IP, otherwise update fails on a service resource. Setting it to `None` works for webhooks and ensures update also succeeds.

https://issues.redhat.com/browse/INTLY-7829
