### PR TITLE
Adding in additional permissions to resolve metrics error in the logs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -101,6 +101,19 @@ rules:
       - list
       - watch
 
+  # Permissions needed to be able to grant to prometheus-k8s SA from openshift-monitoring NS
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+      - services
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  # END Permissions needed to be able to grant to prometheus-k8s SA from openshift-monitoring NS
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,8 +48,10 @@ rules:
       - apps
     resources:
       - deployments/finalizers
+      - replicasets
     verbs:
       - update
+      - get
   # END For monitoring functions by operator-sdk
 
   # Our own Subscription needs to be switched into Manual mode after initial installation


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/DEL-261

Error faced
```
failed to initialize service object for metrics: replicasets.apps \"rhmi-operator-5b7847c84\" is forbidden: User \"system:serviceaccount:redhat-rhmi-operator:rhmi-operator\" cannot get resource \"replicasets\" in API group \"apps\" in the namespace \"redhat-rhmi-operator\""}
```

Note: I didn't deploy this using olm.
I used `make cluster/prepare` `make cluster/prepare/crd` and oc deployed the required resources in the rhmi namespace


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Verified independently on a cluster by reviewer

Please contact me for the cluster where I have this deployed.