### PR TITLE
resync routes 3Scale

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -305,6 +305,19 @@ var threescaleRoute5 = &v1.Route{
 	},
 }
 
+var threescaleRoute6 = &v1.Route{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "3scale-system-provider-route-6",
+		Namespace: "3scale",
+		Labels: map[string]string{
+			"zync.3scale.net/route-to": "backend",
+		},
+	},
+	Spec: v1.RouteSpec{
+		Host: "3scale-admin.backend",
+	},
+}
+
 var postgres = &crov1.Postgres{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "threescale-postgres-test-installation",
@@ -445,6 +458,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		threescaleRoute3,
 		threescaleRoute4,
 		threescaleRoute5,
+		threescaleRoute6,
 		postgres,
 		postgresSec,
 		redis,

--- a/pkg/resources/podHelper.go
+++ b/pkg/resources/podHelper.go
@@ -1,0 +1,77 @@
+package resources
+
+import (
+	"bytes"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	v1 "k8s.io/api/core/v1"
+	kube "k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	restclient "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/remotecommand"
+)
+
+// ExecCmd exec command on specific pod and wait the command's output.
+//func ExecuteRemoteCommand(ns string, podName string, command string, container string) (string, string, error) {
+func ExecuteRemoteCommand(ns string, podName string, command string) (string, string, error) {
+	cmd := []string{
+		"/bin/bash",
+		"-c",
+		command,
+	}
+
+	kubeClient, restConfig, err := getClient()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed to get client")
+	}
+
+	req := kubeClient.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
+		Namespace(ns).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command: cmd,
+		Stdin:   false,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+		//Container: container,
+	}
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	logrus.Infof("Executing command, %s, on pod, %s", command, podName)
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: buf,
+		Stderr: errBuf,
+	})
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	return buf.String(), errBuf.String(), nil
+}
+
+func getClient() (*kube.Clientset, *restclient.Config, error) {
+
+	kubeCfg := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(
+		clientcmd.NewDefaultClientConfigLoadingRules(),
+		&clientcmd.ConfigOverrides{},
+	)
+	restCfg, err := kubeCfg.ClientConfig()
+
+	kubeClient, err := kube.NewForConfig(restCfg)
+	if err != nil {
+		return nil, nil, errors.Wrapf(err, "Failed to generate new client")
+	}
+	return kubeClient, restCfg, nil
+}

--- a/test-cases/tests/backup-restore/j03-verify-that-namespaces-get-recreated-by-the-integreatlyopera.md
+++ b/test-cases/tests/backup-restore/j03-verify-that-namespaces-get-recreated-by-the-integreatlyopera.md
@@ -25,8 +25,6 @@ Namespaces for manual deletion:
 - redhat-rhmi-3scale
 - redhat-rhmi-3scale-operator
 
-**Note known bug:** 3scale is being stucked in "in progress" state after ns deletion - workaround: https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/backup_restore/restore_namespace.md#3scale
-
 ## Steps
 
 1. By default, this test is not run as part of the functional test suite. To run the test as part of the functional test suite, run the following `makefile` command from the RHMI operator repo against a target cluster:

--- a/test/common/namespace_restoration.go
+++ b/test/common/namespace_restoration.go
@@ -71,9 +71,8 @@ var (
 				FuseOperatorNamespace,
 				RHSSOUserProductOperatorNamespace,
 				RHSSOUserOperatorNamespace,
-				// Removing 3scale product ns from test as "bundle exec rake zync:resync:domains" needs to be executed in system-app pod terminal to restore properly
-				// ThreeScaleProductNamespace,
-				// ThreeScaleOperatorNamespace,
+				ThreeScaleProductNamespace,
+				ThreeScaleOperatorNamespace,
 				UPSProductNamespace,
 				UPSOperatorNamespace,
 			},


### PR DESCRIPTION
# Description
Previously there was a need to resync routes after a 3Scale restoration by running the following command in a 3Scale pod:
`bundle exec rake zync:resync:domains`

This is now built into the 3Scale product reconcile. 

## Verification
- Install RHMI 
- Then, delete the redhat-rhmi-3scale namespace and ensure it restores (verify product)
- Then, delete the redhat-rhmi-3scale-operator namespace and ensure the operator and product work as expected.


