### PR TITLE
INTLY-7427-Remove-e2e-test

### DIFF
--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -248,32 +247,6 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	// check no failed PVCs
-	pvcNamespaces := []string{
-		string(integreatlyv1alpha1.Product3Scale),
-		string(integreatlyv1alpha1.ProductFuse),
-		string(integreatlyv1alpha1.ProductRHSSO),
-		string(integreatlyv1alpha1.ProductSolutionExplorer),
-		string(integreatlyv1alpha1.ProductUps),
-		string(integreatlyv1alpha1.ProductRHSSOUser),
-	}
-	err = checkPvcs(t, f, namespace, pvcNamespaces)
-	return err
-}
-
-func checkPvcs(t *testing.T, f *framework.Framework, s string, pvcNamespaces []string) error {
-	for _, pvcNamespace := range pvcNamespaces {
-		pvcs := &corev1.PersistentVolumeClaimList{}
-		err := f.Client.List(goctx.TODO(), pvcs, &k8sclient.ListOptions{Namespace: common.NamespacePrefix + pvcNamespace})
-		if err != nil {
-			return fmt.Errorf("Error getting PVCs for namespace: %v. %w", pvcNamespace, err)
-		}
-		for _, pvc := range pvcs.Items {
-			if pvc.Status.Phase != "Bound" {
-				return fmt.Errorf("Error with pvc: %v. Status: %v", pvc.Name, pvc.Status.Phase)
-			}
-		}
-	}
 	return nil
 }
 


### PR DESCRIPTION
Remove e2e test for checking PVCs as this has been moved to the common tests.

# Description
Remove e2e test for checking PVCs as this has been moved to the common tests based on comments in  https://issues.redhat.com/browse/INTLY-7427.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer