### PR TITLE
Updating steps for k03 - RHSSO performance test case

### DIFF
--- a/test-cases/tests/installation/a21-verify-maintenance-and-backup-windows.md
+++ b/test-cases/tests/installation/a21-verify-maintenance-and-backup-windows.md
@@ -1,18 +1,21 @@
 ---
 targets:
-- 2.3.0
+  - 2.3.0
 tags:
   - automated
 ---
 
 # A21 - Verify maintenance and backup windows
 
-## Automated 
+## Automated
+
 https://github.com/integr8ly/integreatly-operator/blob/master/test/common/rhmi_config_cro_strategy_override.go
 https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/aws_strategy_override.go
 
-## Manual 
+## Manual
+
 ### AWS Infrastructure Steps
+
 The following steps are valid for a cluster provisioned in AWS backed by AWS RDS, Elasticache and S3 resources
 
 1. After RHMI has installed, check for `cloud-resources-aws-strategies` config map in RHMI operator ns

--- a/test-cases/tests/installation/a22-verify-rhmiconfig-maintenance-and-backup-validation.md
+++ b/test-cases/tests/installation/a22-verify-rhmiconfig-maintenance-and-backup-validation.md
@@ -1,6 +1,6 @@
 ---
 targets:
-- 2.3.0
+  - 2.3.0
 tags:
   - automated
 ---
@@ -10,9 +10,11 @@ tags:
 This test is to verify that the RHMIConfig validation webhook for maintenance and backup values works as expected.
 
 ## Automated Test
+
 https://github.com/integr8ly/integreatly-operator/blob/master/test/common/rhmi_config.go
 
 ## Manual Test
+
 The expected value formats are:
 
 ```

--- a/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
+++ b/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
@@ -11,16 +11,17 @@ Note: this test should only be performed at a time it will not affect other ongo
 You should have an AWS IAM account in [QE-AWS account](https://068334777414.signin.aws.amazon.com/console)
 
 ## Steps
+
 1. Get access to ec2 instance to run tests
-   -  Option 1 - Use existing ec2 instance:
-      1. Contact Stephin Thomas for details on accessing this ec2 instance
-   -  Option 2 - Create new ec2 instance:
-      1. Login into [QE-AWS account](https://068334777414.signin.aws.amazon.com/console) using your AWS IAM account credentials and select the region to **London**.
-      2. Create a new **t2.small** ec2 instance from the sso-load-testing AMI. Set the Auto-assign public IP to Enable and select Network as **sso-load-test-vpc** and subnet as **sso-load-test-subnet**. Configure security group to SSH with "myIP".
+   - Option 1 - Use existing ec2 instance:
+     1. Contact Stephin Thomas for details on accessing this ec2 instance
+   - Option 2 - Create new ec2 instance:
+     1. Login into [QE-AWS account](https://068334777414.signin.aws.amazon.com/console) using your AWS IAM account credentials and select the region to **London**.
+     2. Create a new **t2.small** ec2 instance from the sso-load-testing AMI. Set the Auto-assign public IP to Enable and select Network as **sso-load-test-vpc** and subnet as **sso-load-test-subnet**. Configure security group to SSH with "myIP".
 2. SSH into the instance using the public IPv4 address and the centos user. `ssh -i <pemfilename>.pem centos@<public IP>`
 3. `cd keycloak` and `git fetch --tags`
-4. Checkout the Keycloak tag corespinding with RHSSO version on cluster
-   - for example, Keycloak 10 = RHSSO 7.4 
+4. Checkout the Keycloak tag corresponding with RHSSO version on cluster
+   - for example, Keycloak 10 = RHSSO 7.4
 5. `cd testsuite/performance/`
 6. Run `mvn clean install`
 7. Replace the username, password and server properties of `tests/target/provisioned-system.properties` with your clusters RHSSO details.
@@ -31,16 +32,18 @@ You should have an AWS IAM account in [QE-AWS account](https://068334777414.sign
    >
    > keycloak.admin.password= `<admin-pwd>`
 
-8.  Run `mvn verify -Pgenerate-data -Ddataset=1r_10c_100u -DnumOfWorkers=10 -Djackson.version=2.10.1`
-    -   **NOTE:** `-Djackson.version=2.10.1` is a workaround for RHSSO 7.4 only. Please remove this param from the test case when we upgrade to RHSSO 7.5
-9.  Run
-   ```
-   export WARMUP_PERIOD=900
-   export RAMPUP_PERIOD=120
-   export MEASUREMENT_PERIOD=240
-   export STRESS_TEST_UPS_FIRST=14
-   ./stress-test.sh -DmaxMeanReponseTime=1000
-   ```
+8. Run `mvn verify -Pgenerate-data -Ddataset=1r_10c_100u -DnumOfWorkers=10 -Djackson.version=2.10.1`
+   - **NOTE:** `-Djackson.version=2.10.1` is a workaround for RHSSO 7.4 only. Please remove this param from the test case when we upgrade to RHSSO 7.5
+9. Run
+
+```
+export WARMUP_PERIOD=900
+export RAMPUP_PERIOD=120
+export MEASUREMENT_PERIOD=240
+export STRESS_TEST_UPS_FIRST=14
+./stress-test.sh -DmaxMeanReponseTime=1000
+```
+
 10. Once tests have finished, results will be saved to `/home/centos/keycloak/testsuite/performance/tests/target/gatling/`. Copy the last two folders to your local machine to view the tests using something similar to `scp -r -i ../stephin.pem centos@ec2-3-8-28-1.eu-west-2.compute.amazonaws.com:/home/centos/keycloak/testsuite/performance/tests/target/gatling/oidcloginandlogoutsimulation-1580403162107 ./`
 
 > Capture the results and compare them against [the previous run](https://docs.google.com/spreadsheets/d/1VGL87kaSKaz7ndjj1tNlRQiYDf2zn-lT1uHeOCPII3M/edit#gid=1845969669)

--- a/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
+++ b/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
@@ -11,13 +11,19 @@ Note: this test should only be performed at a time it will not affect other ongo
 You should have an AWS IAM account in [QE-AWS account](https://068334777414.signin.aws.amazon.com/console)
 
 ## Steps
-
-1. Login into [QE-AWS account](https://068334777414.signin.aws.amazon.com/console) using your AWS IAM account credentials and select the region to **London**.
-2. Create a new **t2.small** ec2 instance from the sso-load-testing AMI. Set the Auto-assign public IP to Enable and select Network as **sso-load-test-vpc** and subnet as **sso-load-test-subnet**. Configure security group to SSH with "myIP".
-3. SSH into the instance using the public IPv4 address and the centos user. `ssh -i <pemfilename>.pem centos@<public IP>`
-4. `cd keycloak` and `git pull`
+1. Get access to ec2 instance to run tests
+   -  Option 1 - Use existing ec2 instance:
+      1. Contact Stephin Thomas for details on accessing this ec2 instance
+   -  Option 2 - Create new ec2 instance:
+      1. Login into [QE-AWS account](https://068334777414.signin.aws.amazon.com/console) using your AWS IAM account credentials and select the region to **London**.
+      2. Create a new **t2.small** ec2 instance from the sso-load-testing AMI. Set the Auto-assign public IP to Enable and select Network as **sso-load-test-vpc** and subnet as **sso-load-test-subnet**. Configure security group to SSH with "myIP".
+2. SSH into the instance using the public IPv4 address and the centos user. `ssh -i <pemfilename>.pem centos@<public IP>`
+3. `cd keycloak` and `git fetch --tags`
+4. Checkout the Keycloak tag corespinding with RHSSO version on cluster
+   - for example, Keycloak 10 = RHSSO 7.4 
 5. `cd testsuite/performance/`
-6. Replace the username, password and server properties of `tests/target/provisioned-system.properties` with your clusters RHSSO details.
+6. Run `mvn clean install`
+7. Replace the username, password and server properties of `tests/target/provisioned-system.properties` with your clusters RHSSO details.
 
    > keycloak.frontend.servers= `<rhsso-url>`
    >
@@ -25,9 +31,9 @@ You should have an AWS IAM account in [QE-AWS account](https://068334777414.sign
    >
    > keycloak.admin.password= `<admin-pwd>`
 
-7. Run `mvn clean install`
-8. Run `mvn verify -Pgenerate-data -Ddataset=1r_10c_100u -DnumOfWorkers=10`
-9. Run
+8.  Run `mvn verify -Pgenerate-data -Ddataset=1r_10c_100u -DnumOfWorkers=10 -Djackson.version=2.10.1`
+    -   **NOTE:** `-Djackson.version=2.10.1` is a workaround for RHSSO 7.4 only. Please remove this param from the test case when we upgrade to RHSSO 7.5
+9.  Run
    ```
    export WARMUP_PERIOD=900
    export RAMPUP_PERIOD=120
@@ -35,7 +41,7 @@ You should have an AWS IAM account in [QE-AWS account](https://068334777414.sign
    export STRESS_TEST_UPS_FIRST=14
    ./stress-test.sh -DmaxMeanReponseTime=1000
    ```
-10. Once tests have finished, results will be saved to `/home/centos/keycloak/testsuite/performance/tests/target/gatling/`. Copy the last two folders to your local machine to view the tests using something similar to `scp -r -i ../stephin.pem centos@ec2-3-8-28-1.eu-west-2.compute.amazonaws.com:/home/centos/keycloak/testsuite/performance/tests/target/gatling/oidcloginandlogoutsimulation-1580403162107 ./`
+12. Once tests have finished, results will be saved to `/home/centos/keycloak/testsuite/performance/tests/target/gatling/`. Copy the last two folders to your local machine to view the tests using something similar to `scp -r -i ../stephin.pem centos@ec2-3-8-28-1.eu-west-2.compute.amazonaws.com:/home/centos/keycloak/testsuite/performance/tests/target/gatling/oidcloginandlogoutsimulation-1580403162107 ./`
 
 > Capture the results and compare them against [the previous run](https://docs.google.com/spreadsheets/d/1VGL87kaSKaz7ndjj1tNlRQiYDf2zn-lT1uHeOCPII3M/edit#gid=1845969669)
 >

--- a/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
+++ b/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
@@ -41,7 +41,7 @@ You should have an AWS IAM account in [QE-AWS account](https://068334777414.sign
    export STRESS_TEST_UPS_FIRST=14
    ./stress-test.sh -DmaxMeanReponseTime=1000
    ```
-12. Once tests have finished, results will be saved to `/home/centos/keycloak/testsuite/performance/tests/target/gatling/`. Copy the last two folders to your local machine to view the tests using something similar to `scp -r -i ../stephin.pem centos@ec2-3-8-28-1.eu-west-2.compute.amazonaws.com:/home/centos/keycloak/testsuite/performance/tests/target/gatling/oidcloginandlogoutsimulation-1580403162107 ./`
+10. Once tests have finished, results will be saved to `/home/centos/keycloak/testsuite/performance/tests/target/gatling/`. Copy the last two folders to your local machine to view the tests using something similar to `scp -r -i ../stephin.pem centos@ec2-3-8-28-1.eu-west-2.compute.amazonaws.com:/home/centos/keycloak/testsuite/performance/tests/target/gatling/oidcloginandlogoutsimulation-1580403162107 ./`
 
 > Capture the results and compare them against [the previous run](https://docs.google.com/spreadsheets/d/1VGL87kaSKaz7ndjj1tNlRQiYDf2zn-lT1uHeOCPII3M/edit#gid=1845969669)
 >


### PR DESCRIPTION
# Description
Updating steps of k03 - RHSSO performance test case for three reasons:
- An additional option for getting ec2 instance access
- Use the same keycloak version on cluster to run the performance tests
- Added workaround for running against RHSSO 7.4 (will work with 7.3 as well). This workaround will need to exist until 7.5 which likely won't be out for a while.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer