### PR TITLE
fix test flake - grafana route

### DIFF
--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -35,9 +35,14 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	if forbiddenResp.StatusCode != http.StatusForbidden {
 		t.Fatalf("unexpected status code on forbidden request, got=%+v", forbiddenResp)
 	}
+	//create new http client
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal("failed to create testing http client", err)
+	}
 	//retrieve an openshift oauth proxy cookie
 	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
-	if err := resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, httpClient, TestingIDPRealm, t); err != nil {
 		t.Fatal("failed to login through openshift oauth proxy", err)
 	}
 
@@ -45,7 +50,7 @@ func TestGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {
 	if err != nil {
 		t.Fatal("failed to prepare test request to grafana", err)
 	}
-	successResp, err := ctx.HttpClient.Do(req)
+	successResp, err := httpClient.Do(req)
 
 	if err != nil {
 		t.Fatal("failed to perform test request to grafana", err)
@@ -70,14 +75,19 @@ func TestGrafanaExternalRouteDashboardExist(t *testing.T, ctx *TestingContext) {
 	if err != nil {
 		t.Fatal("failed to get grafana route", err)
 	}
+	//create new http client
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal("failed to create testing http client", err)
+	}
 	//retrieve an openshift oauth proxy cookie
 	grafanaOauthHostname := fmt.Sprintf("%s/oauth/start", grafanaRootHostname)
-	if err = resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err = resources.DoAuthOpenshiftUser(grafanaOauthHostname, grafanaCredsUsername, grafanaCredsPassword, httpClient, TestingIDPRealm, t); err != nil {
 		t.Fatal("failed to login through openshift oauth proxy", err)
 	}
 	//get dashboards for grafana from the external route
 	grafanaDashboardsUrl := fmt.Sprintf("%s/api/search", grafanaRootHostname)
-	dashboardResp, err := ctx.HttpClient.Get(grafanaDashboardsUrl)
+	dashboardResp, err := httpClient.Get(grafanaDashboardsUrl)
 	if err != nil {
 		t.Fatal("failed to perform test request to grafana", err)
 	}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

https://issues.redhat.com/browse/INTLY-6738

This change uses new http client to authenticate and send request to grafana to avoid possible issue with cookies remaining from last session.

As suggested by @HubertStefanski I've left the test as skipped if failed as it is hard to verify that this change really fixed the issue. I will observe prow tests and if the test flake won't show up in ~1 week, I will change it so that it won't be skipped in case of error.