### PR TITLE
updating ocm section to link to existing up to date doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Currently the operator installs the following products:
 - Integreatly solution explorer
 
 ## Prerequisites
+
+NOTE: Due to a change in how networking is configured for openshift in v4.4.6 (mentioned in the [cloud resource operator](https://github.com/integr8ly/cloud-resource-operator#supported-openshift-versions)) there is a limitation on the version of Openshift that RHMI can be installed on for BYOC clusters.
+Due to this change the use of integreatly-operator <= v2.4.0 on Openshift >= v4.4.6 is unsupported. Please use >= v2.5.0 of integreatly-operator for Openshift >= v4.4.6.
+
 - [operator-sdk](https://github.com/operator-framework/operator-sdk) version v0.15.1.
 - [go](https://golang.org/dl/) version 1.13.4+
 - [moq](https://github.com/matryer/moq)
@@ -187,53 +191,8 @@ make test/products/local
 
 ## Using `ocm` for installation of RHMI
 
-If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using `ocm`. If you want to spin up a cluster using BYOC (your own AWS credentials), follow the additional steps marked as **BYOC**.
-
-#### Prerequisites
-* [OCM CLI](https://github.com/openshift-online/ocm-cli/releases)
-* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
-* [jq](https://stedolan.github.io/jq/)
-
-#### Steps
-
-1. Download the CLI tool and add it to your PATH
-2. Export [OCM_TOKEN](https://github.com/openshift-online/ocm-cli#log-in): `export OCM_TOKEN="<TOKEN_VALUE>"`
-3. Login via OCM: 
-```
-make ocm/login
-```
-
-**BYOC**
-Make sure you have credentials for IAM user with admin access to AWS and other IAM user called "osdCcsAdmin" created in AWS, also with admin access.
-Export the credentials for your IAM user, set BYOC variable to `true` and create a new access key for "osdCcsAdmin" user:
-```
-export AWS_ACCOUNT_ID=<REPLACE_ME>
-export AWS_ACCESS_KEY_ID=<REPLACE_ME>
-export AWS_SECRET_ACCESS_KEY=<REPLACE_ME>
-export BYOC=true
-make ocm/aws/create_access_key
-```
-
-4. Create cluster template: `make ocm/cluster.json`.
-
-This command will generate `ocm/cluster.json` file with generated cluster name. This file will be used as a template to create your cluster via OCM CLI.
-By default, it will set the expiration timestamp for a cluster for 4 hours, meaning your cluster will be automatically deleted after 4 hours after you generated this template. If you want to change the default timestamp, you can update it in `ocm/cluster.json` or delete the whole line from the file if you don't want your cluster to be deleted automatically at all. 
-
-5. Create the cluster: `make ocm/cluster/create`.
-
-This command will send a request to [Red Hat OpenShift Cluster Manager](https://cloud.redhat.com/) to spin up your cluster and waits until it's ready. You can see the details of your cluster in `ocm/cluster-details.json` file
-
-6. Once your cluster is ready, OpenShift Console URL will be printed out together with the `kubeadmin` user & password. These are also saved to `ocm/cluster-credentials.json` file. Also there will be `ocm/cluster.kubeconfig` file created that you can use for running `oc` commands right away, for example, for listing all projects on your OpenShift cluster:
-
-```
-oc --config ocm/cluster.kubeconfig projects
-```
-
-7. If you want to install the latest released RHMI, you can trigger it by applying an RHMI addon.
-Run `make ocm/install/rhmi-addon` to trigger the installation. Once the installation is completed, the installation CR with RHMI components info will be printed to the console.
-
-8. If you want to delete your cluster, run `make ocm/cluster/delete`
-**BYOC**
+If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using `ocm`.
+See [here](https://github.com/integr8ly/delorean/tree/master/docs/ocm) for an up to date guide on how to do this.
 
 ## Release
 


### PR DESCRIPTION
# Description
As part of a change triggered by https://issues.redhat.com/browse/INTLY-8098 
we need to add details on supported versions of RHMI and byoc clusters supported versions.
I noticed there was a section in this README and a section here: https://github.com/integr8ly/delorean/tree/master/docs/ocm
Seems the linked one is updated more regularly so pointing to that here and removing the duplicated steps.


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer