### PR TITLE
Fix for missing plugins in endpointsdetailed grafana dashboard.

### DIFF
--- a/pkg/products/monitoring/dashboardsHelper.go
+++ b/pkg/products/monitoring/dashboardsHelper.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"fmt"
 
+	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	monitoring "github.com/integr8ly/integreatly-operator/pkg/products/monitoring/dashboards"
 )
 
@@ -35,4 +36,16 @@ func getSpecDetailsForDashboard(dashboard string) (string, string, error) {
 		return "", "", fmt.Errorf("Invalid/Unsupported Grafana Dashboard")
 
 	}
+}
+
+func getPluginsForGrafanaDashboard(name string) grafanav1alpha1.PluginList {
+	var pluginsList grafanav1alpha1.PluginList
+	if name == "endpointsdetailed" {
+		plugin := grafanav1alpha1.GrafanaPlugin{
+			Name:    "natel-discrete-panel",
+			Version: "0.0.9",
+		}
+		pluginsList = append(pluginsList, plugin)
+	}
+	return pluginsList
 }

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -492,6 +492,8 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 		return err
 	}
 
+	pluginList := getPluginsForGrafanaDashboard(dashboard)
+
 	opRes, err := controllerutil.CreateOrUpdate(ctx, serverClient, grafanaDB, func() error {
 		grafanaDB.Labels = map[string]string{
 			"monitoring-key": r.Config.GetLabelSelector(),
@@ -499,6 +501,9 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 		grafanaDB.Spec = grafanav1alpha1.GrafanaDashboardSpec{
 			Json: specJSON,
 			Name: name,
+		}
+		if len(pluginList) > 0 {
+			grafanaDB.Spec.Plugins = pluginList
 		}
 		return nil
 	})


### PR DESCRIPTION

# Description
JIRA Link: https://issues.redhat.com/browse/INTLY-8566

When moving the grafana dashboard definition from yaml to code, the plugins
for endpointsdetailed dashboard was missed. The code changes have been made to
add the plugins list.



## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer