### PR TITLE
INTLY-8120 Strip down rhmi_status metric to only have the overall stage

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -57,6 +57,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatusAvailable)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIInfo)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIVersion)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatus)
 	integreatlymetrics.OperatorVersion.Add(1)
 }
 

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -235,7 +235,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 			Products: stage.Products,
 		})
 	}
-	metrics.ExposeRHMIStatusMetric(stages)
+	metrics.SetRHMIStatus(installation)
 
 	configManager, err := config.NewManager(r.context, r.client, request.NamespacedName.Namespace, installationCfgMap, installation)
 	if err != nil {

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -13,6 +13,7 @@ var (
 	HAPPY_PATH_TESTS = []TestCase{
 		// Add all happy path tests to be executed after RHMI installation is completed here
 		{"A01 - Verify that all stages in the integreatly-operator CR report completed", TestIntegreatlyStagesStatus}, // Keep test as first on the list, as it ensures that all products are reported as complete
+		{"Test RHMI installation CR metric", TestRHMICRMetrics},
 		{"A03 - Verify all namespaces have been created with the correct name", TestNamespaceCreated},
 		{"A18 - Verify RHMI Config CRs Successful", TestRHMIConfigCRs},
 		{"A22 - Verify RHMI Config Updates CRO Strategy Override Config Map", TestRHMIConfigCROStrategyOverride},
@@ -47,7 +48,6 @@ var (
 		{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
 		{"A06 - Verify PVC", TestPVClaims},
 		{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
-		{"Test RHMI installation CR metric", TestRHMICRMetrics},
 		{"C03 - Verify that alerting mechanism works", TestIntegreatlyAlertsMechanism},
 	}
 


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-8120

Removes all labels from the `rhmi_status` metric so the number of series is kept to a minimum (more info in jira & linked document).
These changes will ensure a limit of 8 series (1 for each status).
A metric series will be exposed at all times for the current stage, with a value of 1.
For example:

```
# HELP rhmi_status RHMI status of an installation
# TYPE rhmi_status gauge
rhmi_status{stage="complete"} 1
```

An expression to determine if the RHMI install is complete would be:

```
rhmi_status{stage="complete"} == 1
```

If you want to get the currently active stage:

```
rhmi_status == 1
```
and use the value of the `stage` label

This approach seems more inline with how metrics are used to expose non numerical data, but comes with caveats (hence the need to limit the possible values of labels).

More info on metric cardinality in https://www.robustperception.io/cardinality-is-key

To verify this change with the operator running locally, run:

```
while true; do curl localhost:8383/metrics|grep status & sleep 1; done
``` 
and verify the output looks similar to below, with the current stage having a value of 1 during the installation

```
# HELP rhmi_status RHMI status of an installation
# TYPE rhmi_status gauge
rhmi_status{stage="bootstrap"} 1
```

The stage should change as the CR status.stage field changes


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer