### PR TITLE
INTLY-8270_Do_not_block_smtp_secret

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -601,7 +601,7 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 	// handle smtp credentials
 	smtpSecret := &corev1.Secret{}
 	if err := serverClient.Get(ctx, types.NamespacedName{Name: r.installation.Spec.SMTPSecret, Namespace: rhmiOperatorNs}, smtpSecret); err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not obtain smtp credentials secret: %w", err)
+		logrus.Warnf("could not obtain smtp credentials secret: %v", err)
 	}
 
 	// handle pagerduty credentials

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -682,17 +682,6 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 		wantErr      string
 	}{
 		{
-			name: "fails when smtp secret cannot be found",
-			serverClient: func() k8sclient.Client {
-				return fakeclient.NewFakeClientWithScheme(basicScheme, alertmanagerRoute)
-			},
-			reconciler: func() *Reconciler {
-				return basicReconciler
-			},
-			wantErr: "could not obtain smtp credentials secret: secrets \"test-smtp\" not found",
-			want:    integreatlyv1alpha1.PhaseFailed,
-		},
-		{
 			name: "fails when pager duty secret cannot be found",
 			serverClient: func() k8sclient.Client {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, alertmanagerRoute)


### PR DESCRIPTION
# Description
Remove block on smtp credentials. Added check to ensure credentials match and restart threescale pods safely if credentials are updated. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer