### PR TITLE
[WIP] apicurito update to 7.7.0

### DIFF
--- a/manifests/integreatly-apicurito/7.7.0/apicurito.crd.yaml
+++ b/manifests/integreatly-apicurito/7.7.0/apicurito.crd.yaml
@@ -1,0 +1,38 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apicuritos.apicur.io
+spec:
+  group: apicur.io
+  names:
+    kind: Apicurito
+    listKind: ApicuritoList
+    plural: apicuritos
+    singular: apicurito
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-apicurito/7.7.0/apicuritooperator.v7.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-apicurito/7.7.0/apicuritooperator.v7.7.0.clusterserviceversion.yaml
@@ -16,7 +16,7 @@ metadata:
     capabilities: Seamless Upgrades
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+    containerImage: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
     createdAt: "2020-06-09 10:50:34"
     description: Manages the installation and upgrades of the API Designer, a small/minimal
       version of Apicurio
@@ -103,18 +103,18 @@ spec:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
                 - name: RELATED_IMAGE_APICURITO_OPERATOR
-                  value: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+                  value: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
                 - name: RELATED_IMAGE_APICURITO
-                  value: quay.io/integreatly/delorean:fuse7-fuse-apicurito_1.7
+                  value: registry.redhat.io/fuse7/fuse-apicurito:1.7
                 - name: RELATED_IMAGE_GENERATOR
-                  value: quay.io/integreatly/delorean:fuse7-fuse-apicurito-generator_1.7
+                  value: registry.redhat.io/fuse7/fuse-apicurito-generator:1.7
                 - name: POD_NAME
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: apicurito-operator
-                image: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+                image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
                 imagePullPolicy: Always
                 name: apicurito-operator
                 resources: {}

--- a/manifests/integreatly-apicurito/7.7.0/apicuritooperator.v7.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-apicurito/7.7.0/apicuritooperator.v7.7.0.clusterserviceversion.yaml
@@ -1,0 +1,214 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [{
+              "apiVersion": "apicur.io/v1alpha1",
+              "kind": "Apicurito",
+              "metadata": {
+                "name": "apicurito-service"
+              },
+              "spec": {
+                "size": 2
+              }
+            }]
+    capabilities: Seamless Upgrades
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+    createdAt: "2020-06-09 10:50:34"
+    description: Manages the installation and upgrades of the API Designer, a small/minimal
+      version of Apicurio
+    repository: https://github.com/Apicurio/apicurio-operators/tree/master/apicurito
+    support: Apicurito Project
+  name: apicuritooperator.v7.7.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: CRD for Apicurito
+      displayName: Apicurito CRD
+      kind: Apicurito
+      name: apicuritos.apicur.io
+      specDescriptors:
+      - description: The number of Apicurito pods to deploy
+        displayName: Size
+        path: size
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Deployment
+        - urn:alm:descriptor:com.tectonic.ui:podCount
+      - description: The image used for the Apicurito deployment
+        displayName: Image
+        path: image
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:fieldGroup:Deployment
+        - urn:alm:descriptor:com.tectonic.ui:text
+      version: v1alpha1
+  description: "The API Designer is a small/minimal version of Apicurio, a standalone
+    API design studio that can be used to create new or edit existing API designs
+    (using the OpenAPI specification).\n\nThis operator supports the installation
+    and upgrade of apicurito. Apicurito components are:\n   - apicurito-ui (apicurito
+    application)\n   - apicurito route (to access apicurito from outside openshift)\n\n###
+    How to install\nWhen the operator is installed (you have created a subscription
+    and the operator is running in the selected namespace) create a new CR of Kind
+    Apicurito (click the Create New button). The CR spec contains all defaults.\n\nAt
+    the moment, following fields are supported as part of the CR:\n   - size: number
+    of replicas\n   - image: For testing purposes only. Changing this image in an
+    existing installation will trigger an upgrade of the operand. \n### How to upgrade\nUpgrades
+    are triggered by updating the image field in the CR. This can be done manually
+    via the Openshift console, or with kubectl:\n```\n$ cat apicurito_cr.yaml\n    apiVersion:
+    apicur.io/v1alpha1\n      kind: Apicurito\n      metadata:\n        name: apicurito-service\n
+    \     spec:\n        size: 3            \n $ kubectl apply -f apicurito_cr.yaml\n```\n"
+  displayName: API Designer
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2Q3MWUwMDt9LmNscy0ye2ZpbGw6I2MyMWEwMDt9LmNscy0ze2ZpbGw6I2ZmZjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPnByb2R1Y3RpY29uc18xMDE3X1JHQl9BUEkgZmluYWwgY29sb3I8L3RpdGxlPjxnIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMC43MSA1MCkgcm90YXRlKC00NSkiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik01MC4yNSwzMC44M2EyLjY5LDIuNjksMCwxLDAtMi42OC0yLjY5QTIuNjUsMi42NSwwLDAsMCw1MC4yNSwzMC44M1pNNDMuMzYsMzkuNGEzLjM1LDMuMzUsMCwwLDAsMy4zMiwzLjM0LDMuMzQsMy4zNCwwLDAsMCwwLTYuNjdBMy4zNSwzLjM1LDAsMCwwLDQzLjM2LDM5LjRabTMuOTIsOS44OUEyLjY4LDIuNjgsMCwxLDAsNDQuNiw1MiwyLjcsMi43LDAsMCwwLDQ3LjI4LDQ5LjI5Wk0zMi42MywyOS42NWEzLjI2LDMuMjYsMCwxLDAtMy4yNC0zLjI2QTMuMjYsMy4yNiwwLDAsMCwzMi42MywyOS42NVpNNDAuNTMsMzRhMi43NywyLjc3LDAsMCwwLDAtNS41MywyLjc5LDIuNzksMCwwLDAtMi43NiwyLjc3QTIuODUsMi44NSwwLDAsMCw0MC41MywzNFptMS43Ni05LjMxYTQuNCw0LjQsMCwxLDAtNC4zOC00LjRBNC4zNyw0LjM3LDAsMCwwLDQyLjI5LDI0LjcxWk0zMi43OCw0OWE3LDcsMCwxLDAtNy03QTcsNywwLDAsMCwzMi43OCw0OVptMzIuMTMtNy43YTQuMjMsNC4yMywwLDAsMCw0LjMsNC4zMSw0LjMxLDQuMzEsMCwxLDAtNC4zLTQuMzFabTYuOSwxMC4wNmEzLjA4LDMuMDgsMCwxLDAsMy4wOC0zLjA5QTMuMDksMy4wOSwwLDAsMCw3MS44MSw1MS4zOFpNNzMuOSwzNC43N2E0LjMxLDQuMzEsMCwxLDAtNC4zLTQuMzFBNC4yOCw0LjI4LDAsMCwwLDczLjksMzQuNzdaTTUyLjE2LDQ1LjA2YTMuNjUsMy42NSwwLDEsMCwzLjY1LTMuNjZBMy42NCwzLjY0LDAsMCwwLDUyLjE2LDQ1LjA2Wk01NSwyMmEzLjE3LDMuMTcsMCwwLDAsMy4xNi0zLjE3QTMuMjMsMy4yMywwLDAsMCw1NSwxNS42MywzLjE3LDMuMTcsMCwwLDAsNTUsMjJabS0uNDcsMTAuMDlBNS4zNyw1LjM3LDAsMCwwLDYwLDM3LjU0YTUuNDgsNS40OCwwLDEsMC01LjQ1LTUuNDhaTTY2LjI1LDI1LjVhMi42OSwyLjY5LDAsMSwwLTIuNjgtMi42OUEyLjY1LDIuNjUsMCwwLDAsNjYuMjUsMjUuNVpNNDUuNyw2My4xYTMuNDIsMy40MiwwLDEsMC0zLjQxLTMuNDJBMy40MywzLjQzLDAsMCwwLDQ1LjcsNjMuMVptMTQsMTEuMTlhNC40LDQuNCwwLDEsMCw0LjM4LDQuNEE0LjM3LDQuMzcsMCwwLDAsNTkuNzMsNzQuMjlaTTYyLjMsNTAuNTFhOS4yLDkuMiwwLDEsMCw5LjE2LDkuMkE5LjIyLDkuMjIsMCwwLDAsNjIuMyw1MC41MVpNNTAuMSw2Ni43N2EyLjY5LDIuNjksMCwxLDAsMi42OCwyLjY5QTIuNywyLjcsMCwwLDAsNTAuMSw2Ni43N1pNODEuMjUsNDEuMTJhMi43LDIuNywwLDAsMC0yLjY4LDIuNjksMi42NSwyLjY1LDAsMCwwLDIuNjgsMi42OSwyLjY5LDIuNjksMCwwLDAsMC01LjM3Wk00NC40OSw3Ni40N2EzLjczLDMuNzMsMCwwLDAtMy43MywzLjc0LDMuNzcsMy43NywwLDEsMCwzLjczLTMuNzRaTTc5LjA2LDU2LjcyYTQsNCwwLDEsMCw0LDRBNCw0LDAsMCwwLDc5LjA2LDU2LjcyWm0tNiwxMS43OEEzLjA5LDMuMDksMCwwLDAsNzAsNzEuNmEzLDMsMCwwLDAsMy4wOCwzLjA5LDMuMDksMy4wOSwwLDAsMCwwLTYuMTlaTTI4LjMsNjhhNC4xNiw0LjE2LDAsMCwwLTQuMTQsNC4xNUE0LjIxLDQuMjEsMCwwLDAsMjguMyw3Ni4zYTQuMTUsNC4xNSwwLDAsMCwwLTguM1ptLTguMjItOWEzLDMsMCwxLDAsMywzQTMuMDUsMy4wNSwwLDAsMCwyMC4wOCw1OVptMS44NC05Ljc0YTMsMywwLDEsMCwzLDNBMy4wNSwzLjA1LDAsMCwwLDIxLjkxLDQ5LjIyWk0yMi4zNyw0MmEzLjI0LDMuMjQsMCwxLDAtMy4yNCwzLjI2QTMuMjYsMy4yNiwwLDAsMCwyMi4zNyw0MlpNNDMuMTEsNzAuMmEzLjgsMy44LDAsMCwwLTMuODEtMy43NCwzLjczLDMuNzMsMCwwLDAtMy43MywzLjc0QTMuOCwzLjgsMCwwLDAsMzkuMyw3NCwzLjg3LDMuODcsMCwwLDAsNDMuMTEsNzAuMlpNMzcuNTYsNTguNDNhNC42OCw0LjY4LDAsMCwwLTQuNjItNC42NCw0LjYzLDQuNjMsMCwwLDAtNC42Miw0LjY0LDQuNTgsNC41OCwwLDAsMCw0LjYyLDQuNjRBNC42Myw0LjYzLDAsMCwwLDM3LjU2LDU4LjQzWk0yMy4xMSwzMy44MmEyLjUyLDIuNTIsMCwxLDAtMi41MS0yLjUyQTIuNTMsMi41MywwLDAsMCwyMy4xMSwzMy44MloiLz48L2c+PC9zdmc+
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          - consoleyamlsamples
+          verbs:
+          - get
+          - create
+          - list
+          - update
+          - delete
+        serviceAccountName: apicurito
+      deployments:
+      - name: apicurito-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: apicurito
+              name: apicurito-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app: apicurito
+                name: apicurito-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: RELATED_IMAGE_APICURITO_OPERATOR
+                  value: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+                - name: RELATED_IMAGE_APICURITO
+                  value: quay.io/integreatly/delorean:fuse7-fuse-apicurito_1.7
+                - name: RELATED_IMAGE_GENERATOR
+                  value: quay.io/integreatly/delorean:fuse7-fuse-apicurito-generator_1.7
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: apicurito-operator
+                image: quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7
+                imagePullPolicy: Always
+                name: apicurito-operator
+                resources: {}
+              serviceAccountName: apicurito
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resourceNames:
+          - apicurito
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - apicur.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        serviceAccountName: apicurito
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - api
+  - apicurio
+  - apicurito
+  labels:
+    name: apicuritooperator
+  links:
+  - name: Apicurito source code
+    url: https://github.com/Apicurio/apicurito
+  - name: Apicurito operator source code
+    url: https://github.com/Apicurio/apicurio-operators/tree/master/apicurito
+  maintainers:
+  - email: apicurio@lists.jboss.org
+    name: Apicurito Project
+  maturity: alpha
+  provider:
+    name: Red Hat
+  relatedImages:
+  - image: registry.redhat.io/fuse7-tech-preview/fuse-apicurito-operator:1.7
+    name: fuse-apicurito-operator
+  - image: registry.redhat.io/fuse7/fuse-apicurito:1.7
+    name: fuse-apicurito
+  replaces: apicuritooperator.v7.6.0
+  selector:
+    matchLabels:
+      name: apicuritooperator
+  version: 7.7.0

--- a/manifests/integreatly-apicurito/apicurito.package.yaml
+++ b/manifests/integreatly-apicurito/apicurito.package.yaml
@@ -1,4 +1,5 @@
-packageName: rhmi-apicurito
 channels:
-  - name: rhmi
-    currentCSV: apicuritooperator.v7.6.0
+- currentCSV: apicuritooperator.v7.7.0
+  name: rhmi
+defaultChannel: rhmi
+packageName: rhmi-apicurito

--- a/manifests/integreatly-apicurito/image_mirror_mapping
+++ b/manifests/integreatly-apicurito/image_mirror_mapping
@@ -1,0 +1,3 @@
+registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-apicurito-generator:1.7 quay.io/integreatly/delorean:fuse7-fuse-apicurito-generator_1.7
+registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-apicurito:1.7 quay.io/integreatly/delorean:fuse7-fuse-apicurito_1.7
+registry-proxy.engineering.redhat.com/rh-osbs/fuse7-tech-preview-fuse-apicurito-operator:1.7 quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7

--- a/manifests/integreatly-apicurito/image_mirror_mapping
+++ b/manifests/integreatly-apicurito/image_mirror_mapping
@@ -1,3 +1,0 @@
-registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-apicurito-generator:1.7 quay.io/integreatly/delorean:fuse7-fuse-apicurito-generator_1.7
-registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-apicurito:1.7 quay.io/integreatly/delorean:fuse7-fuse-apicurito_1.7
-registry-proxy.engineering.redhat.com/rh-osbs/fuse7-tech-preview-fuse-apicurito-operator:1.7 quay.io/integreatly/delorean:fuse7-tech-preview-fuse-apicurito-operator_1.7

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -60,7 +60,7 @@ var (
 	// Follow up Jira: https://issues.redhat.com/browse/INTLY-5946
 	VersionAMQOnline           ProductVersion = "1.4"
 	VersionApicurioRegistry    ProductVersion = "1.2.3.final"
-	VersionApicurito           ProductVersion = "7.6"
+	VersionApicurito           ProductVersion = "7.7"
 	VersionAMQStreams          ProductVersion = "1.1.0"
 	VersionCodeReadyWorkspaces ProductVersion = "2.1.1"
 	VersionFuseOnOpenshift     ProductVersion = "7.6"
@@ -100,7 +100,7 @@ var (
 	OperatorVersionCloudResources      OperatorVersion = "0.18.0"
 	OperatorVersionUPS                 OperatorVersion = "0.5.0"
 	OperatorVersionApicurioRegistry    OperatorVersion = "0.0.3"
-	OperatorVersionApicurito           OperatorVersion = "1.6.0"
+	OperatorVersionApicurito           OperatorVersion = "1.7.0"
 	OperatorVersionMonitoringSpec      OperatorVersion = "1.0"
 
 	// Event reasons to be used when emitting events


### PR DESCRIPTION
Update apicurito manifest to 7.7.0 

This is an automatically generated branch to track the '7.7.0' version of the 'apicurito' OLM manifests.
This branch will be automatically updated with any changes related to this version until it finally GAs. 

Changes required to fix installation issues should be applied to this branch following the usual [PR Workflow](https://github.com/integr8ly/delorean/blob/master/docs/integrealy-ci/prow-pr-workflow.md)

More details about the Early Warning System that generated this can be found [here](https://github.com/integr8ly/delorean/tree/master/docs/ews)

## Type of change

- [X] Product Update

## Checklist
- [ ] Older product manifests (N-2) have been removed
- [ ] Operator and Product Versions are updated correctly
- [ ] Go Modules are updated if required