### PR TITLE
Fix error with k8sclient for UpgradeNotifier

### DIFF
--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -59,10 +59,10 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return nil, err
 	}
 
-	webappNotifierClient, err := webapp.NewUpgradeNotifier(context.TODO(), restConfig)
-	if err != nil {
-		return nil, err
-	}
+	webappNotifierClient := webapp.NewLazyUpgradeNotifier(func() (k8sclient.Client, error) {
+		restConfig := controllerruntime.GetConfigOrDie()
+		return k8sclient.New(restConfig, k8sclient.Options{})
+	})
 
 	return &ReconcileSubscription{
 		mgr:                 mgr,
@@ -144,6 +144,11 @@ func (r *ReconcileSubscription) Reconcile(request reconcile.Request) (reconcile.
 func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscription *operatorsv1alpha1.Subscription, installation *integreatlyv1alpha1.RHMI) (reconcile.Result, error) {
 	if !rhmiConfigs.IsUpgradeAvailable(rhmiSubscription) {
 		logrus.Infof("no upgrade available")
+
+		if err := r.webbappNotifier.ClearNotification(); err != nil {
+			return reconcile.Result{}, err
+		}
+
 		return reconcile.Result{}, nil
 	}
 
@@ -234,10 +239,6 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 
 	if !isServiceAffecting || canUpgradeNow {
 		eventRecorder := r.mgr.GetEventRecorderFor("RHMI Upgrade")
-
-		if err := r.webbappNotifier.ClearNotification(); err != nil {
-			return reconcile.Result{}, err
-		}
 
 		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, installation, latestRHMIInstallPlan, eventRecorder)
 		if err != nil {

--- a/pkg/resources/catalogsource/catalogsource_client.go
+++ b/pkg/resources/catalogsource/catalogsource_client.go
@@ -56,7 +56,7 @@ func (client *CatalogSourceClient) GetLatestCSV(catalogSourceKey k8sclient.Objec
 	csv := &olmv1alpha1.ClusterServiceVersion{}
 	err = json.Unmarshal([]byte(bundle.GetCsvJson()), &csv)
 	if err != nil {
-		logrus.Errorf("failed to unmarshal json: %w", err)
+		logrus.Errorf("failed to unmarshal json: %v", err)
 	}
 	return csv, nil
 }


### PR DESCRIPTION
# Description

An issue with kubernetes clients instantiated when the reconciler is created is occurring
as it can't find certain custom resources. This client was being passed to the webapp
UpgradeNotifier, so it fails to notify upgrades to the WebApp CR.
    
Fix by creating an implementation of UpgradeNotifier that delegates its behaviour to a lazily instantiated upgrade notifier. This notifier is instantiated the first time it's used, guaranteeing that the kubernetes client will only be created when needed and avoiding the initial issue.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer