### PR TITLE
fix: delete redis, postgres and blobstorages at the same time

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -169,10 +169,6 @@ func (r *Reconciler) cleanupResources(ctx context.Context, installation *integre
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
 	}
-	if len(postgresInstances.Items) > 0 {
-		r.logger.Info("deletion of postgres instances in progress")
-		return integreatlyv1alpha1.PhaseInProgress, nil
-	}
 
 	// ensure redis instances are cleaned up
 	redisInstances := &crov1alpha1.RedisList{}
@@ -187,10 +183,6 @@ func (r *Reconciler) cleanupResources(ctx context.Context, installation *integre
 		if err := client.Delete(ctx, &redisInst); err != nil {
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
-	}
-	if len(redisInstances.Items) > 0 {
-		r.logger.Info("deletion of redis instances in progress")
-		return integreatlyv1alpha1.PhaseInProgress, nil
 	}
 
 	// ensure blob storage instances are cleaned up
@@ -207,6 +199,17 @@ func (r *Reconciler) cleanupResources(ctx context.Context, installation *integre
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
 	}
+
+	if len(postgresInstances.Items) > 0 {
+		r.logger.Info("deletion of postgres instances in progress")
+		return integreatlyv1alpha1.PhaseInProgress, nil
+	}
+
+	if len(redisInstances.Items) > 0 {
+		r.logger.Info("deletion of redis instances in progress")
+		return integreatlyv1alpha1.PhaseInProgress, nil
+	}
+
 	if len(blobStorages.Items) > 0 {
 		r.logger.Info("deletion of blob storage instances in progress")
 		return integreatlyv1alpha1.PhaseInProgress, nil


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-9101

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verification steps
1. Clone this branch
2. Log in to the provided OpenShift cluster as kubeadmin
3. In terminal window # 1, run:
```
make code/run USE_CLUSTER_STORAGE=false
```
4. In a terminal window # 2, run this command to show the status of postgres, redis and blobstorage CRs
```
watch "echo 'postgres CRs status:' && oc get postgres -o json | jq -r '.items[].status.phase' && echo 'redis CRs status:' && oc get redis -o json | jq -r '.items[].status.phase' && echo 'blobstorage CRs status:' && oc get blobstorages -o json | jq -r '.items[].status.phase'"
```
(all should have the status: `complete`)
5. In a terminal window # 3, trigger RHMI CR deletion
```
oc delete rhmi rhmi -n redhat-rhmi-operator
```
6. In about one minute, in terminal window # 2, you should see the status of postgres, redis and blobstorage CRs changed to "deletion in progress" and eventually you should see no status message, once all CRs are deleted (it takes about 10 minutes)
7. After CRs are deleted, check that all RHMI projects except rhmi-operator are gone (it could take about one more minute to finish installation of RHMI monitoring pieces)
```
watch "oc get projects | grep redhat"
```