### PR TITLE
[Intly-7395] Adds alerts around the rhmi_status metric

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -78,6 +78,7 @@ rules:
       - create
       - update
       - delete
+      - watch
   # Adding a role and rolebinding to allow GitHub Secret management by dedicated-admins
   - apiGroups:
       - rbac.authorization.k8s.io

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -273,6 +273,18 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 	}
 
+	// reconciles rhmi installation alerts
+	_, err = r.reconcileRHMIInstallationAlerts(context.TODO(), r.client, installation)
+	if err != nil {
+		logrus.Infof("Error reconciling alerts for the rhmi installation controller: %w", err)
+	}
+
+	// reconciles rhmi installation completion alert in openshift monitoring
+	_, err = r.reconcileRHMIInstallationAlertsOpenshiftMonitoring(context.TODO(), r.client, installation)
+	if err != nil {
+		logrus.Info("Error reconciling alerts for completion of rhmi installation in openshift monitoring :%w", err)
+	}
+
 	// Reconcile the webhooks
 	if err := webhooks.Config.Reconcile(context.TODO(), r.client, installation); err != nil {
 		return reconcile.Result{}, err

--- a/pkg/controller/installation/prometheusRules.go
+++ b/pkg/controller/installation/prometheusRules.go
@@ -1,0 +1,111 @@
+package installation
+
+import (
+	"context"
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+func (r *ReconcileInstallation) reconcileRHMIInstallationAlerts(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
+	monitoringConfig := config.NewMonitoring(config.ProductConfig{})
+
+	rule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhmi-installation-controller-alerts",
+			Namespace: installation.Namespace,
+		},
+	}
+
+	rules := []monitoringv1.Rule{
+		{
+			Alert: "RHMIInstallationControllerIsNotReconciling",
+			Annotations: map[string]string{
+				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+				"message": "RHMI operator has not reconciled successfully in the interval of 15m over the past 1 hour",
+			},
+			Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[15m]) == 0")),
+			For:    "1h",
+			Labels: map[string]string{"severity": "warning"},
+		},
+		{
+			Alert: "RHMIInstallationControllerStoppedReconciling",
+			Annotations: map[string]string{
+				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+				"message": "RHMI operator has not reconciled successfully in the interval of 30m over the past 2 hours",
+			},
+			Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[30m]) == 0")),
+			For:    "2h",
+			Labels: map[string]string{"severity": "critical"},
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, rule, func() error {
+		rule.ObjectMeta.Labels = map[string]string{"integreatly": "yes", monitoringConfig.GetLabelSelectorKey(): monitoringConfig.GetLabelSelector()}
+		rule.Spec = monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name:  "rhmi-installation.rules",
+					Rules: rules,
+				},
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error creating rhmi installation PrometheusRule: %w", err)
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *ReconcileInstallation) reconcileRHMIInstallationAlertsOpenshiftMonitoring(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
+	monitoringConfig := config.NewMonitoring(config.ProductConfig{})
+
+	rule := &monitoringv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhmi-installation-alerts",
+			Namespace: "openshift-monitoring",
+		},
+	}
+
+	rules := []monitoringv1.Rule{
+		{
+			Alert: "RHMIOperatorInstallCompleted",
+			Annotations: map[string]string{
+				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+				"message": "RHMI operator is taking more than 2 hours to go to a complete stage",
+			},
+			Expr:   intstr.FromString(fmt.Sprint("absent(rhmi_status{stage='complete'})")),
+			For:    "120m",
+			Labels: map[string]string{"severity": "critical"},
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, rule, func() error {
+		rule.ObjectMeta.Labels = map[string]string{"integreatly": "yes", monitoringConfig.GetLabelSelectorKey(): monitoringConfig.GetLabelSelector()}
+		rule.Spec = monitoringv1.PrometheusRuleSpec{
+			Groups: []monitoringv1.RuleGroup{
+				{
+					Name:  "rhmi-installation.rules",
+					Rules: rules,
+				},
+			},
+		}
+		return nil
+	})
+
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error creating rhmi installation PrometheusRule: %w", err)
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}

--- a/pkg/controller/installation/prometheusRules.go
+++ b/pkg/controller/installation/prometheusRules.go
@@ -80,12 +80,12 @@ func (r *ReconcileInstallation) reconcileRHMIInstallationAlertsOpenshiftMonitori
 
 	rules := []monitoringv1.Rule{
 		{
-			Alert: "RHMIOperatorInstallCompleted",
+			Alert: "RHMIOperatorInstallDelayed",
 			Annotations: map[string]string{
 				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
 				"message": "RHMI operator is taking more than 2 hours to go to a complete stage",
 			},
-			Expr:   intstr.FromString(fmt.Sprint("absent(rhmi_status{stage='complete'})")),
+			Expr:   intstr.FromString(fmt.Sprint("absent(rhmi_status{stage='complete'} == 1)")),
 			For:    "120m",
 			Labels: map[string]string{"severity": "critical"},
 		},

--- a/test-cases/tests/alerts/c11-verify-rhmi-installation-alerts-are-firing.md
+++ b/test-cases/tests/alerts/c11-verify-rhmi-installation-alerts-are-firing.md
@@ -13,14 +13,14 @@ More info: <https://issues.redhat.com/browse/INTLY-7395>
 
 ## Steps
 
-1. Verify RHMIOperatorInstallCompleted alert is present and firing:
+1. Verify RHMIOperatorInstallDelayed alert is present and firing:
    1. Open OpenShift console in your browser and login as admin
    2. Login as admin
    3. Go to Deployments, in the `redhat-rhmi-operator` namespace and click on `rhmi-operator`
    4. In the details tab, decrease the pod count by clicking on the down arrow
       > RHMI pod should be scaled to 0
    5. In the left hand side menu, go to Monitoring >> Alerting and select only Firing in the filter bar
-      > RHMIInstallationCompleted should be in the list
+      > RHMIOperatorInstallDelayed should be in the list
    6. Go to `rhmi-operator` deployment and scale the pod up again.
 2. Verify RHMIInstallationControllerIsNotReconciling and RHMIInstallationControllerStoppedReconciling alerts are present and firing:
    1. Open OpenShift console in your browser and login as admin

--- a/test-cases/tests/alerts/c11-verify-rhmi-installation-alerts-are-firing.md
+++ b/test-cases/tests/alerts/c11-verify-rhmi-installation-alerts-are-firing.md
@@ -1,0 +1,33 @@
+---
+targets:
+  - 2.5.0
+---
+
+# C11 - Verify RHMI installation alerts are firing
+
+## Description
+
+Verify that RHMI operator alerts are in place and firing
+
+More info: <https://issues.redhat.com/browse/INTLY-7395>
+
+## Steps
+
+1. Verify RHMIOperatorInstallCompleted alert is present and firing:
+   1. Open OpenShift console in your browser and login as admin
+   2. Login as admin
+   3. Go to Deployments, in the `redhat-rhmi-operator` namespace and click on `rhmi-operator`
+   4. In the details tab, decrease the pod count by clicking on the down arrow
+      > RHMI pod should be scaled to 0
+   5. In the left hand side menu, go to Monitoring >> Alerting and select only Firing in the filter bar
+      > RHMIInstallationCompleted should be in the list
+   6. Go to `rhmi-operator` deployment and scale the pod up again.
+2. Verify RHMIInstallationControllerIsNotReconciling and RHMIInstallationControllerStoppedReconciling alerts are present and firing:
+   1. Open OpenShift console in your browser and login as admin
+   2. Login as admin
+   3. Find route for Prometheus in `redhat-rhmi-middleware-monitoring-operator` namespace
+   4. Open its URL
+   5. Go to the Alerts tab and look for `RHMIInstallationControllerIsNotReconciling` or `RHMIInstallationControllerStoppedReconciling`
+   6. Click on the `expr`
+   7. In the query page change the **15m** to **1m** and click on the excute buttom `rhmi_status{stage="complete"} and on(namespace) rate(controller_runtime_reconcile_total{controller="installation-controller"}[1m]) == 0`
+      > It should return the `rhmi_status` metric

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -390,6 +390,13 @@ var expectedRules = []alertsTestRule{
 			"RHMIUPSUnifiedpushProxyServiceEndpointDown",
 		},
 	},
+	{
+		File: "redhat-rhmi-operator-rhmi-installation-controller-alerts.yaml",
+		Rules: []string{
+			"RHMIInstallationControllerIsNotReconciling",
+			"RHMIInstallationControllerStoppedReconciling",
+		},
+	},
 }
 
 var expectedAWSRules = []alertsTestRule{


### PR DESCRIPTION
# Description

Adds 3 alerts around the `rhmi_status` metric: 

- **RHMIInstallationControllerIsNotReconciling**
  Fires if the rhmi operator hasn't reconciled successfully in an interval of 15m over the past 1h.

- **RHMIInstallationControllerStoppedReconciling**
  Fires if the rhmi operator hasn't reconciled successfully in an interval of 30m over the past 2h.

- **RHMIOperatorInstallCompleted**
  Fires if the rhmi operator is not in its complete stage in the past 2h.
  * This rule is created in the prometheus of the `openshift-monitoring` 

https://issues.redhat.com/browse/INTLY-7395

## Verification steps

1. Install the operator via OLM
2. Verify if RHMIOperatorInstallCompleted alert is present and firing:
    - Go to Deployments, in the `redhat-rhmi-operator` namespace and click on `rhmi-operator`
    - Scale down to 0 the pod count by clicking on the down arrow
    - Go to `openshift-monitoring` namespace and look for prometheusroles `rhmi-installation-alerts`
    - Change the threshold of the metric `RHMIInstallationCompleted` to 1m 
    - In the left hand side menu, go to Monitoring >> Alerting and select only Firing in the filter bar
    - Verify if the `RHMIInstallationCompleted` shows up in the list

3. Verify if RHMIInstallationControllerIsNotReconciling and RHMIInstallationControllerStoppedReconciling are present and firing:
    - Find route for Prometheus in `redhat-rhmi-middleware-monitoring-operator` namespace
    - Open its URL
    - Go to the Alerts tab and look for `RHMIInstallationControllerIsNotReconciling` or `RHMIInstallationControllerStoppedReconciling`
     - Click on the `expr`
     - In the query page change the **15m** to **1m** and click on the excute buttom `rhmi_status{stage="complete"} and on(namespace) rate(controller_runtime_reconcile_total{controller="installation-controller"}[1m]) == 0`
      - Verify if the `rhmi_status` metric is returned

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] This change requires a documentation update 
- [x] I have added a test case that will be used to verify my changes 