### PR TITLE
DEL-253 Fix the JUnit report for the functional test suite

### DIFF
--- a/test/functional/main_test.go
+++ b/test/functional/main_test.go
@@ -99,6 +99,18 @@ func teeOutput(f func()) string {
 		panic(err)
 	}
 
+	wg.Wait()
+
+	err = stdoutReader.Close()
+	if err != nil {
+		panic(err)
+	}
+
+	err = stderrReader.Close()
+	if err != nil {
+		panic(err)
+	}
+
 	return output.String()
 }
 


### PR DESCRIPTION
# Description

The JUnit report was reporting more failures than the actual ones. The reason is that the output collected from the `teeOutput` function is incomplete, and this is happening because the testing module of go us usually flushing all the test results at the end and therefore the tee function is taking more than a cycle for writing it back to the stdout and to the output buffer and by converting the output buffer to a string before the function was completing it was actually cutting it.

**What:**

Add the forgotten `wg.Wait()` to the tee function to wait for all output to be flushed before returning the string

**How I tested it**

I simulated a huge amount of output with a single print:

```

func main() {
	_ = teeOutput(func() {
		fmt.Println(strings.Repeat("a huge amout of text ", 100000))
	})
}
```

and the first time I was trying it without the `wg.Wait()` the function was panicking, and after adding it the function was working correctly again.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer