### PR TITLE
Create and link secrets for 3scale and fuse imagestreams

### DIFF
--- a/scripts/setup-delorean-pullsecret.sh
+++ b/scripts/setup-delorean-pullsecret.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -e
 set -o pipefail
 
 CONFIG_PULLSECRET="$(pwd)/config-pullsecret"
@@ -7,6 +6,8 @@ DECODED_PULLSECRET="$(pwd)/config-pullsecret-decoded"
 DELOREAN_PULLSECRET="$(pwd)/integreatly-delorean-auth.json"
 STAGED_PULLSECRET="$(pwd)/staged-pullsecret"
 COMBINED_PULLSECRET="$(pwd)/combined-pullsecret"
+TEMP_SERVICEACCOUNT_NAME="rhmi-operator"
+OPERATOR_NAMESPACE="redhat-rhmi-operator"
 
 if [ ! -z "${DELOREAN_DOCKER_CONFIG}" ]; then
     echo -e $DELOREAN_DOCKER_CONFIG > $DELOREAN_PULLSECRET
@@ -20,16 +21,42 @@ if [ ! -f ${DELOREAN_PULLSECRET} ]; then
   exit 1
 fi
 
-sed -i 's+quay.io+quay.io/integreatly/delorean+g' $DELOREAN_PULLSECRET
+DELOREAN_PASSWORD="$(cat $DELOREAN_PULLSECRET | grep auth\": | tr -d \" | tr -d , | awk -F ' ' '{print $2}' | base64 --decode| awk -F : '{print $2}')"
+DELOREAN_USERNAME="$(cat $DELOREAN_PULLSECRET | grep auth\": | tr -d \" | tr -d , | awk -F ' ' '{print $2}' | base64 --decode| awk -F : '{print $1}')"
 
 oc get secret pull-secret -n openshift-config -o yaml > "$CONFIG_PULLSECRET"
 yq r $CONFIG_PULLSECRET 'data' | awk '{print $2}' | base64 -d > $DECODED_PULLSECRET
-jq -s -c '{auths: map(.auths) | add}' $DECODED_PULLSECRET $DELOREAN_PULLSECRET | base64 > $STAGED_PULLSECRET
-awk '{ printf "%s", $0 }' $STAGED_PULLSECRET  > $COMBINED_PULLSECRET
-oc patch secret pull-secret -n openshift-config -p='{"data": {".dockerconfigjson": "'$(cat ${COMBINED_PULLSECRET})'"}}'
-rm $CONFIG_PULLSECRET $STAGED_PULLSECRET $COMBINED_PULLSECRET $DECODED_PULLSECRET
+combine_and_deploy_cluster_secret() {
+    jq -s -c '{auths: map(.auths) | add}' $DECODED_PULLSECRET $DELOREAN_PULLSECRET | base64 > $STAGED_PULLSECRET
+    awk '{ printf "%s", $0 }' $STAGED_PULLSECRET  > $COMBINED_PULLSECRET
+    oc patch secret pull-secret -n openshift-config -p='{"data": {".dockerconfigjson": "'$(cat ${COMBINED_PULLSECRET})'"}}'
+    rm -f $CONFIG_PULLSECRET $STAGED_PULLSECRET $COMBINED_PULLSECRET $DECODED_PULLSECRET
+    echo "waiting 10 minutes to allow cluster to stabilize ..."
+    sleep 10m
+    echo "secret 'pull-secret' patched in namespace 'openshift-config' to add delorean quay.io access!"
+}
 
-echo "waiting 10 minutes to allow cluster to stabilize ..."
-sleep 10m
+setup_ns_and_local_secret() {
+  oc new-project redhat-rhmi-3scale --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc new-project redhat-rhmi-fuse --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc create secret docker-registry --docker-server=quay.io --docker-username="${DELOREAN_USERNAME}" --docker-password="${DELOREAN_PASSWORD}" regsecret -n redhat-rhmi-3scale --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc create secret docker-registry --docker-server=quay.io --docker-username="${DELOREAN_USERNAME}" --docker-password="${DELOREAN_PASSWORD}" regsecret -n redhat-rhmi-fuse --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc secrets link default regsecret --for=pull -n redhat-rhmi-3scale --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc secrets link default regsecret --for=pull -n redhat-rhmi-fuse --as system:serviceaccount:${OPERATOR_NAMESPACE}:${TEMP_SERVICEACCOUNT_NAME}
+  oc project ${OPERATOR_NAMESPACE}
+}
 
-echo "secret 'pull-secret' patched in namespace 'openshift-config' to add delorean quay.io access!"
+if [ -n "$(cat ${DECODED_PULLSECRET} | grep delorean)" ]; then
+  echo "Delorean secret found on cluster"
+  rm $CONFIG_PULLSECRET $DECODED_PULLSECRET
+else
+  if [ -n "$(cat ${DELOREAN_PULLSECRET} | grep delorean)" ]; then
+    combine_and_deploy_cluster_secret
+  else
+    sed -i 's+quay.io+quay.io/integreatly/delorean+g' $DELOREAN_PULLSECRET
+    combine_and_deploy_cluster_secret
+  fi
+fi
+
+echo "Setting up secrets for imagestreams"
+setup_ns_and_local_secret


### PR DESCRIPTION
# Description
Editing the cluster pull-secret to allow pulls from the private delorean repository doesn't work for imagestreams. This change makes the delorean setup script also setup a secret and linking for 3scale and fuse so they can successfully create imagestreams based on private images.

## To verify
1. Run `./scripts/setup-delorean-pullsecret.sh`
2. Verify the redhat-rhmi-3scale and redhat-rhmi-fuse namespaces are created
3. Run `oc get serviceaccount default -o yaml -n redhat-rhmi-3scale` and verify `regsecret` is a linked secret
4. Install rhmi from the 3scale-next-0.6.0 branch
5. Verify the imagestreams are created and pull seccessfully from the private delorean repo  

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer