### PR TITLE
INTLY-7964  e2e test flake: TestIntegreatly/integreatly/Cluster

### DIFF
--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -93,9 +93,19 @@ func TestIntegreatly(t *testing.T) {
 			})
 		}
 
+		var err error
 		t.Run("Cluster", func(t *testing.T) {
-			IntegreatlyCluster(t, f, ctx)
+			err = IntegreatlyCluster(t, f, ctx)
+			if err != nil {
+				t.Log(err)
+				t.Fail()
+			}
 		})
+
+		if err != nil {
+			t.Log("cluster not in a testable state, quiting test run")
+			t.FailNow()
+		}
 
 		for _, test := range common.HAPPY_PATH_TESTS {
 			t.Run(test.Description, func(t *testing.T) {
@@ -367,12 +377,13 @@ func waitForInstallationStageCompletion(t *testing.T, f *framework.Framework, na
 	return nil
 }
 
-func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) {
+func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.TestCtx) error {
 	namespace, err := ctx.GetNamespace()
 	// Create SMTP Secret
 	installationPrefix, found := os.LookupEnv("INSTALLATION_PREFIX")
 	if !found {
-		t.Fatal("INSTALLATION_PREFIX env var is not set")
+		err := fmt.Errorf("INSTALLATION_PREFIX env var is not set")
+		return err
 	}
 
 	var smtpSec = &corev1.Secret{
@@ -390,7 +401,7 @@ func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	err = f.Client.Create(context.TODO(), smtpSec, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatal(err)
+		return fmt.Errorf("create SMTP Secret: %w", err)
 	}
 
 	// create pagerduty secret
@@ -406,7 +417,7 @@ func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	err = f.Client.Create(context.TODO(), pagerdutySecret, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatal(err)
+		return fmt.Errorf("create pagerduty secret: %w", err)
 	}
 
 	// create dead mans snitch secret
@@ -422,17 +433,20 @@ func IntegreatlyCluster(t *testing.T, f *framework.Framework, ctx *framework.Tes
 	}
 	err = f.Client.Create(context.TODO(), dmsSecret, &framework.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
 	if err != nil && !apierrors.IsAlreadyExists(err) {
-		t.Fatal(err)
+		return fmt.Errorf("create dead mans snitch secret : %w", err)
 	}
 
 	// wait for integreatly-operator to be ready
 	err = e2eutil.WaitForOperatorDeployment(t, f.KubeClient, namespace, "rhmi-operator", 1, retryInterval, timeout)
 	if err != nil {
-		t.Fatal(err)
+		return fmt.Errorf("wait for integreatly-operator to be ready: %w", err)
+
 	}
 	//TODO: split them into their own test cases
 	// check that all of the operators deploy and all of the installation phases complete
 	if err = integreatlyManagedTest(t, f, ctx); err != nil {
-		t.Fatal(err)
+		return fmt.Errorf("error in fuction integreatlyManagedTest: %w", err)
 	}
+
+	return nil
 }


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

e2e test updated to quit if any part of the Cluster test fails. This causes the test run to exit early and not cause any failures later test due to the cluster install not been fully complete.

**JIRA** https://issues.redhat.com/browse/INTLY-7964

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] e2e test flake fix
 
## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer