### PR TITLE
update keycloak metrics spi to 2.0.0

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -436,7 +436,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.0/keycloak-metrics-spi-2.0.0.jar",
 			"https://github.com/integr8ly/authentication-delay-plugin/releases/download/1.0.1/authdelay.jar",
 		}
 		kc.Labels = GetInstanceLabels()

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -296,7 +296,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		owner.AddIntegreatlyOwnerAnnotations(kc, installation)
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/1.0.4/keycloak-metrics-spi-1.0.4.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.0/keycloak-metrics-spi-2.0.0.jar",
 		}
 		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Labels = getMasterLabels()


### PR DESCRIPTION
Update the keycloak metrics spi to 2.0.0 to fix an issue where the metrics endpoint can return a huge amount of data when there are many users in the keycloak instance.

This happened because the request_duration metric was recorded for every endpoint and there is an endpoint for every user. With thousands of users the amount of metrics data can slow down Prometheus and cause congestion.

In 2.0.0 we do no longer record the route for request durations. You still get the metric but no longer broken down by route.