### PR TITLE
add ocm sendgrid service test cases

### DIFF
--- a/test-cases/fixtures/test-template.md
+++ b/test-cases/fixtures/test-template.md
@@ -6,7 +6,7 @@ automation:
 components:
   - product-3scale
   - product-amq
-environemnts:
+environments:
   - osd-fresh-install
   - rhpds
 estimate: 1h

--- a/test-cases/tests/alerts/c16-verify-ocm-sendgrid-service-alerts.md
+++ b/test-cases/tests/alerts/c16-verify-ocm-sendgrid-service-alerts.md
@@ -1,0 +1,23 @@
+---
+environments:
+  - osd-post-upgrade
+estimate: 30m
+tags:
+  - per-release
+---
+
+# C16 - Verify OCM SendGrid Service alerts
+
+## Description
+
+This test should verify that the expected alerts for the OCM SendGrid Service exist in the OCM Prometheus instance.
+
+## Steps
+
+1. Go to the [OCM staging Prometheus instance](https://prometheus.app-sre-stage-01.devshift.net/alerts)
+
+2. Login via the OpenShift option, using the `github-app-sre` identity provider
+
+   - If you do not have permissions via this identity provider, contact the `sd-app-sre` Slack channel
+
+3. Ensure each alert defined in [the alert definition](https://gitlab.cee.redhat.com/service/app-interface/-/tree/master/resources/observability/prometheusrules/ocm-sendgrid-svc-stage.prometheusrules.yaml) exists in the list of Prometheus alerts, and none are firing

--- a/test-cases/tests/installation/a26-verify-sendgrid-credentials-are-configured-properly.md
+++ b/test-cases/tests/installation/a26-verify-sendgrid-credentials-are-configured-properly.md
@@ -1,0 +1,50 @@
+---
+automation:
+  - INTLY-9950
+environments:
+  - osd-fresh-install
+estimate: 30m
+tags:
+  - per-release
+---
+
+# A26 - Verify SendGrid credentials are configured properly
+
+## Description
+
+This test case should verify that the OCM SendGrid Service has correctly setup SMTP credentials on the OpenShift cluster.
+
+## Steps
+
+1. Retrieve the SendGrid SMTP credentials from the RHMI Operator namespace
+
+   ```
+   # SMTP username, base64 encoded. This will be referred to as <username> from now on.
+   oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.username}'
+
+   # SMTP password, base64 encoded. This will be referred to as <password> from now on.
+   oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.password}'
+   ```
+
+2. Telnet to the SMTP service to ensure the credentials are correct
+
+   ```
+   # Establish connection
+   telnet $(oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.host}' | base64 --decode) $(oc get secret redhat-rhmi-smtp -n redhat-rhmi-operator -o jsonpath='{.data.port}' | base64 --decode)
+
+   # Once connection is established, "service ready at" message is shown
+   EHLO
+
+   # Once EHLO has completed, attempt auth
+   auth login
+
+   # When you see "VXNlcm5hbWU6" (base64 encoded "Username:")
+   <username>
+
+   # When you see "UGFzc3dvcmQ6" (base64 encoded "Password:")
+   <password>
+   ```
+
+   > "Authentication successful" is shown
+
+3. End the Telnet session, enter `Ctrl + ]` and then `Ctrl + d`

--- a/test-cases/tests/uninstallation/o03-verify-sendgrid-credentials-are-removed.md
+++ b/test-cases/tests/uninstallation/o03-verify-sendgrid-credentials-are-removed.md
@@ -1,0 +1,31 @@
+---
+automation:
+  - INTLY-9950
+environments:
+  - osd-fresh-install
+estimate: 30m
+tags:
+  - per-release
+---
+
+# O03 - Verify SendGrid credentials are removed
+
+## Description
+
+This test case should verify that the OCM SendGrid Service has correctly removed the SendGrid sub account for the cluster.
+
+## Prerequisites
+
+- The ID of the OpenShift cluster from OCM e.g. `1f3ufk5dn7suk8m4um8op9k8le9gi64h`, referred to as `<cluster-id>` in this test case
+- SendGrid API key for the staging account, referred to as `<sendgrid-api-key>` in this test case
+- The OpenShift cluster has been deleted
+
+## Steps
+
+1. Ensure a user named after the cluster ID doesn't exist in the SendGrid account
+
+   ```
+   curl -ks -H 'Authorization: Bearer <sendgrid-api-key>' https://api.sendgrid.com/v3/subusers | jq -r '.[] | select(.username=="<cluster-id>")'
+   ```
+
+   > Empty output


### PR DESCRIPTION
## Description

add test cases for the external ocm sendgrid service around cluster creation, deletion and alerts.

## Verification

de2025fb933ce31e3fcfd40bd4aa801679c23894

add test cases to confirm the functionality of the ocm sendgrid
service on both rhmi installation and cluster deletion.

verification:
- install rhmi via the addon flow
- follow a26
- delete the cluster
- follow o03

26278d62d3b604e0d5775db1617dacdc81eabdc9

fix typo in test template

fix minor typo in tags of test template file

f2e2af37cf33d5b825cab1a968196f695d4d1df1

add sop c16 for verifying external ocm sendgrid alerts

currently we will have alerts for the external ocm sendgrid service
that will not appear in the integreatly prometheus stack but in the
ocm prometheus stack.

this new sop ensures we check that alerts have been synced correctly
to the prometheus instance.

this verification only covers the staging environment, a future
commit will cover verifications of the alerts in the production
environment.

verification:
- follow c16