### PR TITLE
feat(CroReconciler): adds delete strategy to remove snapshots

### DIFF
--- a/deploy/olm-catalog/integreatly-operator/2.6.0/integreatly-operator.v2.6.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/integreatly-operator/2.6.0/integreatly-operator.v2.6.0.clusterserviceversion.yaml
@@ -41,7 +41,7 @@ metadata:
     capabilities: Basic Install
     categories: RHMI integration
     certified: "false"
-    containerImage: quay.io/integreatly/integreatly-operator:v2.6.0-rc1
+    containerImage: quay.io/integreatly/integreatly-operator:v2.6.0
     createdAt: "2019-10-15 10:39:00"
     description: RHMI integration suite of tools
     support: RHMI
@@ -311,7 +311,7 @@ spec:
                   value: rhmi-operator
                 - name: USE_CLUSTER_STORAGE
                   value: "true"
-                image: quay.io/integreatly/integreatly-operator:v2.6.0-rc1
+                image: quay.io/integreatly/integreatly-operator:v2.6.0
                 imagePullPolicy: Always
                 name: rhmi-operator
                 ports:

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -2,8 +2,11 @@ package cloudresources
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"strings"
 
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
@@ -14,9 +17,12 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/aws/aws-sdk-go/service/rds"
 	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	crov1alpha1Types "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	croUtil "github.com/integr8ly/cloud-resource-operator/pkg/client"
+	"github.com/integr8ly/cloud-resource-operator/pkg/providers/aws"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -25,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
@@ -93,8 +100,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		// Check if namespace is still present before trying to delete it resources
 		_, err := resources.GetNS(ctx, operatorNamespace, client)
 		if !k8serr.IsNotFound(err) {
+
+			// overrides cro default deletion strategy to delete resources snapshots
+			phase, err := r.createDeletionStrategy(ctx, installation, client)
+			if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+				return phase, err
+			}
+
 			// ensure resources are cleaned up before deleting the namespace
-			phase, err := r.cleanupResources(ctx, installation, client)
+			phase, err = r.cleanupResources(ctx, installation, client)
 			if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 				return phase, err
 			}
@@ -149,6 +163,47 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.CloudResourcesStage, r.Config.GetProductName())
 	r.logger.Infof("%s has reconciled successfully", r.Config.GetProductName())
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) createDeletionStrategy(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+
+	if strings.ToLower(installation.Spec.UseClusterStorage) == "false" {
+		croStrategyConfig := &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "cloud-resources-aws-strategies",
+				Namespace: installation.Namespace,
+			},
+		}
+		_, err := controllerutil.CreateOrUpdate(ctx, serverClient, croStrategyConfig, func() error {
+			forceBucketDeletion := true
+			skipFinalSnapshot := true
+			finalSnapshotIdentifier := ""
+			tier := "production"
+			resources := map[string]interface{}{
+				"blobstorage": aws.S3DeleteStrat{
+					ForceBucketDeletion: &forceBucketDeletion,
+				},
+				"postgres": rds.DeleteDBClusterInput{
+					SkipFinalSnapshot: &skipFinalSnapshot,
+				},
+				"redis": elasticache.DeleteCacheClusterInput{
+					FinalSnapshotIdentifier: &finalSnapshotIdentifier,
+				},
+			}
+			for resource, deleteStrategy := range resources {
+				err := overrideStrategyConfig(resource, tier, croStrategyConfig, deleteStrategy)
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+	}
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
@@ -256,4 +311,27 @@ func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8s
 		serverClient,
 		catalogSourceReconciler,
 	)
+}
+
+func overrideStrategyConfig(resourceType string, tier string, croStrategyConfig *corev1.ConfigMap, deleteStrategy interface{}) error {
+	resource := croStrategyConfig.Data[resourceType]
+	strategyConfig := map[string]*aws.StrategyConfig{}
+	if err := json.Unmarshal([]byte(resource), &strategyConfig); err != nil {
+		return fmt.Errorf("failed to unmarshal strategy mapping for resource type %s %w", resourceType, err)
+	}
+
+	deleteStrategyJSON, err := json.Marshal(deleteStrategy)
+	if err != nil {
+		return err
+	}
+
+	strategyConfig[tier].DeleteStrategy = json.RawMessage(deleteStrategyJSON)
+
+	strategyConfigJSON, err := json.Marshal(strategyConfig)
+	if err != nil {
+		return err
+	}
+	croStrategyConfig.Data[resourceType] = string(strategyConfigJSON)
+
+	return nil
 }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -204,6 +204,7 @@ func (r *Reconciler) createDeletionStrategy(ctx context.Context, installation *i
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
 	}
+
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/test-cases/tests/uninstallation/o02-verify-if-cro-operator-removes-remaining-snapshots-for-rds-e.md
+++ b/test-cases/tests/uninstallation/o02-verify-if-cro-operator-removes-remaining-snapshots-for-rds-e.md
@@ -1,0 +1,91 @@
+---
+environments:
+  - osd-fresh-install
+estimate: 30m
+tags:
+  - destructive
+targets:
+  - 2.6.0
+---
+
+# O02 - Verify if CRO operator removes remaining snapshots for RDS, Elasticache and S3 after the deletion of RHMI operator has finished
+
+Note: this test should only be performed at a time it will not affect other ongoing testing, or on a separate cluster (ideally a cluster that is about to be deleted)
+
+## Description
+
+By following this test case should be able to verify:
+
+- There are no manual or automatic RDS, Elasticache and S3 snapshots remaining in the AWS account
+
+## Prerequisites
+
+- admin access to the AWS account where the OpenShift cluster is provisioned (IAM access key & secret)
+- [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html) installed locally
+- cluster-admin (kubeadmin) access to the OpenShift instance used for verification
+
+## Steps
+
+1. Login via `oc` as a user with **cluster-admin** role (kubeadmin):
+
+```bash
+oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:6443
+```
+
+2. Trigger RHMI uninstallation
+
+```bash
+oc delete rhmi rhmi -n redhat-rhmi-operator
+```
+
+3. Verify the `cloud-resources-aws-strategies` configmap in the rhmi operator has got the fields:
+
+   - `blobstorage.production.deleteStrategy.forceBucketDeletion` set to true.
+   - `postgres.production.deleteStrategy.SkipFinalSnapshot` set to true.
+   - `redis.production.deleteStrategy.FinalSnapshotIdentifier` set to empty.
+
+```bash
+oc describe configmap cloud-resources-aws-strategies -n redhat-rhmi-operator
+```
+
+4. Ensure that there are no manual or automatic RDS snapshots associated to the install remaining in the AWS account.
+
+```bash
+for id in $(oc get postgres -n redhat-rhmi-operator -o json | jq -r ".items[].metadata.annotations.resourceIdentifier");
+do
+  if [[ -n $(aws rds describe-db-snapshots --db-instance-identifier=$id | jq -r '.DBSnapshots[]') ]]
+  then
+    echo "still postgres snapshots remaining";
+    break;
+  fi
+done
+```
+
+> should return empty.
+
+5. Ensure that there are no manual or automatic Elasticache snapshots associated to the install remaining in the AWS account.
+
+```bash
+for id in $(oc get redis -n redhat-rhmi-operator -o json | jq -r ".items[].metadata.annotations.resourceIdentifier");
+do
+  if [[ -n $(aws elasticache describe-snapshots --cache-cluster-id=$id-001 | jq -r '.Snapshots[]') ]]
+  then
+    echo "still snapshots remaining";
+    break;
+  fi
+done
+```
+
+> should return empty.
+
+6. Ensure that there are no S3 buckets for the cluster remaining in the AWS account.
+
+```bash
+aws_s3_buckets=$(aws s3 ls)
+
+for id in $(oc get blobstorages -n redhat-rhmi-operator -o json | jq -r ".items[].metadata.annotations.resourceIdentifier");
+  do echo $aws_s3_buckets | grep $b || echo bucket $id not found ;
+done
+```
+
+> should return `bucket not found` twice.


### PR DESCRIPTION
# Description

adds delete strategy to remove snapshots to the `cloud-resources-aws-strategies` configmap in the rhmi operator namespace

https://issues.redhat.com/browse/INTLY-7184

## Verification Steps

> Requires a BYOC cluster

- Install the rhmi operator with the `USE_CLUSTER_STORAGE` field set to true 
- Uninstall the operator 
- Verify if the `cloud-resources-aws-strategies` configmap in the rhmi operator namespace has gotten the following fields:
  - `blobstorage.production.deleteStrategy.forceBucketDeletion` set to true
  - `postgres.production.deleteStrategy.SkipFinalSnapshot` set to true 
  - `'redis.production.deleteStrategy.FinalSnapshotIdentifier` set to empty 

- Make sure there are not snapshots created


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
