### PR TITLE
fix: Change logic to retrieve CSV from InstallPlan

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -384,3 +384,13 @@ rules:
       - update
       - delete
   # END Permission to manage ValidatingWebhookConfiguration CRs pointing to the webhook server
+
+  # Permission to get the ConfigMap that embeds the CSV for an InstallPlan
+  - verbs:
+      - get
+    apiGroups:
+      - ''
+    resources:
+      - configmaps
+  # END Permission to get the ConfigMap that embeds the CSV for an InstallPlan
+  

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -228,7 +228,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		installation.Spec.AlertingEmailAddress = alertingEmailAddress
 		err = r.client.Update(context.TODO(), installation)
 		if err != nil {
-			logrus.Errorf("Error while copying alerting email address to RHMI CR: %w", err)
+			logrus.Errorf("Error while copying alerting email address to RHMI CR: %v", err)
 		}
 	}
 
@@ -287,7 +287,7 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	// reconciles rhmi installation alerts
 	_, err = r.reconcileRHMIInstallationAlerts(context.TODO(), r.client, installation)
 	if err != nil {
-		logrus.Infof("Error reconciling alerts for the rhmi installation controller: %w", err)
+		logrus.Infof("Error reconciling alerts for the rhmi installation controller: %v", err)
 	}
 
 	// reconciles rhmi installation completion alert in openshift monitoring

--- a/pkg/controller/subscription/csvlocator/csvlocator.go
+++ b/pkg/controller/subscription/csvlocator/csvlocator.go
@@ -1,0 +1,143 @@
+package csvlocator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-registry/pkg/registry"
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type CSVLocator interface {
+	GetCSV(ctx context.Context, client k8sclient.Client, installPlan *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error)
+}
+
+type EmbeddedCSVLocator struct{}
+
+var _ CSVLocator = &EmbeddedCSVLocator{}
+
+func (l *EmbeddedCSVLocator) GetCSV(ctx context.Context, client k8sclient.Client, installPlan *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error) {
+	csv := &olmv1alpha1.ClusterServiceVersion{}
+
+	// The latest CSV is only represented in the new install plan while the upgrade is pending approval
+	for _, installPlanResources := range installPlan.Status.Plan {
+		if installPlanResources.Resource.Kind == olmv1alpha1.ClusterServiceVersionKind {
+			err := json.Unmarshal([]byte(installPlanResources.Resource.Manifest), &csv)
+			if err != nil {
+				return csv, fmt.Errorf("failed to unmarshal json: %w", err)
+			}
+		}
+	}
+
+	return csv, nil
+}
+
+type ConfigMapCSVLocator struct{}
+
+var _ CSVLocator = &ConfigMapCSVLocator{}
+
+type unpackedBundleReference struct {
+	Kind                   string `json:"kind"`
+	Name                   string `json:"name"`
+	Namespace              string `json:"namespace"`
+	CatalogSourceName      string `json:"catalogSourceName"`
+	CatalogSourceNamespace string `json:"catalogSourceNamespace"`
+	Replaces               string `json:"replaces"`
+}
+
+func (l *ConfigMapCSVLocator) GetCSV(ctx context.Context, client k8sclient.Client, installPlan *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error) {
+	csv := &olmv1alpha1.ClusterServiceVersion{}
+
+	// The latest CSV is only represented in the new install plan while the upgrade is pending approval
+	for _, installPlanResources := range installPlan.Status.Plan {
+		if installPlanResources.Resource.Kind != olmv1alpha1.ClusterServiceVersionKind {
+			continue
+		}
+
+		// Get the reference to the ConfigMap that contains the CSV
+		ref := &unpackedBundleReference{}
+		err := json.Unmarshal([]byte(installPlanResources.Resource.Manifest), &ref)
+		if err != nil {
+			return csv, fmt.Errorf("failed to unmarshal json: %w", err)
+		}
+
+		// Get the ConfigMap
+		csvConfigMap := &corev1.ConfigMap{}
+		if err := client.Get(ctx, k8sclient.ObjectKey{
+			Name:      ref.Name,
+			Namespace: ref.Namespace,
+		}, csvConfigMap); err != nil {
+			return csv, fmt.Errorf("error retrieving ConfigMap %s/%s: %v", ref.Namespace, ref.Name, err)
+		}
+
+		// The ConfigMap may contain other manifests other than the CSV. Iterate
+		// through the content and skip the ones that have a kind other than
+		// ClusterSeerviceVersion
+		for _, resourceStr := range csvConfigMap.Data {
+			// Decode the manifest
+			reader := strings.NewReader(resourceStr)
+			resource, decodeErr := registry.DecodeUnstructured(reader)
+			if decodeErr != nil {
+				return nil, decodeErr
+			}
+
+			// If the kind is not CSV, skip it
+			if resource.GetKind() != olmv1alpha1.ClusterServiceVersionKind {
+				continue
+			}
+
+			// Encode the unstructured CSV as Json to decode it back to the
+			// structured object
+			resourceJSON, err := resource.MarshalJSON()
+			if err != nil {
+				return nil, err
+			}
+
+			if err := json.Unmarshal(resourceJSON, csv); err != nil {
+				return csv, fmt.Errorf("failed to unmarshall yaml: %v", err)
+			}
+
+			return csv, nil
+		}
+	}
+
+	return csv, nil
+}
+
+type CachedCSVLocator struct {
+	cache map[string]*olmv1alpha1.ClusterServiceVersion
+
+	locator CSVLocator
+}
+
+var _ CSVLocator = &CachedCSVLocator{}
+
+func NewCachedCSVLocator(innerLocator CSVLocator) *CachedCSVLocator {
+	return &CachedCSVLocator{
+		cache:   map[string]*olmv1alpha1.ClusterServiceVersion{},
+		locator: innerLocator,
+	}
+}
+
+func (l *CachedCSVLocator) GetCSV(ctx context.Context, client k8sclient.Client, installPlan *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error) {
+	key := fmt.Sprintf("%s/%s", installPlan.Namespace, installPlan.Name)
+
+	if found, ok := l.cache[key]; ok {
+		return found, nil
+	}
+
+	csv, err := l.locator.GetCSV(ctx, client, installPlan)
+	if err != nil {
+		return nil, err
+	}
+
+	if csv != nil {
+		l.cache[key] = csv
+	}
+
+	return csv, nil
+}

