### PR TITLE
[WIP] Target down alert creation

### DIFF
--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -282,7 +282,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 				},
 			},
 			{
-				AlertName: "general-monitoring-alerts",
+				AlertName: "target-down-alerts",
 				Namespace: r.Config.GetOperatorNamespace(),
 				GroupName: "general.rules",
 				Rules: []monitoringv1.Rule{
@@ -292,6 +292,15 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }} targets in the {{ $labels.namespace }} namespace are down.",
 						},
 						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up{job!=\"blackbox\"}) BY (job, namespace, service)) > 10"),
+						For:    "10m",
+						Labels: map[string]string{"severity": "warning"},
+					},
+					{
+						Alert: "BlackboxTargetDown",
+						Annotations: map[string]string{
+							"message": "The {{ $labels.service }} blackbox target is down.",
+						},
+						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up{job=\"blackbox\"}) BY (job, namespace, service)) > 10"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -298,9 +298,9 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 					{
 						Alert: "BlackboxTargetDown",
 						Annotations: map[string]string{
-							"message": "The {{ $labels.service }} blackbox target is down.",
+							"message": "The {{ $labels.service }} blackbox probe for the endpoint {{ $labels.instance }} is failing.",
 						},
-						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up{job=\"blackbox\"}) BY (job, namespace, service)) > 10"),
+						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, instance, service) / count(up{job=\"blackbox\"}) BY (job, instance, service)) > 10"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -291,7 +291,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						Annotations: map[string]string{
 							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.",
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) * on (namespace) group_left kube_namespace_labels{namespace=~\"%s.*\"} > 10", r.Config.GetNamespacePrefix())),
+						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -183,12 +183,6 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						For:    "15m",
 						Labels: map[string]string{"severity": "critical"},
 					},
-					{
-						Alert:       "TargetDown",
-						Annotations: map[string]string{"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 300 seconds"},
-						Expr:        intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} > 10 "),
-						Labels:      map[string]string{"severity": "warning"},
-					},
 				},
 			},
 
@@ -295,10 +289,10 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 					{
 						Alert: "TargetDown",
 						Annotations: map[string]string{
-							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.	",
+							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.",
 						},
-						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) on  (namespace=~\"redhat-rhmi-.*\") > 10"),
-						For:    "5m",
+						Expr:   intstr.FromString(fmt.Sprintf("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) * on (namespace) group_left kube_namespace_labels{namespace=~\"%s.*\"} > 10", r.Config.GetNamespacePrefix())),
+						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},
 				},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -291,7 +291,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						Annotations: map[string]string{
 							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }} targets in the {{ $labels.namespace }} namespace are down.",
 						},
-						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up{job!=\"blackbox\"}) BY (job, namespace, service)) > 10"),
+						Expr:   intstr.FromString("100 * (count(up{job!=\"blackbox\"} == 0) BY (job, namespace, service) / count(up{job!=\"blackbox\"}) BY (job, namespace, service)) > 10"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},
@@ -300,7 +300,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						Annotations: map[string]string{
 							"message": "The {{ $labels.service }} blackbox probe for the endpoint {{ $labels.instance }} is failing.",
 						},
-						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, instance, service) / count(up{job=\"blackbox\"}) BY (job, instance, service)) > 10"),
+						Expr:   intstr.FromString("(up{job=\"blackbox\"}==0)"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -289,9 +289,9 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 					{
 						Alert: "TargetDown",
 						Annotations: map[string]string{
-							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.",
+							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }} targets in the {{ $labels.namespace }} namespace are down.",
 						},
-						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) > 10"),
+						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up{job!=\"blackbox\"}) BY (job, namespace, service)) > 10"),
 						For:    "10m",
 						Labels: map[string]string{"severity": "warning"},
 					},

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -287,6 +287,22 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 					},
 				},
 			},
+			{
+				AlertName: "general-monitoring-alerts",
+				Namespace: r.Config.GetOperatorNamespace(),
+				GroupName: "general.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "TargetDown",
+						Annotations: map[string]string{
+							"message": "{{ printf \"%.4g\" $value }}% of the {{ $labels.job }}/{{ $labels.service }} targets in {{ $labels.namespace }} namespace are down.	",
+						},
+						Expr:   intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) on  (namespace=~\"redhat-rhmi-.*\") > 10"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning"},
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -173,7 +173,6 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						For:    "15m",
 						Labels: map[string]string{"severity": "critical"},
 					},
-
 					{
 						Alert: "PersistentVolumeErrors",
 						Annotations: map[string]string{
@@ -183,6 +182,12 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						Expr:   intstr.FromString("(sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~'Failed|Pending|Lost'}) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key='middleware'}) > 0"),
 						For:    "15m",
 						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert:       "TargetDown",
+						Annotations: map[string]string{"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 300 seconds"},
+						Expr:        intstr.FromString("100 * (count(up == 0) BY (job, namespace, service) / count(up) BY (job, namespace, service)) * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} > 10 "),
+						Labels:      map[string]string{"severity": "warning"},
 					},
 				},
 			},

--- a/templates/monitoring/jobs/3scale.yaml
+++ b/templates/monitoring/jobs/3scale.yaml
@@ -10,7 +10,7 @@
       replacement: _$1
     - source_labels: [__meta_kubernetes_namespace]
       action: replace
-      target_label: kubernetes_namespace
+      target_label: namespace
     - source_labels: [__meta_kubernetes_pod_name]
       action: replace
       target_label: kubernetes_pod_name

--- a/templates/monitoring/jobs/openshift_monitoring_federation.yaml
+++ b/templates/monitoring/jobs/openshift_monitoring_federation.yaml
@@ -34,6 +34,10 @@
     source_labels:
     - __meta_kubernetes_service_port_name
     regex: web
+  - action: replace
+    source_labels:
+    - __meta_kubernetes_namespace
+    target_label: namespace
   metric_relabel_configs:
   - action: labeldrop
     regex: prometheus_replica

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -396,9 +396,10 @@ var expectedRules = []alertsTestRule{
 		},
 	},
 	{
-		File: NamespacePrefix + "middleware-monitoring-operator-general-monitoring-alerts.yaml",
+		File: NamespacePrefix + "middleware-monitoring-operator-target-down-alerts.yaml",
 		Rules: []string{
 			"TargetDown",
+			"BlackboxTargetDown",
 		},
 	},
 }

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -91,6 +91,7 @@ var expectedRules = []alertsTestRule{
 	{
 		File: "redhat-rhmi-middleware-monitoring-operator-ksm-alerts.yaml",
 		Rules: []string{
+			"TargetDown",
 			"KubePodCrashLooping",
 			"KubePodNotReady",
 			"KubePodImagePullBackOff",

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -91,7 +91,6 @@ var expectedRules = []alertsTestRule{
 	{
 		File: "redhat-rhmi-middleware-monitoring-operator-ksm-alerts.yaml",
 		Rules: []string{
-			"TargetDown",
 			"KubePodCrashLooping",
 			"KubePodNotReady",
 			"KubePodImagePullBackOff",
@@ -394,6 +393,12 @@ var expectedRules = []alertsTestRule{
 		Rules: []string{
 			"RHMIInstallationControllerIsNotReconciling",
 			"RHMIInstallationControllerStoppedReconciling",
+		},
+	},
+	{
+		File: NamespacePrefix + "middleware-monitoring-operator-general-monitoring-alerts.yaml",
+		Rules: []string{
+			"TargetDown",
 		},
 	},
 }


### PR DESCRIPTION
## Description

- Creation of 2 new target down alerts: `TargetDown` and `BlackboxTargetDown`
- Update to the alerts exist test
- Each alert must be verified independently, with the steps to do so in the verification section

_**NOTE:**_ This PR should not be merged until a new release of the Keycloak Operator is created which includes the below mentioned Keycloak PR

## JIRA
[INTLY-9266](https://issues.redhat.com/browse/INTLY-9266)

Currently blocked by: [keycloak-operator/pull/243](https://github.com/keycloak/keycloak-operator/pull/243)


## Verification
#### TargetDown
- Install using this branch, ensuring that the `TargetDown` alert isn't firing during install. It is OK if the `sso/usersso` pod monitor target alerts are firing - this is expected and the [Keyclock PR](https://github.com/keycloak/keycloak-operator/pull/243) removes these
- Get a list of all current Prometheus targets: `Prometheus -> Status -> Targets`
- To test the alert, change the metrics port number of one the `/metric` targets listed above. For example, to change the port number of  the `3scale-apicast-pods apicast staging` target, execute the below command and ensure that the alert is triggered:
```
oc patch dc apicast-staging -p '{"spec":{"template":{"metadata":{"annotations":{"prometheus.io/port":"9422"}}}}}' -n redhat-rhmi-3scale
```
- Once the alert has triggered, run the below command to reset the port number and ensure that the alert returns to normal:
```
oc patch dc apicast-staging -p '{"spec":{"template":{"metadata":{"annotations":{"prometheus.io/port":"9421"}}}}}' -n redhat-rhmi-3scale
```
-  Ensure the alert triggers and the alert message is clear, concise and descriptive. 

#### BlackboxTargetDown
- In order to get this alert to trigger, we need to change the port number that the Blackbox target uses (`9115 -> 9116`), which requires an update to the AMO as that is where port number gets set. For verification purposes, a pre-built image is available on Quay with this change
- In the `middleware-monitoring` namespace, navigate to `Installed Operators -> Application Monitoring Operator -> YAMK tab` and update the image used on line `11` and `268` to use the pre-built image: `quay.io/robrien/application-monitoring-operator:1.3.0`
- In Prometheus, ensure that the `BlackboxTarget` alert is firing for all targets (11 in total), and the alert is message is clear and concise

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer