### PR TITLE
INTLY-9693: Remove usage of recalculateSchedule annotation

### DIFF
--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
@@ -41,8 +41,6 @@ const (
 
 	// Maximum allowed number of days to schedule an upgrade via `NotBeforeDays`
 	MaxUpgradeDays = 14
-
-	RecalculateScheduleAnnotation = "recalculateSchedule"
 )
 
 // RHMIConfigSpec defines the desired state of RHMIConfig
@@ -241,10 +239,6 @@ func (h *rhmiConfigMutatingHandler) Handle(ctx context.Context, request admissio
 		oldUpgradeSpec.NotBeforeDays,
 		defaultUpgradeSpec.NotBeforeDays,
 	).(*int)
-
-	if !reflect.DeepEqual(oldUpgradeSpec, &rhmiConfig.Spec.Upgrade) {
-		rhmiConfig.Annotations[RecalculateScheduleAnnotation] = "true"
-	}
 
 	marshalled, err := json.Marshal(rhmiConfig)
 	if err != nil {

--- a/pkg/controller/rhmiconfig/rhmiconfig_controller.go
+++ b/pkg/controller/rhmiconfig/rhmiconfig_controller.go
@@ -121,7 +121,6 @@ func (r *ReconcileRHMIConfig) Reconcile(request reconcile.Request) (reconcile.Re
 			return reconcile.Result{}, err
 		}
 
-		rhmiConfig.Annotations[integreatlyv1alpha1.RecalculateScheduleAnnotation] = ""
 		err = r.client.Update(context.TODO(), rhmiConfig)
 		if err != nil {
 			return reconcile.Result{}, err


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/INTLY-9693

This annotation is not needed anymore, after the refactor carried for INTLY-8450,
however it's still being set by the mutating webhook, and removed when setting
the upgrade status. However, in the case that the status is updated and no
annotations have been added to the CR, a panic may arise as the Annotations field
is `nil`.
Removing all usage of this annotation solves this.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer