### PR TITLE
fix backup maintenance window overlap check

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -299,7 +299,7 @@ func ValidateBackupAndMaintenance(backupApplyOn, maintenanceApplyFrom string) (s
 // timeBlockOverlaps checks if two time ranges overlap and returns true
 // if they do
 func timeBlockOverlaps(startA, endA, startB, endB time.Time) bool {
-	return startA.Before(endB) && endA.After(startB)
+	return startA.Unix() <= endB.Unix() && endA.Unix() >= startB.Unix()
 }
 
 func contains(s []string, e string) bool {

--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types_test.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types_test.go
@@ -1,0 +1,67 @@
+package v1alpha1
+
+import "testing"
+
+func TestValidateBackupAndMaintenance(t *testing.T) {
+	type args struct {
+		backupApplyOn        string
+		maintenanceApplyFrom string
+	}
+	tests := []struct {
+		name            string
+		args            args
+		wantBackup      string
+		wantMaintenance string
+		wantErr         bool
+	}{
+		{
+			name: "test exact overlapping window fails",
+			args: args{
+				backupApplyOn:        "01:00",
+				maintenanceApplyFrom: "mon 02:00",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test overlapping window fails",
+			args: args{
+				backupApplyOn:        "01:30",
+				maintenanceApplyFrom: "mon 01:00",
+			},
+			wantErr: true,
+		},
+		{
+			name: "test non-overlapping window succeeds with backup before maintenance",
+			args: args{
+				backupApplyOn:        "01:00",
+				maintenanceApplyFrom: "mon 02:01",
+			},
+			wantBackup:      "01:00",
+			wantMaintenance: "mon 02:01",
+		},
+		{
+			name: "test non-overlapping window succeeds with backup after maintenance",
+			args: args{
+				backupApplyOn:        "01:31",
+				maintenanceApplyFrom: "mon 00:30",
+			},
+			wantBackup:      "01:31",
+			wantMaintenance: "mon 00:30",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBackup, gotMaintenance, err := ValidateBackupAndMaintenance(tt.args.backupApplyOn, tt.args.maintenanceApplyFrom)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBackupAndMaintenance() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotBackup != tt.wantBackup {
+				t.Errorf("ValidateBackupAndMaintenance() got = %v, want %v", gotBackup, tt.wantBackup)
+			}
+			if gotMaintenance != tt.wantMaintenance {
+				t.Errorf("ValidateBackupAndMaintenance() got1 = %v, want %v", gotMaintenance, tt.wantMaintenance)
+			}
+		})
+	}
+}


### PR DESCRIPTION
currently the backup and maintenance windows are allowed to end
and start on the same minute. this is not permitted by the cloud
resource operator and validation on the rhmi operator side should
fail.

verification:
- run the operator on-cluster to ensure webhooks work as expected
- update rhmiconfig '.spec.backup.applyOn' to '01:00' and
  '.spec.maintenance.applyFrom' to '02:00' and ensure an error is
  returned by openshift through the validation webhook.
- update rhmiconfig '.spec.backup.applyOn' to '01:00' and
  '.spec.maintenance.applyFrom' to '02:01' and ensure no error is
  returned by openshift through the validation webhook
- update rhmiconfig '.spec.backup.applyOn' to '03:00' and
  '.spec.maintenance.applyFrom' to '02:00' and ensure an error is
  returned by openshift through the validation webhook.
- update rhmiconfig '.spec.backup.applyOn' to '03:01' and
  '.spec.maintenance.applyFrom' to '02:00' and ensure no error is
  returned by openshift through the validation webhook