### PR TITLE
update backup container image to 1.0.15

### DIFF
--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -228,7 +228,7 @@ func reconcileCronjob(ctx context.Context, serverClient k8sclient.Client, config
 							Containers: []corev1.Container{
 								{
 									Name:            "backup-cronjob",
-									Image:           "quay.io/integreatly/backup-container:1.0.14",
+									Image:           "quay.io/integreatly/backup-container:1.0.15",
 									ImagePullPolicy: "Always",
 									Command: []string{
 										"/opt/intly/tools/entrypoint.sh",


### PR DESCRIPTION
# Description

Update backup container image to fix a bug with CRW 2.0 backups (the pods have many containers with their own project directories)