--- a/pkg/controller/subscription/csvlocator/csvlocator_test.go
+++ b/pkg/controller/subscription/csvlocator/csvlocator_test.go
@@ -1,0 +1,219 @@
+package csvlocator
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type testScenario struct {
+	Name string
+
+	Locator     CSVLocator
+	InstallPlan *olmv1alpha1.InstallPlan
+
+	InitObjs  []runtime.Object
+	Assertion func(t *testing.T, err error, csv *olmv1alpha1.ClusterServiceVersion)
+}
+
+func embeddedScenario(t *testing.T) *testScenario {
+	csvString := `{"metadata":{"name":"test-csv","namespace":"test","creationTimestamp":null},"spec":{"install":{"strategy":""},"version":"1.0.0","customresourcedefinitions":{},"apiservicedefinitions":{},"displayName":"","provider":{}},"status":{"lastUpdateTime":null,"lastTransitionTime":null,"certsLastUpdated":null,"certsRotateAt":null}}`
+
+	installPlan := &olmv1alpha1.InstallPlan{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-ip",
+			Namespace: "test",
+		},
+		Status: olmv1alpha1.InstallPlanStatus{
+			Plan: []*olmv1alpha1.Step{
+				{
+					Resource: olmv1alpha1.StepResource{
+						Kind:     olmv1alpha1.ClusterServiceVersionKind,
+						Manifest: csvString,
+					},
+				},
+			},
+		},
+	}
+
+	return &testScenario{
+		Name:        "EmbeddedCSVLocator",
+		InstallPlan: installPlan,
+		Locator:     &EmbeddedCSVLocator{},
+		Assertion:   assertCorrectCSV,
+	}
+}
+
+func configMapScenario(t *testing.T) *testScenario {
+	csvString := `
+apiVersion: v1alpha1
+kind: ClusterServiceVersion
+metadata:
+    creationTimestamp: null
+    name: test-csv
+    namespace: test
+spec:
+    apiservicedefinitions: {}
+    customresourcedefinitions: {}
+    displayName: ""
+    install:
+        strategy: ""
+        provider: {}
+    version: 1.0.0
+status:
+    certsLastUpdated: null
+    certsRotateAt: null
+    lastTransitionTime: null
+    lastUpdateTime: null`
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-cm",
+			Namespace: "test",
+		},
+		Data: map[string]string{
+			"csv.yaml": csvString,
+		},
+	}
+
+	configMapRef := &unpackedBundleReference{
+		Namespace: "test",
+		Name:      "test-cm",
+	}
+
+	configMapRefJSON, err := json.Marshal(configMapRef)
+	if err != nil {
+		t.Fatalf("failed to marshal config map reference: %v", err)
+	}
+
+	installPlan := &olmv1alpha1.InstallPlan{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-ip",
+			Namespace: "test",
+		},
+		Status: olmv1alpha1.InstallPlanStatus{
+			Plan: []*olmv1alpha1.Step{
+				{
+					Resource: olmv1alpha1.StepResource{
+						Kind:     olmv1alpha1.ClusterServiceVersionKind,
+						Manifest: string(configMapRefJSON),
+					},
+				},
+			},
+		},
+	}
+
+	return &testScenario{
+		Name: "ConfigMapCSVLocator",
+		InitObjs: []runtime.Object{
+			configMap,
+		},
+		InstallPlan: installPlan,
+		Locator:     &ConfigMapCSVLocator{},
+		Assertion:   assertCorrectCSV,
+	}
+}
+
+func TestGetCSV(t *testing.T) {
+	scenarios := []*testScenario{
+		embeddedScenario(t),
+		configMapScenario(t),
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			initObjs := append([]runtime.Object{scenario.InstallPlan}, scenario.InitObjs...)
+			client := fake.NewFakeClientWithScheme(buildScheme(), initObjs...)
+
+			csv, err := scenario.Locator.GetCSV(context.TODO(), client, scenario.InstallPlan)
+			scenario.Assertion(t, err, csv)
+		})
+	}
+}
+
+func TestCachedCSVLocator(t *testing.T) {
+	mockLocator := &mockCSVLocator{
+		CSV: &olmv1alpha1.ClusterServiceVersion{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-csv",
+				Namespace: "test",
+			},
+		},
+		Counter: 0,
+	}
+
+	ip1 := &olmv1alpha1.InstallPlan{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "test-ip-1",
+			Namespace: "test",
+		},
+	}
+
+	cached := NewCachedCSVLocator(mockLocator)
+
+	csv, err := cached.GetCSV(context.TODO(), nil, ip1)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if csv.Name != "test-csv" {
+		t.Errorf("unexpected name for csv. Expected test-csv, got %s", csv.Name)
+	}
+	if csv.Namespace != "test" {
+		t.Errorf("unexpected namespace for csv. Expected test, got %s", csv.Namespace)
+	}
+	if mockLocator.Counter != 1 {
+		t.Errorf("unexpected value for counter. Expected 1, got %d", mockLocator.Counter)
+	}
+
+	// Call GetCSV again, the counter should remain the same as the CSV is cached
+	csv, err = cached.GetCSV(context.TODO(), nil, ip1)
+
+	if mockLocator.Counter != 1 {
+		t.Errorf("unexpected value for counter. Expected 1, got %d", mockLocator.Counter)
+	}
+}
+
+func assertCorrectCSV(t *testing.T, err error, csv *olmv1alpha1.ClusterServiceVersion) {
+	if err != nil {
+		t.Fatalf("no error expected, got %v", err)
+	}
+
+	if csv == nil {
+		t.Fatal("expected csv to be found, but nil was returned")
+	}
+
+	if csv.Name != "test-csv" {
+		t.Errorf("expected csv name to be test-csv, but got %s", csv.Name)
+	}
+	if csv.Namespace != "test" {
+		t.Errorf("expected csv namespace to be test, but got %s", csv.Namespace)
+	}
+	if csv.Spec.Version.String() != "1.0.0" {
+		t.Errorf("expected csv version to be 1.0.0, got %s", csv.Spec.Version.String())
+	}
+}
+
+func buildScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	olmv1alpha1.AddToScheme(scheme)
+	corev1.AddToScheme(scheme)
+	return scheme
+}
+
+type mockCSVLocator struct {
+	CSV     *olmv1alpha1.ClusterServiceVersion
+	Counter int
+}
+
+func (m *mockCSVLocator) GetCSV(_ context.Context, _ k8sclient.Client, _ *olmv1alpha1.InstallPlan) (*olmv1alpha1.ClusterServiceVersion, error) {
+	m.Counter++
+	return m.CSV, nil
+}

--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/version"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/csvlocator"
 	"k8s.io/apimachinery/pkg/runtime"
 
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -700,7 +701,7 @@ func TestApproveUpgrade(t *testing.T) {
 					t.Fatalf("Expected scheduled field to be empty")
 				}
 				if rhmi.Status.ToVersion != version.Version {
-					t.Fatalf("Expected ToVersion to be version.version")
+					t.Fatalf("Expected ToVersion to be version.version, got %s", rhmi.Status.ToVersion)
 				}
 			},
 		},
@@ -708,7 +709,7 @@ func TestApproveUpgrade(t *testing.T) {
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RHMI, scenario.RhmiInstallPlan, scenario.EventRecorder)
+			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RHMI, scenario.RhmiInstallPlan, &csvlocator.EmbeddedCSVLocator{}, scenario.EventRecorder)
 			retrievedInstallPlan := &olmv1alpha1.InstallPlan{}
 			err := scenario.FakeClient.Get(scenario.Context, k8sclient.ObjectKey{Name: scenario.RhmiInstallPlan.Name, Namespace: scenario.RhmiInstallPlan.Namespace}, retrievedInstallPlan)
 			rhmi := &integreatlyv1alpha1.RHMI{}

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -70,7 +70,12 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return k8sclient.New(restConfig, k8sclient.Options{})
 	})
 
