### PR TITLE
Addition of brokermemory amq alert in alert exists test

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -232,6 +232,7 @@ var expectedRules = []alertsTestRule{
 			"AddressHealth",
 			"RouterMeshConnectivityHealth",
 			"RouterMeshUndeliveredHealth",
+			"BrokerMemory",
 		},
 	},
 	{


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-7878

Addition of the new `BrokerMemory` AMQ alert to the tests. 

## Type of change
- Update to the `C04_-_Verify_Alerts_exist` test case

## Verification
- Ensure that the e2e test pass, and do not fail due to the `BrokerMemory` alert not being present

#### Manual Verification
- `oc login` to an OS4 cluster with RHMI installed from master
- Using this branch, run the functional tests
- Ensure that all tests in `alerts_exists.go` pass successfully