### PR TITLE
Fixes a bug in the upgrades when a CSV has the skipRange present

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	// No tags on the apicurio repo so needed to use a commit hash
 	github.com/apicurio/apicurio-operators/apicurito v0.0.0-20200123142409-83e0a91dd6be
 	github.com/aws/aws-sdk-go v1.25.50
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/coreos/prometheus-operator v0.35.0
 	github.com/eclipse/che-operator v0.0.0-20191122191946-81d08d3f0fde
 	github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32


### PR DESCRIPTION
# Description

https://issues.redhat.com/browse/INTLY-9817

## Verification Steps

Install the operator via OLM using the CSV below:

- CSVs for upgrade with skipRange

  `quay.io/jjaferson/integreatly-index:2.6.0` -> install the operator from this CSV
  `quay.io/jjaferson/integreatly-index:2.7.0` -> skipped CSV
  `quay.io/jjaferson/integreatly-index:2.8.0` -> skipped CSV
  `quay.io/jjaferson/integreatly-index:2.8.1` -> CSV with skipRange (olm.skipRange: '>=2.6.0 <2.8.1') after the install point the catalogsource to this CSV

- CSVs for patch upgrade 

  `quay.io/jjaferson/integreatly-index2.6.0` -> install the operator from this CSV
  `quay.io/jjaferson/integreatly-index2.6.1` -> replaces 2.6.0 and is non service affecting
  `quay.io/jjaferson/integreatly-index2.6.2` -> replaces 2.6.1
  `quay.io/jjaferson/integreatly-index2.6.2-rc` -> replaces 2.6.0

> All those CSVs use the same image `quay.io/jjaferson/integreatly-operator:2.6.0` which is an image that was built from this PR


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