-	csvLocator := csvlocator.NewCachedCSVLocator(&csvlocator.ConfigMapCSVLocator{})
+	csvLocator := csvlocator.NewCachedCSVLocator(csvlocator.NewConditionalCSVLocator(
+		csvlocator.SwitchLocators(
+			csvlocator.ForReference,
+			csvlocator.ForEmbedded,
+		),
+	))
 
 	return &ReconcileSubscription{
 		mgr:                 mgr,

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/csvlocator"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/rhmiConfigs"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/webapp"
 	"github.com/integr8ly/integreatly-operator/version"
@@ -69,13 +70,16 @@ func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
 		return k8sclient.New(restConfig, k8sclient.Options{})
 	})
 
+	csvLocator := csvlocator.NewCachedCSVLocator(&csvlocator.ConfigMapCSVLocator{})
+
 	return &ReconcileSubscription{
 		mgr:                 mgr,
-		client:              mgr.GetClient(),
+		client:              client,
 		scheme:              mgr.GetScheme(),
 		operatorNamespace:   operatorNs,
 		catalogSourceClient: catalogSourceClient,
 		webbappNotifier:     webappNotifierClient,
+		csvLocator:          csvLocator,
 	}, nil
 }
 
@@ -111,6 +115,7 @@ type ReconcileSubscription struct {
 	mgr                 manager.Manager
 	catalogSourceClient catalogsourceClient.CatalogSourceClientInterface
 	webbappNotifier     webapp.UpgradeNotifier
+	csvLocator          csvlocator.CSVLocator
 }
 
 // Reconcile will ensure that that Subscription object(s) have Manual approval for the upgrades
@@ -178,7 +183,7 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 		return reconcile.Result{}, err
 	}
 
-	latestRHMICSV, err := rhmiConfigs.GetCSV(latestRHMIInstallPlan)
+	latestRHMICSV, err := r.csvLocator.GetCSV(ctx, r.client, latestRHMIInstallPlan)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -279,7 +284,7 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 	if !isServiceAffecting || canUpgradeNow {
 		eventRecorder := r.mgr.GetEventRecorderFor("RHMI Upgrade")
 
-		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, installation, latestRHMIInstallPlan, eventRecorder)
+		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, installation, latestRHMIInstallPlan, r.csvLocator, eventRecorder)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -10,6 +10,7 @@ import (
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/csvlocator"
 	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/webapp"
 
 	catalogsourceClient "github.com/integr8ly/integreatly-operator/pkg/resources/catalogsource"
@@ -294,6 +295,7 @@ func TestSubscriptionReconciler(t *testing.T) {
 				catalogSourceClient: scenario.catalogsourceClient,
 				operatorNamespace:   operatorNamespace,
 				webbappNotifier:     &webapp.NoOp{},
+				csvLocator:          &csvlocator.EmbeddedCSVLocator{},
 			}
 			res, err := reconciler.Reconcile(scenario.Request)
 			scenario.Verify(client, res, err, t)


### PR DESCRIPTION
# Description

Due to an OLM upgrade, CSVs are no longer embedded directly in the InstallPlan, causing the `GetCSV` function
to fail silently and return an empty CSV.

Decouple the logic to retrieve the CSV into an interface `CSVLocator` and create two implementations:

* `EmbeddedCSVLocator`: with the old logic, as the unit tests currently rely heavily on that logic
* `ConfigMapCSVLocator`: with the updated logic

Make the subscription controller reconciler depend on the interface and use correct implementation.

## Verification steps

1. Create a release 2.5.0 from this branch. Follow [the OLM guide to install RHMI](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md)
2. Install RHMI from this release and wait for the installation to be complete
2. Simulate an upgrade to 2.6.0
3. Let the operator approve the upgrade:
    1. When the upgrade is made available, set the following upgrade spec in the `RHMIConfig` instance
    ```yaml
    upgrade:
      notBeforeDays: 0
      waitForMaintenance: false
    ```
    2. Wait for the upgrade to be approved
5. Check that the `toVersion` field in the RHMI CR is set to `2.6.0`
6. Wait for the upgrade to complete
7. Check that the `version` field in the RHMI CR is set to `2.6.0`
8. In Prometheus, check that the `rhmi_version` metric contains the correct values

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer