### PR TITLE
Add prow make targets

### DIFF
--- a/make/prow.mk
+++ b/make/prow.mk
@@ -1,0 +1,10 @@
+
+.PHONY: prow/e2e/credentials
+prow/e2e/credentials:
+	$(CONTAINER_ENGINE) pull quay.io/integreatly/delorean-cli:master
+	$(CONTAINER_ENGINE) run -it --rm -e KUBECONFIG=/kube.config -v "${HOME}/.kube/config":/kube.config:z quay.io/integreatly/delorean-cli:master e2e-test-extract-creds.sh $(CI_NAMESPACE)
+
+
+.PHONY: prow/e2e/tail
+prow/e2e/tail: prow/e2e/credentials
+	oc -n $(CI_NAMESPACE) logs -f e2e -c test --tail=50


### PR DESCRIPTION
# Description

Add prow make targets:
prow/e2e/credentials: Extract the cluster credentials from an e2e test container in a known CI namespace
```
make prow/e2e/credentials CONTAINER_ENGINE=podman CI_NAMESPACE=ci-op-hndh5cb6
```
prow/e2e/tail: Tail the logs of the test container running the e2e tests in a known CI namespace
```
make prow/e2e/tail CONTAINER_ENGINE=podman CI_NAMESPACE=ci-op-hndh5cb6
```
Assumes you are oc logged into the correct CI cluster where the e2e test is running (https://api.ci.openshift.org)

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer