### PR TITLE
INTLY-7949 - update default operator group name in template

### DIFF
--- a/deploy/operator-subscription-template.yml
+++ b/deploy/operator-subscription-template.yml
@@ -39,7 +39,7 @@ parameters:
   - description: The name of the operator group
     displayName: Operator Group Name
     name: OPERATOR_GROUP_NAME
-    value: rhmi-operator
+    value: rhmi-registry-og
   - description: The name of the subscription
     displayName: Subscription Name
     name: SUBSCRIPTION_NAME


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Role aggregation occurs for dedicated admins when operator is installed via OLM. Because we are not using an Operator group name ignored in staging/production in the upgrade pipeline, dedicated admins would have full access to RHMI CRs and so would fail these specific e2e tests.

* https://issues.redhat.com/browse/OSD-3636?focusedCommentId=14090821&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14090821

This update would use `rhmi-registry-og` as the default operator group name in the template

Jira:
* https://issues.redhat.com/browse/INTLY-7949

Assicated Pipeline PR:
* https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/merge_requests/163

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer