### PR TITLE
Make maintenance window for RHMIConfig case insensitive

### DIFF
--- a/pkg/controller/subscription/rhmiConfigs/main.go
+++ b/pkg/controller/subscription/rhmiConfigs/main.go
@@ -187,7 +187,7 @@ func getWeeklyWindow(from time.Time, windowStartStr string, duration time.Durati
 	}
 
 	//calculate how far away from maintenance day today is, within the current week
-	dayDiff := shortDays[windowDay] - int(from.Weekday())
+	dayDiff := shortDays[strings.ToLower(windowDay)] - int(from.Weekday())
 	if dayDiff < 0 {
 		dayDiff = 7 + dayDiff
 	}

--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -722,3 +722,40 @@ func TestApproveUpgrade(t *testing.T) {
 		})
 	}
 }
+
+func TestGetWeeklyWindow(t *testing.T) {
+	// Monday
+	from := time.Date(2020, time.June, 1, 0, 0, 0, 0, time.UTC)
+
+	// Test same day
+	r, _, err := getWeeklyWindow(from, "Mon 00:00", time.Hour)
+	if err != nil {
+		t.Errorf("Error calculating weekly window for same day: %v", err)
+	} else if r.Day() != from.Day() || r.Month() != from.Month() || r.Year() != from.Year() {
+		t.Errorf("Expected result to be same day, got %s", r.Format(integreatlyv1alpha1.DateFormat))
+	}
+
+	// Test next day
+	r, _, err = getWeeklyWindow(from, "Tue 00:00", time.Hour)
+	if err != nil {
+		t.Errorf("Error calculating weekly window for same day: %v", err)
+	} else if r.Day() != from.Day()+1 || r.Month() != from.Month() || r.Year() != from.Year() {
+		t.Errorf("Expected result to be next day, got %s", r.Format(integreatlyv1alpha1.DateFormat))
+	}
+
+	// Test day before
+	r, _, err = getWeeklyWindow(from, "SuN 00:00", time.Hour)
+	if err != nil {
+		t.Errorf("Error calculating weekly window for same day: %v", err)
+	} else if r.Day() != from.Day()+6 || r.Month() != from.Month() || r.Year() != from.Year() {
+		t.Errorf("Expected result to be next Sunday, got %s", r.Format(integreatlyv1alpha1.DateFormat))
+	}
+
+	// Test 3 days after
+	r, _, err = getWeeklyWindow(from, "Thu 02:00", time.Hour)
+	if err != nil {
+		t.Errorf("Error calculating weekly window for same day: %v", err)
+	} else if r.Day() != from.Day()+3 || r.Month() != from.Month() || r.Year() != from.Year() {
+		t.Errorf("Expected result to be Thursday, got %s", r.Format(integreatlyv1alpha1.DateFormat))
+	}
+}


### PR DESCRIPTION
# Description

The days difference calculated from a date to the next maintenance window uses a
`map[string]int` with the different week days in lowercase. If the value
from the maintenance window is not in lowercase it will fail silently to
match a value from that `map`, so it'll default to 0 as the zero value
of the map, which is Sunday, resulting in the day difference until the
next Sunday.

Convert the week day to lower case before indexing the map.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer