### PR TITLE
Fix the rolebinding permission issue

### DIFF
--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -321,7 +321,7 @@ func (r *Reconciler) reconcileRole(ctx context.Context,
 		return nil
 	})
 	if opRes != controllerutil.OperationResultNone {
-		r.Logger.Infof("operation result of creating role: %v was %v", roleBindingName, opRes)
+		r.Logger.Infof("operation result of creating role: %v was %v", roleRefName, opRes)
 	}
 	return err
 }

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -293,7 +293,7 @@ func (r *Reconciler) reconcileRole(ctx context.Context,
 
 	role := &rbac.Role{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      roleBindingName,
+			Name:      roleRefName,
 			Namespace: namespace,
 		},
 	}

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -29,11 +29,11 @@ import (
 const (
 	defaultInstallationNamespace              = "monitoring"
 	packageName                               = "monitoringspec"
-	roleBindingName                           = "prometheus-k8s"
+	roleBindingName                           = "rhmi-prometheus-k8s"
 	clusterMonitoringPrometheusServiceAccount = "prometheus-k8s"
 	clusterMonitoringNamespace                = "openshift-monitoring"
 	roleRefAPIGroup                           = "rbac.authorization.k8s.io"
-	roleRefName                               = "view"
+	roleRefName                               = "rhmi-prometheus-k8s"
 	labelSelector                             = "monitoring-key=middleware"
 	clonedServiceMonitorLabelKey              = "integreatly.org/cloned-servicemonitor"
 	clonedServiceMonitorLabelValue            = "true"
@@ -117,7 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.reconcileMonitoring(ctx, serverClient, installation)
 	logrus.Infof("Phase: %s reconcileMonitoring", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		logrus.Errorf("ailed to reconcile: %v", err)
+		logrus.Errorf("failed to reconcile: %v", err)
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile:", err)
 		return phase, err
 	}
@@ -218,7 +218,7 @@ func (r *Reconciler) reconcileMonitoring(ctx context.Context, serverClient k8scl
 			}
 			//Remove rolebindings
 			for _, namespace := range sm.Spec.NamespaceSelector.MatchNames {
-				err := r.removeRoleBinding(ctx, serverClient, namespace, roleBindingName)
+				err := r.removeRoleandRoleBinding(ctx, serverClient, namespace, roleRefName, roleBindingName)
 				if err != nil {
 					return integreatlyv1alpha1.PhaseFailed, err
 				}
@@ -276,10 +276,52 @@ func (r *Reconciler) reconcileRoleBindingsForServiceMonitor(ctx context.Context,
 	}
 	//Create role binding for each of the namespace label selectors
 	for _, namespace := range sermon.Spec.NamespaceSelector.MatchNames {
-		err := r.reconcileRoleBinding(ctx, serverClient, namespace)
+		err := r.reconcileRole(ctx, serverClient, namespace)
 		if err != nil {
 			return err
 		}
+		err = r.reconcileRoleBinding(ctx, serverClient, namespace)
+		if err != nil {
+			return err
+		}
+	}
+	return err
+}
+
+func (r *Reconciler) reconcileRole(ctx context.Context,
+	serverClient k8sclient.Client, namespace string) (err error) {
+
+	role := &rbac.Role{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roleBindingName,
+			Namespace: namespace,
+		},
+	}
+	opRes, err := controllerutil.CreateOrUpdate(ctx, serverClient, role, func() error {
+		resources := []string{
+			"services",
+			"endpoints",
+			"pods",
+		}
+
+		verbs := []string{
+			"get",
+			"list",
+			"watch",
+		}
+		apiGroups := []string{""}
+
+		role.Rules = []rbac.PolicyRule{
+			{
+				APIGroups: apiGroups,
+				Resources: resources,
+				Verbs:     verbs,
+			},
+		}
+		return nil
+	})
+	if opRes != controllerutil.OperationResultNone {
+		r.Logger.Infof("operation result of creating role: %v was %v", roleBindingName, opRes)
 	}
 	return err
 }
@@ -303,7 +345,7 @@ func (r *Reconciler) reconcileRoleBinding(ctx context.Context,
 		}
 		roleBinding.RoleRef = rbac.RoleRef{
 			APIGroup: roleRefAPIGroup,
-			Kind:     bundle.ClusterRoleKind,
+			Kind:     bundle.RoleKind,
 			Name:     roleRefName,
 		}
 		return nil
@@ -330,8 +372,8 @@ func (r *Reconciler) removeServiceMonitor(ctx context.Context,
 	return err
 }
 
-func (r *Reconciler) removeRoleBinding(ctx context.Context,
-	serverClient k8sclient.Client, namespace, name string) (err error) {
+func (r *Reconciler) removeRoleandRoleBinding(ctx context.Context,
+	serverClient k8sclient.Client, namespace, roleName, rbName string) (err error) {
 
 	// Check if the namespace has service monitors
 	// if so do not delete the rolebinding
@@ -347,13 +389,23 @@ func (r *Reconciler) removeRoleBinding(ctx context.Context,
 		return nil
 	}
 
+	//Get the role
+	role := &rbac.Role{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: roleName, Namespace: namespace}, role)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return err
+	}
+
+	//Delete the role
+	err = serverClient.Delete(ctx, role)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return err
+	}
+
 	//Get the rolebinding
 	rb := &rbac.RoleBinding{}
-	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: name, Namespace: namespace}, rb)
-	if err != nil && k8serr.IsNotFound(err) {
-		return nil
-	}
-	if err != nil {
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: rbName, Namespace: namespace}, rb)
+	if err != nil && !k8serr.IsNotFound(err) {
 		return err
 	}
 

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -64,7 +64,7 @@ func TestServiceMonitorsCloneAndRolebindingsExist(t *testing.T, ctx *TestingCont
 		for _, namespace := range sm.Spec.NamespaceSelector.MatchNames {
 			err := checkRoleExists(ctx, roleRefName, namespace)
 			if err != nil {
-				t.Fatal("Error retrieving rolebinding: ", err, "in namespace:", namespace)
+				t.Fatal("Error retrieving role: ", err, "in namespace:", namespace)
 			}
 			err = checkRoleBindingExists(ctx, roleBindingName, namespace)
 			if err != nil {


### PR DESCRIPTION
# Description
JIRA Link: https://issues.redhat.com/browse/INTLY-7854

Operator did not have permissions to create cluster role bindings, since
it runs with service account privileges. Code has been modified to create
a new role with the minimal required permissions and create a corresponding rolebinding
for them, so that prometheus can scrape metrics from the services.


<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer