### PR TITLE
Updated test case targets post 2.6.0 GA

### DIFF
--- a/test-cases/tests/authorization/b05-verify-codeready-crudl-permissions.md
+++ b/test-cases/tests/authorization/b05-verify-codeready-crudl-permissions.md
@@ -6,7 +6,8 @@ components:
 environments:
   - osd-post-upgrade
 targets:
-  - 2.6.0
+  - 2.4.0
+  - 2.7.0
 ---
 
 # B05 - Verify Codeready CRUDL Permissions

--- a/test-cases/tests/authorization/b08-verify-user-rhsso-permissions.md
+++ b/test-cases/tests/authorization/b08-verify-user-rhsso-permissions.md
@@ -6,7 +6,7 @@ components:
 environments:
   - osd-post-upgrade
 targets:
-  - 2.8.0
+  - 2.6.0
 ---
 
 # B08 - Verify User RHSSO Permissions

--- a/test-cases/tests/backup-restore/j10-verify-amq-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j10-verify-amq-backup-and-restore.md
@@ -7,7 +7,8 @@ estimate: 2h
 tags:
   - destructive
 targets:
-  - 2.6.0
+  - 2.4.0
+  - 2.7.0
 ---
 
 # J10 - Verify AMQ backup and restore

--- a/test-cases/tests/performance/k01-run-performance-test-against-amq-online.md
+++ b/test-cases/tests/performance/k01-run-performance-test-against-amq-online.md
@@ -7,7 +7,8 @@ estimate: 4h
 tags:
   - destructive
 targets:
-  - 2.6.0
+  - 2.4.0
+  - 2.7.0
 ---
 
 # K01 - Run performance test against AMQ Online

--- a/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
+++ b/test-cases/tests/performance/k03-run-performance-test-against-rhsso.md
@@ -7,7 +7,7 @@ estimate: 2h
 tags:
   - destructive
 targets:
-  - 2.8.0
+  - 2.7.0
 ---
 
 # K03 - Run performance test against RHSSO

--- a/test-cases/tests/products/h01-ups-verify-that-ups-can-send-push-notification.md
+++ b/test-cases/tests/products/h01-ups-verify-that-ups-can-send-push-notification.md
@@ -6,7 +6,7 @@ components:
 environments:
   - osd-post-upgrade
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # H01 - UPS: Verify that UPS can send push notification

--- a/test-cases/tests/products/h05-verify-integration-between-fuse-online-and-openshift.md
+++ b/test-cases/tests/products/h05-verify-integration-between-fuse-online-and-openshift.md
@@ -7,7 +7,7 @@ environments:
   - osd-post-upgrade
 estimate: 30m
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # H05 - Verify integration between Fuse Online and OpenShift

--- a/test-cases/tests/products/h08-verify-amq-online-crs-can-be-modified-and-are-not-reset.md
+++ b/test-cases/tests/products/h08-verify-amq-online-crs-can-be-modified-and-are-not-reset.md
@@ -7,7 +7,7 @@ environments:
   - osd-post-upgrade
 estimate: 1h
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # H08 - Verify AMQ Online CRs can be modified and are not reset

--- a/test-cases/tests/uninstallation/o01-verify-cloud-resources-can-be-properly-cleaned-up-in-case-of.md
+++ b/test-cases/tests/uninstallation/o01-verify-cloud-resources-can-be-properly-cleaned-up-in-case-of.md
@@ -5,7 +5,7 @@ estimate: 30m
 tags:
   - destructive
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # O01 - Verify cloud resources can be properly cleaned up in case of failing RHMI uninstallation

--- a/test-cases/tests/uninstallation/o02-verify-if-cro-operator-removes-remaining-snapshots-for-rds-e.md
+++ b/test-cases/tests/uninstallation/o02-verify-if-cro-operator-removes-remaining-snapshots-for-rds-e.md
@@ -5,7 +5,7 @@ estimate: 30m
 tags:
   - destructive
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # O02 - Verify if CRO operator removes remaining snapshots for RDS, Elasticache and S3 after the deletion of RHMI operator has finished

--- a/test-cases/tests/walkthroughs/g02-verify-sso-walkthrough.md
+++ b/test-cases/tests/walkthroughs/g02-verify-sso-walkthrough.md
@@ -5,7 +5,7 @@ environments:
   - osd-fresh-install
 estimate: 30m
 targets:
-  - 2.7.0
+  - 2.6.0
 ---
 
 # G02 - Verify SSO walkthrough

--- a/test-cases/tests/walkthroughs/g04-verify-api-management-walkthrough.md
+++ b/test-cases/tests/walkthroughs/g04-verify-api-management-walkthrough.md
@@ -5,7 +5,7 @@ environments:
   - osd-fresh-install
 estimate: 45m
 targets:
-  - 2.6.0
+  - 2.7.0
 ---
 
 # G04 - Verify API management walkthrough


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Updated test case targets based on what was tested in 2.6.0.

No need to verify. If you really want, look at the test plan (https://docs.google.com/document/d/1d1_J6gPulw38llMV_xzTlb5iUR11jY3fWPJQ6nxtTuE/edit#heading=h.ragbu4u7yagw) and go through the testing epics to see what was tested in 2.6.0 and what was not (so it was moved to 2.7.0).