### PR TITLE
Added trepel to test-case owners

### DIFF
--- a/test-cases/OWNERS
+++ b/test-cases/OWNERS
@@ -10,3 +10,4 @@ approvers:
 - tonyxrmdavidson
 - trdoyle81
 - mmusil
+- trepel


### PR DESCRIPTION
# Description
Added 'trepel' (myself) to the test-case owners.

To verify I think it is enough to check there's no typo there.