### PR TITLE
Expose metrics for the rhmi installation CR

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -55,6 +55,7 @@ func init() {
 	// Register custom metrics with the global prometheus registry
 	customMetrics.Registry.MustRegister(integreatlymetrics.OperatorVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatusAvailable)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIInfo)
 }
 
 func printVersion() {

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
 	github.com/keycloak/keycloak-operator v0.0.0-20200207072807-b527c8b26465
 	github.com/matryer/moq v0.0.0-20200310130814-7721994d1b54
-	github.com/onsi/gomega v1.8.1
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v3.9.0+incompatible
 	github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -13,6 +13,7 @@ import (
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
@@ -93,7 +94,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	}
 	events.HandleStageComplete(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
 
-	logrus.Infof("Bootstrap stage reconciled successfully")
+	metrics.SetRHMIInfo(installation)
+	logrus.Info("Metric rhmi_info exposed")
+
+	logrus.Info("Bootstrap stage reconciled successfully")
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,9 +1,14 @@
 package metrics
 
 import (
+	"fmt"
+	"strings"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/prometheus/client_golang/prometheus"
+	customMetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 )
 
 // Custom metrics
@@ -25,4 +30,107 @@ var (
 			Help: "RHMI status available",
 		},
 	)
+
+	RHMIInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhmi_spec",
+			Help: "RHMI info variables",
+		},
+		[]string{
+			"use_cluster_storage",
+			"master_url",
+			"installation_type",
+			"operator_name",
+			"namespace",
+			"namespace_prefix",
+			"operators_in_product_namespace",
+			"routing_subdomain",
+			"self_signed_certs",
+		},
+	)
+
+	RHMIStatus *prometheus.GaugeVec = nil
+
+	rhmiStatusLabels = []string{
+		"operator_name",
+		"namespace",
+		"last_error",
+		"preflight_message",
+		"preflight_status",
+		"stage",
+	}
 )
+
+// SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
+func SetRHMIInfo(installation *integreatlyv1alpha1.RHMI) {
+	RHMIInfo.WithLabelValues(installation.Spec.UseClusterStorage,
+		installation.Spec.MasterURL,
+		installation.Spec.Type,
+		installation.GetName(),
+		installation.GetNamespace(),
+		installation.Spec.NamespacePrefix,
+		fmt.Sprintf("%t", installation.Spec.OperatorsInProductNamespace),
+		installation.Spec.RoutingSubdomain,
+		fmt.Sprintf("%t", installation.Spec.SelfSignedCerts),
+	)
+}
+
+func SetRHMIStatus(installation *integreatlyv1alpha1.RHMI) {
+
+	isCompleted := float64(0)
+	if installation.Status.Stage == "complete" {
+		isCompleted = float64(1)
+	}
+
+	// creates the metric labels with values
+	labelsWithValue := make(map[string]string, len(rhmiStatusLabels))
+	for _, label := range rhmiStatusLabels {
+		labelsWithValue[label] = ""
+	}
+
+	// sets value from rhmi installation to labels
+	labelsWithValue["operator_name"] = installation.GetName()
+	labelsWithValue["namespace"] = installation.GetNamespace()
+	labelsWithValue["last_error"] = installation.Status.LastError
+	labelsWithValue["preflight_message"] = installation.Status.PreflightMessage
+	labelsWithValue["preflight_status"] = string(installation.Status.PreflightStatus)
+	labelsWithValue["stage"] = string(installation.Status.Stage)
+
+	for _, stage := range installation.Status.Stages {
+		for _, product := range stage.Products {
+			labelsWithValue[SanitizeForPrometheusLabel(product.Name)] = string(product.Status)
+		}
+	}
+
+	if RHMIStatus != nil {
+		RHMIStatus.Reset()
+		RHMIStatus.With(labelsWithValue).Set(isCompleted)
+	}
+}
+
+func ExposeRHMIStatusMetric(stages []integreatlyv1alpha1.RHMIStageStatus) {
+
+	if RHMIStatus == nil {
+		for _, stage := range stages {
+			for _, product := range stage.Products {
+				rhmiStatusLabels = append(rhmiStatusLabels, SanitizeForPrometheusLabel(product.Name))
+			}
+		}
+
+		RHMIStatus = prometheus.NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name: "rhmi_status",
+				Help: "RHMI status for when installation completes",
+			},
+			rhmiStatusLabels,
+		)
+		customMetrics.Registry.MustRegister(RHMIStatus)
+	}
+}
+
+func SanitizeForPrometheusLabel(productName integreatlyv1alpha1.ProductName) string {
+	if productName == integreatlyv1alpha1.Product3Scale {
+		productName = "threescale"
+	}
+	return fmt.Sprintf("%s_status", strings.ReplaceAll(string(productName), "-", "_"))
+}

--- a/test-cases/tests/monitoring/m01-verify-rhmi-cr-metric-exposed.md
+++ b/test-cases/tests/monitoring/m01-verify-rhmi-cr-metric-exposed.md
@@ -1,0 +1,8 @@
+---
+tags:
+  - automated
+---
+
+# M01 - Verify RHMI CR metric exposed
+
+https://github.com/integr8ly/integreatly-operator/blob/master/test/common/rhmicr_metrics.go

--- a/test/common/rhmicr_metrics.go
+++ b/test/common/rhmicr_metrics.go
@@ -1,0 +1,146 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestRHMICRMetrics(t *testing.T, ctx *TestingContext) {
+
+	rhmi, err := getRHMI(ctx.Client)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	rhmiOperatorPod, err := getRHMIOperatorPod(ctx)
+	if err != nil {
+		t.Fatalf("error getting rhmi-operator pod: %v", err)
+	}
+
+	output, err := execToPod("curl --silent localhost:8383/metrics",
+		rhmiOperatorPod.GetName(),
+		RHMIOperatorNamespace,
+		"rhmi-operator",
+		ctx)
+	if err != nil {
+		t.Fatalf("failed to exec to prometheus pod: %w", err)
+	}
+
+	// check if rhmi_status value matches with status.stage
+	isCompleted := 0
+	if string(rhmi.Status.Stage) == "complete" {
+		isCompleted = 1
+	}
+	rhmiStatusMetricValid := regexp.MustCompile(fmt.Sprintf(`rhmi_status{.*} [%v]`, isCompleted))
+	if !rhmiStatusMetricValid.MatchString(output) {
+		t.Fatalf("rhmi_status metric is not present: %w", err)
+	}
+
+	// check if rhmi_status is present
+	rhmiStatusMetricPresent := regexp.MustCompile(`rhmi_status{.*}`)
+	if !rhmiStatusMetricPresent.MatchString(output) {
+		t.Fatalf("rhmi_status metric is not present: %w", err)
+	}
+
+	// check if the metric labels matches rhmi CR
+	stringRHMIStatus := rhmiStatusMetricPresent.FindString(output)
+	labels := parsePrometheusMetricToMap(stringRHMIStatus, "rhmi_status")
+	doRHMIStatusLabelsMatch := true
+	if labels["operator_name"] != rhmi.GetName() ||
+		labels["namespace"] != rhmi.GetNamespace() ||
+		labels["last_error"] != rhmi.Status.LastError ||
+		labels["preflight_message"] != rhmi.Status.PreflightMessage ||
+		labels["preflight_status"] != string(rhmi.Status.PreflightStatus) ||
+		labels["stage"] != string(rhmi.Status.Stage) {
+		doRHMIStatusLabelsMatch = false
+	}
+
+	for _, stage := range rhmi.Status.Stages {
+		for _, product := range stage.Products {
+			productStatus := labels[sanitizeForPrometheusLabel(product.Name)]
+			if productStatus != string(product.Status) {
+				doRHMIStatusLabelsMatch = false
+			}
+		}
+	}
+	if !doRHMIStatusLabelsMatch {
+		t.Fatalf("rhmi_status metric labels do not match with rhmi CR: %w", err)
+	}
+
+	// check if rhmi_info is present
+	rhmiInfoMetricPresent := regexp.MustCompile(`rhmi_spec{.*}`)
+	if !rhmiInfoMetricPresent.MatchString(output) {
+		t.Fatalf("rhmi_spec metric is not present: %w", err)
+	}
+
+	// check if rhmi_info metric labels matches with rhmi installation CR
+	stringRHMIInfo := rhmiInfoMetricPresent.FindString(output)
+	rhmiInfoLabels := parsePrometheusMetricToMap(stringRHMIInfo, "rhmi_spec")
+
+	doRHMIInfoLabelsMatch := true
+	if rhmiInfoLabels["use_cluster_storage"] != rhmi.Spec.UseClusterStorage ||
+		rhmiInfoLabels["master_url"] != rhmi.Spec.MasterURL ||
+		rhmiInfoLabels["installation_type"] != rhmi.Spec.Type ||
+		rhmiInfoLabels["operator_name"] != rhmi.GetName() ||
+		rhmiInfoLabels["namespace"] != rhmi.GetNamespace() ||
+		rhmiInfoLabels["namespace_prefix"] != rhmi.Spec.NamespacePrefix ||
+		rhmiInfoLabels["operators_in_product_namespace"] != fmt.Sprintf("%t", rhmi.Spec.OperatorsInProductNamespace) ||
+		rhmiInfoLabels["routing_subdomain"] != rhmi.Spec.RoutingSubdomain ||
+		rhmiInfoLabels["self_signed_certs"] != fmt.Sprintf("%t", rhmi.Spec.SelfSignedCerts) {
+		doRHMIInfoLabelsMatch = false
+	}
+	if !doRHMIInfoLabelsMatch {
+		t.Fatalf("rhmi_info metric labels do not match with rhmi CR: %w", err)
+	}
+}
+
+func getRHMIOperatorPod(ctx *TestingContext) (*corev1.Pod, error) {
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"name": "rhmi-operator",
+		}),
+		k8sclient.InNamespace(RHMIOperatorNamespace),
+	}
+
+	rhmiOperatorPod := &corev1.PodList{}
+
+	err := ctx.Client.List(goctx.TODO(), rhmiOperatorPod, listOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("error listing rhmi-operator pod: %v", err)
+	}
+
+	if len(rhmiOperatorPod.Items) < 0 {
+		return nil, fmt.Errorf("rhmi-operator pod doesn't exist: %v", err)
+	}
+
+	return &rhmiOperatorPod.Items[0], nil
+}
+
+func parsePrometheusMetricToMap(metric, metricName string) map[string]string {
+	// remove unwanted part of the string
+	metric = strings.ReplaceAll(metric, fmt.Sprintf("%s{", metricName), "")
+	metric = strings.ReplaceAll(metric, "}", "")
+
+	labelsWithValue := strings.Split(metric, ",")
+	parsedStrings := map[string]string{}
+	for _, labelAndValue := range labelsWithValue {
+		value := strings.Split(labelAndValue, "=")
+		parsedStrings[value[0]] = strings.ReplaceAll(value[1], "\"", "")
+	}
+	return parsedStrings
+}
+
+func sanitizeForPrometheusLabel(productName integreatlyv1alpha1.ProductName) string {
+	if productName == integreatlyv1alpha1.Product3Scale {
+		productName = "threescale"
+	}
+	return fmt.Sprintf("%s_status", strings.ReplaceAll(string(productName), "-", "_"))
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -44,6 +44,7 @@ var (
 		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
 		{"A06 - Verify PVC", TestPVClaims},
 		{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
+		{"Test RHMI installation CR metric", TestRHMICRMetrics},
 	}
 
 	DESTRUCTIVE_TESTS = []TestCase{


### PR DESCRIPTION
# Description
Exposes two metrics for the RHMI installation CR

rhmi_status and rhmi_info 

https://issues.redhat.com/browse/INTLY-6667

## Verification steps

1) Install operator via OLM
2) Go to the rhmi-operator pod
3) In the terminal tab curl the metric endpoint to verify if metrics are present 
- `curl 0.0.0.0:8383/metrics | grep rhmi_status{` 
-  `curl 0.0.0.0:8383/metrics | grep rhmi_info{`

4) Check if metrics have all the labels created and if their values match with installation CR
```
rhmi_info{installation_type="", master_url="", namespace="", operator_name="", use_cluster_storage=""}
rhmi_status{namespace="", last_error="", operator_name="", preflight_message="", preflight_status="", stage="", <product_name>-status="" ...}
```
5) Go to redhat-rhmi-middleware-monitoring-operator namespace 
6) Access Prometheus and verify if rhmi_status and rhmi_info are available  





## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer