### PR TITLE
INTLY-7932 - fix + re-enable AuthService test causing enmasse operator crash & test flake

### DIFF
--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -114,7 +114,7 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	verifyDedicatedAdminAddressPlanPermissions(t, openshiftClient)
 
 	// Verify dedicated admin permissions around AuthenticationService
-	//verifyDedicatedAdminAuthenticationServicePermissions(t, openshiftClient) - comment out due to causing e2e flake https://issues.redhat.com/browse/INTLY-7932
+	verifyDedicatedAdminAuthenticationServicePermissions(t, openshiftClient)
 
 	// Verify dedicated admin Role / Role binding for AMQ Online resources
 	verifyDedicatedAdminAMQOnlineRolePermissions(t, ctx)
@@ -394,6 +394,14 @@ func verifyDedicatedAdminAuthenticationServicePermissions(t *testing.T, openshif
 			},
 			Spec: enmasseadminv1beta1.AuthenticationServiceSpec{
 				Type: enmasseadminv1beta1.External,
+				External: &enmasseadminv1beta1.AuthenticationServiceSpecExternal{
+					Host: "test",
+					Port: 0,
+				},
+			},
+			Status: enmasseadminv1beta1.AuthenticationServiceStatus{
+				Host:  "test",
+				Phase: enmasseadminv1beta1.AuthenticationServiceActive,
 			},
 		},
 	}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

The `verifyDedicatedAdminAuthenticationServicePermissions` test previously caused the enmasse operator to crash and subsequently sometimes fail the deployment replica check as it might not have recovered causing flakiness in the e2e tests.

The crash was due to the `AuthenticationService` spec was empty, so this was added to the test. In addition a status was also added to hopefully prevent `409` conflict that may occur when the enmasse operator reconciles the CR in the `Update` part of the test ([relevant comment in previous PR](https://github.com/integr8ly/integreatly-operator/pull/699#issuecomment-629186926)).

Jira:
* https://issues.redhat.com/browse/INTLY-7932
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [ ] Verified independently on a cluster by reviewer