### PR TITLE
Remove the servicemonitors from watchable CRDs

### DIFF
--- a/pkg/config/monitoringspec.go
+++ b/pkg/config/monitoringspec.go
@@ -3,9 +3,7 @@ package config
 import (
 	"errors"
 
-	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -18,15 +16,7 @@ func NewMonitoringSpec(config ProductConfig) *MonitoringSpec {
 }
 
 func (m *MonitoringSpec) GetWatchableCRDs() []runtime.Object {
-
-	return []runtime.Object{
-		&monitoringv1.ServiceMonitor{
-			TypeMeta: metav1.TypeMeta{
-				APIVersion: monitoringv1.SchemeGroupVersion.String(),
-				Kind:       monitoringv1.ServiceMonitorsKind,
-			},
-		},
-	}
+	return []runtime.Object{}
 }
 
 func (m *MonitoringSpec) GetNamespace() string {


### PR DESCRIPTION
# Description
JIRA Link: https://issues.redhat.com/browse/INTLY-7853

Servicemonitors type was added to the watchable CRDs previously.
RHMI operator cannot watch for service monitors.

[gryan@localhost ~]$ oc auth can-i list servicemonitors -n redhat-rhmi-monitoring
yes
[gryan@localhost ~]$ oc auth can-i watch servicemonitors -n redhat-rhmi-monitoring
no


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer