### PR TITLE
INTLY-7831 Fix attempt to index first element of possibly empty list

### DIFF
--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -223,7 +223,6 @@ func checkPodStatus(ctx *TestingContext, podCR *corev1.Pod) (bool, error) {
 }
 
 func get3ScaleAPIcastPod(ctx *TestingContext) (*corev1.Pod, error) {
-
 	listOptions := []k8sclient.ListOption{
 		k8sclient.MatchingLabels(map[string]string{
 			"threescale_component": "apicast",
@@ -232,14 +231,16 @@ func get3ScaleAPIcastPod(ctx *TestingContext) (*corev1.Pod, error) {
 	}
 
 	tsApicastPods := &corev1.PodList{}
-
 	err := ctx.Client.List(goctx.TODO(), tsApicastPods, listOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("error listing 3scale apicast pods: %v", err)
 	}
 
-	tsApicastPod := tsApicastPods.Items[0]
-	return &tsApicastPod, nil
+	if len(tsApicastPods.Items) == 0 {
+		return nil, fmt.Errorf("Expected 3scale apicast pods to be created, none found")
+	}
+
+	return &tsApicastPods.Items[0], nil
 }
 
 func getTestingCurlLabels() map[string]string {


### PR DESCRIPTION
# Description

The `get3ScaleAPIcasePod` function in the `TestNetworkPolicyAccessNSToSVC` test retrieves
a list of the APICast pods in the 3scale namespace, and returns the first element on the
list. This has caused some tests to fail, possibly because the test is executed before
any pod has been created.

Modify the `get3ScaleAPIcasePod` function to wait for the pod list to have at least one
element, or fail with timeout.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer