### PR TITLE
add test cases a26 and o03 for sendgrid credentials checks

### DIFF
--- a/test-cases/fixtures/test-template.md
+++ b/test-cases/fixtures/test-template.md
@@ -6,7 +6,7 @@ automation:
 components:
   - product-3scale
   - product-amq
-environemnts:
+environments:
   - osd-fresh-install
   - rhpds
 estimate: 1h

--- a/test-cases/tests/installation/a26-verify-sendgrid-credentials-are-configured-properly.md
+++ b/test-cases/tests/installation/a26-verify-sendgrid-credentials-are-configured-properly.md
@@ -1,0 +1,50 @@
+---
+# See the metatadata section in the README.md for details on the
+# allowed fields and values
+automation:
+  - INTLY-9950
+environments:
+  - osd-fresh-install
+estimate: 30m
+tags:
+  - per-release
+---
+
+# A26 - Verify SendGrid credentials are configured properly
+
+## Description
+
+This test case should verify that the OCM SendGrid Service has correctly setup SMTP credentials on the OpenShift cluster.
+
+## Steps
+
+1. Retrieve the SendGrid SMTP credentials from the RHMI Operator namespace
+
+   ```
+   # SMTP username, base64 encoded. This will be referred to as <username> from now on.
+   oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.username}'
+
+   # SMTP password, base64 encoded. This will be referred to as <password> from now on.
+   oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.password}'
+   ```
+
+2. Telnet to the SMTP service to ensure the credentials are correct
+
+   ```
+   # Establish connection
+   telnet $(oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.host}' | base64 --decode) $(oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.port}' | base64 --decode)
+
+   # Once connection is established, "service ready at" message is shown
+   EHLO
+
+   # Once EHLO has completed, attempt auth
+   auth login
+
+   # When you see "VXNlcm5hbWU6" (base64 encoded "Username:")
+   <username>
+
+   # When you see "UGFzc3dvcmQ6" (base64 encoded "Password:")
+   <password>
+   ```
+
+   > "Authentication successful" is shown

--- a/test-cases/tests/uninstallation/o03-verify-sendgrid-credentials-are-removed.md
+++ b/test-cases/tests/uninstallation/o03-verify-sendgrid-credentials-are-removed.md
@@ -1,0 +1,31 @@
+---
+# See the metatadata section in the README.md for details on the
+# allowed fields and values
+automation:
+  - INTLY-9950
+environments:
+  - osd-fresh-install
+estimate: 30m
+tags:
+  - per-release
+---
+
+# O03 - Verify SendGrid credentials are removed
+
+## Description
+
+This test case should verify that the OCM SendGrid Service has correctly removed the SendGrid sub account for the cluster.
+
+## Prerequisites
+
+- The ID of the OpenShift cluster from OCM e.g. `1f3ufk5dn7suk8m4um8op9k8le9gi64h`
+- SendGrid credentials for the SendGrid account
+- The OpenShift cluster has been deleted
+
+## Steps
+
+1. Login to [SendGrid](https://app.sendgrid.com/login/)
+
+2. Go to _Settings -> Subuser Management_
+
+3. Search for the Cluster ID, ensure it doesn't exist


### PR DESCRIPTION
add test cases to confirm the functionality of the ocm sendgrid
service on both rhmi installation and cluster deletion.

verification:
- install rhmi via the addon flow
- follow a26
- delete the cluster
- follow o03