### PR TITLE
INTLY-9832 Fix installation on OSD 4.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ scripts/htpasswd
 htpasswd
 .DS_Store
 router-ca.tmp
+TMP_SA_KUBECONFIG
 # Temporary Build Files
 tmp/_output/bin/integreatly-operator
 cmd/manager/debug

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -214,7 +214,7 @@ rules:
     resources:
       - secrets
     resourceNames:
-      - samples-registry-credentials
+      - pull-secret
     verbs:
       - get
 

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -110,8 +110,8 @@ var (
 	EventPreflightCheckPassed  string = "PreflightCheckPassed"
 	EventUpgradeApproved       string = "UpgradeApproved"
 
-	DefaultOriginPullSecretName      = "samples-registry-credentials"
-	DefaultOriginPullSecretNamespace = "openshift"
+	DefaultOriginPullSecretName      = "pull-secret"
+	DefaultOriginPullSecretNamespace = "openshift-config"
 )
 
 // RHMISpec defines the desired state of Installation

--- a/pkg/products/apicurito/reconciler_test.go
+++ b/pkg/products/apicurito/reconciler_test.go
@@ -260,8 +260,8 @@ func TestReconciler_handleProgress(t *testing.T) {
 func getSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "samples-registry-credentials",
-			Namespace: "openshift",
+			Name:      "pull-secret",
+			Namespace: "openshift-config",
 		},
 		Data: map[string][]byte{
 			"credentialKeyID":     []byte("test"),

--- a/test/common/rhmicr_metrics.go
+++ b/test/common/rhmicr_metrics.go
@@ -89,7 +89,7 @@ func getRHMIOperatorPod(ctx *TestingContext) (*corev1.Pod, error) {
 		return nil, fmt.Errorf("error listing rhmi-operator pod: %v", err)
 	}
 
-	if len(rhmiOperatorPod.Items) < 0 {
+	if len(rhmiOperatorPod.Items) == 0 {
 		return nil, fmt.Errorf("rhmi-operator pod doesn't exist: %v", err)
 	}
 


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/INTLY-9832

## Main change: 
Fixing the pull secret source because originally used secret is not available on OSD 4.5.

## Additional changes:
I fixed a logical error in test/common/rhmicr_metrics.go
I edited `make code/run` target to use service account via temporary kubeconfig file. This should prevent unexpected RBAC issues during local development and testing.


## Verification:
Verify this installs correctly on OSD 4.5.x (maybe use `make code/run` to test secondary changes at the same time)
Check that monitoring is green
Verify that you are able to create and deploy an integration in Fuse


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Verified independently on a cluster by reviewer