### PR TITLE
use code base version as apposed to csv version, on upgrade

### DIFF
--- a/pkg/controller/subscription/rhmiConfigs/main.go
+++ b/pkg/controller/subscription/rhmiConfigs/main.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/csvlocator"
-	"github.com/integr8ly/integreatly-operator/pkg/metrics"
-	"github.com/sirupsen/logrus"
-
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"k8s.io/client-go/tools/record"
 
@@ -125,7 +121,7 @@ func IsUpgradeServiceAffecting(csv *olmv1alpha1.ClusterServiceVersion) bool {
 	return serviceAffectingUpgrade
 }
 
-func ApproveUpgrade(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI, installPlan *olmv1alpha1.InstallPlan, csvLocator csvlocator.CSVLocator, eventRecorder record.EventRecorder) error {
+func ApproveUpgrade(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI, installPlan *olmv1alpha1.InstallPlan, eventRecorder record.EventRecorder) error {
 
 	if installPlan.Status.Phase == olmv1alpha1.InstallPlanPhaseInstalling {
 		return nil
@@ -139,21 +135,6 @@ func ApproveUpgrade(ctx context.Context, client k8sclient.Client, installation *
 	if err != nil {
 		return err
 	}
-
-	csv, err := csvLocator.GetCSV(ctx, client, installPlan)
-	if err != nil {
-		return err
-	}
-
-	version := csv.Spec.Version.String()
-	logrus.Infof("Update approved, setting rhmi version to install %s", version)
-	installation.Status.ToVersion = version
-	err = client.Status().Update(ctx, installation)
-	if err != nil {
-		return err
-	}
-
-	metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 
 	return nil
 }

--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	"github.com/integr8ly/integreatly-operator/pkg/controller/subscription/csvlocator"
 	"github.com/integr8ly/integreatly-operator/version"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -451,16 +450,13 @@ func TestApproveUpgrade(t *testing.T) {
 				if config.Status.Upgrade.Scheduled != nil {
 					t.Fatalf("Expected scheduled field to be empty")
 				}
-				if rhmi.Status.ToVersion != version.Version {
-					t.Fatalf("Expected ToVersion to be version.version, got %s", rhmi.Status.ToVersion)
-				}
 			},
 		},
 	}
 
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
-			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RHMI, scenario.RhmiInstallPlan, &csvlocator.EmbeddedCSVLocator{}, scenario.EventRecorder)
+			ApproveUpgrade(context.TODO(), scenario.FakeClient, scenario.RHMI, scenario.RhmiInstallPlan, scenario.EventRecorder)
 			retrievedInstallPlan := &olmv1alpha1.InstallPlan{}
 			err := scenario.FakeClient.Get(scenario.Context, k8sclient.ObjectKey{Name: scenario.RhmiInstallPlan.Name, Namespace: scenario.RhmiInstallPlan.Namespace}, retrievedInstallPlan)
 			rhmi := &integreatlyv1alpha1.RHMI{}

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -283,7 +283,7 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 			}
 		}
 
-		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, installation, latestRHMIInstallPlan, r.csvLocator, eventRecorder)
+		err = rhmiConfigs.ApproveUpgrade(ctx, r.client, installation, latestRHMIInstallPlan, eventRecorder)
 		if err != nil {
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/subscription/subscription_controller_test.go
+++ b/pkg/controller/subscription/subscription_controller_test.go
@@ -28,8 +28,11 @@ const (
 
 func getBuildScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
-	integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme)
-	err := v1alpha1.SchemeBuilder.AddToScheme(scheme)
+	err := integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme)
+	if err != nil {
+		return scheme, err
+	}
+	err = v1alpha1.SchemeBuilder.AddToScheme(scheme)
 	return scheme, err
 }
 
@@ -117,7 +120,10 @@ func TestSubscriptionReconciler(t *testing.T) {
 					t.Fatalf("unexpected error: %s", err.Error())
 				}
 				sub := &v1alpha1.Subscription{}
-				c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: operatorNamespace}, sub)
+				err = c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: operatorNamespace}, sub)
+				if err != nil {
+					t.Fatalf("unexpected error getting subscription: %s", err.Error())
+				}
 				if sub.Spec.InstallPlanApproval != v1alpha1.ApprovalManual {
 					t.Fatalf("expected Manual but got %s", sub.Spec.InstallPlanApproval)
 				}
@@ -146,7 +152,10 @@ func TestSubscriptionReconciler(t *testing.T) {
 					t.Fatalf("unexpected error: %s", err.Error())
 				}
 				sub := &v1alpha1.Subscription{}
-				c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: "other-ns"}, sub)
+				err = c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: "other-ns"}, sub)
+				if err != nil {
+					t.Fatalf("unexpected error getting subscription : %s", err.Error())
+				}
 				if sub.Spec.InstallPlanApproval != v1alpha1.ApprovalAutomatic {
 					t.Fatalf("expected Automatic but got %s", sub.Spec.InstallPlanApproval)
 				}
@@ -175,7 +184,10 @@ func TestSubscriptionReconciler(t *testing.T) {
 					t.Fatalf("unexpected error: %s", err.Error())
 				}
 				sub := &v1alpha1.Subscription{}
-				c.Get(context.TODO(), k8sclient.ObjectKey{Name: "other-package", Namespace: operatorNamespace}, sub)
+				err = c.Get(context.TODO(), k8sclient.ObjectKey{Name: "other-package", Namespace: operatorNamespace}, sub)
+				if err != nil {
+					t.Fatalf("unexpected error getting subscription: %s", err.Error())
+				}
 				if sub.Spec.InstallPlanApproval != v1alpha1.ApprovalAutomatic {
 					t.Fatalf("expected Automatic but got %s", sub.Spec.InstallPlanApproval)
 				}
@@ -229,7 +241,10 @@ func TestSubscriptionReconciler(t *testing.T) {
 				}
 
 				sub := &v1alpha1.Subscription{}
-				c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: operatorNamespace}, sub)
+				err = c.Get(context.TODO(), k8sclient.ObjectKey{Name: IntegreatlyPackage, Namespace: operatorNamespace}, sub)
+				if err != nil {
+					t.Fatalf("unexpected error getting sublscription: %s", err.Error())
+				}
 				if sub.Status.InstalledCSV != sub.Status.CurrentCSV {
 					t.Fatalf("expected installedCSV %s to be the same as currentCSV  %s", sub.Status.InstalledCSV, sub.Status.CurrentCSV)
 				}


### PR DESCRIPTION
# Description
Change from previously adding logic in the subscription controller. 

## How to verify
Perform an install and upgrade and verify that the 'toVersion' is set on the CR during install and upgrade 
and unset after. 
Verify 'version' is set appropriately after install and upgrade