### PR TITLE
changing from container_memory_usage_bytes to container_memory_workin…

### DIFF
--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -423,7 +423,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 			"stack": false,
 			"steppedLine": false,
 			"targets": [{
-				"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace', container!=''}) by (pod)",
+				"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace', container=''}) by (pod)",
 				"format": "time_series",
 				"intervalFactor": 2,
 				"legendFormat": "{{pod}}",
@@ -632,7 +632,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 				}
 			],
 			"targets": [{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace',container!=''}) by (pod)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace',container=''}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -650,7 +650,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 					"step": 10
 				},
 				{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace',container!=''}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'$namespace'}) by (pod)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace',container=''}) by (pod) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'$namespace'}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -668,7 +668,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 					"step": 10
 				},
 				{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace',container!=''}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=~'$namespace'}) by (pod)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace',container=''}) by (pod) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=~'$namespace'}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -439,7 +439,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 			"stack": false,
 			"steppedLine": false,
 			"targets": [{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace', pod=~'$pod', container!='POD', container!=''}) by (pod)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace', pod=~'$pod', container=''}) by (pod)",
 					"format": "time_series",
 					"intervalFactor": 2,
 					"legendFormat": "{{pod}}",
@@ -664,7 +664,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 				}
 			],
 			"targets": [{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace', pod=~'$pod', container!='POD', container!=''}) by (container)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace', pod=~'$pod', container=''}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -682,7 +682,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 					"step": 10
 				},
 				{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -700,7 +700,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 					"step": 10
 				},
 				{
-					"expr": "sum(container_memory_usage_bytes{namespace=~'$namespace', pod=~'$pod', container!=''}) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container)",
+					"expr": "sum(container_memory_working_set_bytes{namespace=~'$namespace', pod=~'$pod', container=''}) by (container) / sum(kube_pod_container_resource_limits_memory_bytes{namespace=~'$namespace', pod=~'$pod'}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,


### PR DESCRIPTION
# Description
[Jira](https://issues.redhat.com/browse/INTLY-8591) Change container_memory_usage_bytes to container_memory_working_set_bytes


## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Verification
1.Install RHMI from master and compare and take note of values gotten from the memory usage graph in both resource usage by pod and resource usage by namespace against the equivalent values in the openshift console metrics e.g keycloak-0 in rhsso in a dashboard and keycloak-0 in the same namespace in the openshift-console metrics. These values should be different. 
2. When gathering values in resource usage by pod  and namespace take note the values the pod requests% and limits% values. There is no opensift metric equivalent to this but they will be compared against the new values later
3. Install Rhmi from this branch
4. Compare these new values again, the values from the dashboard should now be the same as the openshift console values now and shouldnt have changed much from the original openshift metrics values .
5. Do the same for the request% and limit % but compare them against the older version they should be slightly different either positively or negatively different
## Checklist
- [ ] Verified independently on a cluster by reviewer