### PR TITLE
Add manifest/check/registries make target

### DIFF
--- a/make/manifest.mk
+++ b/make/manifest.mk
@@ -8,5 +8,11 @@ else
 		@echo "No image_mirror_mapping files found in manifests directory"
 endif
 
+.PHONY: manifest/check/registries
+manifest/check/registries:
+	@! grep "registry.stage.redhat.io" -r manifests/ --include=*clusterserviceversion.{yml,yaml}
+	@! grep "quay.io/integreatly/delorean" -r manifests/ --include=*clusterserviceversion.{yml,yaml}
+	@! grep "registry-proxy.engineering.redhat.com" -r manifests/ --include=*clusterserviceversion.{yml,yaml}
+
 .PHONY: manifest/check
-manifest/check: manifest/check/image_mirror_mapping
+manifest/check: manifest/check/image_mirror_mapping manifest/check/registries


### PR DESCRIPTION
# Description
Add manifest/check/registries target, runs as part of manifest/check command.

Ensure no internal registries are being referenced in any of the manifests.

/cc @wei-lee 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer