### PR TITLE
[WIP] fuse-online update to 7.7.0

### DIFF
--- a/manifests/integreatly-fuse-online/7.7.0/fuse-online-operator.v7.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-fuse-online/7.7.0/fuse-online-operator.v7.7.0.clusterserviceversion.yaml
@@ -1,0 +1,711 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |
+      [{
+          "apiVersion": "syndesis.io/v1beta1",
+          "kind": "Syndesis",
+          "metadata": {
+            "name": "app"
+          },
+          "spec" : {
+            "addons": {
+              "todo": {
+                "enabled": false
+              },
+              "ops": {
+                "enabled": false
+              }
+            }
+          }
+      }]
+    capabilities: Seamless Upgrades
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/integreatly/delorean:fuse7-fuse-online-operator_latest
+    createdAt: "2020-06-04T16:12:00Z"
+    description: Manages the installation of Fuse Online, a flexible and customizable
+      open source platform that provides core integration capabilities as a service.
+    repository: https://github.com/syndesisio/syndesis/
+    support: Syndesis
+  name: fuse-online-operator.v7.7.0
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: Syndesis CRD
+      displayName: Syndesis CRD
+      kind: Syndesis
+      name: syndesises.syndesis.io
+      version: v1beta1
+  description: "\nFuse Online is a flexible and customizable, open source platform
+    that provides core integration capabilities as a service.\n\nThis operator installs
+    as well as configures the following Fuse Online components:\n- syndesis-server\n-
+    syndesis-meta\n- syndesis-ui\n- syndesis-db\n- syndesis-prometheus\n- syndesis-proxy\n-
+    syndesis-oauthproxy\n\n### Before you begin\nYou must configure authentication
+    to Red Hat container registry before you can import and use the Red Hat Fuse OpenShift
+    Image Streams. Follow instruction given below to configure the registration to
+    container registry.\n\n1. Log in to the OpenShift Server as an administrator,
+    as follow:\n    ```\n    oc login -u system:admin\n    ```\n2. Log in to the OpenShift
+    project where you will be installing the operator.\n    ```\n    oc project fuse-online\n
+    \   ```\n3. Create a docker-registry secret using either Red Hat Customer Portal
+    account or Red Hat Developer Program account credentials.\n    ```\n    oc create
+    secret docker-registry syndesis-pull-secret \\\n      --docker-server=registry.redhat.io
+    \\\n      --docker-username=CUSTOMER_PORTAL_USERNAME \\\n      --docker-password=CUSTOMER_PORTAL_PASSWORD
+    \\\n      --docker-email=EMAIL_ADDRESS\n    ```\n    NOTE: You need to create
+    a docker-registry secret in every new namespace where the image streams reside
+    and which use registry.redhat.io.\n\n    If you do not wish to use your Red Hat
+    account username and password to create the secret, it is recommended to create
+    an authentication token using a [registry service account](https://access.redhat.com/terms-based-registry/).\n\n###
+    How to install\n- When the operator is installed (you have created a subscription
+    and the operator is running in the selected namespace) and before you create a
+    new CR of Kind Syndesis, you have to link the secret created in the previous section
+    to the operator service account.\n```\noc secrets link syndesis-operator syndesis-pull-secret
+    --for=pull\n```\n\n- Create a new CR of Kind Syndesis (click the Create New button).
+    The CR spec contains all defaults (see below).\n\n### CR Defaults\nThe CR definition
+    is pretty simple and an empy CR will trigger a base installation.\n\nWithin the
+    addons section, users are able to enable specific addons. The available addons
+    at the moment are:\n- dv: enables the data integration capabilities\n- camelk:
+    enables kamelk\n- jaeger: enable jaeger\n- ops: enables monitoring, requires extra
+    CRDs\n- todo: a simple todo application\n\n- When you enable Jaeger addon, you
+    should link the previously created `syndesis-pull-secret` secret to jaeger service
+    accounts.\n```\noc secrets link jaeger-operator syndesis-pull-secret --for=pull\noc
+    secrets link syndesis-jaeger-ui-proxy syndesis-pull-secret --for=pull\n```\n\nTo
+    enable addons, set \"addon_name\": {\"enabled\": true} in the CR.\n\nFor a more
+    detailed set of instructions and a complete reference of config options, \nplease
+    refer to the product documentation at https://access.redhat.com/documentation/en-us/red_hat_fuse\n"
+  displayName: Red Hat Integration - Fuse Online
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2Q3MWUwMDt9LmNscy0ye2ZpbGw6I2MyMWEwMDt9LmNscy0ze2ZpbGw6I2ZmZjt9LmNscy00e2ZpbGw6I2VhZWFlYTt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPnByb2R1Y3RpY29uc18xMDE3X1JHQl9JbnRlZ3JhdGlvbiBmaW5hbCBjb2xvcjwvdGl0bGU+PGcgaWQ9IkxheWVyXzEiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PGNpcmNsZSBjbGFzcz0iY2xzLTEiIGN4PSI1MCIgY3k9IjUwIiByPSI1MCIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIwLjcxIDUwKSByb3RhdGUoLTQ1KSIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTg1LjM2LDE0LjY0QTUwLDUwLDAsMCwxLDE0LjY0LDg1LjM2WiIvPjxwYXRoIGQ9Ik0zMSwzMS4zNmExLjk0LDEuOTQsMCwwLDEtMy42Mi0uODkuNDMuNDMsMCwwLDEsLjUzLS40NCwzLjMyLDMuMzIsMCwwLDAsMi44MS43QS40My40MywwLDAsMSwzMSwzMS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik03Ny42Myw0NC43NkM3Ny4xMiw0MS4zNCw3MywyMSw2Ni4zMiwyMWMtMi40NCwwLTQuNTksMy4zNS02LDYuODgtLjQ0LDEuMDYtMS4yMywxLjA4LTEuNjMsMEM1Ny4yNCwyNC4xNiw1NS44OCwyMSw1My4yOCwyMSw0My4zNCwyMSw0Ny44NCw0NS4xOCwzOSw0NS4xOGMtNC41NywwLTUuMzctMTAuNTktNS41LTE0LjcyLDIuMTkuNjUsMy4zLTEsMy41NS0yLjYxYS42My42MywwLDAsMC0uNDgtLjcyLDMuMzYsMy4zNiwwLDAsMC0zLC44OUgyNy4zMWExLDEsMCwwLDAtLjY4LjI4bC0uNTMuNTNIMjIuMjFhLjU0LjU0LDAsMCwwLS4zOC4xNmwtMy45NSwzLjk1YS41NC41NCwwLDAsMCwuMzguOTFoLjM2bDAsMEgyOS43MWMuNiw2LjI2LDEuNzUsMjIsMTYuNDIsMTcuMTlsLS4zMiw1TDQ0LjM3LDc4LjQ2YTEsMSwwLDAsMCwxLDFoNC45YTEsMSwwLDAsMCwxLTFsLS42MS0yMy4zMy0uMTUtNS44MWM2LTIuNzgsOS01LjY2LDE2LjE5LTYuNzUtMS41OSwyLjYyLTIuMDUsNi44Ny0yLjA2LDgtLjA2LDYsMi41NSw4Ljc0LDUsMTMuMjJMNjMuNzMsNzhhMSwxLDAsMCwwLC44OSwxLjMyaDQuNjRhMSwxLDAsMCwwLC45My0uNzRMNzQsNjIuNmMtNC44My03LjQzLDEuODMtMTUuMzEsMy40MS0xN0ExLDEsMCwwLDAsNzcuNjMsNDQuNzZaTTMxLDMxLjM2YTEuOTQsMS45NCwwLDAsMS0zLjYyLS44OS40My40MywwLDAsMSwuNTMtLjQ0LDMuMzIsMy4zMiwwLDAsMCwyLjgxLjdBLjQzLjQzLDAsMCwxLDMxLDMxLjM2WiIvPjxwYXRoIGNsYXNzPSJjbHMtNCIgZD0iTTQ2LjEzLDUxLjA3QzMxLjQ2LDU1LjkyLDMwLjMxLDQwLjE0LDI5LjcxLDMzLjg4SDE4LjY1TDIwLjc1LDM2YTEsMSwwLDAsMCwuNjguMjhoNmMwLDUuOCwxLjEzLDIwLjIsMTQsMjAuMmEzMS4zNCwzMS4zNCwwLDAsMCw0LjQyLS4zNVoiLz48cGF0aCBjbGFzcz0iY2xzLTQiIGQ9Ik01MC40MSw0OS4zNmwuMTUsNS44MWExMDguMiwxMDguMiwwLDAsMCwxNC00LjU0LDE5Ljc5LDE5Ljc5LDAsMCwxLDIuMDYtOEM1OS40Niw0My43LDU2LjQ0LDQ2LjU4LDUwLjQxLDQ5LjM2WiIvPjwvZz48L3N2Zz4=
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: syndesis-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: syndesis-operator
+              syndesis.io/app: syndesis
+              syndesis.io/component: syndesis-operator
+              syndesis.io/type: operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: syndesis-operator
+                syndesis.io/app: syndesis
+                syndesis.io/component: syndesis-operator
+                syndesis.io/type: operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: syndesis-operator
+                image: quay.io/integreatly/delorean:fuse7-fuse-online-operator_1.7
+                imagePullPolicy: Always
+                name: syndesis-operator
+                ports:
+                - containerPort: 60000
+                  name: metrics
+                resources: {}
+              initContainers:
+              - command:
+                - bash
+                - -c
+                - postgres -V
+                image: registry.redhat.io/rhscl/postgresql-96-rhel7:latest
+                name: postgres-version
+                resources: {}
+              serviceAccountName: syndesis-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - get
+        - apiGroups:
+          - batch
+          - extensions
+          resources:
+          - jobs
+          verbs:
+          - get
+          - list
+          - create
+          - delete
+          - update
+          - watch
+          - deletecollection
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - pods/exec
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - apps
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - replicasets
+          - replicasets/scale
+          - statefulsets
+          - statefulsets/scale
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - extensions
+          resources:
+          - daemonsets
+          - deployments
+          - deployments/scale
+          - ingresses
+          - networkpolicies
+          - replicasets
+          - replicasets/scale
+          - replicationcontrollers/scale
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - bindings
+          - events
+          - limitranges
+          - namespaces/status
+          - pods/log
+          - pods/status
+          - replicationcontrollers/status
+          - resourcequotas
+          - resourcequotas/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs
+          - buildconfigs/webhooks
+          - builds
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildconfigs/instantiate
+          - buildconfigs/instantiatebinary
+          - builds/clone
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/details
+          verbs:
+          - update
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds/log
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          - deploymentconfigs/finalizers
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigrollbacks
+          - deploymentconfigs/instantiate
+          - deploymentconfigs/rollback
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/log
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams/secrets
+          - imagestreamtags
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreamimports
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - buildlogs
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - syndesis.io
+          resources:
+          - '*'
+          - '*/finalizers'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - pods/log
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - replicationcontrollers
+          - replicationcontrollers/scale
+          - replicationcontrollers/status
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          - build.openshift.io
+          resources:
+          - builds
+          - buildconfigs
+          - builds/details
+          - buildconfigs/webhooks
+          - buildconfigs/instantiatebinary
+          - builds/log
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          - deploymentconfigs/scale
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigrollbacks
+          - deploymentconfigs/instantiate
+          - deploymentconfigs/rollback
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/log
+          - deploymentconfigs/status
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreamimages
+          - imagestreammappings
+          - imagestreams/secrets
+          - imagestreamtags
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - ""
+          - image.openshift.io
+          resources:
+          - imagestreams/status
+          - imagestreamimports
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          - template.openshift.io
+          resources:
+          - processedtemplates
+          - templateconfigs
+          - templateinstances
+          - templates
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - authorization.openshift.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          - routes/custom-host
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+          - patch
+        - apiGroups:
+          - camel.apache.org
+          resources:
+          - '*'
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - alertmanagers
+          - prometheuses
+          - servicemonitors
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - deletecollection
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - serving.knative.dev
+          resources:
+          - services
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - eventing.knative.dev
+          resources:
+          - channels
+          verbs:
+          - get
+          - list
+          - watch
+        serviceAccountName: syndesis-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - camel
+  - integration
+  - syndesis
+  - fuse
+  - online
+  labels:
+    name: syndesis-operator
+  links:
+  - name: Red Hat Fuse Online Documentation
+    url: https://access.redhat.com/documentation/en-us/red-hat-fuse
+  - name: Upstream project Syndesis
+    url: https://github.com/syndesisio/syndesis
+  - name: Upstream Syndesis Operator
+    url: https://github.com/syndesisio/syndesis/tree/master/install/operator
+  maintainers:
+  - email: janstey@redhat.com
+    name: Jon Anstey
+  maturity: alpha
+  provider:
+    name: Red Hat
+  replaces: fuse-online-operator.v7.6.0
+  selector:
+    matchLabels:
+      name: syndesis-operator
+  version: 7.7.0

--- a/manifests/integreatly-fuse-online/7.7.0/fuse-online-operator.v7.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-fuse-online/7.7.0/fuse-online-operator.v7.7.0.clusterserviceversion.yaml
@@ -23,7 +23,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/integreatly/delorean:fuse7-fuse-online-operator_latest
+    containerImage: registry.redhat.io/fuse7/fuse-online-operator
     createdAt: "2020-06-04T16:12:00Z"
     description: Manages the installation of Fuse Online, a flexible and customizable
       open source platform that provides core integration capabilities as a service.
@@ -112,7 +112,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: syndesis-operator
-                image: quay.io/integreatly/delorean:fuse7-fuse-online-operator_1.7
+                image: registry.redhat.io/fuse7/fuse-online-operator:1.7
                 imagePullPolicy: Always
                 name: syndesis-operator
                 ports:

--- a/manifests/integreatly-fuse-online/7.7.0/fuse-online.crd.yaml
+++ b/manifests/integreatly-fuse-online/7.7.0/fuse-online.crd.yaml
@@ -1,0 +1,31 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: syndesises.syndesis.io
+  labels:
+    app: syndesis
+spec:
+  group: syndesis.io
+  names:
+    kind: Syndesis
+    listKind: SyndesisList
+    plural: syndesises
+    singular: syndesis
+  scope: Namespaced
+  version: v1beta1
+  versions:
+    - name: v1beta1
+      served: true
+      storage: true
+    - name: v1alpha1
+      served: true
+      storage: false
+  additionalPrinterColumns:
+    - JSONPath: .status.phase
+      description: The syndesis phase
+      name: Phase
+      type: string
+    - JSONPath: .status.version
+      description: The syndesis version
+      name: Version
+      type: string

--- a/manifests/integreatly-fuse-online/fuse-online.package.yaml
+++ b/manifests/integreatly-fuse-online/fuse-online.package.yaml
@@ -1,4 +1,5 @@
-packageName: rhmi-syndesis
 channels:
-- name: rhmi
-  currentCSV: fuse-online-operator.v7.6.0
+- currentCSV: fuse-online-operator.v7.7.0
+  name: rhmi
+defaultChannel: rhmi
+packageName: rhmi-syndesis

--- a/manifests/integreatly-fuse-online/image_mirror_mapping
+++ b/manifests/integreatly-fuse-online/image_mirror_mapping
@@ -1,0 +1,1 @@
+registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.7 quay.io/integreatly/delorean:fuse7-fuse-online-operator_1.7

--- a/manifests/integreatly-fuse-online/image_mirror_mapping
+++ b/manifests/integreatly-fuse-online/image_mirror_mapping
@@ -1,1 +1,0 @@
-registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.7 quay.io/integreatly/delorean:fuse7-fuse-online-operator_1.7

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -63,12 +63,12 @@ var (
 	VersionApicurito           ProductVersion = "7.6"
 	VersionAMQStreams          ProductVersion = "1.1.0"
 	VersionCodeReadyWorkspaces ProductVersion = "2.1.1"
-	VersionFuseOnOpenshift     ProductVersion = "7.6"
+	VersionFuseOnOpenshift     ProductVersion = "7.7"
 	VersionMonitoring          ProductVersion = "1.2.1"
 	Version3Scale              ProductVersion = "2.8"
 	VersionUps                 ProductVersion = "2.3.2"
 	VersionCloudResources      ProductVersion = "0.18.0"
-	VersionFuseOnline          ProductVersion = "7.6"
+	VersionFuseOnline          ProductVersion = "7.7"
 	VersionDataSync            ProductVersion = "0.9.4"
 	VersionRHSSO               ProductVersion = "7.4"
 	VersionRHSSOUser           ProductVersion = "7.4"
@@ -79,8 +79,8 @@ var (
 	// It is currently implicitly tied to version 7.6 of Fuse, hence the 7.6 value for VersionFuseOnOpenshift above
 	// The need for the below tag references is due to the nature of installing which is documented here: (for 7.6)
 	// https://access.redhat.com/documentation/en-us/red_hat_fuse/7.6/html-single/fuse_on_openshift_guide/index#install-fuse-on-openshift4
-	TagFuseOnOpenShiftCore        string = "application-templates-2.1.0.fuse-760043-redhat-00001"
-	TagFuseOnOpenShiftSpringBoot2 string = "application-templates-2.1.0.fuse-sb2-760039-redhat-00001"
+	TagFuseOnOpenShiftCore        string = "application-templates-2.1.0.fuse-770012-redhat-00004"
+	TagFuseOnOpenShiftSpringBoot2 string = "application-templates-2.1.0.fuse-sb2-770017-redhat-00001"
 
 	PreflightInProgress PreflightStatus = ""
 	PreflightSuccess    PreflightStatus = "successful"
@@ -96,7 +96,7 @@ var (
 
 	OperatorVersionCodeReadyWorkspaces OperatorVersion = "2.1.1"
 	OperatorVersion3Scale              OperatorVersion = "0.5.4"
-	OperatorVersionFuse                OperatorVersion = "1.6.0"
+	OperatorVersionFuse                OperatorVersion = "7.7.0"
 	OperatorVersionCloudResources      OperatorVersion = "0.18.0"
 	OperatorVersionUPS                 OperatorVersion = "0.5.0"
 	OperatorVersionApicurioRegistry    OperatorVersion = "0.0.3"


### PR DESCRIPTION
Update fuse-online manifest to 7.7.0 

This is an automatically generated branch to track the '7.7.0' version of the 'fuse-online' OLM manifests.
This branch will be automatically updated with any changes related to this version until it finally GAs. 

Changes required to fix installation issues should be applied to this branch following the usual [PR Workflow](https://github.com/integr8ly/delorean/blob/master/docs/integrealy-ci/prow-pr-workflow.md)

More details about the Early Warning System that generated this can be found [here](https://github.com/integr8ly/delorean/tree/master/docs/ews)

## Type of change

- [X] Product Update

## Checklist
- [ ] Older product manifests (N-2) have been removed
- [ ] Operator and Product Versions are updated correctly
- [ ] Go Modules are updated if required