### PR TITLE
Intly-8185-fix

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -40,6 +40,8 @@ const (
 
 	// Maximum allowed number of days to schedule an upgrade via `NotBeforeDays`
 	MaxUpgradeDays = 14
+
+	RecalculateScheduleAnnotation = "recalculateSchedule"
 )
 
 // RHMIConfigSpec defines the desired state of RHMIConfig
@@ -229,6 +231,10 @@ func (h *rhmiConfigMutatingHandler) Handle(ctx context.Context, request admissio
 		oldUpgradeSpec.NotBeforeDays,
 		defaultUpgradeSpec.NotBeforeDays,
 	).(*int)
+
+	if !reflect.DeepEqual(oldUpgradeSpec, &rhmiConfig.Spec.Upgrade) {
+		rhmiConfig.Annotations[RecalculateScheduleAnnotation] = "true"
+	}
 
 	marshalled, err := json.Marshal(rhmiConfig)
 	if err != nil {

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -3,6 +3,7 @@ package subscription
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/rhmiConfigs"
@@ -11,12 +12,14 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	catalogsourceClient "github.com/integr8ly/integreatly-operator/pkg/resources/catalogsource"
 
 	"github.com/sirupsen/logrus"
 
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -86,6 +89,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	if err != nil {
 		return err
 	}
+
+	err = c.Watch(&source.Kind{Type: &integreatlyv1alpha1.RHMIConfig{}}, &handler.EnqueueRequestForOwner{
+		IsController: true,
+		OwnerType:    &operatorsv1alpha1.Subscription{},
+	})
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -156,6 +168,13 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 
 	latestRHMIInstallPlan, err := rhmiConfigs.GetLatestInstallPlan(ctx, rhmiSubscription, r.client)
 	if err != nil {
+		if errors.IsNotFound(err) {
+			// if installplan is not found trigger the creation of a new one
+			err = rhmiConfigs.CreateInstallPlan(ctx, rhmiSubscription, r.client)
+			if err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 		return reconcile.Result{}, err
 	}
 
@@ -175,15 +194,20 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 		return reconcile.Result{}, err
 	}
 
-	objectKey := k8sclient.ObjectKey{
-		Name:      rhmiSubscription.Spec.CatalogSource,
-		Namespace: rhmiSubscription.Spec.CatalogSourceNamespace,
-	}
-	csvFromCatalogSource, err := r.catalogSourceClient.GetLatestCSV(objectKey, rhmiSubscription.Spec.Package, rhmiSubscription.Spec.Channel)
-	if err != nil {
-		return reconcile.Result{}, fmt.Errorf("error getting the csv from catalogsource %w", err)
+	// checks if the operator is running locally don't use the catalogsource
+	csvFromCatalogSource := latestRHMICSV
+	if os.Getenv(k8sutil.ForceRunModeEnv) != string(k8sutil.LocalRunMode) {
+		objectKey := k8sclient.ObjectKey{
+			Name:      rhmiSubscription.Spec.CatalogSource,
+			Namespace: rhmiSubscription.Spec.CatalogSourceNamespace,
+		}
+		csvFromCatalogSource, err = r.catalogSourceClient.GetLatestCSV(objectKey, rhmiSubscription.Spec.Package, rhmiSubscription.Spec.Channel)
+		if err != nil {
+			return reconcile.Result{}, fmt.Errorf("Error getting the csv from catalogsource %w", err)
+		}
 	}
 
+	isInstallPlanDeleted := false
 	currentOperatorVersionName := fmt.Sprintf("%s.v%s", CSVNamePrefix, version.Version)
 	if csvFromCatalogSource.Spec.Replaces != currentOperatorVersionName {
 
@@ -193,31 +217,46 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 				return reconcile.Result{}, fmt.Errorf("error deleting installplan %w", err)
 			}
 
-			// workaround to trigger the creation of another installplan
-			rhmiSubscription.Status.State = operatorsv1alpha1.SubscriptionStateAtLatest
-			rhmiSubscription.Status.InstallPlanRef = nil
-			rhmiSubscription.Status.Install = nil
-			rhmiSubscription.Status.CurrentCSV = rhmiSubscription.Status.InstalledCSV
-			err = r.client.Status().Update(ctx, rhmiSubscription)
+			isInstallPlanDeleted = true
+			logrus.Info("Installplan deleted for the install of patch upgrade")
+
+			err = rhmiConfigs.CreateInstallPlan(ctx, rhmiSubscription, r.client)
 			if err != nil {
-				return reconcile.Result{}, fmt.Errorf("error updating the subscripion status block %w", err)
+				return reconcile.Result{}, err
 			}
 		}
 
-		err := r.client.Get(ctx, k8sclient.ObjectKey{Name: rhmiSubscription.Name, Namespace: rhmiSubscription.Namespace}, rhmiSubscription)
-		if err != nil {
-			return reconcile.Result{}, err
-		}
-		if rhmiSubscription.Status.State != operatorsv1alpha1.SubscriptionStateUpgradePending {
-			// reconcile until the installplan is recreated
+		if isInstallPlanDeleted {
+			// Requeue reconciler until the installplan is recreated
 			return reconcile.Result{
 				Requeue:      true,
 				RequeueAfter: 10 * time.Second,
 			}, nil
 		}
+
+		// gets the subscription wit the recreated installplan
+		err := r.client.Get(ctx, k8sclient.ObjectKey{Name: rhmiSubscription.Name, Namespace: rhmiSubscription.Namespace}, rhmiSubscription)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
 	}
 
-	if rhmiConfigs.IsUpgradeServiceAffecting(latestRHMICSV) && rhmiSubscription.Status.CurrentCSV != config.Status.TargetVersion {
+	isServiceAffecting := rhmiConfigs.IsUpgradeServiceAffecting(latestRHMICSV)
+
+	// checks if there is changes in the rhmiconfig cr and recalculate the status
+	if reschedule, ok := config.Annotations[v1alpha1.RecalculateScheduleAnnotation]; ok && reschedule == "true" {
+		err = rhmiConfigs.UpdateStatus(ctx, r.client, config, latestRHMIInstallPlan, rhmiSubscription.Status.CurrentCSV)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+		config.Annotations[v1alpha1.RecalculateScheduleAnnotation] = ""
+		err = r.client.Update(ctx, config)
+		if err != nil {
+			return reconcile.Result{}, err
+		}
+
+	} else if isServiceAffecting && rhmiSubscription.Status.CurrentCSV != config.Status.TargetVersion {
 		err = rhmiConfigs.UpdateStatus(ctx, r.client, config, latestRHMIInstallPlan, rhmiSubscription.Status.CurrentCSV)
 		if err != nil {
 			return reconcile.Result{}, err
@@ -228,8 +267,6 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-
-	isServiceAffecting := rhmiConfigs.IsUpgradeServiceAffecting(latestRHMICSV)
 
 	phase, err := r.webbappNotifier.NotifyUpgrade(config, latestRHMICSV.Spec.Version.String(), isServiceAffecting)
 	if err != nil {


### PR DESCRIPTION
# Description

Fixes a bug that prevents the rescheduling of upgrades when there is a pending upgrade waiting to be approved

# Verification steps
Follow the steps described in this PR to verify the install of patch upgrades https://github.com/integr8ly/integreatly-operator/pull/879

* When the latest CSV is published and a pending installplan is available go to the rhmiconfig crd change the `notBeforeDays` to 0 and `waitForMaintenance` to false, notice that a `recalculateSchedule: ''` annotation will be added and the status block of the cr will change. Go to the pending installplan and check if will get approved and installed by the operator 

* CSV are already created in my quay.io 

CSV 2.3.0 - quay.io/jjaferson/integreatly-index:2.3.0
CSV 2.4.0 - quay.io/jjaferson/integreatly-index:2.4.0
CSV 2.3.1 (patch upgrade) - quay.io/jjaferson/integreatly-index:2.3.0
CSV 2.4.0-rc (modified to include the patch upgrade) - quay.io/jjaferson/integreatly-index:2.4.0-rc

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
