### PR TITLE
INTLY-9233

### DIFF
--- a/pkg/resources/marketplace/configmap_catalog_source_reconciler.go
+++ b/pkg/resources/marketplace/configmap_catalog_source_reconciler.go
@@ -82,7 +82,7 @@ func (r *ConfigMapCatalogSourceReconciler) reconcileRegistryConfigMap(ctx contex
 	case controllerutil.OperationResultNone:
 		break
 	default:
-		return configMapName, fmt.Errorf("Unknown controllerutil.OperationResult '%v'", or)
+		logrus.Infof("Unknown controllerutil.OperationResult '%v'", or)
 	}
 
 	logrus.Infof("Successfully reconciled registry config map for namespace %s", r.Namespace)


### PR DESCRIPTION
# Description
Refactor of https://github.com/integr8ly/integreatly-operator/blob/master/pkg/resources/marketplace/configmap_catalog_source_reconciler.go#L60 - addressing ticket https://issues.redhat.com/browse/INTLY-9233.
The function was refactored so that it uses `CreateOrUpdate` function.

# Verification

On a fresh cluster run:
- `make cluster/prepare/local`
- `make code/run`
RHMI Operator should successfully install with all the config maps created. Once installed, change some value in the manifests folder to test update functionality. For example:
- On your cluster open config map YAML for cloud resources 
- On your machine navigate to https://github.com/integr8ly/integreatly-operator/blob/master/manifests/integreatly-cloud-resources/0.18.0/cloud-resources.v0.18.0.clusterserviceversion.yaml#L116 and set the media type to image. 
- Once the cloud resources operator is reconciled you should see the config map update happening. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer