### PR TITLE
[INTLY 8454] Update alerting mechanism test to accept multiple alerts

### DIFF
--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -34,10 +34,10 @@ type alertManagerConfig struct {
 const (
 	fuseOperatorDeploymentName            = "syndesis-operator"
 	fuseUIDeploymentConfigName            = "syndesis-ui"
-	monitoringTimeout                     = 15 * time.Minute
+	monitoringTimeout                     = time.Minute * 15
 	monitoringRetryInterval               = time.Minute
-	verifyOperatorDeploymentTimeout       = 5 * time.Minute
-	verifyOperatorDeploymentRetryInterval = 15 * time.Second
+	verifyOperatorDeploymentTimeout       = time.Minute * 5
+	verifyOperatorDeploymentRetryInterval = time.Second * 15
 )
 
 var fuseAlertsToTest = map[string]string{
@@ -365,7 +365,7 @@ func scaleDeploymentConfig(name string, namespace string, replicas int32, client
 }
 
 func checkFuseOperatorReplicasAreReady(ctx *TestingContext, t *testing.T) error {
-	t.Logf("Checking correct number of fuse operator replicas (%s) are set", fmt.Sprint(originalOperatorReplicas))
+	t.Logf("Checking correct number of fuse operator replicas (%d) are set", originalOperatorReplicas)
 	err := wait.Poll(verifyOperatorDeploymentRetryInterval, verifyOperatorDeploymentTimeout, func() (done bool, err error) {
 		numberOfOperatorReplicas, err := getNumOfReplicasDeployment(fuseOperatorDeploymentName, FuseOperatorNamespace, ctx.KubeClient)
 

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -51,7 +51,6 @@ func TestIntegreatlyAlertsMechanism(t *testing.T, ctx *TestingContext) {
 
 	fuseAlertsFiring := false
 
-	// check if any alerts are firing before test execution
 	for fuseAlertName, fuseAlertState := range fuseAlertsToTest {
 		if fuseAlertState != "none" {
 			fuseAlertsFiring = true
@@ -59,7 +58,6 @@ func TestIntegreatlyAlertsMechanism(t *testing.T, ctx *TestingContext) {
 		}
 	}
 
-	// fail test if any alerts are firing
 	if fuseAlertsFiring {
 		t.FailNow()
 	}
@@ -269,7 +267,6 @@ func getFuseAlertState(ctx *TestingContext) error {
 		return fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 
-	// reset the state to "none" as the prom api only returns alerts that are triggering hence the state needs to be reset.
 	for fuseAlertName := range fuseAlertsToTest {
 		fuseAlertsToTest[fuseAlertName] = "none"
 	}

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -177,11 +177,11 @@ func performTest(t *testing.T, ctx *TestingContext) error {
 		return err
 	}
 
-	err = checkAlertManager(ctx)
+	err = checkAlertManager(ctx, t)
 	return err
 }
 
-func checkAlertManager(ctx *TestingContext) error {
+func checkAlertManager(ctx *TestingContext, t *testing.T) error {
 	output, err := execToPod("amtool alert --alertmanager.url=http://localhost:9093",
 		"alertmanager-application-monitoring-0",
 		MonitoringOperatorNamespace,
@@ -191,10 +191,16 @@ func checkAlertManager(ctx *TestingContext) error {
 		return fmt.Errorf("failed to exec to alertmanger pod: %w", err)
 	}
 
+	alertsFiringInAlertManager := false
 	for fuseAlertName := range fuseAlertsToTest {
 		if !strings.Contains(output, fuseAlertName) {
-			return fmt.Errorf("%s alert not firing in alertmanager", fuseAlertName)
+			alertsFiringInAlertManager = true
+			t.Errorf("%s alert not firing in alertmanager", fuseAlertName)
 		}
+	}
+
+	if alertsFiringInAlertManager {
+		t.FailNow()
 	}
 
 	return nil

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -226,7 +226,7 @@ func waitForFuseAlertState(expectedState string, ctx *TestingContext, t *testing
 		for fuseAlertName, fuseAlertState := range fuseAlertsToTest {
 			if fuseAlertState != expectedState {
 				alertsInExpectedState = false
-				t.Log(fuseAlertName+" alert is not in expected state ("+expectedState+") yet, current state:", fuseAlertState)
+				t.Logf("%s alert is not in expected state (%s) yet, current state: %s", fuseAlertName, expectedState, fuseAlertState)
 				t.Log("waiting 1 minute before retrying")
 			}
 		}


### PR DESCRIPTION
## Description
https://issues.redhat.com/browse/INTLY-8454

Updated the `TestIntegreatlyAlertsMechanism` test to allow the alerting mechanism for multiple Fuse alerts to be tested, as opposed to a single Fuse alert.

The test checks that the `FuseOnlineSyndesisUIInstanceDown` and `RHMIFuseOnlineSyndesisUiServiceEndpointDown` Fuse alerts go through the following process: `not firing before test execution -> pending -> firing -> not firing`

**This PR should be tested using both a 4.3 and 4.4 OS4 cluster**

## Verification Steps

- Install via this branch
- Run the `TestIntegreatlyAlertsMechanism` locally against your cluster: `go clean -testcache && go test -v ./test/functional -run=//^C03 -timeout=80m`
- Ensure the that test passes and that the logging is clear and concise
- During the execution of the test, when the alerts are in a pending/firing state, open a new tab/terminal and execute the test again. Verify that the test fails due to the alerts already firing, and that this is reflected clearly in the logs.

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer