### PR TITLE
DEL-292 - GrafanaDashboard Upgrade Visulisation

### DIFF
--- a/templates/monitoring/cluster-resources.yaml
+++ b/templates/monitoring/cluster-resources.yaml
@@ -9,7 +9,35 @@ spec:
   name: cluster-resources-new.json
   json: >
     {
-      "annotations": {},
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
+          }
+        ]
+      },
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
@@ -3201,5 +3229,5 @@ spec:
       },
       "timezone": "",
       "title": "Resource Usage for Cluster",
-      "version": 8
+      "version": 9
     }

--- a/templates/monitoring/endpointsdetailed.yaml
+++ b/templates/monitoring/endpointsdetailed.yaml
@@ -12,7 +12,7 @@ spec:
   json: |
     {
       "annotations": {
-        "list": [
+         "list": [
           {
             "builtIn": 1,
             "datasource": "-- Grafana --",
@@ -21,6 +21,22 @@ spec:
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
           }
         ]
       },
@@ -1302,6 +1318,6 @@ spec:
       "timezone": "",
       "title": "Endpoints Detailed",
       "uid": "xtkCtBkiz2",
-      "version": 13
+      "version": 14
     }
   name: endpointsdetailed.json

--- a/templates/monitoring/endpointsreport.yaml
+++ b/templates/monitoring/endpointsreport.yaml
@@ -9,8 +9,8 @@ spec:
   json: |
     {
         "annotations": {
-        "list": [
-            {
+         "list": [
+          {
             "builtIn": 1,
             "datasource": "-- Grafana --",
             "enable": true,
@@ -18,7 +18,23 @@ spec:
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
-            }
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
+          }
         ]
         },
         "editable": true,
@@ -1691,7 +1707,7 @@ spec:
         },
         "timezone": "",
         "title": "Endpoints Report",
-        "version": 18
+        "version": 19
     }
 
   name: endpointsreport.json

--- a/templates/monitoring/endpointssummary.yaml
+++ b/templates/monitoring/endpointssummary.yaml
@@ -9,8 +9,8 @@ spec:
   json: |
     {
         "annotations": {
-        "list": [
-            {
+         "list": [
+          {
             "builtIn": 1,
             "datasource": "-- Grafana --",
             "enable": true,
@@ -18,7 +18,23 @@ spec:
             "iconColor": "rgba(0, 211, 255, 1)",
             "name": "Annotations & Alerts",
             "type": "dashboard"
-            }
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
+          }
         ]
         },
         "editable": true,
@@ -398,6 +414,6 @@ spec:
         "timezone": "",
         "title": "Endpoints Summary",
         "uid": "hZJ_054Zk",
-        "version": 4
+        "version": 5
     }
   name: endpointssummary.json

--- a/templates/monitoring/resources-by-namespace.yaml
+++ b/templates/monitoring/resources-by-namespace.yaml
@@ -9,7 +9,35 @@ spec:
   name: resources-by-namespace.json
   json: >
     {
-      "annotations": {},
+      "annotations": {
+         "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
+          }
+        ]
+      },
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
@@ -773,5 +801,5 @@ spec:
       "timezone": "",
       "uid": "a9ce5290ba1d485ca67e05c0a63aa2d8",
       "title": "Resource Usage By Namespace",
-      "version": 1
+      "version": 2
     }

--- a/templates/monitoring/resources-by-pod.yaml
+++ b/templates/monitoring/resources-by-pod.yaml
@@ -9,7 +9,35 @@ spec:
   name: resources-by-pod.json
   json: >
     {
-      "annotations": {},
+      "annotations": {
+         "list": [
+          {
+            "builtIn": 1,
+            "datasource": "-- Grafana --",
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          },
+          {
+            "datasource": "Prometheus",
+            "enable": true,
+            "expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+            "hide": false,
+            "iconColor": "#FADE2A",
+            "limit": 100,
+            "name": "Upgrade",
+            "showIn": 0,
+            "step": "",
+            "tagKeys": "stage,version,to_version",
+            "tags": "",
+            "titleFormat": "Upgrade",
+            "type": "tags",
+            "useValueForTime": false
+          }
+        ]
+      },
       "editable": true,
       "gnetId": null,
       "graphTooltip": 0,
@@ -820,5 +848,5 @@ spec:
       "timezone": "",
       "title": "Resource Usage By Pod",
       "uid": "c84ae905b9f54268be6be82c9a5b7dd6",
-      "version": 1
+      "version": 2
     }


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/DEL-292

Depends on https://github.com/integr8ly/integreatly-operator/pull/798

# Description
Change to GrafanaDashboard json to add annotations which show upgrade data based on the pr above.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification

I've deployed this to a cluster using image quay.io/laurafitzgerald/integreatly-operator:v2.3.4

You can see Dashboards  [here](https://grafana-route-redhat-rhmi-middleware-monitoring-operator.apps.lfitzger.h1a9.s1.devshift.org/d/c84ae905b9f54268be6be82c9a5b7dd6/resource-usage-by-pod?orgId=1&refresh=10s&from=now-6h&to=now) - contact me for creds

You should see the tags as well if you hover on the annotations.
![Screenshot 2020-06-02 at 16 29 06](https://user-images.githubusercontent.com/6498727/83538903-4846e980-a4ee-11ea-9cf7-5baf982cae91.png)


Note: upgrade verification depends on Upgrade Depends on https://issues.redhat.com/browse/INTLY-6831

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer