### PR TITLE
refactor rhmi_version logic

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -48,6 +48,10 @@ const (
 	DefaultCloudResourceConfigName   = "cloud-resource-config"
 )
 
+var (
+	allProductsReconciled = false
+)
+
 // Add creates a new Installation Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager, products []string) error {
@@ -382,7 +386,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	metrics.SetRHMIStatus(installation)
 
 	// Check if the version needs to be updated
-	if (isFirstInstallReconcile(installation) || isUpgradeReconcile(installation)) && allProductsReconciled(installation) {
+	if (isFirstInstallReconcile(installation) || isUpgradeReconcile(installation)) && allProductsReconciled {
 		installation.Status.Version = installation.Status.ToVersion
 		installation.Status.ToVersion = ""
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
@@ -439,240 +443,6 @@ func isUpgradeReconcile(installation *integreatlyv1alpha1.RHMI) bool {
 		return true
 	}
 	return false
-}
-
-func allProductsReconciled(installation *integreatlyv1alpha1.RHMI) bool {
-	stages := installation.Status.Stages
-
-	return (verifyClusterRHSSOVersions(stages) &&
-		verifyCloudResourceVersions(stages) &&
-		verifyAMQOnlineVersions(stages) &&
-		verifyApicuritoVersions(stages) &&
-		verifyCodeReadyWorkspacesVersions(stages) &&
-		verifyFuseOnOpenshiftVersions(stages) &&
-		verifyMonitoringVersions(stages) &&
-		verify3ScaleVersions(stages) &&
-		verifyFuseOnlineVersions(stages) &&
-		verifyDataSyncVersions(stages) &&
-		verifyRHSSOUserVersions(stages) &&
-		verifyUPSVersions(stages) &&
-		verifySolutionExplorerVersions(stages))
-}
-
-func verifySolutionExplorerVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.SolutionExplorerStage].Products[integreatlyv1alpha1.ProductSolutionExplorer]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionSolutionExplorer)
-	installedOpVersion := string(versions.OperatorVersion)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Solution Explorer Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	return true
-}
-
-func verifyClusterRHSSOVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.AuthenticationStage].Products[integreatlyv1alpha1.ProductRHSSO]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionRHSSO)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionRHSSO)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Cluster RHSSO Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Cluster RHSSO Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyMonitoringVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.MonitoringStage].Products[integreatlyv1alpha1.ProductMonitoring]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionMonitoring)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionMonitoring)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Monitoring Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Monitoring Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyCloudResourceVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.CloudResourcesStage].Products[integreatlyv1alpha1.ProductCloudResources]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionCloudResources)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionCloudResources)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Cloud Resource Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Cloud Resource Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyApicuritoVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductApicurito]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionApicurito)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionApicurito)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Apicurito Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Apicurito Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyRHSSOUserVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductRHSSOUser]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionRHSSOUser)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionRHSSOUser)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("RHSSOUser Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("RHSSOUser Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyUPSVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductUps]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionUPS)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionUps)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("UPS Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("UPS Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verify3ScaleVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.Product3Scale]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersion3Scale)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.Version3Scale)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("3Scale Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("3Scale Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyDataSyncVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductDataSync]
-	expectedProductVersion := string(integreatlyv1alpha1.VersionDataSync)
-	installedProductVersion := string(versions.Version)
-
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Data Sync Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyFuseOnlineVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuse]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionFuse)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionFuseOnline)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("Fuse Online Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("Fuse Online Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyCodeReadyWorkspacesVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductCodeReadyWorkspaces]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionCodeReadyWorkspaces)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionCodeReadyWorkspaces)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("CodeReady Workspaces Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("CodeReady Workspaces Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyAMQOnlineVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductAMQOnline]
-	expectedOpVersion := string(integreatlyv1alpha1.OperatorVersionAMQOnline)
-	installedOpVersion := string(versions.OperatorVersion)
-	expectedProductVersion := string(integreatlyv1alpha1.VersionAMQOnline)
-	installedProductVersion := string(versions.Version)
-
-	if expectedOpVersion != installedOpVersion {
-		logrus.Debugf("AMQOnline Operator Version is not as expected. Expected %s, Actual %s", expectedOpVersion, installedOpVersion)
-		return false
-	}
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("AMQOnline Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
-}
-
-func verifyFuseOnOpenshiftVersions(stages map[integreatlyv1alpha1.StageName]integreatlyv1alpha1.RHMIStageStatus) bool {
-	versions := stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuseOnOpenshift]
-	expectedProductVersion := string(integreatlyv1alpha1.VersionFuseOnOpenshift)
-	installedProductVersion := string(versions.Version)
-
-	if expectedProductVersion != installedProductVersion {
-		logrus.Debugf("FuseOnOpenShift Version is not as expected. Expected %s, Actual %s", expectedProductVersion, installedProductVersion)
-		return false
-	}
-	return true
 }
 
 func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha1.RHMI, installationType *Type, configManager *config.Manager) (reconcile.Result, error) {
@@ -821,6 +591,9 @@ func (r *ReconcileInstallation) processStage(installation *integreatlyv1alpha1.R
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to build a reconciler for %s: %w", product.Name, err)
 		}
+
+		allProductsReconciled = reconciler.VerifyVersion(installation)
+
 		serverClient, err := k8sclient.New(r.restConfig, k8sclient.Options{})
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create server client: %w", err)
@@ -868,6 +641,7 @@ func (r *ReconcileInstallation) processStage(installation *integreatlyv1alpha1.R
 	if incompleteStage {
 		return integreatlyv1alpha1.PhaseInProgress, mErr
 	}
+
 	return integreatlyv1alpha1.PhaseCompleted, mErr
 }
 

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/sirupsen/logrus"
 
@@ -93,6 +94,15 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	product := installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductAMQOnline]
+	return version.VerifyProductAndOperatorVersion(
+		product,
+		string(integreatlyv1alpha1.VersionAMQOnline),
+		string(integreatlyv1alpha1.OperatorVersionAMQOnline),
+	)
 }
 
 // Reconcile reads that state of the cluster for amq online and makes changes based on the state read

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -84,6 +84,10 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	}
 }
 
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return true
+}
+
 // Reconcile reads that state of the cluster for amq streams and makes changes based on the state read
 // and what is required
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/apicurito/reconciler.go
+++ b/pkg/products/apicurito/reconciler.go
@@ -3,9 +3,11 @@ package apicurito
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoring"
-	"strings"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
@@ -87,6 +89,14 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductApicurito],
+		string(integreatlyv1alpha1.VersionApicurito),
+		string(integreatlyv1alpha1.OperatorVersionApicurito),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/sirupsen/logrus"
 
@@ -70,6 +71,15 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	product := installation.Status.Stages[integreatlyv1alpha1.CloudResourcesStage].Products[integreatlyv1alpha1.ProductCloudResources]
+	return version.VerifyProductAndOperatorVersion(
+		product,
+		string(integreatlyv1alpha1.VersionCloudResources),
+		string(integreatlyv1alpha1.OperatorVersionCloudResources),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -91,6 +92,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductCodeReadyWorkspaces],
+		string(integreatlyv1alpha1.VersionCodeReadyWorkspaces),
+		string(integreatlyv1alpha1.OperatorVersionCodeReadyWorkspaces),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/datasync/reconciler.go
+++ b/pkg/products/datasync/reconciler.go
@@ -13,6 +13,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/version"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil"
 	"github.com/sirupsen/logrus"
 
@@ -51,6 +52,14 @@ type Reconciler struct {
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductDataSync],
+		string(integreatlyv1alpha1.VersionDataSync),
+		"",
+	)
 }
 
 func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder) (*Reconciler, error) {

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -10,6 +10,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -105,6 +106,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuse],
+		string(integreatlyv1alpha1.VersionFuseOnline),
+		string(integreatlyv1alpha1.OperatorVersionFuse),
+	)
 }
 
 // Reconcile reads that state of the cluster for fuse and makes changes based on the state read

--- a/pkg/products/fuseonopenshift/reconciler.go
+++ b/pkg/products/fuseonopenshift/reconciler.go
@@ -9,8 +9,9 @@ import (
 	"net/http"
 	"path/filepath"
 	"reflect"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/sirupsen/logrus"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	samplesv1 "github.com/openshift/cluster-samples-operator/pkg/apis/samples/v1"
 
@@ -134,6 +136,14 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		recorder:      recorder,
 		installation:  installation,
 	}, nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductFuseOnOpenshift],
+		string(integreatlyv1alpha1.VersionFuseOnOpenshift),
+		string(integreatlyv1alpha1.OperatorVersionFuse),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 
@@ -114,6 +115,14 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		Reconciler:    resources.NewReconciler(mpm),
 		recorder:      recorder,
 	}, nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.MonitoringStage].Products[integreatlyv1alpha1.ProductMonitoring],
+		string(integreatlyv1alpha1.VersionMonitoring),
+		string(integreatlyv1alpha1.OperatorVersionMonitoring),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -6,6 +6,7 @@ import (
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
+	"github.com/integr8ly/integreatly-operator/version"
 	"github.com/operator-framework/operator-registry/pkg/lib/bundle"
 
 	"github.com/sirupsen/logrus"
@@ -52,6 +53,14 @@ type Reconciler struct {
 
 func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	return nil
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.MonitoringStage].Products[integreatlyv1alpha1.ProductMonitoringSpec],
+		string(integreatlyv1alpha1.VersionMonitoringSpec),
+		"",
+	)
 }
 
 func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI,

--- a/pkg/products/reconciler.go
+++ b/pkg/products/reconciler.go
@@ -85,6 +85,10 @@ type Interface interface {
 	//For example, codeready looks for a deployment in the scanned namespace with the name "codeready", if found this
 	//installation will stall until that product is removed.
 	GetPreflightObject(ns string) runtime.Object
+
+	//VerifyVersion checks if the version of the product installed is the same as the one defined in the operator
+	//
+	VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool
 }
 
 func NewReconciler(product integreatlyv1alpha1.ProductName, rc *rest.Config, configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mgr manager.Manager) (reconciler Interface, err error) {
@@ -182,4 +186,8 @@ func (n *NoOp) Reconcile(_ context.Context, _ *integreatlyv1alpha1.RHMI, _ *inte
 
 func (n *NoOp) GetPreflightObject(ns string) runtime.Object {
 	return &appsv1.Deployment{}
+}
+
+func (n *NoOp) VerifyVersion(_ *integreatlyv1alpha1.RHMI) bool {
+	return true
 }

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,8 +3,11 @@ package rhsso
 import (
 	"context"
 	"fmt"
-	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"strings"
+
+	"github.com/integr8ly/integreatly-operator/version"
+
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
@@ -113,6 +116,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.AuthenticationStage].Products[integreatlyv1alpha1.ProductRHSSO],
+		string(integreatlyv1alpha1.VersionRHSSO),
+		string(integreatlyv1alpha1.OperatorVersionRHSSO),
+	)
 }
 
 // Reconcile reads that state of the cluster for rhsso and makes changes based on the state read

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -9,6 +9,7 @@ import (
 
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoring"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
@@ -144,6 +145,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductRHSSOUser],
+		string(integreatlyv1alpha1.VersionRHSSOUser),
+		string(integreatlyv1alpha1.OperatorVersionRHSSOUser),
+	)
 }
 
 // Reconcile reads that state of the cluster for rhsso and makes changes based on the state read

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -129,6 +129,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 	}
 }
 
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.SolutionExplorerStage].Products[integreatlyv1alpha1.ProductSolutionExplorer],
+		string(integreatlyv1alpha1.VersionSolutionExplorer),
+		string(integreatlyv1alpha1.OperatorVersionSolutionExplorer),
+	)
+}
+
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	logrus.Info("Reconciling solution explorer")
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/sirupsen/logrus"
 
@@ -120,6 +121,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.Product3Scale],
+		string(integreatlyv1alpha1.Version3Scale),
+		string(integreatlyv1alpha1.OperatorVersion3Scale),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	"github.com/sirupsen/logrus"
@@ -93,6 +94,14 @@ func (r *Reconciler) GetPreflightObject(ns string) runtime.Object {
 			Namespace: ns,
 		},
 	}
+}
+
+func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool {
+	return version.VerifyProductAndOperatorVersion(
+		installation.Status.Stages[integreatlyv1alpha1.ProductsStage].Products[integreatlyv1alpha1.ProductUps],
+		string(integreatlyv1alpha1.VersionUps),
+		string(integreatlyv1alpha1.OperatorVersionUPS),
+	)
 }
 
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/version/version.go
+++ b/version/version.go
@@ -1,6 +1,26 @@
 package version
 
+import (
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/sirupsen/logrus"
+)
+
 var (
 	Version            = "2.3.0"
 	IntegreatlyVersion = "2.3.0"
 )
+
+func VerifyProductAndOperatorVersion(product integreatlyv1alpha1.RHMIProductStatus, expectedProductVersion string, expectedOpVersion string) bool {
+	installedOpVersion := string(product.OperatorVersion)
+	installedProductVersion := string(product.Version)
+
+	if expectedOpVersion != installedOpVersion {
+		logrus.Debugf("%s Operator Version is not as expected. Expected %s, Actual %s", product.Name, expectedOpVersion, installedOpVersion)
+		return false
+	}
+	if expectedProductVersion != installedProductVersion {
+		logrus.Debugf("%s Version is not as expected. Expected %s, Actual %s", product.Name, expectedProductVersion, installedProductVersion)
+		return false
+	}
+	return true
+}


### PR DESCRIPTION
# Description

Refactored code around rhmi_version metric based on this PR https://github.com/integr8ly/integreatly-operator/pull/776

## Steps to verify

1) install the operator via OLM using CSV 2.3.0
2) create a new version for the operator using the script 
`SEMVER=2.3.1 ./scripts/prepare-release.sh`
3) build a new image and push to quay.io using your own account 
`make image/build/push ORG= QUAY_USERNAME= QUAY_PASSWORD="" TAG=2.3.1`
4) change the image field in the csv 2.3.1 to point to your quay.io account and push the csv
https://github.com/integr8ly/integreatly-operator/blob/2e975e9ec2fc7a2beb0f1fe478b6d6f08f9b426d/deploy/olm-catalog/integreatly-operator/2.3.0/integreatly-operator.v2.3.0.clusterserviceversion.yaml#L306
5) change the rhmi_config CR to always approve an upgrade
6) Verify if the version field in the rhmi CR is has changed to version 2.3.1
7) Check if the metric is present in prometheus and shows the upgrade from 2.3.0 to 2.3.1
