### PR TITLE
INTLY-9201

### DIFF
--- a/manifests/integreatly-monitoring/1.2.1/application-monitoring-operator.v1.2.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/application-monitoring-operator.v1.2.1.clusterserviceversion.yaml
@@ -63,6 +63,7 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
+          - get
         serviceAccountName: alertmanager-service-account
       - rules:
         - apiGroups:


### PR DESCRIPTION
Add a limited permission to bypass OLM bug.
The important thing about this change is that the rules for the alertmanager-service-account is different is some way than the rules for the grafana-serviceaccount.
This ensures the generated names of the corresponding clusterRoles & clusterRoleBindings will be different.

Related OLM issue https://github.com/operator-framework/operator-lifecycle-manager/issues/1625

The granted additional permission is to `get` `subjectaccessreviews`,
which will allow the SA to read an individual subjectaccessreviews resource by id.
Although not ideal, this permission is fairly limited.

# Description
https://issues.redhat.com/browse/INTLY-9201

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer