### PR TITLE
Remove fuse pod count check from user permissions test.

### DIFF
--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -18,7 +18,6 @@ import (
 
 const (
 	expectedRhmiDeveloperProjectCount = 1
-	expectedFusePodCount              = 6
 )
 
 // struct used to create query string for fuse logs endpoint
@@ -66,17 +65,6 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	podlist, err := openshiftClient.ListPods(fuseNamespace)
 	if err != nil {
 		t.Fatalf("error occured while getting pods : %v", err)
-	}
-
-	// check if six pods are running
-	runningCount := 0
-	for _, p := range podlist.Items {
-		if p.Status.Phase == "Running" {
-			runningCount++
-		}
-	}
-	if runningCount != expectedFusePodCount {
-		t.Fatalf("test-failed - expected fuse pod count : %d found fuse pod count: %d", expectedFusePodCount, runningCount)
 	}
 
 	// log through rhmi developer fuse podlist


### PR DESCRIPTION
# Description
This check:
a) doesn't provide much value considering all other tests that check Fuse status
b) fails if there are any deployed integrations


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)