### PR TITLE
workaround olm bug when sas have the exact same rules

### DIFF
--- a/manifests/integreatly-amq-online/1.4.4/amq-online.1.4.4.clusterserviceversion.yaml
+++ b/manifests/integreatly-amq-online/1.4.4/amq-online.1.4.4.clusterserviceversion.yaml
@@ -905,6 +905,7 @@ spec:
           - get
           - list
           - watch
+          - update
         serviceAccountName: iot-protocol-adapter
       - rules:
         - apiGroups:


### PR DESCRIPTION
Similar to https://github.com/integr8ly/integreatly-operator/pull/983 but applies to the AMQ Online manifest. I had to grant `update` permissions because both sas already have get, list and watch.