### PR TITLE
feat(InstallationController): Adds ability to pass installType as env var

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -51,6 +51,7 @@ const (
 	DefaultInstallationPrefix        = "redhat-rhmi-"
 	DefaultCloudResourceConfigName   = "cloud-resource-config"
 	alertingEmailAddressEnvName      = "ALERTING_EMAIL_ADDRESS"
+	installTypeEnvName               = "INSTALLATION_TYPE"
 )
 
 var (
@@ -148,8 +149,13 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 
 		useClusterStorage, _ := os.LookupEnv("USE_CLUSTER_STORAGE")
 		alertingEmailAddress, _ := os.LookupEnv(alertingEmailAddressEnvName)
+		installType, _ := os.LookupEnv(installTypeEnvName)
 
 		logrus.Infof("Creating a %s rhmi CR with USC %s, as no CR rhmis were found in %s namespace", string(integreatlyv1alpha1.InstallationTypeManaged), useClusterStorage, namespace)
+
+		if installType == "" {
+			installType = string(integreatlyv1alpha1.InstallationTypeManaged)
+		}
 
 		installation = &integreatlyv1alpha1.RHMI{
 			ObjectMeta: metav1.ObjectMeta{
@@ -157,7 +163,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 				Namespace: namespace,
 			},
 			Spec: integreatlyv1alpha1.RHMISpec{
-				Type:                        string(integreatlyv1alpha1.InstallationTypeManaged),
+				Type:                        installType,
 				NamespacePrefix:             DefaultInstallationPrefix,
 				SelfSignedCerts:             false,
 				SMTPSecret:                  DefaultInstallationPrefix + "smtp",

--- a/pkg/controller/installation/installation_controller_test.go
+++ b/pkg/controller/installation/installation_controller_test.go
@@ -167,6 +167,72 @@ func TestCreateInstallationCR_alertingEmailAddressIsNotPresent(t *testing.T) {
 	}
 }
 
+func TestCreateInstallationCR_installationTypeInEnvVar(t *testing.T) {
+
+	mockClient := fake.NewFakeClientWithScheme(buildScheme())
+	ctx := context.TODO()
+
+	installationType := "test"
+	os.Setenv("INSTALLATION_TYPE", installationType)
+	os.Setenv("WATCH_NAMESPACE", defaultNamespace)
+
+	// Defer unsetting the environment variables regardless of test results
+	defer os.Unsetenv("INSTALLATION_TYPE")
+	defer os.Unsetenv("WATCH_NAMESPACE")
+
+	// Function to test
+	err := createInstallationCR(ctx, mockClient)
+
+	if err != nil {
+		t.Fatalf("Error creating installation CR: %v", err)
+	}
+
+	installation, err := getInstallationCR(ctx, mockClient)
+	if err != nil {
+		t.Fatalf("Error getting installation CR: %v", err)
+	}
+
+	if installation.Spec.Type != installationType {
+		t.Fatalf(
+			"Expected installationType value of Installation.Spec.Type to be %s, instead got %s",
+			installationType,
+			installation.Spec.Type,
+		)
+	}
+}
+
+func TestCreateInstallationCR_installationTypeDefault(t *testing.T) {
+
+	mockClient := fake.NewFakeClientWithScheme(buildScheme())
+	ctx := context.TODO()
+
+	installationType := "managed"
+	os.Setenv("WATCH_NAMESPACE", defaultNamespace)
+
+	// Defer unsetting the environment variables regardless of test results
+	defer os.Unsetenv("WATCH_NAMESPACE")
+
+	// Function to test
+	err := createInstallationCR(ctx, mockClient)
+
+	if err != nil {
+		t.Fatalf("Error creating installation CR: %v", err)
+	}
+
+	installation, err := getInstallationCR(ctx, mockClient)
+	if err != nil {
+		t.Fatalf("Error getting installation CR: %v", err)
+	}
+
+	if installation.Spec.Type != installationType {
+		t.Fatalf(
+			"Expected installationType value of Installation.Spec.Type to be %s, instead got %s",
+			installationType,
+			installation.Spec.Type,
+		)
+	}
+}
+
 // Utility function to retrieve the Installation CR
 func getInstallationCR(ctx context.Context, serverClient k8sclient.Client) (*integreatlyv1alpha1.RHMI, error) {
 	namespace, err := k8sutil.GetWatchNamespace()


### PR DESCRIPTION
# Description

Adds ability to pass installType as env var

https://issues.redhat.com/browse/MGDAPI-7

## Verification steps

1) export an env var
`export INSTALLATION_TYPE=managed`
2) install the operator locally
3) verify if the installation type in the RHMI CR is the same as the one in the env var
`oc get rhmi rhmi -o json -n redhat-rhmi-operator | jq .spec.type`

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] I have added tests that prove my fix is effective or that my feature works