### PR TITLE
[WIP] 3scale update to 0.5.5

### DIFF
--- a/manifests/integreatly-3scale/0.5.5/3scale-operator.v0.5.5.clusterserviceversion.yaml
+++ b/manifests/integreatly-3scale/0.5.5/3scale-operator.v0.5.5.clusterserviceversion.yaml
@@ -1,0 +1,340 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: '[{"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager"},"spec":{"wildcardDomain":"example.com"}},
+      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-ha"},"spec":{"highAvailability":{"enabled":true},"wildcardDomain":"example.com"}},
+      {"apiVersion":"apps.3scale.net/v1alpha1","kind":"APIManager","metadata":{"name":"example-apimanager-s3"},"spec":{"system":{"fileStorage":{"simpleStorageService":{"configurationSecretRef":{"name":"aws-auth"}}}},"wildcardDomain":"\u003cdesired-domain\u003e"}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"API","metadata":{"labels":{"environment":"testing"},"name":"example-api"},"spec":{"description":"api01","integrationMethod":{"apicastHosted":{"apiTestGetRequest":"/","authenticationSettings":{"credentials":{"apiKey":{"authParameterName":"user-key","credentialsLocation":"headers"}},"errors":{"authenticationFailed":{"contentType":"text/plain;
+      charset=us-ascii","responseBody":"Authentication failed","responseCode":403},"authenticationMissing":{"contentType":"text/plain;
+      charset=us-ascii","responseBody":"Authentication Missing","responseCode":403}},"hostHeader":"","secretToken":"MySecretTokenBetweenApicastAndMyBackend_1237120312"},"mappingRulesSelector":{"matchLabels":{"api":"api01"}},"privateBaseURL":"https://echo-api.3scale.net:443"}}}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Binding","metadata":{"name":"example-binding"},"spec":{"APISelector":{"matchLabels":{"environment":"testing"}},"credentialsRef":{"name":"ecorp-tenant-secret"}}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Limit","metadata":{"labels":{"api":"api01"},"name":"plan01-metric01-day-10"},"spec":{"description":"Limit
+      for metric01 in plan01","maxValue":10,"metricRef":{"name":"metric01"},"period":"day"}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"MappingRule","metadata":{"labels":{"api":"api01"},"name":"metric01-get-path01"},"spec":{"increment":1,"method":"GET","metricRef":{"name":"metric01"},"path":"/path01"}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Metric","metadata":{"labels":{"api":"api01"},"name":"metric01"},"spec":{"description":"metric01","incrementHits":false,"unit":"hit"}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Plan","metadata":{"labels":{"api":"api01"},"name":"example-plan"},"spec":{"approvalRequired":false,"costs":{"costMonth":0,"setupFee":0},"default":true,"limitSelector":{"matchLabels":{"plan":"plan01"}},"trialPeriod":0}},
+      {"apiVersion":"capabilities.3scale.net/v1alpha1","kind":"Tenant","metadata":{"name":"example-tenant"},"spec":{"email":"admin@example.com","masterCredentialsRef":{"name":"system-seed"},"organizationName":"Example.com","passwordCredentialsRef":{"name":"ecorp-admin-secret"},"systemMasterUrl":"https://master.example.com","tenantSecretRef":{"name":"ecorp-tenant-secret","namespace":"operator-test"},"username":"admin"}}]'
+    capabilities: Full Lifecycle
+    categories: Integration & Delivery
+    certified: "false"
+    containerImage: quay.io/integreatly/delorean:3scale-amp2-3scale-rhel7-operator_latest
+    createdAt: "2019-05-30T22:40:00Z"
+    description: 3scale Operator to provision 3scale and publish/manage API
+    repository: https://github.com/3scale/3scale-operator
+    support: Red Hat, Inc.
+    tectonic-visibility: ocs
+  name: 3scale-operator.v0.5.5
+  namespace: placeholder
+spec:
+  customresourcedefinitions:
+    owned:
+    - description: API Manager
+      displayName: API Manager
+      kind: APIManager
+      name: apimanagers.apps.3scale.net
+      resources:
+      - kind: DeploymentConfig
+        name: ""
+        version: apps.openshift.io/v1
+      - kind: PersistentVolumeClaim
+        name: ""
+        version: v1
+      - kind: Service
+        name: ""
+        version: v1
+      - kind: Route
+        name: ""
+        version: route.openshift.io/v1
+      - kind: ImageStream
+        name: ""
+        version: image.openshift.io/v1
+      specDescriptors:
+      - description: Wildcard domain as configured in the API Manager object
+        displayName: Wildcard Domain
+        path: wildcardDomain
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:label
+      statusDescriptors:
+      - description: API Manager Deployment Configs
+        displayName: Deployments
+        path: deployments
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:podStatuses
+      version: v1alpha1
+    - description: API
+      displayName: API
+      kind: API
+      name: apis.capabilities.3scale.net
+      version: v1alpha1
+    - description: Binding
+      displayName: Binding
+      kind: Binding
+      name: bindings.capabilities.3scale.net
+      version: v1alpha1
+    - description: Limit
+      displayName: Limit
+      kind: Limit
+      name: limits.capabilities.3scale.net
+      version: v1alpha1
+    - description: MappingRule
+      displayName: MappingRule
+      kind: MappingRule
+      name: mappingrules.capabilities.3scale.net
+      version: v1alpha1
+    - description: Metric
+      displayName: Metric
+      kind: Metric
+      name: metrics.capabilities.3scale.net
+      version: v1alpha1
+    - description: Plan
+      displayName: Plan
+      kind: Plan
+      name: plans.capabilities.3scale.net
+      version: v1alpha1
+    - description: Tenant
+      displayName: Tenant
+      kind: Tenant
+      name: tenants.capabilities.3scale.net
+      version: v1alpha1
+  description: |
+    The 3scale Operator creates and maintains the Red Hat 3scale API Management on OpenShift in various deployment configurations.
+
+    3scale API Management makes it easy to manage your APIs.
+    Share, secure, distribute, control, and monetize your APIs on an infrastructure platform built for performance, customer control, and future growth.
+
+    ### Supported Features
+    * **Installer** A way to install a 3scale API Management solution, providing configurability options at the time of installation
+    * **Upgrade** Upgrade from previously installed 3scale API Management solution
+    * **Reconcilliation** Tunable CRD parameters after 3scale API Management solution is installed
+    * **Capabilities** Ability to define 3scale API definitions and set them into a 3scale API Management solution
+
+    ### Documentation
+    [3scale api management](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management)
+    [Deploying 3scale using the operator](https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.8/html/installing_3scale/install-threescale-on-openshift-guide#deploying-threescale-using-the-operator)
+
+    ### Getting help
+    If you encounter any issues while using 3scale operator, you can create an issue on our [Github repo](https://github.com/3scale/3scale-operator) for bugs, enhancements, or other requests.
+
+    ### Contributing
+    You can contribute by:
+
+    * Raising any issues you find using 3scale Operator
+    * Fixing issues by opening [Pull Requests](https://github.com/3scale/3scale-operator/pulls)
+    * Talking about 3scale Operator
+
+    All bugs, tasks or enhancements are tracked as [GitHub issues](https://github.com/3scale/3scale-operator/issues).
+
+    ### License
+    3scale Operator is licensed under the [Apache 2.0 license](https://github.com/3scale/3scale-operator/blob/master/LICENSE)
+  displayName: Red Hat Integration - 3scale
+  icon:
+  - base64data: PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxMDAgMTAwIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2Q3MWUwMDt9LmNscy0ye2ZpbGw6I2MyMWEwMDt9LmNscy0ze2ZpbGw6I2ZmZjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPnByb2R1Y3RpY29uc18xMDE3X1JHQl9BUEkgZmluYWwgY29sb3I8L3RpdGxlPjxnIGlkPSJMYXllcl8xIiBkYXRhLW5hbWU9IkxheWVyIDEiPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iNTAiIGN5PSI1MCIgcj0iNTAiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yMC43MSA1MCkgcm90YXRlKC00NSkiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik04NS4zNiwxNC42NEE1MCw1MCwwLDAsMSwxNC42NCw4NS4zNloiLz48cGF0aCBjbGFzcz0iY2xzLTMiIGQ9Ik01MC4yNSwzMC44M2EyLjY5LDIuNjksMCwxLDAtMi42OC0yLjY5QTIuNjUsMi42NSwwLDAsMCw1MC4yNSwzMC44M1pNNDMuMzYsMzkuNGEzLjM1LDMuMzUsMCwwLDAsMy4zMiwzLjM0LDMuMzQsMy4zNCwwLDAsMCwwLTYuNjdBMy4zNSwzLjM1LDAsMCwwLDQzLjM2LDM5LjRabTMuOTIsOS44OUEyLjY4LDIuNjgsMCwxLDAsNDQuNiw1MiwyLjcsMi43LDAsMCwwLDQ3LjI4LDQ5LjI5Wk0zMi42MywyOS42NWEzLjI2LDMuMjYsMCwxLDAtMy4yNC0zLjI2QTMuMjYsMy4yNiwwLDAsMCwzMi42MywyOS42NVpNNDAuNTMsMzRhMi43NywyLjc3LDAsMCwwLDAtNS41MywyLjc5LDIuNzksMCwwLDAtMi43NiwyLjc3QTIuODUsMi44NSwwLDAsMCw0MC41MywzNFptMS43Ni05LjMxYTQuNCw0LjQsMCwxLDAtNC4zOC00LjRBNC4zNyw0LjM3LDAsMCwwLDQyLjI5LDI0LjcxWk0zMi43OCw0OWE3LDcsMCwxLDAtNy03QTcsNywwLDAsMCwzMi43OCw0OVptMzIuMTMtNy43YTQuMjMsNC4yMywwLDAsMCw0LjMsNC4zMSw0LjMxLDQuMzEsMCwxLDAtNC4zLTQuMzFabTYuOSwxMC4wNmEzLjA4LDMuMDgsMCwxLDAsMy4wOC0zLjA5QTMuMDksMy4wOSwwLDAsMCw3MS44MSw1MS4zOFpNNzMuOSwzNC43N2E0LjMxLDQuMzEsMCwxLDAtNC4zLTQuMzFBNC4yOCw0LjI4LDAsMCwwLDczLjksMzQuNzdaTTUyLjE2LDQ1LjA2YTMuNjUsMy42NSwwLDEsMCwzLjY1LTMuNjZBMy42NCwzLjY0LDAsMCwwLDUyLjE2LDQ1LjA2Wk01NSwyMmEzLjE3LDMuMTcsMCwwLDAsMy4xNi0zLjE3QTMuMjMsMy4yMywwLDAsMCw1NSwxNS42MywzLjE3LDMuMTcsMCwwLDAsNTUsMjJabS0uNDcsMTAuMDlBNS4zNyw1LjM3LDAsMCwwLDYwLDM3LjU0YTUuNDgsNS40OCwwLDEsMC01LjQ1LTUuNDhaTTY2LjI1LDI1LjVhMi42OSwyLjY5LDAsMSwwLTIuNjgtMi42OUEyLjY1LDIuNjUsMCwwLDAsNjYuMjUsMjUuNVpNNDUuNyw2My4xYTMuNDIsMy40MiwwLDEsMC0zLjQxLTMuNDJBMy40MywzLjQzLDAsMCwwLDQ1LjcsNjMuMVptMTQsMTEuMTlhNC40LDQuNCwwLDEsMCw0LjM4LDQuNEE0LjM3LDQuMzcsMCwwLDAsNTkuNzMsNzQuMjlaTTYyLjMsNTAuNTFhOS4yLDkuMiwwLDEsMCw5LjE2LDkuMkE5LjIyLDkuMjIsMCwwLDAsNjIuMyw1MC41MVpNNTAuMSw2Ni43N2EyLjY5LDIuNjksMCwxLDAsMi42OCwyLjY5QTIuNywyLjcsMCwwLDAsNTAuMSw2Ni43N1pNODEuMjUsNDEuMTJhMi43LDIuNywwLDAsMC0yLjY4LDIuNjksMi42NSwyLjY1LDAsMCwwLDIuNjgsMi42OSwyLjY5LDIuNjksMCwwLDAsMC01LjM3Wk00NC40OSw3Ni40N2EzLjczLDMuNzMsMCwwLDAtMy43MywzLjc0LDMuNzcsMy43NywwLDEsMCwzLjczLTMuNzRaTTc5LjA2LDU2LjcyYTQsNCwwLDEsMCw0LDRBNCw0LDAsMCwwLDc5LjA2LDU2LjcyWm0tNiwxMS43OEEzLjA5LDMuMDksMCwwLDAsNzAsNzEuNmEzLDMsMCwwLDAsMy4wOCwzLjA5LDMuMDksMy4wOSwwLDAsMCwwLTYuMTlaTTI4LjMsNjhhNC4xNiw0LjE2LDAsMCwwLTQuMTQsNC4xNUE0LjIxLDQuMjEsMCwwLDAsMjguMyw3Ni4zYTQuMTUsNC4xNSwwLDAsMCwwLTguM1ptLTguMjItOWEzLDMsMCwxLDAsMywzQTMuMDUsMy4wNSwwLDAsMCwyMC4wOCw1OVptMS44NC05Ljc0YTMsMywwLDEsMCwzLDNBMy4wNSwzLjA1LDAsMCwwLDIxLjkxLDQ5LjIyWk0yMi4zNyw0MmEzLjI0LDMuMjQsMCwxLDAtMy4yNCwzLjI2QTMuMjYsMy4yNiwwLDAsMCwyMi4zNyw0MlpNNDMuMTEsNzAuMmEzLjgsMy44LDAsMCwwLTMuODEtMy43NCwzLjczLDMuNzMsMCwwLDAtMy43MywzLjc0QTMuOCwzLjgsMCwwLDAsMzkuMyw3NCwzLjg3LDMuODcsMCwwLDAsNDMuMTEsNzAuMlpNMzcuNTYsNTguNDNhNC42OCw0LjY4LDAsMCwwLTQuNjItNC42NCw0LjYzLDQuNjMsMCwwLDAtNC42Miw0LjY0LDQuNTgsNC41OCwwLDAsMCw0LjYyLDQuNjRBNC42Myw0LjYzLDAsMCwwLDM3LjU2LDU4LjQzWk0yMy4xMSwzMy44MmEyLjUyLDIuNTIsMCwxLDAtMi41MS0yLjUyQTIuNTMsMi41MywwLDAsMCwyMy4xMSwzMy44MloiLz48L2c+PC9zdmc+
+    mediatype: image/svg+xml
+  install:
+    spec:
+      deployments:
+      - name: 3scale-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: threescale-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: threescale-operator
+            spec:
+              containers:
+              - command:
+                - 3scale-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: threescale-operator
+                - name: BACKEND_IMAGE
+                  value: quay.io/integreatly/delorean:3scale-amp2-backend-rhel7_latest
+                - name: APICAST_IMAGE
+                  value: quay.io/integreatly/delorean:3scale-amp2-apicast-gateway-rhel8_latest
+                - name: SYSTEM_IMAGE
+                  value: quay.io/integreatly/delorean:3scale-amp2-system-rhel7_latest
+                - name: ZYNC_IMAGE
+                  value: quay.io/integreatly/delorean:3scale-amp2-zync-rhel7_latest
+                - name: SYSTEM_MEMCACHED_IMAGE
+                  value: quay.io/integreatly/delorean:3scale-amp2-memcached-rhel7_latest
+                - name: BACKEND_REDIS_IMAGE
+                  value: quay.io/integreatly/delorean:rhscl-redis-32-rhel7_latest
+                - name: SYSTEM_REDIS_IMAGE
+                  value: quay.io/integreatly/delorean:rhscl-redis-32-rhel7_latest
+                - name: SYSTEM_MYSQL_IMAGE
+                  value: quay.io/integreatly/delorean:rhscl-mysql-57-rhel7_latest
+                - name: SYSTEM_POSTGRESQL_IMAGE
+                  value: quay.io/integreatly/delorean:rhscl-postgresql-10-rhel7_latest
+                - name: ZYNC_POSTGRESQL_IMAGE
+                  value: quay.io/integreatly/delorean:rhscl-postgresql-10-rhel7_latest
+                image: quay.io/integreatly/delorean:3scale-amp2-3scale-rhel7-operator_latest
+                name: 3scale-operator
+                resources: {}
+              serviceAccountName: 3scale-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - replicationcontrollers
+          - services
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          - serviceaccounts
+          - bindings/finalizers
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - '*'
+        - apiGroups:
+          - apps
+          resourceNames:
+          - 3scale-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - '*'
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          - imagestreams/layers
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/status
+          verbs:
+          - get
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - '*'
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - apps.3scale.net
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - capabilities.3scale.net
+          resources:
+          - '*'
+          - bindings
+          - metrics
+          - plans
+          - limits
+          - mappingrules
+          - tenants
+          verbs:
+          - '*'
+        serviceAccountName: 3scale-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - 3scale
+  - API
+  links:
+  - name: GitHub
+    url: https://github.com/3scale/3scale-operator
+  - name: Documentation
+    url: https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.8/html/installing_3scale/install-threescale-on-openshift-guide#deploying-threescale-using-the-operator
+  maintainers:
+  - email: eastizle+3scaleoperator@redhat.com
+    name: 3scale
+  - email: msoriano+3scaleoperator@redhat.com
+    name: 3scale
+  maturity: stable
+  provider:
+    name: Red Hat
+  relatedImages:
+  - image: registry.stage.redhat.io/3scale-amp2/apicast-gateway-rhel8@sha256:3023b37ccfc902bfafd2c344dc5595295369a2dc00ea38b27c193ca5b138942b
+    name: apicast-gateway-rhel8
+  - image: registry.stage.redhat.io/3scale-amp2/backend-rhel7@sha256:bd626295c55a7815a816d7049fba1febdec6a3305dee2a3292e92a26d56036b0
+    name: backend-rhel7
+  - image: registry.stage.redhat.io/3scale-amp2/system-rhel7@sha256:29836068f71f53f88b75345055808106cb4620bf3d488bd458709936d716377f
+    name: system-rhel7
+  - image: registry.stage.redhat.io/3scale-amp2/zync-rhel7@sha256:f46b47b84450a81cb463b66dc86b91baf0dd60bdca275192925f6924b90a57bf
+    name: zync-rhel7
+  - image: registry.stage.redhat.io/3scale-amp2/memcached-rhel7@sha256:2be57d773843135c0677e31d34b0cd24fa9dafc4ef1367521caa2bab7c6122e6
+    name: memcached-rhel7
+  - name: redis-32-rhel7
+    value: registry.redhat.io/rhscl/redis-32-rhel7@sha256:a9bdf52384a222635efc0284db47d12fbde8c3d0fcb66517ba8eefad1d4e9dc9
+  - name: mysql-57-rhel7
+    value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
+  - name: postgresql-10-rhel7
+    value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd
+  replaces: 3scale-operator.v0.5.2
+  version: 0.5.5

--- a/manifests/integreatly-3scale/0.5.5/apps_v1alpha1_apimanager_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/apps_v1alpha1_apimanager_crd.yaml
@@ -1,0 +1,238 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apimanagers.apps.3scale.net
+spec:
+  group: apps.3scale.net
+  names:
+    kind: APIManager
+    listKind: APIManagerList
+    plural: apimanagers
+    singular: apimanager
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            apicast:
+              properties:
+                image:
+                  type: string
+                managementAPI:
+                  type: string
+                openSSLVerify:
+                  type: boolean
+                productionSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+                registryURL:
+                  type: string
+                responseCodes:
+                  type: boolean
+                stagingSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+              type: object
+            appLabel:
+              type: string
+            backend:
+              properties:
+                cronSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+                image:
+                  type: string
+                listenerSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+                redisImage:
+                  type: string
+                workerSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+              type: object
+            highAvailability:
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+            imageStreamTagImportInsecure:
+              type: boolean
+            podDisruptionBudget:
+              properties:
+                enabled:
+                  type: boolean
+              type: object
+            resourceRequirementsEnabled:
+              type: boolean
+            system:
+              properties:
+                appSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+                database:
+                  properties:
+                    mysql:
+                      description: Union type. Only one of the fields can be set
+                      properties:
+                        image:
+                          type: string
+                      type: object
+                    postgresql:
+                      properties:
+                        image:
+                          type: string
+                      type: object
+                  type: object
+                fileStorage:
+                  properties:
+                    amazonSimpleStorageService:
+                      description: Deprecated
+                      properties:
+                        awsBucket:
+                          description: Deprecated
+                          type: string
+                        awsCredentialsSecret:
+                          properties:
+                            name:
+                              type: string
+                          description: Deprecated
+                          type: object
+                        awsRegion:
+                          description: Deprecated
+                          type: string
+                      required:
+                      - awsBucket
+                      - awsRegion
+                      - awsCredentialsSecret
+                      type: object
+                    persistentVolumeClaim:
+                      description: Union type. Only one of the fields can be set.
+                      properties:
+                        storageClassName:
+                          type: string
+                      type: object
+                    simpleStorageService:
+                      properties:
+                        configurationSecretRef:
+                          type: object
+                          properties:
+                            name:
+                              type: string
+                      required:
+                      - configurationSecretRef
+                      type: object
+                  type: object
+                image:
+                  type: string
+                memcachedImage:
+                  type: string
+                redisImage:
+                  type: string
+                sidekiqSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+              type: object
+            tenantName:
+              type: string
+            wildcardDomain:
+              type: string
+            zync:
+              properties:
+                appSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+                image:
+                  type: string
+                postgreSQLImage:
+                  type: string
+                queSpec:
+                  properties:
+                    replicas:
+                      format: int64
+                      type: integer
+                  type: object
+              type: object
+          required:
+          - wildcardDomain
+          type: object
+        status:
+          properties:
+            conditions:
+              items:
+                properties:
+                  status:
+                    type: string
+                  type:
+                    type: string
+                required:
+                - type
+                - status
+                type: object
+              type: array
+            deployments:
+              properties:
+                ready:
+                  description: Deployments are ready to serve requests
+                  items:
+                    type: string
+                  type: array
+                starting:
+                  description: Deployments are starting, may or may not succeed
+                  items:
+                    type: string
+                  type: array
+                stopped:
+                  description: Deployments are not starting, unclear what next step
+                    will be
+                  items:
+                    type: string
+                  type: array
+              type: object
+          required:
+          - deployments
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_api_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_api_crd.yaml
@@ -1,0 +1,363 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: apis.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: API
+    listKind: APIList
+    plural: apis
+    singular: api
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            description:
+              type: string
+            integrationMethod:
+              properties:
+                apicastHosted:
+                  properties:
+                    apiTestGetRequest:
+                      type: string
+                    authenticationSettings:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              properties:
+                                authParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - authParameterName
+                              - credentialsLocation
+                              type: object
+                            appID:
+                              properties:
+                                appIDParameterName:
+                                  type: string
+                                appKeyParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
+                              type: object
+                            openIDConnector:
+                              properties:
+                                credentialsLocation:
+                                  type: string
+                                issuer:
+                                  type: string
+                              required:
+                              - issuer
+                              - credentialsLocation
+                              type: object
+                          type: object
+                        errors:
+                          properties:
+                            authenticationFailed:
+                              properties:
+                                contentType:
+                                  type: string
+                                responseBody:
+                                  type: string
+                                responseCode:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - responseCode
+                              - contentType
+                              - responseBody
+                              type: object
+                            authenticationMissing:
+                              properties:
+                                contentType:
+                                  type: string
+                                responseBody:
+                                  type: string
+                                responseCode:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - responseCode
+                              - contentType
+                              - responseBody
+                              type: object
+                          required:
+                          - authenticationFailed
+                          - authenticationMissing
+                          type: object
+                        hostHeader:
+                          type: string
+                        secretToken:
+                          type: string
+                      required:
+                      - hostHeader
+                      - secretToken
+                      - credentials
+                      - errors
+                      type: object
+                    mappingRulesSelector:
+                      type: object
+                      properties:
+                        matchLabels:
+                          type: object
+                        matchExpressions:
+                          type: array
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                    policiesSelector:
+                      type: object
+                      properties:
+                        matchLabels:
+                          type: object
+                        matchExpressions:
+                          type: array
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                    privateBaseURL:
+                      type: string
+                  required:
+                  - privateBaseURL
+                  - apiTestGetRequest
+                  - authenticationSettings
+                  type: object
+                apicastOnPrem:
+                  properties:
+                    apiTestGetRequest:
+                      type: string
+                    authenticationSettings:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              properties:
+                                authParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - authParameterName
+                              - credentialsLocation
+                              type: object
+                            appID:
+                              properties:
+                                appIDParameterName:
+                                  type: string
+                                appKeyParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
+                              type: object
+                            openIDConnector:
+                              properties:
+                                credentialsLocation:
+                                  type: string
+                                issuer:
+                                  type: string
+                              required:
+                              - issuer
+                              - credentialsLocation
+                              type: object
+                          type: object
+                        errors:
+                          properties:
+                            authenticationFailed:
+                              properties:
+                                contentType:
+                                  type: string
+                                responseBody:
+                                  type: string
+                                responseCode:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - responseCode
+                              - contentType
+                              - responseBody
+                              type: object
+                            authenticationMissing:
+                              properties:
+                                contentType:
+                                  type: string
+                                responseBody:
+                                  type: string
+                                responseCode:
+                                  format: int64
+                                  type: integer
+                              required:
+                              - responseCode
+                              - contentType
+                              - responseBody
+                              type: object
+                          required:
+                          - authenticationFailed
+                          - authenticationMissing
+                          type: object
+                        hostHeader:
+                          type: string
+                        secretToken:
+                          type: string
+                      required:
+                      - hostHeader
+                      - secretToken
+                      - credentials
+                      - errors
+                      type: object
+                    mappingRulesSelector:
+                      type: object
+                      properties:
+                        matchLabels:
+                          type: object
+                        matchExpressions:
+                          type: array
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                    policiesSelector:
+                      type: object
+                      properties:
+                        matchLabels:
+                          type: object
+                        matchExpressions:
+                          type: array
+                          items:
+                            properties:
+                              key:
+                                type: string
+                              operator:
+                                type: string
+                              values:
+                                type: array
+                    privateBaseURL:
+                      type: string
+                    productionPublicBaseURL:
+                      type: string
+                    stagingPublicBaseURL:
+                      type: string
+                  required:
+                  - privateBaseURL
+                  - apiTestGetRequest
+                  - authenticationSettings
+                  - stagingPublicBaseURL
+                  - productionPublicBaseURL
+                  type: object
+                codePlugin:
+                  properties:
+                    authenticationSettings:
+                      properties:
+                        credentials:
+                          properties:
+                            apiKey:
+                              properties:
+                                authParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - authParameterName
+                              - credentialsLocation
+                              type: object
+                            appID:
+                              properties:
+                                appIDParameterName:
+                                  type: string
+                                appKeyParameterName:
+                                  type: string
+                                credentialsLocation:
+                                  type: string
+                              required:
+                              - appIDParameterName
+                              - appKeyParameterName
+                              - credentialsLocation
+                              type: object
+                            openIDConnector:
+                              properties:
+                                credentialsLocation:
+                                  type: string
+                                issuer:
+                                  type: string
+                              required:
+                              - issuer
+                              - credentialsLocation
+                              type: object
+                          type: object
+                      required:
+                      - credentials
+                      type: object
+                  required:
+                  - authenticationSettings
+                  type: object
+              type: object
+            metricSelector:
+              type: object
+              properties:
+                matchLabels:
+                  type: object
+                matchExpressions:
+                  type: array
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+            planSelector:
+              type: object
+              properties:
+                matchLabels:
+                  type: object
+                matchExpressions:
+                  type: array
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+          required:
+          - description
+          - integrationMethod
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_binding_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_binding_crd.yaml
@@ -1,0 +1,65 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: bindings.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: Binding
+    listKind: BindingList
+    plural: bindings
+    singular: binding
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            apiSelector:
+              type: object
+              properties:
+                matchLabels:
+                  type: object
+                matchExpressions:
+                  type: array
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+            credentialsRef:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+          required:
+          - credentialsRef
+          type: object
+        status:
+          properties:
+            currentState:
+              type: string
+            desiredState:
+              type: string
+            lastSync:
+              type: object
+              properties:
+                seconds:
+                  type: integer
+                nanos:
+                  type: integer
+            previousState:
+              type: string
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_limit_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_limit_crd.yaml
@@ -1,0 +1,53 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: limits.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: Limit
+    listKind: LimitList
+    plural: limits
+    singular: limit
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          properties:
+            maxValue:
+              format: int64
+              type: integer
+            metricRef:
+              type: object
+              properties:
+                kind:
+                  type: string
+                namespace:
+                  type: string
+                name:
+                  type: string
+                uid:
+                  type: string
+                apiVersion:
+                  type: string
+                resourceVersion:
+                  type: string
+                fieldPath:
+                  type: string
+            period:
+              type: string
+          required:
+          - period
+          - maxValue
+          - metricRef
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_mappingrule_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_mappingrule_crd.yaml
@@ -1,0 +1,56 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: mappingrules.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: MappingRule
+    listKind: MappingRuleList
+    plural: mappingrules
+    singular: mappingrule
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            increment:
+              format: int64
+              type: integer
+            method:
+              type: string
+            metricRef:
+              type: object
+              properties:
+                kind:
+                  type: string
+                namespace:
+                  type: string
+                name:
+                  type: string
+                uid:
+                  type: string
+                apiVersion:
+                  type: string
+                resourceVersion:
+                  type: string
+                fieldPath:
+                  type: string
+            path:
+              type: string
+          required:
+          - path
+          - method
+          - increment
+          - metricRef
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_metric_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_metric_crd.yaml
@@ -1,0 +1,37 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: metrics.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: Metric
+    listKind: MetricList
+    plural: metrics
+    singular: metric
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            description:
+              type: string
+            incrementHits:
+              type: boolean
+            unit:
+              type: string
+          required:
+          - unit
+          - description
+          - incrementHits
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_plan_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_plan_crd.yaml
@@ -1,0 +1,63 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: plans.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: Plan
+    listKind: PlanList
+    plural: plans
+    singular: plan
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            approvalRequired:
+              type: boolean
+            costs:
+              properties:
+                costMonth:
+                  format: double
+                  type: number
+                setupFee:
+                  format: double
+                  type: number
+              type: object
+            default:
+              type: boolean
+            limitSelector:
+              type: object
+              properties:
+                matchLabels:
+                  type: object
+                matchExpressions:
+                  type: array
+                  items:
+                    properties:
+                      key:
+                        type: string
+                      operator:
+                        type: string
+                      values:
+                        type: array
+            trialPeriod:
+              format: int64
+              type: integer
+          required:
+          - default
+          - trialPeriod
+          - approvalRequired
+          - limitSelector
+          type: object
+        status:
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_tenant_crd.yaml
+++ b/manifests/integreatly-3scale/0.5.5/capabilities_v1alpha1_tenant_crd.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: tenants.capabilities.3scale.net
+spec:
+  group: capabilities.3scale.net
+  names:
+    kind: Tenant
+    listKind: TenantList
+    plural: tenants
+    singular: tenant
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            email:
+              type: string
+            masterCredentialsRef:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            organizationName:
+              type: string
+            passwordCredentialsRef:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            systemMasterUrl:
+              type: string
+            tenantSecretRef:
+              type: object
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+            username:
+              type: string
+          required:
+          - username
+          - email
+          - organizationName
+          - systemMasterUrl
+          - tenantSecretRef
+          - passwordCredentialsRef
+          - masterCredentialsRef
+          type: object
+        status:
+          properties:
+            adminId:
+              format: int64
+              type: integer
+            tenantId:
+              format: int64
+              type: integer
+          required:
+          - tenantId
+          - adminId
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-3scale/3scale.package.yaml
+++ b/manifests/integreatly-3scale/3scale.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: 3scale-operator.v0.5.2
+- currentCSV: 3scale-operator.v0.5.5
   name: rhmi
 defaultChannel: rhmi
 packageName: rhmi-3scale

--- a/manifests/integreatly-3scale/image_mirror_mapping
+++ b/manifests/integreatly-3scale/image_mirror_mapping
@@ -1,0 +1,9 @@
+registry-proxy.engineering.redhat.com/rh-osbs/rhscl-redis-32-rhel7@sha256:a9bdf52384a222635efc0284db47d12fbde8c3d0fcb66517ba8eefad1d4e9dc9 quay.io/integreatly/delorean:rhscl-redis-32-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/rhscl-mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe quay.io/integreatly/delorean:rhscl-mysql-57-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator@sha256:1ba6ec8ed984a011796bbe1eafabb2791957f58ed66ec4a484c024dd96eaf427 quay.io/integreatly/delorean:3scale-amp2-3scale-rhel7-operator_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8@sha256:3023b37ccfc902bfafd2c344dc5595295369a2dc00ea38b27c193ca5b138942b quay.io/integreatly/delorean:3scale-amp2-apicast-gateway-rhel8_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-system-rhel7@sha256:29836068f71f53f88b75345055808106cb4620bf3d488bd458709936d716377f quay.io/integreatly/delorean:3scale-amp2-system-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-memcached-rhel7@sha256:2be57d773843135c0677e31d34b0cd24fa9dafc4ef1367521caa2bab7c6122e6 quay.io/integreatly/delorean:3scale-amp2-memcached-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/rhscl-postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd quay.io/integreatly/delorean:rhscl-postgresql-10-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-backend-rhel7@sha256:bd626295c55a7815a816d7049fba1febdec6a3305dee2a3292e92a26d56036b0 quay.io/integreatly/delorean:3scale-amp2-backend-rhel7_latest
+registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-zync-rhel7@sha256:f46b47b84450a81cb463b66dc86b91baf0dd60bdca275192925f6924b90a57bf quay.io/integreatly/delorean:3scale-amp2-zync-rhel7_latest


### PR DESCRIPTION
Update 3scale manifest to 0.5.5 

This is an automatically generated branch to track the '0.5.5' version of the '3scale' OLM manifests.
This branch will be automatically updated with any changes related to this version until it finally GAs. 

Changes required to fix installation issues should be applied to this branch following the usual [PR Workflow](https://github.com/integr8ly/delorean/blob/master/docs/integrealy-ci/prow-pr-workflow.md)

More details about the Early Warning System that generated this can be found [here](https://github.com/integr8ly/delorean/tree/master/docs/ews)

## Type of change

- [X] Product Update

## Checklist
- [ ] Older product manifests (N-2) have been removed
- [ ] Operator and Product Versions are updated correctly
- [ ] Go Modules are updated if required