### PR TITLE
Pending alerts should not be created before RDS/Elasticache are created

### DIFF
--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -196,19 +196,21 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres: %w", err)
 	}
-	// cr returning a failed state
+
+	// create prometheus failed rule
 	_, err = resources.CreatePostgresResourceStatusPhaseFailedAlert(ctx, serverClient, r.installation, postgres)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider: %w", err)
-	}
-	// cr stuck in a pending state for greater that 5 min
-	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, postgres)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider stuck in a pending state: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres failure alert: %w", err)
 	}
 
 	if postgres.Status.Phase != cro1types.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	// create the prometheus pending rule
+	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, postgres)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres pending alert: %w", err)
 	}
 
 	// create the prometheus availability rule

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -280,20 +280,21 @@ func (r *Reconciler) reconcileCloudResources(ctx context.Context, rhmi *integrea
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres instance for fuse: %w", err)
 	}
 
-	// cr returning a failed state
+	// create prometheus failed rule
 	_, err = resources.CreatePostgresResourceStatusPhaseFailedAlert(ctx, client, rhmi, postgres)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider: %w", err)
-	}
-	// cr stuck in a pending state for greater that 5 min
-	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, client, rhmi, postgres)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider stuck in a pending state: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres failure alert: %w", err)
 	}
 
 	// postgres provisioning is still in progress
 	if postgres.Status.Phase != croTypes.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingCloudResources, nil
+	}
+
+	// create prometheus pending rule
+	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, client, rhmi, postgres)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres pending alert: %w", err)
 	}
 
 	// create the prometheus availability rule

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"strings"
 
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
@@ -271,17 +272,20 @@ func (r *Reconciler) reconcileCloudResources(ctx context.Context, installation *
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile database credentials secret while provisioning user sso: %w", err)
 	}
 
-	// create prometheus failed rule
-	_, err = resources.CreatePostgresResourceStatusPhaseFailedAlert(ctx, serverClient, installation, postgres)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres failure alert: %w", err)
-	}
-
+	// at this point it should be ok to create the failed alert.
 	if postgres != nil {
-		// create prometheus pending rule
-		_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, installation, postgres)
+		// create prometheus failed rule
+		_, err = resources.CreatePostgresResourceStatusPhaseFailedAlert(ctx, serverClient, installation, postgres)
 		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres pending alert: %w", err)
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres failure alert: %w", err)
+		}
+
+		// create prometheus pending rule only when CR has completed for the first time.
+		if postgres.Status.Phase == types.PhaseComplete {
+			_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, installation, postgres)
+			if err != nil {
+				return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres pending alert: %w", err)
+			}
 		}
 	}
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -3,9 +3,10 @@ package threescale
 import (
 	"context"
 	"fmt"
-	rbacv1 "k8s.io/api/rbac/v1"
 	"net/http"
 	"strings"
+
+	rbacv1 "k8s.io/api/rbac/v1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -648,17 +649,18 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	// redis cr returning a failed state
 	_, err = resources.CreateRedisResourceStatusPhaseFailedAlert(ctx, serverClient, r.installation, backendRedis)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create backend-redis resource on provider: %w", err)
-	}
-	// redis cr stuck in a pending state for greater that 5 min
-	_, err = resources.CreateRedisResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, backendRedis)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create backend-redis resource on provider stuck in a pending state: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create redis failure alert: %w", err)
 	}
 
 	// wait for the backend redis cr to reconcile
 	if backendRedis.Status.Phase != types.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	// create prometheus pending rule
+	_, err = resources.CreateRedisResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, backendRedis)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create redis pending alert: %w", err)
 	}
 
 	// create the prometheus availability rule
@@ -697,20 +699,21 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create or update 3scale %s connection secret: %w", externalBackendRedisSecretName, err)
 	}
 
-	// cr returning a failed state
+	// create prometheus failure rule
 	_, err = resources.CreateRedisResourceStatusPhaseFailedAlert(ctx, serverClient, r.installation, systemRedis)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create system-redis resource on provider: %w", err)
-	}
-	// cr stuck in a pending state for greater that 5 min
-	_, err = resources.CreateRedisResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, systemRedis)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create system-redis resource on provider stuck in a pending state: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create system redis failure alert: %w", err)
 	}
 
 	// wait for the system redis cr to reconcile
 	if systemRedis.Status.Phase != types.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	// create prometheus pending rule
+	_, err = resources.CreateRedisResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, systemRedis)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create system redis pending alert: %w", err)
 	}
 
 	// create the prometheus availability rule
@@ -755,17 +758,18 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	// cr returning a failed state
 	_, err = resources.CreatePostgresResourceStatusPhaseFailedAlert(ctx, serverClient, r.installation, postgres)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider: %w", err)
-	}
-	// cr stuck in a pending state for greater that 5 min
-	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, postgres)
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to create postgres resource on provider stuck in a pending state: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres failure alert: %w", err)
 	}
 
 	// wait for the postgres cr to reconcile
 	if postgres.Status.Phase != types.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	// create prometheus pending rule
+	_, err = resources.CreatePostgresResourceStatusPhasePendingAlert(ctx, serverClient, r.installation, postgres)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create postgres pending alert: %w", err)
 	}
 
 	// create the prometheus availability rule

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	alertFor10Mins = "10m"
+	alertFor20Mins = "20m"
 	alertFor5Mins  = "5m"
 )
 
@@ -96,13 +96,13 @@ func CreatePostgresResourceStatusPhasePendingAlert(ctx context.Context, client k
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 1)",
 			croResources.DefaultPostgresStatusMetricName, cr.Namespace, cr.Name, productName),
 	)
-	alertDescription := fmt.Sprintf("The creation of the Postgres instance has take longer that %s. Postgres Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor10Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
+	alertDescription := fmt.Sprintf("The creation of the Postgres instance has take longer that %s. Postgres Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor20Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
 	labels := map[string]string{
 		"severity":    "warning",
 		"productName": productName,
 	}
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresResourceStatusPhasePending, alertFor10Mins, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresResourceStatusPhasePending, alertFor20Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}
@@ -150,13 +150,13 @@ func CreateRedisResourceStatusPhasePendingAlert(ctx context.Context, client k8sc
 		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 1)",
 			croResources.DefaultRedisStatusMetricName, cr.Namespace, cr.Name, productName),
 	)
-	alertDescription := fmt.Sprintf("The creation of the Redis cache has take longer that %s. Redis Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor10Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
+	alertDescription := fmt.Sprintf("The creation of the Redis cache has take longer that %s. Redis Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor20Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
 	labels := map[string]string{
 		"severity":    "warning",
 		"productName": productName,
 	}
 	// create the rule
-	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisResourceStatusPhasePending, alertFor10Mins, alertExp, labels)
+	pr, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisResourceStatusPhasePending, alertFor20Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/resources/rhsso.go
+++ b/pkg/resources/rhsso.go
@@ -39,7 +39,7 @@ func ReconcileRHSSOPostgresCredentials(ctx context.Context, installation *integr
 		return nil, nil, fmt.Errorf("failed to provision postgres instance while reconciling rhsso postgres credentials, %s: %w", name, err)
 	}
 	if postgres.Status.Phase != types.PhaseComplete {
-		return nil, nil, nil
+		return postgres, nil, nil
 	}
 	postgresSec := &corev1.Secret{}
 	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: postgres.Status.SecretRef.Name, Namespace: postgres.Status.SecretRef.Namespace}, postgresSec)

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -6,8 +6,8 @@ const (
 	sopUrlPostgresConnectionFailed           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_connection_failed.asciidoc"
 	sopUrlRedisCacheUnavailable              = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_cache_unavailable.asciidoc"
 	sopUrlRedisConnectionFailed              = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_connection_failed.asciidoc"
-	sopUrlPostgresResourceStatusPhasePending = ""
+	sopUrlPostgresResourceStatusPhasePending = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_resource_status_phase_pending.asciidoc"
 	sopUrlPostgresResourceStatusPhaseFailed  = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/postgres_resource_status_phase_failed.asciidoc"
-	sopUrlRedisResourceStatusPhasePending    = ""
+	sopUrlRedisResourceStatusPhasePending    = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_resource_status_phase_pending.asciidoc"
 	sopUrlRedisResourceStatusPhaseFailed     = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/redis_resource_status_phase_failed.asciidoc"
 )


### PR DESCRIPTION
# Description
Jira: https://issues.redhat.com/browse/INTLY-8116

The creation of status phase alert pending check should be moved to after the CR phase is complete. We know that the resource will be pending until then, but do not know how long it'll last.

The pending check time should also be extended to 10 minutes.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer