### PR TITLE
adding alert_exists check for redis cpu usage alert

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -680,6 +680,12 @@ var expectedAWSRules = []alertsTestRule{
 			"RedisMemoryUsageMaxIn4Days",
 		},
 	},
+	{
+		File: "redhat-rhmi-operator-redis-cpu-usage-high.yaml",
+		Rules: []string{
+			"RedisCpuUsageHigh",
+		},
+	},
 }
 
 func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/INTLY-8382

adding alert_exists check for redis cpu usage alert