### PR TITLE
Update test wording for clarity

### DIFF
--- a/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
+++ b/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
@@ -48,7 +48,7 @@ JIRA: [INTLY-5434](https://issues.redhat.com/browse/INTLY-5434)
 
 JIRA: [INTLY-7792](https://issues.redhat.com/browse/INTLY-7792)
 
-1. Navigate to the console & log in as an RHMI developer user (eg. a test user).
+1. Navigate to the console & log in as an RHMI developer user (e.g. as a test-userXX)
 2. Go to **Home** > **Search**
 3. Select **RHMI** from the custom resource dropdown
    > Verify that you are not be able to view any RHMI custom resources

--- a/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
+++ b/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
@@ -21,8 +21,8 @@ The following steps are still not automated in [user_rhmi_developer_permissions.
 
 JIRA: [INTLY-5434](https://issues.redhat.com/browse/INTLY-5434)
 
-1. Log into AMQ Online via Solution Explorer
-2. Click **Create Address Space**
+1. Log into AMQ Online via Solution Explorer as a RHMI developer user (eg as a test user)
+2. Click **Create Address Space** (If **Create Address Space** button is not visible, click the home link, **Red Hat AMQ**. Top left).
 3. Enter the following details in the configuration form:
    - Namespace: Select the namespace with the format `<username>-shar-<uid>`
    - Name: Enter any name
@@ -41,14 +41,14 @@ JIRA: [INTLY-5434](https://issues.redhat.com/browse/INTLY-5434)
 9. Click **Next**
 10. Click **Finish**
     > Verify that you are able to see the address you have just created. Once ready, the `Status` field of your address should be set to `Active` (this may take up to ~3mins).
-11. Login as a different RHMI developer user to the AMQ Online Console
+11. Login as a different RHMI developer user to the AMQ Online Console (eg. a test user)
     > Verify that you cannot see any address spaces and addresses created by the previous user
 
 ### No Access to RHMI Custom Resource
 
 JIRA: [INTLY-7792](https://issues.redhat.com/browse/INTLY-7792)
 
-1. Go to the **redhat-rhmi-operator** namespace
+1. Navigate to the console & log in as an RHMI developer user (eg. a test user).
 2. Go to **Home** > **Search**
 3. Select **RHMI** from the custom resource dropdown
    > Verify that you are not be able to view any RHMI custom resources

--- a/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
+++ b/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
@@ -41,7 +41,7 @@ JIRA: [INTLY-5434](https://issues.redhat.com/browse/INTLY-5434)
 9. Click **Next**
 10. Click **Finish**
     > Verify that you are able to see the address you have just created. Once ready, the `Status` field of your address should be set to `Active` (this may take up to ~3mins).
-11. Login as a different RHMI developer user to the AMQ Online Console (eg. a test user)
+11. Login as a different RHMI developer user to the AMQ Online Console (e.g. as a test-userXX)
     > Verify that you cannot see any address spaces and addresses created by the previous user
 
 ### No Access to RHMI Custom Resource

--- a/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
+++ b/test-cases/tests/authorization/b03-verify-rhmi-developer-user-permissions-are-correct.md
@@ -21,7 +21,7 @@ The following steps are still not automated in [user_rhmi_developer_permissions.
 
 JIRA: [INTLY-5434](https://issues.redhat.com/browse/INTLY-5434)
 
-1. Log into AMQ Online via Solution Explorer as a RHMI developer user (eg as a test user)
+1. Log into AMQ Online via Solution Explorer as a RHMI developer user (e.g. as a test-userXX)
 2. Click **Create Address Space** (If **Create Address Space** button is not visible, click the home link, **Red Hat AMQ**. Top left).
 3. Enter the following details in the configuration form:
    - Namespace: Select the namespace with the format `<username>-shar-<uid>`


### PR DESCRIPTION
# Description
Update wording of test for clarity - removed 'Go to the **redhat-rhmi-operator** namespace' step as this option is not available to RHMI developer user.

