### PR TITLE
Implement CRO PostgreSQL as Apicurio Registry's database

### DIFF
--- a/pkg/resources/constants/croConstants.go
+++ b/pkg/resources/constants/croConstants.go
@@ -1,15 +1,16 @@
 package constants
 
 const (
-	CodeReadyPostgresPrefix      = "codeready-postgres-"
-	ThreeScaleBackendRedisPrefix = "threescale-backend-redis-"
-	ThreeScaleSystemRedisPrefix  = "threescale-redis-"
-	ThreeScalePostgresPrefix     = "threescale-postgres-"
-	RHSSOPostgresPrefix          = "rhsso-postgres-"
-	RHSSOUserProstgresPrefix     = "rhssouser-postgres-"
-	UPSPostgresPrefix            = "ups-postgres-"
-	FusePostgresPrefix           = "fuse-postgres-"
-	AMQAuthServicePostgres       = "standard-authservice-postgresql"
-	ThreeScaleBlobStoragePrefix  = "threescale-blobstorage-"
-	BackupsBlobStoragePrefix     = "backups-blobstorage-"
+	CodeReadyPostgresPrefix        = "codeready-postgres-"
+	ThreeScaleBackendRedisPrefix   = "threescale-backend-redis-"
+	ThreeScaleSystemRedisPrefix    = "threescale-redis-"
+	ThreeScalePostgresPrefix       = "threescale-postgres-"
+	RHSSOPostgresPrefix            = "rhsso-postgres-"
+	RHSSOUserProstgresPrefix       = "rhssouser-postgres-"
+	UPSPostgresPrefix              = "ups-postgres-"
+	FusePostgresPrefix             = "fuse-postgres-"
+	AMQAuthServicePostgres         = "standard-authservice-postgresql"
+	ThreeScaleBlobStoragePrefix    = "threescale-blobstorage-"
+	BackupsBlobStoragePrefix       = "backups-blobstorage-"
+	ApicurioRegistryPostgresPrefix = "apicurio-registry-postgres-"
 )


### PR DESCRIPTION
# Description

This PR implements CRO PostgreSQL as Apicurio Registry's database.

Additionally, the other code that assumes AMQStreams was being used
has been moved to its own reconciliation method that as of now is
unused. This means that AMQ Streams for the moment is no longer being used
as Apicurio Registry's data source but the idea is to make the datasource configurable in future
changes.

There are several subjects that I'd like to discuss:

* This PR implements the deployment of Apicurio Registry's own PostgreSQL through CRO. There were talks about whether a shared database should be used between the different products instead. At the moment I've implemented it using its own dedicated database as I've seen the other PostgreSQL database (for rhsso?) is tied to the product's lifecycle so going for the shared database approach would require some additional changes. So, the current implementation has been done taking rhsso and its postgrsql database as the "model". My opinion on this is there's no "ideal" solution that fits for all cases. It would depend on the environment's workload, HA requirements, etc...
* This PR effectively replaces and stops using AMQ Streams usage as apicurio registry's data source. However, Apicurio Registry supports several data sources and we need to support them. As a requirement we need to be able to choose the desired datasource for Apicurio Registry between AMQ Streams, PostgreSQL and others it offers.  We would also be interested, in the case of PostgreSQL, the ability to provide an external endpoint so the database is not managed by the operator at all as a possible case. Is there some product-level configurability mechanism that integreatly operator provides to allow that?We can do this in another PR if it is not trivial / needs additional work/discussion and we want to apply changes incrementally

Let me know about this PR code changes and the subjects I mentioned above.

Thank you.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer