### PR TITLE
N02 and E04 test case descriptions updated

### DIFF
--- a/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
@@ -31,7 +31,7 @@ Note: this test should only be performed at a time it will not affect other ongo
    > redhat-rhmi-solution-explorer -> Workloads -> Deployment Configs -> Scale to 1
    > redhat-rhmi-ups -> Workloads -> Deployments -> Scale to 1
 
-Execute the scripts below in a separate terminal tab/window and keep them running. It will keep scaling down stuff so that things don't start working automatically.
+Execute the scripts below in a separate terminal tab/window and keep them running. It will keep scaling down resources and prevent from automatic scale up by the operator(s).
 
 Bringing things up might not be so simple. Make sure you have access to the terminal output of the scripts to see how many pods (replicas) were there originally and manually change that back if some alerts don't stop firing.
 

--- a/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
@@ -18,7 +18,7 @@ Note: this test should only be performed at a time it will not affect other ongo
 
 ## Steps
 
-1. Make sure that there is at least one active alert for every panel in SLO dasboard (e.g. pod_down)
+1. Make sure that there is at least one active alert for every panel in Grafana SLO dasboard (e.g. pod_down)
    1. Make sure rhmi-operator pod is scaled down to 0 pods
    2. Make sure all rhmi product operator pods are scaled down to 0, you can use code #1 below
    3. Make sure all keycloak stateful sets are scaled down to 0, you can use code #2 and #3 below
@@ -30,6 +30,10 @@ Note: this test should only be performed at a time it will not affect other ongo
    > redhat-rhmi-codeready-workspaces -> Workloads -> Deployments -> Scale to 1
    > redhat-rhmi-solution-explorer -> Workloads -> Deployment Configs -> Scale to 1
    > redhat-rhmi-ups -> Workloads -> Deployments -> Scale to 1
+
+Execute the scripts below in a separate terminal tab/window and keep them running. It will keep scaling down stuff so that things don't start working automatically.
+
+Bringing things up might not be so simple. Make sure you have access to the terminal output of the scripts to see how many pods (replicas) were there originally and manually change that back if some alerts don't stop firing.
 
 ### Code #1
 

--- a/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04-verify-slo-dashboard.md
@@ -33,7 +33,7 @@ Note: this test should only be performed at a time it will not affect other ongo
 
 Execute the scripts below in a separate terminal tab/window and keep them running. It will keep scaling down resources and prevent from automatic scale up by the operator(s).
 
-Bringing things up might not be so simple. Make sure you have access to the terminal output of the scripts to see how many pods (replicas) were there originally and manually change that back if some alerts don't stop firing.
+Bringing resources up might not be so simple. Make sure you have access to the terminal output of the scripts to see how many pods (replicas) were there originally and manually change that back if some alerts don't stop firing.
 
 ### Code #1
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

E04 updates:
Small notes on how to use the scripts and that it might be slightly tricky to bring stuff back up. Based on my experience doing the test case during 2.6.0

N02 updates:
Removed step 8 - CLUSTER_ID is not used in subsequent steps
Added steps 14 and 15 - these describe how to use workload-web-app to see the downtimes. These steps were just copy-pasted from H21.
The rest of the diff is just due to changing the step numbers, no content changes there.

Not sure how to verify this. Probably just read through the changes if that makes sense.