### PR TITLE
INTLY-9061 FIX(e2e): Stage completion more specific

### DIFF
--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -272,7 +272,7 @@ func waitForInstallationStageCompletion(t *testing.T, f *framework.Framework, na
 			return false, err
 		}
 
-		phaseStatus := fmt.Sprintf("%#v", installation.Status.Stages[integreatlyv1alpha1.StageName(phase)])
+		phaseStatus := fmt.Sprintf("%#v", installation.Status.Stages[integreatlyv1alpha1.StageName(phase)].Phase)
 		if strings.Contains(phaseStatus, "completed") {
 			return true, nil
 		}


### PR DESCRIPTION


# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
By checking the Stage.Phase for completion, if the timeout elapses the correct failing stage is reported.

**JIRA**
https://issues.redhat.com/browse/INTLY-9061

**VERIFY**
* Change the timeout delay for `productsStageTimout` in `test/e2e/integreatly_test.go` to a value that a would not allow the products to be installed. eg 2 minutes
* Run the e2e tests
 
**expected:**
* `FAIL: TestIntegreatly/integreatly/Cluster` e2e test fails
* in the logs `integreatly_test.go:281: Waiting for completion of products` should be repeated followed by `integreatly_test.go:100: error in fuction integreatlyManagedTest: timed out waiting for the condition` and `integreatly_test.go:106: cluster not in a testable state, quiting test run`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer