### PR TITLE
detect profile type for the integration test based on created CR

### DIFF
--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -297,3 +297,17 @@ func verifyCRUDLPermissions(t *testing.T, openshiftClient *resources.OpenshiftCl
 		t.Errorf("failed to close response body: %s", err)
 	}
 }
+
+//Detect profile based on CR type
+func IsManaged(client dynclient.Client) (bool, error) {
+	rhmi := &integreatlyv1alpha1.RHMI{}
+	err := client.Get(goctx.TODO(), types.NamespacedName{Name: InstallationName, Namespace: RHMIOperatorNamespace}, rhmi)
+	if err != nil {
+		return true, fmt.Errorf("error getting RHMI CR: %v", err)
+	}
+
+	if rhmi.Spec.Type == "managed" {
+		return true, nil
+	}
+	return false, nil
+}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
INTLY-8771

Adding a utility method to detect the profile based on the CR instance. It can help in sorting the test cases based on profiles.

## Type of change

<!-- Please delete options that are not relevant. -->
- [X] New feature (non-breaking change which adds functionality)


