### PR TITLE
added automation-jira tag

### DIFF
--- a/test-cases/tests/alerts/c05-verify-that-no-alerts-were-firing-during-and-after-installat.md
+++ b/test-cases/tests/alerts/c05-verify-that-no-alerts-were-firing-during-and-after-installat.md
@@ -1,5 +1,7 @@
 ---
 estimate: 15m
+automation_jiras:
+  - INTLY-7413
 ---
 
 # C05 - Verify that no alerts were firing during and after installation

--- a/test-cases/tests/alerts/c07-verify-rhmi-alerts-metrics-exposed-via-telemtry.md
+++ b/test-cases/tests/alerts/c07-verify-rhmi-alerts-metrics-exposed-via-telemtry.md
@@ -1,5 +1,7 @@
 ---
 estimate: 15m
+automation_jiras:
+  - INTLY-7415
 ---
 
 # C07 - Verify RHMI Alerts Metrics Exposed Via Telemtry

--- a/test-cases/tests/authorization/b01-verify-that-the-users-can-login-in-all-products.md
+++ b/test-cases/tests/authorization/b01-verify-that-the-users-can-login-in-all-products.md
@@ -2,6 +2,8 @@
 estimate: 15m
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-7416
 ---
 
 # B01 - Verify that the users can login in all products

--- a/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
+++ b/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
@@ -1,6 +1,7 @@
 ---
 estimate: 1h
-tags: [] # Add tags here. See the tags section in the README for the list of tags that we use
+automation_jiras:
+  - INTLY-7748
 ---
 
 # B03 - Verify RHMI Developer User Permissions are Correct

--- a/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
@@ -1,5 +1,7 @@
 ---
 estimate: 30m
+automation_jiras:
+  - INTLY-7421
 ---
 
 # E04 - Verify SLO dashboard

--- a/test-cases/tests/high-availability/f04-verify-aws-s3-resources-exist-and-are-in-expected-state.md
+++ b/test-cases/tests/high-availability/f04-verify-aws-s3-resources-exist-and-are-in-expected-state.md
@@ -1,5 +1,7 @@
 ---
 estimate: 15m
+automation_jiras:
+  - INTLY-6654
 ---
 
 # F04 - Verify AWS s3 resources exist and are in expected state

--- a/test-cases/tests/installation/a07-all-operand-versions-are-correct.md
+++ b/test-cases/tests/installation/a07-all-operand-versions-are-correct.md
@@ -1,6 +1,8 @@
 ---
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-7961
 ---
 
 # A07 - All operand versions are correct

--- a/test-cases/tests/products/h01-ups-verify-that-ups-can-send-push-notification.md
+++ b/test-cases/tests/products/h01-ups-verify-that-ups-can-send-push-notification.md
@@ -1,4 +1,6 @@
 ---
+automation_jiras:
+  - INTLY-7430
 ---
 
 # H01 - UPS: Verify that UPS can send push notification

--- a/test-cases/tests/products/h03-verify-integration-between-3scale-and-openshift.md
+++ b/test-cases/tests/products/h03-verify-integration-between-3scale-and-openshift.md
@@ -2,6 +2,8 @@
 estimate: 15m
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-5441
 ---
 
 # H03 - Verify integration between 3Scale and OpenShift

--- a/test-cases/tests/products/h04-verify-integration-between-amq-online-and-openshift.md
+++ b/test-cases/tests/products/h04-verify-integration-between-amq-online-and-openshift.md
@@ -2,6 +2,8 @@
 estimate: 30m
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-7432
 ---
 
 # H04 - Verify integration between AMQ Online and OpenShift

--- a/test-cases/tests/products/h05-verify-integration-between-fuse-online-and-openshift.md
+++ b/test-cases/tests/products/h05-verify-integration-between-fuse-online-and-openshift.md
@@ -2,6 +2,8 @@
 estimate: 30m
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-7433
 ---
 
 # H05 - Verify integration between Fuse Online and OpenShift

--- a/test-cases/tests/products/h06-verify-integration-between-codeready-and-openshift.md
+++ b/test-cases/tests/products/h06-verify-integration-between-codeready-and-openshift.md
@@ -2,6 +2,8 @@
 tags:
   - happy-path
 estimate: 30m
+automation_jiras:
+  - INTLY-7434
 ---
 
 # H06 - Verify integration between CodeReady and OpenShift

--- a/test-cases/tests/products/h07-verify-3scale-user-promotion-works-and-stays-permanent.md
+++ b/test-cases/tests/products/h07-verify-3scale-user-promotion-works-and-stays-permanent.md
@@ -2,6 +2,8 @@
 estimate: 1h
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-7435
 ---
 
 # H07 - Verify 3scale User Promotion Works and Stays Permanent

--- a/test-cases/tests/products/h08-verify-amq-online-crs-can-be-modified-and-are-not-reset.md
+++ b/test-cases/tests/products/h08-verify-amq-online-crs-can-be-modified-and-are-not-reset.md
@@ -2,6 +2,8 @@
 estimate: 4h
 tags:
   - happy-path
+automation_jiras:
+  - INTLY-6123
 ---
 
 # H08 - Verify AMQ Online CRs can be modified and are not reset

--- a/test-cases/tests/products/h11-verify-3scale-smtp-configuration.md
+++ b/test-cases/tests/products/h11-verify-3scale-smtp-configuration.md
@@ -1,5 +1,7 @@
 ---
 estimate: 15m
+automation_jiras:
+  - INTLY-7439
 ---
 
 # H11 - Verify 3scale SMTP Configuration


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Added `automation-jira-created` tag, so that it is easier to filter manual test cases for which automation jira does not exist yet. This could be improved by updating tooling to allow creating jiras for test cases that are not covered yet by jira ticket.
