### PR TITLE
INTLY-7435 - e2e test verify 3Scale user promotion does not revert

### DIFF
--- a/test-cases/tests/products/h07-verify-3scale-user-promotion-works-and-stays-permanent.md
+++ b/test-cases/tests/products/h07-verify-3scale-user-promotion-works-and-stays-permanent.md
@@ -1,35 +1,14 @@
 ---
-automation:
-  - INTLY-7435
 components:
   - product-3scale
 environments:
   - osd-post-upgrade
-estimate: 1h
 targets:
   - 2.8.0
+tags:
+  - automated
 ---
 
 # H07 - Verify 3scale User Promotion Works and Stays Permanent
 
-## Prerequisites
-
-Login to OpenShift console as a **kubeadmin** (user with cluster-admin permissions).
-In different window, login as a user from the **developer** group.
-In another window, login as a user from the **dedicated-admin** group.
-
-## Steps
-
-1. As a **dedicated-admin** user, go to Projects -> redhat-rhmi-3scale
-2. Select Networking -> Routes
-3. Go to 3scale API Management console (route is starting with "https://3scale-admin")
-4. Select "Authenticate through Red Hat Single Sign-On" and login as a user with **dedicated-admin** permissions
-5. Select Account Settings (Top right corner) and select Users -> Listing
-6. Select a user from the **developer** group (the one you've previously logged in)
-7. Under Administrative, select Admin and hit "Update User"
-   > The **developer** user you've changed should have "admin" role now (see the users table),
-8. Try to login to 3scale API Management console as a **developer** user you previously promoted
-   > You should successfully log in and have "admin" permissions: go to Account Settings (Top right corner) and you should be able to see "Users" menu in left column)
-9. Force reconcile rhmi-operator (by scaling it down & up): As a **kubeadmin**, go to Projects -> redhat-rhmi-operator -> Workloads -> Deployments -> rhmi-operator and hit the "down arrow" and "up arrow" to scale it down and up
-10. Try to login again to 3scale API Management console as a user from **developer** group
-    > You should still be able to log in and still have "admin" permissions
+https://github.com/integr8ly/integreatly-operator/blob/master/test/common/3Scale_user_promotion.go

--- a/test/common/3Scale_user_promotion.go
+++ b/test/common/3Scale_user_promotion.go
@@ -1,0 +1,101 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"testing"
+	"time"
+)
+
+func Test3ScaleUserPromotion(t *testing.T, ctx *TestingContext) {
+
+	var (
+		developerUser      = fmt.Sprintf("%v-%d", DefaultTestUserName, 0)
+		dedicatedAdminUser = fmt.Sprintf("%v-%d", defaultDedicatedAdminName, 0)
+	)
+
+	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// get console master url
+	rhmi, err := getRHMI(ctx.Client)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Get the 3Scale host url from the rhmi status
+	host := rhmi.Status.Stages[v1alpha1.ProductsStage].Products[v1alpha1.Product3Scale].Host
+
+	if host == "" {
+		t.Fatalf("Failed to retrieve 3scale host from RHMI CR: %v", rhmi)
+	}
+
+	keycloakHost := rhmi.Status.Stages[v1alpha1.AuthenticationStage].Products[v1alpha1.ProductRHSSO].Host
+
+	if keycloakHost == "" {
+		t.Fatalf("Failed to retrieve keycloak host from RHMI CR: %v", rhmi)
+	}
+
+	redirectUrl := fmt.Sprintf("%v/p/admin/dashboard", host)
+
+	loginTo3ScaleAsDeveloper(t, developerUser, host, ctx)
+
+	err = loginToThreeScale(t, host, dedicatedAdminUser, DefaultPassword, TestingIDPRealm, ctx.HttpClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, ctx.HttpClient, ctx.Client, t)
+
+	// Make sure 3Scale is available
+	err = tsClient.Ping()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	userId, err := tsClient.GetUserId(developerUser)
+	if err != nil || userId == "" {
+		t.Fatal("Failed to retrieve user id for ", developerUser, "userId: ", userId, err)
+	}
+
+	err = tsClient.SetUserAsAdmin(developerUser, fmt.Sprintf("%v@example.com", developerUser), userId)
+	if err != nil {
+		t.Fatal("Failed to set user as admin ", err)
+	}
+
+	// TODO: Waiting an arbitrary amount of time to verify that a 3Scale reconcile was complete
+	// and did not result in reverting the promotion of test-user to admin
+	// Change this when https://issues.redhat.com/browse/INTLY-7770 implemented
+	_ = wait.Poll(time.Second*350, time.Minute*7, func() (done bool, err error) {
+
+		isAdmin, err := tsClient.VerifyUserIsAdmin(userId)
+		if err != nil {
+			t.Fatal("Error attempting to verify that the user is an admin ", err)
+		}
+		if !isAdmin {
+			t.Fatal("User reverted from admin back to member")
+		}
+
+		return true, nil
+	})
+
+}
+
+// Login as a developer and create a separate HTTP client. This will mimic what would happen in reality
+// i.e. 2 users using separate browsers.
+func loginTo3ScaleAsDeveloper(t *testing.T, user string, host string, ctx *TestingContext) {
+
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = loginToThreeScale(t, host, user, DefaultPassword, TestingIDPRealm, httpClient)
+	if err != nil {
+		t.Fatalf("Failed to log into 3Scale: %v", err)
+	}
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -43,6 +43,7 @@ var (
 		{"A09 - Verify Subscription Install Plan Strategy", TestSubscriptionInstallPlanType},
 		{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
 		{"A16 - Custom first broker login flow", TestAuthDelayFirstBrokerLogin},
+		{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
 		{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},
 		{"F06 - Verify Replicas Scale correctly in Apicurito", TestReplicasInApicurito},
 		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Rebased off from https://github.com/integr8ly/integreatly-operator/pull/717

Automated e2e test for user promotion in 3scale does not get reverted by the operator

Jira:
* https://issues.redhat.com/browse/INTLY-7435

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Test Automation

## Checklist
- [ ] Verified independently on a cluster by reviewer