### PR TITLE
expose upgrade metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,8 @@ func init() {
 	// Register custom metrics with the global prometheus registry
 	customMetrics.Registry.MustRegister(integreatlymetrics.OperatorVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatusAvailable)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIVersion)
+	integreatlymetrics.OperatorVersion.Add(1)
 }
 
 func printVersion() {

--- a/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
@@ -46,7 +46,6 @@ spec:
                   type: string
               type: object
             upgrade:
-              description: 'configure when we will apply upgrades of RHMI to the cluster'
               properties:
                 alwaysImmediately:
                   description: 'always-immediately: boolean value, if set to true
@@ -79,7 +78,10 @@ spec:
           description: RHMIConfigStatus defines the observed state of RHMIConfig
           properties:
             maintenance:
-              description: 'configure when we will apply OSD maintenance to the cluster'
+              description: "status block reflects the current configuration of the
+                cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00
+                \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 -
+                17 Jan 1980\""
               properties:
                 applyFrom:
                   type: string

--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -140,6 +140,10 @@ spec:
                 code after modifying this file Add custom validation using kubebuilder
                 tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: object
+            toVersion:
+              type: string
+            version:
+              type: string
           required:
           - lastError
           - stage

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -172,6 +172,8 @@ type RHMIStatus struct {
 	LastError          string                        `json:"lastError"`
 	GitHubOAuthEnabled bool                          `json:"gitHubOAuthEnabled,omitempty"`
 	SMTPEnabled        bool                          `json:"smtpEnabled,omitempty"`
+	Version            string                        `json:"version,omitempty"`
+	ToVersion          string                        `json:"toVersion,omitempty"`
 }
 
 type RHMIStageStatus struct {

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -228,6 +228,18 @@ func schema_pkg_apis_integreatly_v1alpha1_RHMIStatus(ref common.ReferenceCallbac
 							Format: "",
 						},
 					},
+					"version": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
+					"toVersion": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 				},
 				Required: []string{"stages", "stage", "lastError"},
 			},

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -3,11 +3,11 @@ package installation
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
+	"github.com/integr8ly/integreatly-operator/version"
 	"os"
 	"strings"
 	"time"
-
-	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
 
 	"k8s.io/apimachinery/pkg/types"
 
@@ -305,6 +305,20 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return retryRequeue, nil
 	}
 
+	// If no current or target version is set this is the first installation of rhmi.
+	if installation.Status.Version == "" && installation.Status.ToVersion == "" {
+		installation.Status.ToVersion = version.IntegreatlyVersion
+		logrus.Infof("Setting installation.Status.ToVersion on initial install %s", version.IntegreatlyVersion)
+		if err := r.client.Status().Update(r.context, installation); err != nil {
+			return reconcile.Result{}, err
+		}
+	}
+
+	// It's important to set the metric values at this point to account for the upgrade scenario. The ToVersion
+	// is set on the CR when the install plan is approved, however, the operator pod is terminated shortly
+	// after this point which may not be enough time for prometheus to scrape the metric.
+	metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion)
+
 	// Reconcile the webhooks
 	if err := webhooks.Config.Reconcile(r.context, r.client); err != nil {
 		return reconcile.Result{}, err
@@ -377,10 +391,263 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return retryRequeue, nil
 	}
 	installation.Status.Stage = integreatlyv1alpha1.StageName("complete")
+
+	if (isFirstInstallReconcile(installation) || isUpgradeReconcile(installation)) && allProductsReconciled(installation) {
+		installation.Status.Version = installation.Status.ToVersion
+		installation.Status.ToVersion = ""
+		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion)
+	}
+
 	_ = r.client.Status().Update(r.context, installation)
 	metrics.RHMIStatusAvailable.Set(1)
 	logrus.Infof("installation completed succesfully")
 	return reconcile.Result{Requeue: true, RequeueAfter: 5 * time.Minute}, nil
+}
+
+func isFirstInstallReconcile(installation *integreatlyv1alpha1.RHMI) bool {
+	return installation.Status.Version == ""
+}
+
+func isUpgradeReconcile(installation *integreatlyv1alpha1.RHMI) bool {
+	status := installation.Status
+	if status.ToVersion != "" {
+		return true
+	}
+	return false
+}
+
+func allProductsReconciled(installation *integreatlyv1alpha1.RHMI) bool {
+	stages := installation.Status.Stages
+
+	return (verifyClusterRHSSOVersions(stages) &&
+		verifyCloudResourceVersions(stages) &&
+		verifyAMQOnlineVersions(stages) &&
+		verifyApicuritoVersions(stages) &&
+		verifyCodeReadyWorkspacesVersions(stages) &&
+		verifyFuseOnOpenshiftVersions(stages) &&
+		verifyMonitoringVersions(stages) &&
+		verify3ScaleVersions(stages) &&
+		verifyFuseOnlineVersions(stages) &&
+		verifyDataSyncVersions(stages) &&
+		verifyRHSSOUserVersions(stages) &&
+		verifyUPSVersions(stages) &&
+		verifySolutionExplorerVersions(stages))
+}
+
+func verifySolutionExplorerVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.SolutionExplorerStage].Products[integreatlyv1alpha1.ProductSolutionExplorer]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionSolutionExplorer)
+	installedOpVersion := string(versions.OperatorVersion)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Solution Explorer Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	return true
+}
+
+func verifyClusterRHSSOVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.AuthenticationStage].Products[integreatlyv1alpha1.ProductRHSSO]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionRHSSO)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionRHSSO)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Cluster RHSSO Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Cluster RHSSO Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyMonitoringVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.MonitoringStage].Products[integreatlyv1alpha1.ProductMonitoring]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionMonitoring)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionMonitoring)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Monitoring Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Monitoring Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyCloudResourceVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.CloudResourcesStage].Products[integreatlyv1alpha1.ProductCloudResources]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionCloudResources)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionCloudResources)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Cloud Resource Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Cloud Resource Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyApicuritoVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductApicurito]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionApicurito)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionApicurito)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Apicurito Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Apicurito Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyRHSSOUserVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductRHSSOUser]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionRHSSOUser)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionRHSSOUser)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("RHSSOUser Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("RHSSOUser Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyUPSVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductUps]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionUPS)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionUps)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("UPS Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("UPS Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verify3ScaleVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.Product3Scale]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersion3Scale)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.Version3Scale)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("3Scale Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("3Scale Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyDataSyncVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductDataSync]
+	expectedProductVersion := string(integreatlyv1alpha1.VersionDataSync)
+	installedProductVersion := string(versions.Version)
+
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Data Sync Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyFuseOnlineVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuse]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionFuse)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionFuseOnline)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("Fuse Online Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("Fuse Online Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyCodeReadyWorkspacesVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductCodeReadyWorkspaces]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionCodeReadyWorkspaces)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionCodeReadyWorkspaces)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("CodeReady Workspaces Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("CodeReady Workspaces Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyAMQOnlineVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductAMQOnline]
+	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionAMQOnline)
+	installedOpVersion := string(versions.OperatorVersion)
+	expectedProductVersion := string(integreatlyv1alpha1.VersionAMQOnline)
+	installedProductVersion := string(versions.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("AMQOnline Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("AMQOnline Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}
+
+func verifyFuseOnOpenshiftVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
+	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuseOnOpenshift]
+	expectedProductVersion := string(integreatlyv1alpha1.VersionFuseOnOpenshift)
+	installedProductVersion := string(versions.Version)
+
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("FuseOnOpenShift Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
 }
 
 func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha1.RHMI, installationType *Type, configManager *config.Manager) (reconcile.Result, error) {

--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -2,6 +2,7 @@ package rhmiConfigs
 
 import (
 	"context"
+	"github.com/integr8ly/integreatly-operator/version"
 	"strings"
 	"testing"
 	"time"
@@ -445,6 +446,23 @@ func TestApproveUpgrade(t *testing.T) {
 				"RHMI-v1.0.0",
 			},
 		},
+		Status: olmv1alpha1.InstallPlanStatus{
+			Plan: []*olmv1alpha1.Step{
+				{
+					Resource: olmv1alpha1.StepResource{
+						Kind:     "ClusterServiceVersion",
+						Manifest: "{\"kind\":\"ClusterServiceVersion\",    \"spec\": {      \"version\": \"2.2.0\"}}",
+					},
+				},
+			},
+		},
+	}
+
+	rhmiMock := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhmi",
+			Namespace: "redhat-rhmi-operator",
+		},
 	}
 
 	installPlanAlreadyUpgrading := &olmv1alpha1.InstallPlan{
@@ -463,15 +481,17 @@ func TestApproveUpgrade(t *testing.T) {
 		Context         context.Context
 		EventRecorder   record.EventRecorder
 		RhmiInstallPlan *olmv1alpha1.InstallPlan
-		Verify          func(rhmiInstallPlan *olmv1alpha1.InstallPlan, err error)
+		RHMI            *integreatlyv1alpha1.RHMI
+		Verify          func(rhmiInstallPlan *olmv1alpha1.InstallPlan, rhmi *integreatlyv1alpha1.RHMI, err error)
 	}{
 		{
 			Name:            "Test install plan already upgrading",
-			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanAlreadyUpgrading),
+			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanAlreadyUpgrading, rhmiMock),
 			Context:         context.TODO(),
 			EventRecorder:   setupRecorder(),
 			RhmiInstallPlan: installPlanAlreadyUpgrading,
-			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, err error) {
+			RHMI:            rhmiMock,
+			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, rhmi *integreatlyv1alpha1.RHMI, err error) {
 				// Should not return an error
 				if err != nil {
 					t.Fatalf("Unexpected error %v", err)
@@ -484,11 +504,12 @@ func TestApproveUpgrade(t *testing.T) {
 		},
 		{
 			Name:            "Test install plan ready to upgrade",
-			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanReadyForApproval),
+			FakeClient:      fake.NewFakeClientWithScheme(buildScheme(), installPlanReadyForApproval, rhmiMock),
 			Context:         context.TODO(),
 			EventRecorder:   setupRecorder(),
 			RhmiInstallPlan: installPlanReadyForApproval,
-			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, err error) {
+			RHMI:            rhmiMock,
+			Verify: func(updatedRhmiInstallPlan *olmv1alpha1.InstallPlan, rhmi *integreatlyv1alpha1.RHMI, err error) {
 				// Should not return an error
 				if err != nil {
 					t.Fatalf("Unexpected error %v", err)
@@ -497,17 +518,23 @@ func TestApproveUpgrade(t *testing.T) {
 				if updatedRhmiInstallPlan.Spec.Approved != true {
 					t.Fatalf("Expected installplan.Spec.Approved to be true")
 				}
+
+				if rhmi.Status.ToVersion != version.Version {
+					t.Fatalf("Expected ToVersion to be version.version")
+				}
 			},
 		},
 	}
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RhmiInstallPlan, scenario.EventRecorder)
+			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RhmiInstallPlan, scenario.RHMI, scenario.EventRecorder)
 
 			retrievedInstallPlan := &olmv1alpha1.InstallPlan{}
 			err := scenario.FakeClient.Get(scenario.Context, k8sclient.ObjectKey{Name: scenario.RhmiInstallPlan.Name, Namespace: scenario.RhmiInstallPlan.Namespace}, retrievedInstallPlan)
-			scenario.Verify(retrievedInstallPlan, err)
+			rhmi := &integreatlyv1alpha1.RHMI{}
+			err = scenario.FakeClient.Get(scenario.Context, k8sclient.ObjectKey{Name: scenario.RHMI.Name, Namespace: scenario.RHMI.Namespace}, rhmi)
+			scenario.Verify(retrievedInstallPlan, rhmi, err)
 		})
 	}
 }

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -136,7 +136,14 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 
 	if !rhmiConfigs.IsUpgradeServiceAffecting(latestRHMICSV) || canUpgradeNow {
 		eventRecorder := r.mgr.GetEventRecorderFor("RHMI Upgrade")
-		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, latestRHMIInstallPlan, eventRecorder)
+
+		// TODO: investigate a better approach to getting RHMI rather than hardcoding values
+		installation := &integreatlyv1alpha1.RHMI{}
+		err = r.client.Get(ctx, k8sclient.ObjectKey{Name: "rhmi", Namespace: "redhat-rhmi-operator"}, installation)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, latestRHMIInstallPlan, installation, eventRecorder)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -25,4 +25,20 @@ var (
 			Help: "RHMI status available",
 		},
 	)
+
+	RHMIVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhmi_version",
+			Help: "RHMI versions",
+		},
+		[]string{
+			"stage",
+			"version",
+			"to_version",
+		},
+	)
 )
+
+func SetRhmiVersions(stage string, version string, toVersion string) {
+	RHMIVersion.WithLabelValues(stage, version, toVersion).Add(1)
+}


### PR DESCRIPTION
# Description
Update RHMI CR to reflect current version and upgrading version, meaning, the version RHMI is attempting to upgrade to. Add prometheus metrics around this data.  Explained in detail in JIRA
[INTLY-7394](https://issues.redhat.com/browse/INTLY-7394)

## Why
**Track the following**
- If an upgrade is happening
- how long an upgrade took
- what version we are upgrading to

## Type of Change
- New feature (non-breaking change which adds functionality)

## Verification

**NOTE:** Verifying this JIRA is dependant on the below JIRAs. 
These PRs do not block this PR as this change is independant.
I've added work arounds below also. https://github.com/integr8ly/integreatly-operator/pull/756 https://github.com/integr8ly/integreatly-operator/pull/776 https://github.com/integr8ly/integreatly-operator/pull/677


### How to Verify (short)
- Deploy 2.2.0 of RHMI via OLM 
- Update RHMIConfig to immediately install upgrades
- Upgrade RHMI to version 2.2.1 via OLM 
- Verify CR updates and Metrics Created
- Upgrade RHMI to version 2.2.2 via OLM 
- Verify CR updates and Metrics Created

**NOTE:** The reason for upgrading twice is:
The first upgrade is from a CR without the new fields to one with the new fields (toVersion, Version). The second upgrade is from a CR with the new fields.
Different parts of the code base are used in these 2 scenarios, hence the need to test both.


### How to Verify (long)

### Install 2.2.0 via OLM (use master branch)
* Change makefile `ORG` to your own quay.io registry
  * https://github.com/integr8ly/integreatly-operator/blob/8eee7ace6c571569d62eddca93cc8d18b2daced6/Makefile#L3
* Build and push RHMI image to your own registry
  * `make image/build/push`
* Replace image in csv with built image
  * https://github.com/integr8ly/integreatly-operator/blob/8eee7ace6c571569d62eddca93cc8d18b2daced6/deploy/olm-catalog/integreatly-operator/integreatly-operator-2.0.0/integreatly-operator.v2.0.0.clusterserviceversion.yaml#L44
  * https://github.com/integr8ly/integreatly-operator/blob/8eee7ace6c571569d62eddca93cc8d18b2daced6/deploy/olm-catalog/integreatly-operator/integreatly-operator-2.0.0/integreatly-operator.v2.0.0.clusterserviceversion.yaml#L273
* Push csv to your registry
  * `make push/csv  REPO=<your_registry> QUAY_USERNAME=<your_registry> QUAY_PASSWORD=<password>`
* After pushing CSV make sure to make the Application Repo in Quay public
* Install operator source with your registry
```
apiVersion: operators.coreos.com/v1
kind: OperatorSource
metadata:
  name: RHMI
  namespace: openshift-marketplace
spec:
  authorizationToken: {}
  displayName: RHMI Operators
  endpoint: 'https://quay.io/cnr'
  publisher: Integreatly Publisher
  registryNamespace: ${REPO}
  type: appregistry
```
* Create operator namespace and setup secrets
  * `make cluster/prepare/project && make cluster/prepare/smtp && make cluster/prepare/dms && make cluster/prepare/pagerduty`
* Install RHMI from operator hub to the `redhat-rhmi-operator` namespace

### Upgrade to 2.2.1 via OLM (use INTLY-7394-expose-upgrade-metrics branch)

**NOTE:** Before starting check if workarounds below required.

Switch branch to INTLY-7394-expose-upgrade-metrics branch
Change the 
* Update versions in version.go to 2.2.1
* Build and push RHMI image to your own registry
  * `make image/build/push TAG=2.2.1 ORG=<yourQuayOrg>`
* Copy and Paste ./deploy/olm-catalog/integreatly-operator/2.2.0 and rename to 2.2.1
  * Rename csv file to 2.2.1
  * Change the following fields in the CSV file:
    * verison to 2.2.1
    * replaces: integreatly-operator.v2.2.0
    * Change 2 quay image references same as above
    * name: integreatly-operator.v2.2.1
* Update integreatly-operator.package.yaml to reference 2.2.1
* Push csv to your registry
  * make push/csv TAG=2.2.1 REPO=<REPO> QUAY_USERNAME=<user> QUAY_PASSWORD=<password>
* After pushing CSV make sure to make the Application Repo in Quay public
* Update the RHMIConfig CR spec.upgrade.alwaysImmediately = true
* Delete the Status Block from the OperatorSource created above to force the operator to check Quay for updates.
* Start watching the RHMI CR at this point
* Check the RHMI operator, after a period of time the new version should be available and start automatically upgrading due to the RHMIConfig CR setting (alwaysImmediately)
* When the upgrade starts the CR should add a new field Status.toVersion: 2.2.1
* After a successful reconcile the CR should have Status.Version: 2.2.1. toVersion will be removed. 
* Verify Prometheus using the API and a command similar to below. Tweak start and end query parameters as appropriate. 
```/api/v1/query_range?query=rhmi_version&start=2020-05-20T05:10:30.781Z&end=2020-05-21T20:11:00.781Z&step=15s```
There should be at least 2 entries in prometheus, one with toVersion: 2.2.1 and the other with Version: 2.2.1 

### Upgrade to 2.2.2 via OLM (use INTLY-7394-expose-upgrade-metrics branch)
* Repeat the previous steps changing values from 2.2.1 to 2.2.2 where appropriate.
* Verify the CR. In this case you should initially see:
  * Status.version: 2.2.1 and Status.toVersion: 2.2.2, then:
  * Status.version: 2.2.0 
* There should be another 2 entries in Prometheus reflecting the CR values.


### PR Workarounds
For 756, **after every install of RHMI delete** the **_rhmi-webhooks_** service in the redhat-rhmi-operator ns. Also, delete **_ValidatingWebhookConfiguration_** and **_MutatingWebhookConfiguration_**
For 776, run: 
`oc policy add-role-to-user admin system:serviceaccount:redhat-rhmi-operator:rhmi-operator
`

