### PR TITLE
INTLY-9315 - add note to make tester aware of alert firing time range

### DIFF
--- a/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
@@ -23,6 +23,10 @@ Note: this test should only be performed at a time it will not affect other ongo
    > redhat-rhmi-solution-explorer -> Workloads -> Deployment Configs -> Scale to 1
    > redhat-rhmi-ups -> Workloads -> Deployments -> Scale to 1
 
+**_Note_**: The alerts firing panel in the SLO summary dashboard may show alerts firing even if the product is no longer triggering an alert in prometheus.
+If the alert box shows alerts firing, change the `quick range` in the top right of Grafana UI to a lower range (such as 5 minutes) and check the `alert firing` box again and ensure
+that the graph is true to the actual state of the alerts in prometheus, if the `alert firing` box is no longer showing alerts and the graph is true to the actual state then no further action is required.
+
 ### Code #1
 
 ```bash


### PR DESCRIPTION
# Description
Adding a note for future testers to make them aware of the `time range` function in grafana UI, for which if the time range is too high will not reflect the actual and current state of the alerts, possibly showing up false positives for testers.

## Type of change
[:heavy_check_mark: ] Test case