### PR TITLE
Updated test case on how to trigger RHMI upgrade

### DIFF
--- a/test-cases/tests/upgrade/n02-upgrade-rhmi.md
+++ b/test-cases/tests/upgrade/n02-upgrade-rhmi.md
@@ -55,7 +55,7 @@ Note: If [N09 test case](https://github.com/integr8ly/integreatly-operator/blob/
 
    > The upgrade should start shortly. Have a look at `status.upgrade.scheduled.for`. In rare situations it might get scheduled more that 6 hours in past, in that case upgrade won't be triggered. Play with the `spec.maintenance.*` and `spec.upgrade.*` values to get it scheduled some other time.
 
-   Use the command below to check whether the installPlan exists and is approved. The operator should approve the installPlan based on **rhmi-config**. If the installPlan is not approved shortly, restart the rhmi-operator (delete the pod or scale down to 0 and then scale back up to 1).
+   Use the command below to check whether the installPlan exists and is approved. The operator should approve the installPlan based on **rhmi-config**. The installPlan should not be approved manually - if the installPlan is not approved shortly, restart the rhmi-operator (delete the pod or scale down to 0 and then scale back up to 1).
 
    ```
    oc get installplans -n redhat-rhmi-operator


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Updated N02 (Upgrade RHMI) test case. Most notable modifications done

- It is no longer required to prevent the available upgrade to start automatically since by default it won't start sooner than 7 days after cluster creation (`notbeforedays` value is `7` by default)
- Updated section how to actually trigger the upgrade and added few notes what might go wrong and how to workaround it.
- Added note about N09 test case
- Small note on how to verfiy workload-webapp was deployed OK
- rest are just step numbering modifications

Verification
I think just reading through the test case is sufficient.