### PR TITLE
INTLY-8421: Ensure that no alerts are left during uninstall

### DIFF
--- a/pkg/controller/installation/prometheusRules.go
+++ b/pkg/controller/installation/prometheusRules.go
@@ -1,111 +1,67 @@
 package installation
 
 import (
-	"context"
 	"fmt"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/sirupsen/logrus"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func (r *ReconcileInstallation) reconcileRHMIInstallationAlerts(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
-	monitoringConfig := config.NewMonitoring(config.ProductConfig{})
-
-	rule := &monitoringv1.PrometheusRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rhmi-installation-controller-alerts",
-			Namespace: installation.Namespace,
-		},
-	}
-
-	rules := []monitoringv1.Rule{
-		{
-			Alert: "RHMIInstallationControllerIsNotReconciling",
-			Annotations: map[string]string{
-				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-				"message": "RHMI operator has not reconciled successfully in the interval of 15m over the past 1 hour",
-			},
-			Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[15m]) == 0")),
-			For:    "1h",
-			Labels: map[string]string{"severity": "warning"},
-		},
-		{
-			Alert: "RHMIInstallationControllerStoppedReconciling",
-			Annotations: map[string]string{
-				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-				"message": "RHMI operator has not reconciled successfully in the interval of 30m over the past 2 hours",
-			},
-			Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[30m]) == 0")),
-			For:    "2h",
-			Labels: map[string]string{"severity": "critical"},
-		},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, client, rule, func() error {
-		rule.ObjectMeta.Labels = map[string]string{"integreatly": "yes", monitoringConfig.GetLabelSelectorKey(): monitoringConfig.GetLabelSelector()}
-		rule.Spec = monitoringv1.PrometheusRuleSpec{
-			Groups: []monitoringv1.RuleGroup{
-				{
-					Name:  "rhmi-installation.rules",
-					Rules: rules,
+func (r *ReconcileInstallation) newAlertsReconciler(logger *logrus.Entry, installation *integreatlyv1alpha1.RHMI) resources.AlertReconciler {
+	return &resources.AlertReconcilerImpl{
+		ProductName:  "installation",
+		Installation: installation,
+		Logger:       logger,
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "rhmi-installation-controller-alerts",
+				Namespace: installation.Namespace,
+				GroupName: "rhmi-installation.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHMIInstallationControllerIsNotReconciling",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "RHMI operator has not reconciled successfully in the interval of 15m over the past 1 hour",
+						},
+						Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[15m]) == 0")),
+						For:    "1h",
+						Labels: map[string]string{"severity": "warning"},
+					},
+					{
+						Alert: "RHMIInstallationControllerStoppedReconciling",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "RHMI operator has not reconciled successfully in the interval of 30m over the past 2 hours",
+						},
+						Expr:   intstr.FromString(fmt.Sprint("rhmi_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='success'}[30m]) == 0")),
+						For:    "2h",
+						Labels: map[string]string{"severity": "critical"},
+					},
 				},
 			},
-		}
-		return nil
-	})
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error creating rhmi installation PrometheusRule: %w", err)
-	}
-
-	return integreatlyv1alpha1.PhaseCompleted, nil
-}
-
-func (r *ReconcileInstallation) reconcileRHMIInstallationAlertsOpenshiftMonitoring(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
-	monitoringConfig := config.NewMonitoring(config.ProductConfig{})
-
-	rule := &monitoringv1.PrometheusRule{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rhmi-installation-alerts",
-			Namespace: "openshift-monitoring",
-		},
-	}
-
-	rules := []monitoringv1.Rule{
-		{
-			Alert: "RHMIOperatorInstallDelayed",
-			Annotations: map[string]string{
-				"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-				"message": "RHMI operator is taking more than 2 hours to go to a complete stage",
-			},
-			Expr:   intstr.FromString(fmt.Sprint("absent(rhmi_status{stage='complete'} == 1)")),
-			For:    "120m",
-			Labels: map[string]string{"severity": "critical"},
-		},
-	}
-
-	_, err := controllerutil.CreateOrUpdate(ctx, client, rule, func() error {
-		rule.ObjectMeta.Labels = map[string]string{"integreatly": "yes", monitoringConfig.GetLabelSelectorKey(): monitoringConfig.GetLabelSelector()}
-		rule.Spec = monitoringv1.PrometheusRuleSpec{
-			Groups: []monitoringv1.RuleGroup{
-				{
-					Name:  "rhmi-installation.rules",
-					Rules: rules,
+			{
+				AlertName: "rhmi-installation-alerts",
+				Namespace: "openshift-monitoring",
+				GroupName: "rhmi-installation.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHMIOperatorInstallDelayed",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "RHMI operator is taking more than 2 hours to go to a complete stage",
+						},
+						Expr:   intstr.FromString(fmt.Sprint("absent(rhmi_status{stage='complete'} == 1)")),
+						For:    "120m",
+						Labels: map[string]string{"severity": "critical"},
+					},
 				},
 			},
-		}
-		return nil
-	})
-
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error creating rhmi installation PrometheusRule: %w", err)
+		},
 	}
-	return integreatlyv1alpha1.PhaseCompleted, nil
 }


### PR DESCRIPTION
# Description

> * Initial PR: https://github.com/integr8ly/integreatly-operator/pull/935
> * Link to Jira: https://issues.redhat.com/browse/INTLY-8421

There's still a few alerts firing during uninstall. This fix ensures that no unwanted alerts are firing

* Add logic to remove all PrometheusRules with the `integreatly` label during
uninstall.
* Refactor new installation alerts to use AlertReconciler.

# Verification

Install RHMI and run the following script, outputing the result into a Markdown file:

```bash
#!/usr/bin/env bash

echo '# Deleting RHMI CR'
echo "Time of deletion: $(date)"

oc delete rhmis rhmi -n redhat-rhmi-operator > /dev/null 2>&1 &

echo '# Alerts during uninstall'

echo '| Timestamp | Alerts |'
echo '| --------- | ------ |'

while true
do
    oc get rhmis rhmi -n redhat-rhmi-operator > /dev/null 2>&1
    if [ $? -ne 0 ]; then
        break
    fi
    
    ALERTS=`oc exec -n redhat-rhmi-middleware-monitoring-operator prometheus-application-monitoring-0 -c prometheus curl localhost:9090/api/v1/query?query=ALERTS| jq -jc '.data.result[] | {alert: .metric.alertname, namespace: .metric.namespace, pod: .metric.pod, severity: .metric.severity}'`
    echo "| $(date) | \`$ALERTS\` |"

    sleep 30
done


echo '# Uninstall finished'
echo "Time uninstall finished: $(date)"
```

Verify in the table that no unwanted alerts have fired during the uninstallation

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer