### PR TITLE
Restore code accidentally deleted in #795

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -209,7 +209,7 @@ func (h *rhmiConfigMutatingHandler) Handle(ctx context.Context, request admissio
 		rhmiConfig.Annotations["lastEditUsername"] = request.UserInfo.Username
 		rhmiConfig.Annotations["lastEditTimestamp"] = time.Now().UTC().Format(DateFormat)
 	}
-	
+
 	if rhmiConfig.Spec.Maintenance.ApplyFrom == "" {
 		rhmiConfig.Spec.Maintenance.ApplyFrom = DefaultMaintenanceApplyFrom
 	}

--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -209,6 +209,13 @@ func (h *rhmiConfigMutatingHandler) Handle(ctx context.Context, request admissio
 		rhmiConfig.Annotations["lastEditUsername"] = request.UserInfo.Username
 		rhmiConfig.Annotations["lastEditTimestamp"] = time.Now().UTC().Format(DateFormat)
 	}
+	
+	if rhmiConfig.Spec.Maintenance.ApplyFrom == "" {
+		rhmiConfig.Spec.Maintenance.ApplyFrom = DefaultMaintenanceApplyFrom
+	}
+	if rhmiConfig.Spec.Backup.ApplyOn == "" {
+		rhmiConfig.Spec.Backup.ApplyOn = DefaultBackupApplyOn
+	}
 
 	marshalled, err := json.Marshal(rhmiConfig)
 	if err != nil {


### PR DESCRIPTION
# Description
Restoring code that was deleted in[1] commit of #795 
It was deleted because GH was showing incorrect diff on PR that was not rebased.

https://github.com/integr8ly/integreatly-operator/pull/795/commits/727c92206ac3fcb1ed222ae1f9a98db620d65a18#diff-13000454a7f0fc659c7c887cb6a0b140

This code has been part of RC1, and I would like to merge it before RC2, so there will not be any impact on testing.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)