### PR TITLE
deploy RHMI with bundle format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -194,6 +194,13 @@ cluster/deploy/integreatly-rhmi-cr.yml: deploy/integreatly-rhmi-cr.yml
 .PHONY: cluster/prepare
 cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 
+.PHONY: cluster/prepare/bundle
+cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
+
+.PHONY: install/olm/bundle
+install/olm/bundle:
+	./scripts/bundle-rhmi-operators.sh
+
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
 	@ - oc new-project $(NAMESPACE)

--- a/deploy/catalog-source-template.yml
+++ b/deploy/catalog-source-template.yml
@@ -1,0 +1,18 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhmi-deploy
+objects:
+  - apiVersion: operators.coreos.com/v1alpha1
+    kind: CatalogSource
+    metadata:
+      name: rhmi-operators
+      namespace: openshift-marketplace
+    spec:
+      sourceType: grpc
+      image: ${INDEX_IMAGE}
+parameters:
+  - description: Index Image
+    displayName: Index Image
+    name: INDEX_IMAGE
+    value: redhat-rhmi-operator

--- a/scripts/bundle-rhmi-operators.sh
+++ b/scripts/bundle-rhmi-operators.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+
+LATEST_VERSION=$(grep integreatly-operator deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml | awk -F v '{print $2}')
+CHANNEL="${CHANNEL:-alpha}"
+ORG="${ORG:-integreatly}"
+REG="${REG:-quay.io}"
+BUILD_TOOL="${BUILD_TOOL:-docker}"
+UPGRADE_RHMI="${UPGRADE:-false}"
+VERSIONS="${BUNDLE_VERSIONS:-$LATEST_VERSION}"
+ROOT=$(pwd)
+INDEX_IMAGE=""
+
+start() {
+  # TODO: validate input
+  create_work_area
+  copy_bundles
+  check_upgrade_install
+  generate_bundles
+  generate_index
+  create_catalog_source
+  clean_up
+}
+
+create_work_area() {
+  printf "Creating Work Area \n"
+
+  cd ./deploy/olm-catalog/integreatly-operator/
+  mkdir temp && cd temp
+}
+
+copy_bundles() {
+  for i in $(echo $VERSIONS | sed "s/,/ /g")
+  do
+      printf 'Copying bundle version: \n'$i
+      cp -R ../$i ./
+  done
+}
+
+# Remove the replaces field in the csv to allow for a single bundle install. i.e.
+# The install will not require a previous version to replace.
+check_upgrade_install() {
+  if [ "$UPGRADE_RHMI" = true ] ; then
+    # We can return as the csv will have the replaces field by default
+    echo 'Not replacing rhmi operator'
+    return
+  fi
+
+  echo "versions:::: "$VERSIONS
+  # Get the oldest version, example: VERSIONS="2.5,2.4,2.3" oldest="2.3"
+  OLDEST_VERSION=${VERSIONS##*,}
+
+  printf "Removing replaces field from CSV \n"
+  file='./'${OLDEST_VERSION}'/integreatly-operator.v'${OLDEST_VERSION}'.clusterserviceversion.yaml'
+  sed '/replaces/d' $file > newfile ; mv newfile $file
+}
+
+generate_bundles() {
+  printf "Generating Bundle \n"
+
+  for VERSION in $(echo $VERSIONS | sed "s/,/ /g")
+  do
+    cd ./$VERSION
+    opm alpha bundle generate -d . --channels $CHANNEL \
+        --package integreatly --output-dir bundle \
+        --default $CHANNEL
+
+    cd ./bundle/
+
+    opm alpha bundle build --directory ./manifests --tag $REG/$ORG/integreatly-bundle:${VERSION} \
+        --package integreatly --channels $CHANNEL --default $CHANNEL
+
+    docker push $REG/$ORG/integreatly-bundle:$VERSION
+    operator-sdk bundle validate $REG/$ORG/integreatly-bundle:$VERSION
+
+    cd ../../
+  done
+}
+
+generate_index() {
+
+  bundles=""
+  for VERSION in $(echo $VERSIONS | sed "s/,/ /g")
+  do
+      bundles=$bundles"$REG/$ORG/integreatly-bundle:$VERSION,"
+  done
+  # remove last comma
+  bundles=${bundles%?}
+
+  NEWEST_VERSION="$( cut -d ',' -f 1 <<< "$VERSIONS" )"
+  opm index add \
+      --bundles $bundles \
+      --build-tool ${BUILD_TOOL} \
+      --tag $REG/$ORG/integreatly-index:$NEWEST_VERSION
+
+  INDEX_IMAGE=$REG/$ORG/integreatly-index:$NEWEST_VERSION
+
+  printf 'Pushing index image:'$INDEX_IMAGE'\n'
+
+  docker push $INDEX_IMAGE
+}
+
+create_catalog_source() {
+  printf 'Creating catalog source '$INDEX_IMAGE'\n'
+  cd $ROOT
+  oc delete catalogsource rhmi-operators -n openshift-marketplace --ignore-not-found=true
+  oc process -p INDEX_IMAGE=$INDEX_IMAGE  -f ./deploy/catalog-source-template.yml | oc apply -f - -n openshift-marketplace
+}
+
+clean_up() {
+  printf 'Cleaning up work area \n'
+  rm -rf $ROOT/deploy/olm-catalog/integreatly-operator/temp
+}
+
+start


### PR DESCRIPTION
# Description
Add a new mechanism to deploy the RHMI operator, i.e. the bundle format. This is an alternative to using an OperatorSource. As OperatorSource is being deprecated and the bundle format will become the standard packaging for operators, this updates installs the RHMI operator through OLM, by creating bundles and indices and a CatalogSource. Mainly for development/testing purposes.

See detailed manual steps [here](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md)

## Type of change
- New feature (non-breaking change which adds functionality)

## How to Verify 
See details in README.md on how to run the scripts and make target
Suggested testing:
- On a new cluster, deploy the latest bundle and verify the installation through Operator Hub
> (ORG=<YOUR_ORG> make install/bundle)

- Then create a new bundle version and index image. Verify the upgraded version of RHMI in the Operator Hub
> SEMVER=<X.Y.Z> make release/prepare
> ORG=<YOUR_ORG> TAG=<X.Y.Z> make image/build/push     (build a new operator image if required)
> **NOTE:** Update the operator image references in the CSV files if necessary
> ORG=<YOUR_ORG> BUNDLE_VERSIONS="NewVersion,OldVersion" make install/olm/bundle 
