### PR TITLE
Mgdapi 31 Updating the prepeare release script 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ router-ca.tmp
 TMP_SA_KUBECONFIG
 # Temporary Build Files
 tmp/_output/bin/integreatly-operator
+tmp/_output/bin/managed-api-service
 cmd/manager/debug
 build/_output
 build/_test

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,9 @@ TEST_RESULTS_DIR ?= "test-results"
 TEMP_SERVICEACCOUNT_NAME="rhmi-operator"
 CLUSTER_URL:=$(shell sh -c "oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*'")
 
+# These tags are modified by the prepare-release script.
 RHMI_TAG ?= 2.7.0
-RHOAM_TAG ?= 0.1.0-rc2
+RHOAM_TAG ?= 0.1.0
 
 # If openapi-gen is available on the path, use that; otherwise use it through
 # "go run" (slower)
@@ -46,6 +47,7 @@ else
 endif
 
 export SELF_SIGNED_CERTS   ?= true
+# Setting the INSTALLATION_TYPE to managed-api will configure the values required for RHOAM installs
 export INSTALLATION_TYPE   ?= managed
 export INSTALLATION_NAME   ?= rhmi
 
@@ -70,7 +72,8 @@ ifeq ($(INSTALLATION_TYPE), managed-api)
 	OPERATOR_IMAGE=$(REG)/$(ORG)/$(PROJECT):v$(TAG)
 	NAMESPACE_PREFIX ?= redhat-rhoam-
 	APPLICATION_REPO ?= managed-api-service
-	export INSTALLATION_PREFIX ?= redhat-rhoam
+	# TODO follow on naming of this folder by INSTALLATION_PREFIX and contents of the role_binding.yaml
+	export INSTALLATION_PREFIX ?= redhat-managed-api
 	export OLM_TYPE ?= managed-api-service
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -13,13 +13,14 @@ OPERATOR_SDK_VERSION=0.17.1
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "$(QUAY_PASSWORD)"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 
-INTEGREATLY_OPERATOR_IMAGE ?= $(REG)/$(ORG)/$(PROJECT):v$(TAG)
-MANAGED_API_OPERATOR_IMAGE ?= $(REG)/$(ORG)/managed-api-service:v$(MGDAPI_TAG)
 
 CONTAINER_ENGINE ?= docker
 TEST_RESULTS_DIR ?= "test-results"
 TEMP_SERVICEACCOUNT_NAME="rhmi-operator"
 CLUSTER_URL:=$(shell sh -c "oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*'")
+
+RHMI_TAG ?= 2.7.0
+RHOAM_TAG ?= 0.1.0-rc2
 
 # If openapi-gen is available on the path, use that; otherwise use it through
 # "go run" (slower)
@@ -47,29 +48,29 @@ endif
 export SELF_SIGNED_CERTS   ?= true
 export INSTALLATION_TYPE   ?= managed
 export INSTALLATION_NAME   ?= rhmi
-export INSTALLATION_PREFIX ?= redhat-rhmi
+
 export USE_CLUSTER_STORAGE ?= true
 export OPERATORS_IN_PRODUCT_NAMESPACE ?= false # e2e tests and createInstallationCR() need to be updated when default is changed
 export DELOREAN_PULL_SECRET_NAME ?= integreatly-delorean-pull-secret
 export ALERTING_EMAIL_ADDRESS = noreply-test@rhmi-redhat.com
 
 ifeq ($(INSTALLATION_TYPE), managed)
-	RHMI_TAG ?= 2.7.0
 	PROJECT=integreatly-operator
-	OPERATOR_IMAGE=$(REG)/$(ORG)/$(PROJECT):v$(RHMI_TAG)
 	TAG ?= RHMI_TAG
+	OPERATOR_IMAGE=$(REG)/$(ORG)/$(PROJECT):v$(TAG)
 	NAMESPACE_PREFIX ?= redhat-rhmi-
 	APPLICATION_REPO ?= integreatly
+	export INSTALLATION_PREFIX ?= redhat-rhmi
 	export OLM_TYPE ?= integreatly-operator
 endif
 
 ifeq ($(INSTALLATION_TYPE), managed-api)
-	RHOAM_TAG ?= 0.1.0
 	PROJECT=managed-api-service
-	OPERATOR_IMAGE=$(REG)/$(ORG)/$(PROJECT):v$(RHOAM_TAG)
 	TAG ?= RHOAM_TAG
+	OPERATOR_IMAGE=$(REG)/$(ORG)/$(PROJECT):v$(TAG)
 	NAMESPACE_PREFIX ?= redhat-rhoam-
 	APPLICATION_REPO ?= managed-api-service
+	export INSTALLATION_PREFIX ?= redhat-rhoam
 	export OLM_TYPE ?= managed-api-service
 endif
 
@@ -181,19 +182,14 @@ test/e2e/prow: test/e2e
 
 .PHONY: test/e2e/rhoam/prow
 test/e2e/rhoam/prow: export component := integreatly-operator
-test/e2e/rhoam/prow: export INTEGREATLY_OPERATOR_IMAGE := "${IMAGE_FORMAT}"
-test/e2e/rhoam/prow: test/e2e/rhoam
-
-.PHONY: test/e2e/rhoam
-test/e2e/rhoam: export INSTALLATION_TYPE := "managed-api"
-test/e2e/rhoam:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
-	$(OPERATOR_SDK) --verbose test local ./test/e2e --operator-namespace="$(NAMESPACE)" --go-test-flags "-timeout=120m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
+test/e2e/rhoam/prow: export MANAGED_API_OPERATOR_IMAGE := "${IMAGE_FORMAT}"
+test/e2e/rhoam/prow: export INSTALLATION_TYPE := "managed-api"
+test/e2e/rhoam/prow:
+	echo $(OPERATOR_SDK) --verbose test local ./test/e2e --operator-namespace="$(NAMESPACE)" --go-test-flags "-timeout=120m" --debug --image=$(MANAGED_API_OPERATOR_IMAGE)
 
 .PHONY: test/e2e
 test/e2e:  export SURF_DEBUG_HEADERS=1
 test/e2e:  cluster/cleanup cluster/cleanup/crds cluster/prepare cluster/prepare/crd deploy/integreatly-rhmi-cr.yml
-	$(OPERATOR_SDK) --verbose test local ./test/e2e --operator-namespace="$(NAMESPACE)" --go-test-flags "-timeout=120m" --debug --image=$(INTEGREATLY_OPERATOR_IMAGE)
-	 export SURF_DEBUG_HEADERS=1
 	$(OPERATOR_SDK) --verbose test local ./test/e2e --operator-namespace="$(NAMESPACE)" --go-test-flags "-timeout=120m" --debug --image=$(OPERATOR_IMAGE)
 
 .PHONY: test/e2e/local
@@ -379,11 +375,19 @@ deploy/integreatly-rhmi-cr.yml:
 .PHONY: prepare-patch-release
 prepare-patch-release:
 	$(CONTAINER_ENGINE) pull quay.io/integreatly/delorean-cli:master
-	$(CONTAINER_ENGINE) run --rm -e KUBECONFIG=/kube.config -v "${HOME}/.kube/config":/kube.config:z -v "${HOME}/.delorean.yaml:/.delorean.yaml" quay.io/integreatly/delorean-cli:master delorean release openshift-ci-release --config /.delorean.yaml --olmType $(olmType) --version $(TAG)
+	$(CONTAINER_ENGINE) run --rm -e KUBECONFIG=/kube.config -v "${HOME}/.kube/config":/kube.config:z -v "${HOME}/.delorean.yaml:/.delorean.yaml" quay.io/integreatly/delorean-cli:master delorean release openshift-ci-release --config /.delorean.yaml --olmType $(OLMTYPE) --version $(TAG)
 
 .PHONY: release/prepare
 release/prepare:
 	@./scripts/prepare-release.sh
+
+.PHONY: push/csv
+push/csv:
+	operator-courier verify deploy/olm-catalog/$(PROJECT)
+	-operator-courier push deploy/olm-catalog/$(PROJECT)/ $(REPO) $(APPLICATION_REPO) $(TAG) "$(AUTH_TOKEN)"
+
+.PHONY: gen/push/csv
+gen/push/csv: release/prepare push/csv
 
 # Generate namespace names to be used in docs
 .PHONY: gen/namespaces

--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Integreatly Operator
 
+---
+**NOTE**
+
+When working on `RHOAM`, all `make` commands should be prefixed with `INSTALLATION_TYPE=managed-api`.
+This will configure any variables that may be required.
+
+The default `INSTALLATION_TYPE` is `managed` which configures variables for use with `RHMI`
+
+---
+
 A Kubernetes Operator based on the Operator SDK for installing and reconciling Integreatly products.
 
 ### Project status: _alpha_

--- a/deploy/olm-catalog/managed-api-service/0.1.0/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/olm-catalog/managed-api-service/0.1.0/integreatly.org_rhmiconfigs_crd.yaml
@@ -1,0 +1,96 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rhmiconfigs.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: RHMIConfig
+    listKind: RHMIConfigList
+    plural: rhmiconfigs
+    singular: rhmiconfig
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: RHMIConfig is the Schema for the rhmiconfigs API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RHMIConfigSpec defines the desired state of RHMIConfig
+          properties:
+            backup:
+              properties:
+                applyOn:
+                  description: 'apply-on: string, day time. Format: "DDD hh:mm" > "wed 20:00". UTC time'
+                  type: string
+              type: object
+            maintenance:
+              properties:
+                applyFrom:
+                  description: 'apply-from: string, day time. Currently this is a 6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                  type: string
+              type: object
+            upgrade:
+              properties:
+                contacts:
+                  description: 'contacts: list of contacts which are comma separated "user1@example.com,user2@example.com"'
+                  type: string
+                notBeforeDays:
+                  description: Minimum of days since an upgrade is made available until it's approved
+                  nullable: true
+                  type: integer
+                schedule:
+                  type: boolean
+                waitForMaintenance:
+                  description: If this value is true, upgrades will be approved in the next maintenance window n days after the upgrade is made available. Being n the value of `notBeforeDays`.
+                  nullable: true
+                  type: boolean
+              type: object
+          type: object
+        status:
+          description: RHMIConfigStatus defines the observed state of RHMIConfig
+          properties:
+            maintenance:
+              description: "status block reflects the current configuration of the cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00 \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 - 17 Jan 1980\""
+              properties:
+                applyFrom:
+                  type: string
+                duration:
+                  type: string
+              type: object
+            upgrade:
+              properties:
+                scheduled:
+                  description: Scheduled contains the information on the next upgrade schedule
+                  properties:
+                    for:
+                      description: For is the calculated time when the upgrade is scheduled for, in format "2 Jan 2006 15:04"
+                      type: string
+                  type: object
+              type: object
+            upgradeAvailable:
+              properties:
+                availableAt:
+                  description: 'Time of new update becoming available Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                  format: date-time
+                  type: string
+                targetVersion:
+                  description: 'target-version: string, version of incoming RHMI Operator'
+                  type: string
+              type: object
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/managed-api-service/0.1.0/integreatly.org_rhmis_crd.yaml
+++ b/deploy/olm-catalog/managed-api-service/0.1.0/integreatly.org_rhmis_crd.yaml
@@ -1,0 +1,137 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: rhmis.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: RHMI
+    listKind: RHMIList
+    plural: rhmis
+    singular: rhmi
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      description: RHMI is the Schema for the RHMI API
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          description: RHMISpec defines the desired state of Installation
+          properties:
+            alertingEmailAddress:
+              type: string
+            deadMansSnitchSecret:
+              description: "DeadMansSnitchSecret is the name of a secret in the installation namespace containing connection details for Dead Mans Snitch. The secret must contain the following fields: \n url"
+              type: string
+            masterURL:
+              type: string
+            namespacePrefix:
+              type: string
+            operatorsInProductNamespace:
+              description: OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.
+              type: boolean
+            pagerDutySecret:
+              description: "PagerDutySecret is the name of a secret in the installation namespace containing PagerDuty account details. The secret must contain the following fields: \n serviceKey"
+              type: string
+            pullSecret:
+              properties:
+                name:
+                  type: string
+                namespace:
+                  type: string
+              required:
+              - name
+              - namespace
+              type: object
+            routingSubdomain:
+              type: string
+            selfSignedCerts:
+              type: boolean
+            smtpSecret:
+              description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields: \n host port tls username password"
+              type: string
+            type:
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: string
+            useClusterStorage:
+              type: string
+          required:
+          - namespacePrefix
+          - type
+          type: object
+        status:
+          description: RHMIStatus defines the observed state of Installation
+          properties:
+            gitHubOAuthEnabled:
+              type: boolean
+            lastError:
+              type: string
+            preflightMessage:
+              type: string
+            preflightStatus:
+              type: string
+            smtpEnabled:
+              type: boolean
+            stage:
+              type: string
+            stages:
+              additionalProperties:
+                properties:
+                  name:
+                    type: string
+                  phase:
+                    type: string
+                  products:
+                    additionalProperties:
+                      properties:
+                        host:
+                          type: string
+                        mobile:
+                          type: boolean
+                        name:
+                          type: string
+                        operator:
+                          type: string
+                        status:
+                          type: string
+                        type:
+                          type: string
+                        version:
+                          type: string
+                      required:
+                      - host
+                      - name
+                      - status
+                      - version
+                      type: object
+                    type: object
+                required:
+                - name
+                - phase
+                type: object
+              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              type: object
+            toVersion:
+              type: string
+            version:
+              type: string
+          required:
+          - lastError
+          - stage
+          - stages
+          type: object
+      type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/deploy/olm-catalog/managed-api-service/0.1.0/managed-api-service.v0.1.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/managed-api-service/0.1.0/managed-api-service.v0.1.0.clusterserviceversion.yaml
@@ -1,0 +1,533 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "integreatly.org/v1alpha1",
+          "kind": "RHMIConfig",
+          "metadata": {
+            "name": "rhmi-config"
+          }
+        },
+        {
+          "apiVersion": "integreatly.org/v1alpha1",
+          "kind": "RHMI",
+          "metadata": {
+            "name": "INSTALLATION_NAME"
+          },
+          "spec": {
+            "deadMansSnitchSecret": "INSTALLATION_PREFIX-deadmanssnitch",
+            "namespacePrefix": "INSTALLATION_PREFIX-",
+            "operatorsInProductNamespace": "OPERATORS_IN_PRODUCT_NAMESPACE",
+            "pagerDutySecret": "INSTALLATION_PREFIX-pagerduty",
+            "selfSignedCerts": "SELF_SIGNED_CERTS",
+            "smtpSecret": "INSTALLATION_PREFIX-smtp",
+            "type": "INSTALLATION_TYPE",
+            "useClusterStorage": "USE_CLUSTER_STORAGE"
+          }
+        },
+        {
+          "apiVersion": "integreatly.org/v1alpha1",
+          "kind": "RHMI",
+          "metadata": {
+            "name": "example-rhmi"
+          },
+          "spec": {
+            "deadMansSnitchSecret": "redhat-rhmi-deadmanssnitch",
+            "namespacePrefix": "redhat-rhmi-",
+            "pagerDutySecret": "redhat-rhmi-pagerduty",
+            "selfSignedCerts": true,
+            "smtpSecret": "redhat-rhmi-smtp",
+            "type": "managed",
+            "useClusterStorage": "true"
+          }
+        },
+        {
+          "apiVersion": "integreatly.org/v1alpha1",
+          "kind": "RHMI",
+          "metadata": {
+            "name": "rhmi"
+          },
+          "spec": {
+            "deadMansSnitchSecret": "redhat-rhmi-deadmanssnitch",
+            "namespacePrefix": "redhat-rhmi-",
+            "operatorsInProductNamespace": false,
+            "pagerDutySecret": "redhat-rhmi-pagerduty",
+            "selfSignedCerts": true,
+            "smtpSecret": "redhat-rhmi-smtp",
+            "type": "managed",
+            "useClusterStorage": "true"
+          }
+        }
+      ]
+    capabilities: Basic Install
+    categories: RHOAM integration
+    certified: "false"
+    containerImage: quay.io/integreatly/managed-api-service:v0.1.0
+    description: RHOAM integration suite of tools
+    support: RHOAM
+  name: managed-api-service.v0.1.0
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: RHMIConfig is the Schema for the rhmiconfigs API
+      kind: RHMIConfig
+      name: rhmiconfigs.integreatly.org
+      version: v1alpha1
+    - description: RHMI is the Schema for the RHMI API used by RHOAM
+      displayName: RHOAM Installation
+      kind: RHMI
+      name: rhmis.integreatly.org
+      version: v1alpha1
+  description: RHOAM installation and reconciliation operator
+  displayName: RHOAM
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAUAAAAFACAYAAADNkKWqAAAfI3pUWHRSYXcgcHJvZmlsZSB0eXBlIGV4aWYAAHjarZtpdmM3koX/YxW9BMzDcgLTOb2DXn5/F5TSaTuzXNWnJStJk9R7ACLiDgHInf/57+v+i69Wine5tF5HrZ6vPPKIxpPuP1/j/Rt8fv++r/z9LPz5dffjjchj4jF93mj2eQzG6+WPX/i+R5h/ft31r3di/7rQ1xvfF0y6c+TJ/nmQvB4/r4f8daFxPk/q6O3noc74eVxfH3xD+fqpy7+lCF8X1/+7n1/IjVXahRulGE8Kyb9/82cE6fNj/KT3b+RzIRWe8+XeS/1rJCzIn6b3/ej9zwv0p0X+fub+uvr+N4sf7ev19Je1rF9rxJNfvhHKrxf/LfFPN04/RhT//EbuYf1tOl8/9+5+7/nMznJlRetXRnn3vTr6HT44uVR6v1b5bvwUnrf3Pfju3vwi5NsvP/leYYRIVK4LOexg4YbzHldYDDHHExuPMa6Y3ms9tTjiSopT1ne4saWRdurEcsXjiFxO8cdYwrvvePdboXPnHfhoDFws8Cu//Xb/6s3/5Nvdq7UNwfcfa8W4ovKaYShy+pdPqSjvV9zKW+Dv76/w+5/yh1QlguUtc2eC5ufnErOEP3IrvTgnPld4/JRQcG1/XYAl4t6FwYREBHwl+0MNvsXYQmAdOwEyRh5TjpMIhFLiZpAxp1Sja7FH3ZvfaeF9NpZYo14GmwhESTU1YjOSEaycC/nTcieHrKSSSym1tNJdGcVqqrmWWmurAjlrqeVWWm2t9Taa9dRzL7321nsf3UYcCQwso442+hjDLDrjRsa1jM8br8w408yzzDrb7HNMW6TPyqusutrqayzbcacNTOy62+57bDvBHZDi5FNOPe30M45dcu2mm2+59bbb77j2I2pfUf3b938QtfAVtfgipc+1H1HjVdfa9yWC4KQoZkQs5kDEmyJAQkfFzPeQc1TkFDM/IkVRIoMsio3bQREjhPmEWG74Ebs/Ivdvxc2V/m/FLf5T5JxC9/8ROUfo/h63X0Rti+fWi9inCrWmPlF9vH+6udhNpGa/e+S+8eYw7y65E6vM0p4b5yWgvdk9oWxWY7rj1wyzeLstr3pqWSDa9YNhMJpdQ+HWmXH2fay1E1rcKxOJ0lmCc9bxtpkoCXkJVjwMfcTSLrdcTHWeHidplK/PB+IC4tIaoUwW/fixV9u3h3tS2RfcXMXVG+IqftVJyC+xBBbjuGWVxMryqWirzUn1B0thV5sttttiGnWW61Ppucy8l8uXDFrJeuCVxLTL3Xwkkmn7DGYFkpTONT2pcEe/p/J27XbaKJUs2HucsZNb/gQbGl7R8pNM96w7QXEEw02z3TtvTm9k0TpKyOyL/sK2wRXXnnUdN0rIs1IQZd6Zzpr3tHU29HU3/ORtplz8IKlgdmvTUrTyGW1ctfjNaM3fxtRGZiBREZjLEyaepHrT2qTK6Qx4Z4K12y12jBHsmIpZbpQBBfJmxOq6pgqPd/Wb9pyfGJFAG/kWyvIB2cMU2iZcitG6e20jFGPNU/ZalDcD6cfNznuJ9d1Ux4y5hLV64V3wUyuzqP1pMVAFdvvgSqnOQ/HWwtjqIT5GfKvrxlLuPOFeajwzgp3HpBKRAGFBwUuXm53MTi/BYx+JuitG7kVr5Hgnd2Hassk6JS/zp84aGWdrAkO97prtTNY3fWpmk8be3vO/PbpfvrHRATdT+ZvCmst6O+AOg0YVpF6U0QzcSiwBrCk7WXORnEJwxDlrSeBGHeeQTQwHHTFAKSqbIbGulWoj2pXUaNv6IRF12d7b3uU6uwakHMAtgSgj1cObwPlIAUjLgMiwCSOuaRtoyjMDbqwKqXLyzvrFVmYZrnHLeRdZhYapPbBaJPABn8ldPhMIHxE4Xs+khX/z6P7+BtMIFZjvxwLJSkGjqVkGAdTh3XHRw6mFO89mMcgkwkvRNjK6Cb5mb1OBJ6oV5D5wfrdcjtlKoZzVuITZ6bdOo2JGPy1D/ItaKD45FtbOsqT5I7OP9etv2EP6ebZB/CIJYklFjDQD4BTTml5MgymmY56aXV1cWoTH2pJaIATsYYNIDzI6nUKNpsF/sMguwz5pMoZ/K1H896N7TwiZpToSSRMaIrJTJbw8Kc2X139OGTImfWVMvuZPR9ZMV9CrhHrPGO4+GeTavs03EYpHi5F7XOY/mVU6hXsAuZsswkhCjcmL+ziEOSAL0dwLwJEe1W4hw9rJlPwB7RqgNzzMAeJ+JgY07b/WiPtt8fzTYwzEmHHe6GtHHoNSyIEa0G27DavUKJBpQh6f1wBEgfoWK4yZDtLkzC3mYGy2W4A6ys7QV3bk8CG73nXQEccIZ7oEmi/pzYVkAB+44roxMy3EYFembZzY1YcPRTijA4SA57dCC2ouJ6EhCxJicStFCPbxQ8j9iTNZ/s3Do8KMViaTACG3OHfH3Fcg4s2MLABKg+WNZQghUvNZlu8C0irwcLETucIUm+DWvjbOIC+gti9WoTTQnUneCMIrXRkQBD4Qx3sE4ggu+LbJzFtZpHOhHlG0JHzWEIHak9Je/4fYQbloncB6gBzm5IqYC2QKJLJy2B7GbwZWp4t4iSd3MO9WOR/uX8hR1h/0KqLt1reuts2BC7cNSltx3Ivf3yB4mXHUAIij+mYuLPCjNcDLFgAKayS/d5bURLsctKLL8DUjqAWpxTqiHkuEI6KBdmnw+4TpTceAWbQdygb39v6lQC2jA0m76N3nQwuRSG0Yys4MgTGw5aSrR+JOoD7Us1F0rSWtMEElU7kDsE0uR1O03d4t3iOOghjIVDReCJV87B2tq0IuaEAGp6Q23CeQhp6aewx+q94eATp/q9ueWELZaCwUImLuVaUuW4D8jOrbcR2b4GRDP7aFhBggLpqFogfBsq0FTjjkZEUCXqAmika2MvbAEOFQUA1eRwJGoS0iENuRoM3DEqHdymXlI9mOhkGxkaW9S66xYlJAr8XRi8AeEirpaHHtnzSrEvLzZCL10rUI5jEIYHnkiHpPCLouCO4TGZI6UnuQ6iGNVQf/g65GWsbbXZtkXgP80pRGhCZWH6TGpcCxSaYk7OMK7sDOqUzOB9a2wBAwmfDkTJCHo5TQ5dnIRmpxT5aqYvYl/fuSyunYI8QpYFQqYNQgHHAjldaABMor3EFhwGv4AZTCDoTgVFYO08NyjVojcNBQSlIgwJWU4bRCxm5yO6JEIxSJnJL6NBByGlHApRAzMnRhdcSgCNJCbcKopF5YF9YmjyglUSlAJESJsPBEbi1CwmKji1Ij/UE7sCO+/sbcggyly0FzI5kjjDYZCatO4mNK5p68Pdrd+xbVuYNME1kUys0kOUm7cru+2QqTJGZoCZYBfBEqQeKi3ano7uZrTN4G1OUTN2CxJS5jNUQV5ujeXOGApygwVW2ePxi1L6kKysQXASr0Rw6jO9CxnhGlLDwif1Fj2N8oJgec0OxtShbj3Qy5e0MjcWbD1iGz0AkHqIRiEiIDm3fdkVsiqljTI5M0lgyUFmcmItKo+jkRDpIXM2AMEHhU8oKlqW1cIBQTgG9H/uC6GL7KKVIuTLxDbV7rBqdhhfRJgBw/4cEEmAreZql9kzLntxEFHlULygyGVkHGJcvKtFsRIjRBhPKaoH4wAcnX8m8Kzv29AoEa1mYhhKZRbZ50gWHgw5sOC0nygE3Qk8kJMDZM/E7ZqeRIC/QBVo2UncqVMlt+OgQFgijNVB/QTG3BOWiRhVmENzE9PmnSJ2VzKQ+iQD1i5FDBB8DcTZnCXA+lvuBAcgnPTkUGSVjCAD0kFNnOWAAU3ewV6ZcxoTfigCpVgVY4jYhP4RjJvZBeDXwh7kwIU3T4MGJxqgsB3eAXCNXicg6tUKqHhiZCBbEGPM9nVa2J2e7rFzNYgKUJXusEVDwY2whpCEqKOkJqTh4Q/ECwhUHZvgUkQ4EqUpUZ26pvuSS7CCL/y9BHA+KwpIP68YO0PNvJDp26iz2wYnJow0QUcusQD9INa5aPFEMmVReli0+ZjPE5KqLGXYHu6aw+dkSkU/SmpjYRph6J+NjVY/1hZIyuIarlQTKUheySXZHSrv0WyPo0B9h03QkNUwGj175EI8KYych22aDkSeqUrCJyPd6ENCGSdyPfiVyaKu/iIIpWqmIIJwbgJ1DfUeZjF/LkMN5WJOKhoqv+D4nXxWeoswO2g2xD7sBVEGsg9aNAIrYgH30aXrih11QtJn4loyF51Df5sTK29Z5SxiYDoNZOMXpVf0XpeFgaKeabUAHOJYUpFpTADADhJGbrBCHKxqOpBPbHBRU4tOuZkyGSFiijRomdWqQdRzirotuoBfzoDHNJMIJ0LD7jCxskmZsEoK4Dlq3Da6XmsTFn0MlIq2GKG3jLhABcOAm8BzIiGJGFEmbEUqBQ67kdRiGTqec63LKKJBoN5Q109NBB8kMhghqY6bSD7wR+JnUj/OjSAIhOXKqRQAc+RJKYOlpnHl8HnLUSsz9fIrjCaP/kGb8fic9zR8zVmswF/NRUWxY8kisCKK299gjSRGigZ5uKR8p+fUTyBxOz4rrD4RTJhpiZRC8NJkTaRKSA36AQ2g/V+ETw9mvruoXkhCnvlZvK1OZ8H9jO4wNJ004c390vyXQ6rySFOytZpKoKCpAbkxgNmUYaEjfSqMl3JbiiOOyzZeqYzAvVPHwDGaVWYQnDdxITUh8hOtsCUkmq7lMmih213+Au1Cn8Th4VVDA3LuqCHyKL3lTzh6wKW63Jg1iRyYOzZb+R/Gt2BkcJA39YpkKhlE0evWYLbLsyuVcqBpSgGfw3JZve8sN5SEehEpXTsNyT1Cf9+Li4K1Hx1c0ATmJ64L2Q5lQDDNxBMIGiZ4i6WCzrNRyPh92grzokUiVNHtveqMQi9TXnJTEi+YagZ2gNhf8SYVciCVvCCAiV2hZSSsaDomAtJqtACd2uzo+TMmOOM2oWAaGLzFLIInpKBAYEyU+sPltHbFPExK7LUqPgtZBHwm2iRvhIJ9L80rMs/VPUfew/dAias/V19lw4O9LDC+WxFmskwGA8WHL9FWgCC2HxGBKk3TC2KDXYoPoEpmP+sZTUPjZywXVVpg1QHuokA+ChxGFO5CAm6jmb9jwGicmKv4LDAAkXgwDiq7J6/UsH4qsBERzZyPSpeNIU7bLq22kUmMkQISQbCjyP2WpmOE3902VPXI8rM7OAf4TQcYuQckd+mNFAFKJMxV1cROYhAyjG4qQitWodwwN5S5ETQaSziqVpxw1zTC3DikSSYvPwC/qAkrpkdKfEqSSIMd9PyxUVq5Yr7I+nBgXBb/U0mJLzXBkKxs6HCW2FXPGeS7By1aaBTBYGHx0A9sMKZCGDRy5SB5hC7JgauVcbvkxhvKYKviwws467ovwNfnyf+f7AX95mQhirmTAqGJY+HNUgbcy95/nASAJnuv9MBfmLzoUa+BRoRbGorQE86A2h3PxAIeFn2fFCuB1KKWv3AEUr5ydhLJ9P+oDnFc0MNkAY2IIMzCQt9UmyrxtVQa1NcTvZzTJ6Ro6AfbqRICLM5siFuElcpTTUCqOq4VqE8xg3gTaAS1U6I/1AXq8mSsWCIX8xmqVJPoHK6tjg7AOCUXCMi4L96kaiI//a3h1h3XDpDW/mNnmp1mPsaEh8KHyEHkLQz7cfiv4tmA6ojExC1oJppCGpanLFALf8j5pFDv23EaZcB0KfCHaEpw/PXB0DPygZIA86jUfbPFuGefhAuBbSBsnxxFfYjtEJd+D0kg9Y3XD71yNySHaoDQxPndyfFKY6McWE/fUEUipKS5yOC7g+OBbzuWCwjK91gZ2F7lIL+btQQ/4DULxMq0A2yUsDByA8FZm6MxF6oDDAeYpebQlUyyT0SKzBRBFgER+JLhipay8NYMTqb4sH6/XVlvTL/Sz80Uk5X9KeN7S9hWT2Zg/cG1Dcw6Ophl4/uLkOBRL6k7W3t1FsQGjKU94wqQU5jGhsvQRpxLjg3YgGC5DEPNBlJ90TJq9kbWr0wWyY5sLUYDdIL1aUhCJbmnYS8FbwBRd+EWjSdGmQQ9oeKhnCUiPgqQFNDjwtboghtC2Qr97XOJC3FOKoUGj3BQEjdg9QYQZ2q3aTQc8dSFV+s01U+93UmllpXbtGjEqbXle7FiQ/+mdKLAKIuI8TcbNLnWMEQ4NsrqITvPZMZQCQxweGo5LvfDa/PH9BJRZ5g6c7dKxDZweQjWmEJ3Mm2USezw7Oc4tbJng0oAiT8SLGlAPKY8oT5i8f8nu0StTKK3BD0yFr5IcQel8aqEgSEw+ABBWqbp16yl/i6QNHuP4/A5Lg6DrT7l5DinE7VvIn7fQRVwAPnqgv3JCIFm8BOKjCtGDpS8UlMFtbhK/tjFuzfBl0AXfUkECgxJMpDqCoYeE8S+q9iGU+KsAYSbzfq90pLkToPlAGZDFdhDLphbFA4GANCF/JfZZK0tihwvWUhZY21E4jSozVg4ydzhENP8ZC2xECUjHcptYv60OBDpRzwWt6a1g6qQqiy0zPOlAqRZnIVCpxuYE1m6FP4AmEW6SQxsdvkZXIgaWE8Ocw70L9HiyX5qzdUQKMicLlq7CKayG9NkgDaQ1ZxGoe2A0I86AhKqh+gQi0/UulnVPjjsFt/CFzf9u+wSOASTCScYhBR2i9WZFECbUu5oxEYTG5KavyLPeaMhInLbeocOTaPJA71yTppun8TdPG2nyghwkBLjJhQFviSLEI5W8W4bkjrN/ExlG3ZUrFoHvxGRQmuCRZRxmrnaX9DexRXh29IwR/jjR3bXZGxyXgL6w5EqCUmDDXacAICDPt9VyJAGxzV79c6DhhJDTfY4z8gzHqdGR6Vxtlg+kMChjCWBt+WydJBHJcEJWOouf+MQontHOMlZ9Sn9RnYx6zOz0SWDU7CFXquOoEaV6UGQoMtqBoinbrEkmStJmwL64WVUOFVjQsNRxw1w70RDsNfoMwtT4yOgeWPtLIMemGpHZ8JI1jxVUjBEg74oPa6phqdUBvCg7A6doZy9oujDgQwa4n85CgA11S8MsNnstBPlDnNbDJiLuo80lefZTXH5oO9R6QehrmwjjEggsMz8Lj1lhkj+1Hi0rrdQTm1QfRIJ0qi2ntQHQQeIJabeFTH9p6GkruDoJIjv4srqruCwYP5dADvCAwe9roAqVX/Wx1IBtFLt1VxtqIi9W+5Vev87NFxpU/GMW136W4ev1xddybUwia3rOPPNNJLYgYKsygwqUGLznNLF9Fsijp197W/cr0SinvyJrmJEd0n7026l32WkyC9iKBZflY0tdgImrGU+7OyLNOO1AfKDQcAyuZcn+OId+qAy3AXVdHJktiqQ+NuT8eYFcn0W0VlnovcKs3CJyFJ4tQcWQMpPBpPghjJ8uq7S7tuQ4DzMAptS2SR2th/HTMJW7I6GAQKnx60ScT+G7aUX48tgIg96tWJPdWMxfQSK7IKaHPK+68iE19foYLwzaX+i+Ty0DHZwQsMSV7tHHnyeNoGaPi5REH1U92BapSUJbUBn4WNJjsHrUfNyMbhqMI2hPns9ycqCP+JAVP1fGaPagBag0goT6wWNqeTdu0CaOGCvPFzopFGhfPpA2FC4PLEz3eyXcVAmXy39PhMcZDPJk1EqrJ7XWf+fCzLf00nfJjEIjGgohbOrlyhj8gAaMBiIVJzaFFQoYWSk9xMCiqNzAqaqYCQ5Q8g6DcuzWqGFk8VrlSmsiJjFkw0A2HnCKyJvYlud7VwRrEP+m4hZxFEyZj1s4+W2cJVmN+xOaKnRsFHnTQpVKWFIIL2l9J8PXFLmA4SAssQgAteFK1ywlRq0tA4qjFjZwYWEFpMbiaQWgHBKntUGHT4E8L6nXr3NIs4YZ6QBOYB1AdPq8NM7aBbpEX9Dr9gbSGB7IOMy00XXVAqfasEfp7SeGMFxG0yaraut4ozoz3C+o/X8ZetAOMebotgYcEWtuyELdbOnsLoFJZDTMXj3ZNBtwIig7pE8QyMuy8RnChCJ8fpYYoZxSvqXsBsizV2o1ro6MLwWHZWf2mnR1tcaRkXSLkQ4YtKFK/sus/Dg786Y3CcoAaqDzSIGZ0SIwhL9QRq9iAYyp1MxiUctBGwotFcf3F4gCpQzs70jqThDlvpwJ6IvY6rYX/9mTHmjO8XmKZ6l/DTejDt3vsMldB1iHyEPZoWXyQwXcp7jmWD5vbHLGJBqLTVLKER/Lzue3BAp6iBi5eRFfkusQp4U9xLXiSmY0c2uu+02ayV0gVE8CxbltHtLIO+OlsUQTFkKcuJmxsobDEwX/dsaaE0/I42pp3fRsT6SPEtKdJieIK1ULV3qDDeJiogGBi7ibyGbpO6lSNTLmA+1EHQbSLW8gkqFq0J7dPBDBnFW8ISgbXqzrlaHokAHVCDQM8VTsLLGcRfiElRMUDqCavGDuy423q2hjPBKLDTtapeigM1kZ7ePneYNp/yPv5d3I1zrhJ0IOVjYCjTnOp9bJ0lE0IxAzwWsfhyUy7hAiaBNaeqiM0vmyoHFLiezdgigviVeE41tFTiDD4FY8gvLxQ2LyDtxkN6QwJeLmepIorOr0W1ggoraIq3pX7AdFotIt/89rz9Aiz9Q7LIw4cgRnARkNVC5rxhmqLA1cJMSypD7agWzfwQ1axIm8bdqAGqg5cgWSQN3nhwoH0BxWOMwjqhFK9EGtWA4CVXoD2/pw/oCjJg6CTC1x0QuOay5R8SpYcUFcf5KkfCdqQ/4DFQEkScJReUEcEgF/pXwtu93c98NPsiyBGJ9vAciJOCGB+BetW9ZSnztv1pa3946zpOJvSjRQmIXDZYBGKX71sr5OAsNuqYi8iBc9PdabfdiUVpm7zZ7vSrayIwBVkSyVdPyffungQdKxnomLVFsTFMCUgvLQUhvYHNIDwJIca2w69Af0vHcoryLtM1cPeOp0C6MLngYyXzZpQ+QFdr05yx5y9znYRUd6kHmd0L2dwkTNW6BAMQY5gzjbX/8Lv7mv/YwO446GmtprzZ8OZZeCy2Rz8QnZ1VKvXGZAOML5jVOqGsbi5razkVtOgC4HVMyr6UwsAUCunce2KGMWRURxbu+BkM2sNZE6WGKxNOoLa1OiGpAFs4rlRMDbVkjDgb4Khl5Ul4RMlAgQTblwrjpFqh7KR8ovKSVV/SNACNFt2whYhhijcc8czxU3lG17fGjJx6CCMNkBBoWkjnfzUoYilU8VMq6GM0JO+TuwX2Oa5YYjXUw7elvhe+/B1b4zfQXozClkXWOOrIRTqb2jnV6yDFZtIv/Z1JokibsK+FAv5oI19lDwGA4ofeDfkhDbVDWc15YzhihSChYQSY8xuLpa1nijqBPGOTl+9A1Klq02DvAxHzf6LV9QJa3gKtEYTIS/RhqKiJ+Sdz91eNl+dfSx/wL8OBWCCWH1cijYNr5qXS0fOz9JB0jrBWFM3blAjLuKz8lCzfayw+SzlQV1Wsm7qEKF2ghC1S611Q0VTIoOIy11BMRk7BlkstX3QXlR2CZ/2idS2LoTKWbLWkmY1M5VFoGNEpzLxd+rOqqdW8TsGzAx5WtNWR38bczP/O8dofvno/vqCRPlUv7p69Js8n04CAilaaTSMcmpYGxQuaoXXCSFVv528NAY4IGsAEuzQZ6bvOJ5N+f0i4s/NQ5the539RU2oFUQotE8FOrH6Tt0yAjBICVRYfsfNP0dOwXAFdBIligWE5T9Uw957/uJ0pftOz3YzyIdOiRFlTdKdmj/BxlnVd8hcC/gd7a9gM7evYDvUDFqzSIdoD255Mu41fUZaKBed1Ucwkas6shwgOV4NOARkLpK7IU+UqAe/1i+0QrRF2ViZrPbR606sY8oanTRVXYt/keGRShGsDDTVp9/2fBPcD0WHtztTAVaqGncxWDM47zsX/q36dT9e6GAdNVhfo/f1eakiH0O1rr9tmBIkxaMQN15wBQBC565SEWzBnO6+U8nAlNCaVYM2iYa2PPWqWkNR59UQ3fja3bRTOqLOXyKeoA/SwjBpazqdWdh9L22nITm1ozBZDZ2vn1yMyuIHLSYCGUjW/g5/ILI+ibJfolAq7itTKJl/ypR//egg1zEZ3WWJYeaqM1G4NEBdB/O2EBWllHVsaA+he56EQ1v2Oh6jVnAQch/ndeSfxJUhZA4DK14XqX5Q+agv0GLJWZ/MeL3apCADUx0LByeK0TkzdO9wlE3VeYgbEkCvrbUzqcKp1jFiO0eMGqAvgZ+e8sr6SwQ7giqo7TD8pEPOjiGEUbWMOoTYtOWOpNHhnKKzWVVQEEsHy6E1MY10BJoV6GHhU9YxkIUOcNH7K//4ED7o6HPX4bBcYfqm9hq0ikjmTqjegxF4/RMQ36sJvj7bElCra8huacMXpsf1Oun62RR7f21wj5q3qAooF4WAkylDGeg3OQkRqr3dw3YD2H1nN9Qy0XQ6N5s6DzMGjkObsta+p6ODoGlUWSKk4VZUWfC8w1YnAkkaInoadS/mBKWazGYmC1k9099nShhRMWqIev3xytRBXZL/AI2XFa97OUg+Tu29ywRlOXXgx2uUsdUkBFA4uoS/2ryylhNqOPG+P8XRMWcdglADAXWGakpvn5MRlJedpvNUwBhiQIdiO9n5zgLb0vmNd5KzZ4KrtAnaw3PSP6x2Ld97TizTir8rBEKGmHT/Cy3A7S28fxZiAAABg2lDQ1BJQ0MgcHJvZmlsZQAAeJx9kT1Iw0AcxV9TpSKVDnYo4pChOlkQFXHUKhShQqgVWnUwufQLmjQkKS6OgmvBwY/FqoOLs64OroIg+AHi5Oik6CIl/i8ptIjx4Lgf7+497t4BQrPKNKtnHNB028ykkmIuvyqGXhGEgAhExGRmGXOSlIbv+LpHgK93CZ7lf+7PMaAWLAYEROJZZpg28Qbx9KZtcN4njrKyrBKfE4+ZdEHiR64rHr9xLrks8Myomc3ME0eJxVIXK13MyqZGPEUcVzWd8oWcxyrnLc5atc7a9+QvDBf0lWWu0xxGCotYgkQdKaijgipsJGjVSbGQof2kj3/I9UvkUshVASPHAmrQILt+8D/43a1VnJzwksJJoPfFcT5GgNAu0Go4zvex47ROgOAzcKV3/LUmMPNJeqOjxY+AyDZwcd3RlD3gcgeIPRmyKbtSkKZQLALvZ/RNeWDwFuhf83pr7+P0AchSV+kb4OAQGC1R9rrPu/u6e/v3TLu/HyfbcoluTFgAAAAABmJLR0QAAAAAAAD5Q7t/AAAACXBIWXMAABYlAAAWJQFJUiTwAAAAB3RJTUUH5AMCDyEIJbCbgwAAIABJREFUeNrtnXeYVOXZh+8p2/vCLlXquiyKGtBVNlYUNfaKNdZg76Ix0WiM5ktii7FhD/YaNaCJsSuKIKtSRF1g6b1sr7PTvj/mLC64u8ycnTM75Xdf11xCwpwz85z33PO85TyvDSEsorKsuLv/27nD3z1d/cMNLjcHfrtCARVhx6YQiB5IrQAYaLwKjFdfIBfIA3KAbCADSAWyADvg6ESAXkOCfqAecAFNxp9rO7yqgM3GayOwzvgzAEWzl+giCQlQhEVy+cAwYBQwEhgODDX+uwuQFCUf2QOsAVYCq4AVQCWwxPhzleQoJEDRleySgD2AscAY48+jgcJOMrVYwwNsBX4EvjNe843/uiRFCVAknuxGAeOBUmBvYK84EF2oeA0JfgPMBWYDi4E2SVECFPElvH2BCcCBhvTyFJ1OqQW+Br4APjWkKCFKgCKGhGc3urBHAocBBwDpio4pWg0ZfgS8DywAvBKiBCiiAAewOCC9TOBXwDHAEQRmZUX42WyI8B3gXaB+9OwluBUXCVBEPNMbABwPnGBkesmKTERxG93k6cC/gXXKDCVAYa30CoBTgbOB/Ui8iYtoxQN8BbwKvAZsOvCrpWzw+RUZCVD0UHoZwImG9I4wer4ievERGDN8AXgLaFBmKAGK0MRnA8qA3wCTCDxBIWKPJkOCTwKfA37JUAIUXWd7fYBzgIuA3RSVuGIp8BTwDLBZIpQAE56JGUk8tudwgHHA1cBpQJoiE9e4gH8BDwJz71yylmermhUVCTDhsj0HcLIhvgMUlYTkK+ABQ4huZYUSYCKIL53A2N71BAoNCLEG+AfwBNAoEUqA8Si+XOAq4BoCY31C7EgN8IiRFW6VCCXAeBBfH+BG4FIC9fGE2BmNhgjvAaokQgkwVjO+64HrCDyqJoQZET4M3KeMUAKMFfGlGd3c3ynjE2GiHvi7IUKNEUqAUSk/B3AhcDsqRiCsYRNwB/Bk0ewlqsEgAUZN1nc4cD+wuyIiIsBiYArw36LZS/TAsQTYa+IrNrolxyoiohd4n8A48/fqFkuAkRRfBnArgQkOlaESvYkHeIjA0Eu9RCgBWi2/k43u7hBFREQR641u8SuSoARohfgGA1OB4xQREcW8B1wGrJAId45dIdip/GzA5cAPkp+IAY4EFgHXV5YV6/5WBtijrK8ImIaKFYjYZA5wPrBY2aAywFCzvisJ7AIm+YlYZTwwD5iibFAZYLBZ3yAj6ztcERFxxEzgXGCVskFlgF3J7xRgoeQn4pCDjLZ9ttHWhQQIZalOKsuK04HHCRSmzFezEHFKNoHNmp6rLCvOOjQ9SV1gZX3sRmArQz3GJhKJJQS2YFiQyF3ihM0ADfmdA5RLfiIBKSYwS3xRIneJEzIDrCwrTiFQdfcS3QdC8CxwWdHsJS0SYPxnfYOAN4D91O6F2MY8Ao95rkykLnHCdIEfLeoHsD/wteQnxM8YS2A4aMLLoxOnnGVCZIBG5ncBgZleTX0J0TUeAhXNpyZCJhj3GaCxAv4e4GnJT4id4iSwIdPDRpVzZYAxLL904EXgRLVrIULmXeD0otlLGiTA2JNfAfAOsK/asRCmWQAc/eq6qvW3rK6SAGNAfAAjCdRFG6n2K0SPWQ38Cvgx3sYF42oM0JDfOOBLyU+IsDEE+AIoi7dF03EjQOPCHAx8AhSqzQoRVvKBD4Aj40mCcSFA44IcbXR7s9VWhbCEDGAGMCleJBjzAjQuxKnAdCBFbVQIS0kGXgLOiwcJxrQAjQtwNvAygfVLQgjrcQL/BC6IdQnGrAA7PN3xnOQnRK+446k2v+2C8tKSmP0SMbkMxpDfrwlUsVBVayF6gTa/jSavzQdMBqaVlldIgBGS3yQC4xDK/IToPfm1/9UHTLbbmLb33NiSYEwJ0JDfscBbkp8QUSG/drzAmcDrsZQJxowADfkdAvwPzfYKEU3ya8cNnAC8GysSjAkBGvLbh8Ai50w1QyGiTn7tNANH2GDWPjEgwViZQNgV+K/kJ0RUyw8gHXjHD2NiYXY4qgV4Yd8MKsuK+wPvAwVqhkJEtfzaySUwVDV4ysDo3mU2qrvAlWXFGcCnRvdXCBH98uvId8CBpeUVdcoAQ5efHXhV8hMiJuUHsAfwRnlpSdRWYo9KARqTHvcDx6gZChGT8mvnMGBqtI4HRp0ADfldAlytZihETMuvncnAtdEowagS4AiHDQJr/R5SMxQiLuTXzn3AUdEmwaja9al8fPFQ4EMgS01RiLiRHwQmXI8F3sjy+6pnN7YoA9yh65tG4BG3vmqKQsSV/NrJAaafNbgwatbzRoUAK8uKbcCjBHanF0LEn/zaGe2Hf5aXlkTFErxeF6Ax6TEZOE9NUYi4ll87k4Cro2E8sFfHAA35jQXeQNVdhEgE+bVzGPChu821dn5zW8JmgFnAa6i6ixCJJD+AJOCVK4cP6tVn5XpNgEb29xhQpOYoRELJr50hfniqNz9Ar0TBkN+5BEraCyEST34duRx4tDdqCPZWBjgceFjNUYiElx/AvUCvzIhEXICVZcUO4Hm02FkIyS9AOvBibxRNiKgAja7vDcD+apJCSH4dGAfcGumlMZHOAPcA/qQmKYTk1wm/J8Ll7yIWmcqyYifwlWF6IYTk1xnfA3uXlle44iYD7ND1lfyEkPy6Y3fglkh1hSPVBd4V+KOapRCSXxD8jsBwWewL0Mj+ngBS1TSFkPyCIAl4ct5+JZY/qmtppAz5nQc8o6YpogqvB3xt2Pvugq1gEPasbOwZGdicgZUYfq8HX1MjvsYm/FvW4duyCmxOcETt9hbxIr+OWL5A2uoCBLnAPbrbRK/i92PPLyT18BNIKSomedBgkvr0wZnXB3tyMraU5G5zAX+bC1+bG09NNe6aatrWrcNVuRjXp//Du34F2Hq/qlwcyg/gL8CbwKaYywCN7G8qcJnuQBFp4dmy+5B25Imkl44nrWhXkvsPAFv4m7t7y2ZaKpfS/G05Le++ha9qfcSFGKfya+d54FyrskArBTgOmEuUld0XcYzdTvppk8k6aALpo0qwp6VH1rsuF82VS2ic9TlNL0zF73FLfj3HBxx0xcLKWXNdntgQoFHheSZwgO5KYXW25xg5hpxzJpM1/pc4c3Kj4mN5GxtpKP+Kuleew7NgFtjDnwckgPza+RoYX1pe4Y0VAZ5GYFNzISwjaa8y8i64lMyxe2NLis7JCb/XS9OihdQ89zRtsz+Q/Mxzwcrm1mcmfb8yugVYWVacCvwIDNMtKqzAMXIM+VdcT1bpeGyOGBlh8floXDCP6icexr1gVo9uvQSUH8AGYNfS8oqmqBWgMfFxI3C3blMR9u6KM5ncG+8k9/BfYU+NzWWlfreb2s8+oebuW/E31kp+ofEn4PZwToiEW4D5QCWQp9tVhM8aflImnkThFdcGZnPjAHd1FVueepSWN58JenwwweUH0AiMLC2v2Bx1AjSyv7uNDFCIMPV3neTfei+5hx0RO93doMXuo/7LWWy9fQr+pjrJLzgeBS4PVxYYzgVLg4ArdX1EuHCOGsug594m74ij4k9+ADY72fsfyODnp5NUOkHyC47JBCrKh+f3NYzZ319QoVMRJlKPPp2Bd9xFcr9+8Z/kZmaRNeEw3C4f7kXfSH47d1bexYP6/vvJ9VujJgMcClysayN63i30k3XRDQy86VYcmZkJ87XtqWn0v+o6cqbcCT6v5Nc9ZxOoMNX7AjSyv5uBZF0X0VP55f72/yg8f3LUruuzukvc95TT6PPXx2jzIfl1nwXeFo6ageHIAAcT2OJSCPP4fOTdei99TjrVkmd2Y4ncCRPpe9/TCR+HnXBGOLLAHgmwQ6Vn1foTPcr88m65m/yjj6eXtqqOOgr2P4Ch9z0Gfr+C0TlO4MaeZoE9zQD7ABfpWoiekHPNbeQfd5ICsaMEDziIQXf+XRLsmnOBgb0iQCP7u5rAnp5CmCLjrEvpe9pZCkQXDDjyKAqu+b0C0TkpwPU9yQJ7kgGmE6jYKoQpkvc/ksKLLgO7XcHoCpuNIWecTdZJZysWnXMRkNMbAjwH6Kv4C1MNr2Aw/X93G/YUDR/v1IFOJyOuvJqkUXsoGD8nG5hsNgs0JUCj3t+1ir0whd9PwR33ktRHv5/BkpSVzcjb/6JAdM6VmHyow2wGeDhQorgLM2RdehOZe41VIEIkc2QRA26RBDthGHCCmTeGbE1j8uNBwrQSWyQWjuK9GHDTrVGx0NlTXUXL8uU0L1qAu6aGlAHbTyg2//g9TfO/xdvchM3hwJGW3utr87KKiqj9oQLP2pVqTNvT7+JBfZ8N9fE4M7vCjQCOULxF6F1fHwVTbon4Xh3bTu/10rqsksZvyml+bwaepQvB7wNsZF10A1nj9tnu37cuq6TmL79tfzeOIaNIP/okMvYuJX3UaGxOZ8S/g82ZxNBrb6Ri1oeWlNmPYQ4CdgN+sEyARvY3Geu30xRxSPqkyWSM2TPi5/U2NlI/ayb1Lz+DZ/G8HXZtCzajs+FdvYSGx+6iwe/HMaSY7F9PJvvAg3HmRrb8Zebw4fS98ia2Tr1Xjeon7MAl5aUl14RSKivUMUAncKFiLUJvnnb6nHVuRLuQPpeL6v/9h1WnHk71n67Ds2RBeLastNnwrllKzV9vYvWpR7D1jVfxNjdFNJyDTjwFe04ftavtOZfA2kDLBHgs0E9xFqGSdfGNEa3m3PTDItZcdj41d1yPv77aum51cz11993GmgvPoOGb8oh9v6TcXPpddYMa1vbkApMsEWCH7q8QoSVMSSnkHXN8RM7ld7vZ8uKzbJx8Kp6KbyPXzV69hM1X/ZpNjz2Mr6UlIufsP/EI7PmFamDb85tQ1gSGkgEOQJMfwgSZ510ZkTV/3oZ61t1xC/WP/AXonednG597iLW/vx731i2Wn8uRnk7hpdeogW3PgYRQMToUAZ4OJCm+IiR8XnKOPMry03iqq1g75QpcH03v9a/snvsxK666iOZ1ay0/V+HBh2BL1tM0HX8XCBRMDZ8Aje7vOYqtCJXUo04nZdAuFsuvmnW/uxbPorlR8Z1dfhv1yxaz+IrJtGxYb+m5kvPyyT37N2po23P2+2OD6wYHmwGOAsYpriIk/H6yjznB0lP4WppZf8ctUSW/ZqOSs3f9Kpb89jrcdbWWnrPg0Ing86m9/URJnjM4X+1UgEb2d6ZiKkLFltePjDEWPsDv87Fp6oO4534cdfLb1h1evJDKe/6G3+Ox7LxZu+5K0ui91OC258xgJkOCzQBPUzxFqKQfNwl7applx6/99COa//XPqJVfO03vT2fdv9+w7ofG7qDPCaeqwf3cWTv1WzAC3B0VPhAmyPzlgZYd2715E9V/vikq9s3oTn7tbLz3ThpXLLfsM+SO21uVo7dnCLBPOAR4CtqoQYSK30f6rsWWHX7Ls0/jb23q9a8ZjPwC3XUvqx7+B36LxuoyhgzFUThQ7e7n7jIvQGP87wTFUYRK6pGTsKdnWHLs5sUVtLw5LTwH83lJPfxk0jspz5VaVEzasWcaBRN6ID+Dls8/oNqip0VsTifZR+tW3YETdjYOuLOiBrug2V9hgrTS8ZYdu+bVF3r8TK8tNYPsS6aQM/HILhdpp5eMJv3m2/FccS11n31M3dR78ddXmZJfOxumPUn+uH2wOcJfySVrz19Qo6bXkVEEhu8qzHaB9ZMiTHR//aQMH2FNl3P1Klr/83KPjpFyyLEMfuk/9D397KCeUHHm5NLn+JPZ5aW3ST3mTNPyA2idO5P6ih8tiU3m8BHg9aj9bc/xprrARvf3WMVPhC5ALykDB1ty6PovPgOH+WpsGWdewqDb/2qqMENSfh+yr7gW/+k92AnW7mDLh+9bM+zQr19UFJqNMo7rrhvcXQaYARyg+IlQcQzdDWd2dvi96nbT+MaL5rvlJ51Hv8uuxpacbOr9DQ0N1Dc1knvqaaROOtf056h79Rk8TeGfwLEnJZP6y8PUALdnXyDfjAAPMCQoRGiZ0qjdLNnqsnXNanzrlpmTctEe9Lv8atNVnBsaGqivrwv8xWYj99TTce6xj6lj+T1uGpYusST2aaNGqwFuTzJwiBkBqvKLMCfAXa1ZNtq6ZLG5MvB+H32vvxlHRmbP5WdgS04m58KLTX+Xhh8WWRKjHfc1Ed27rFMBGuN/yqWFKZz51lQqbv3hO3MpwPiJpneh60x+2447bDjJhx1j7rhfW7McJrmgQA3w5xzW1ThgVxlgX0APFwpz3U2LBNj29SxT78s+6TRTT4x0J7920idMxEztQde3X+Jrawt/9p2ZpQb4c4oIPBkStAAnKGbCtABNTjJ024ttc+GpMJc1pZfsZon8gMByHxOz0t7qTXgaGsIf+9RUPRLXOYcGJcA3dh8M3QwaCrEz7Onh3/bSU1cHSaEf1953IEkFoZWNb2ioD0p+7d/VuVvo3WtbchruhvrwCzAtjd6qhh3lHNxZN/hnAtwrOx0Ce2wKYdKA4X/Kwe92mzquc1hRSN3fQOYXgphsNhwDB5mKkdcd/kXL9tQ0+a9zDmzx2YLqAucTeIRECHM3YUb4V0/5fD5T43j2vODHI0PJ/H4ysx9MLj72y1SRZHia3T8gGAGOQ3t/iDjBF6TQAvIz0SW12cBksVObiixF9HcZ2C8YAZYpViJe8KxYap38DLxm9v3w+XAkOcP+fX2uVhWv65qgBLiv4iTiJgPcsrbbLSp7Kj9fSzPeHxeE3v1ta8GZmRn27+ttaUEG7JJ9F+w7qmsBGgug91GcRNzg99O8uMIS+QG0rVyJ39Uaen8sO48kC56X9ra2RkWV7CiltM1v6zYDHAj0V5xEPNHwzls/WxsXDvkBNM/81JRwUvfeH3tySvi7/I2NuuBdkwXs2p0AVfxUxB2uT2bQ1OHZ23DJr23dWlzvvmnqvZn7WDPS1LZlsy5494zrToB6/E3EH3YHW/9xF77WlrDJz+/xUP+c+bL8WbvtbslXbbV4I/Y44BedCtAY/9tT8RHxiOf7clY9/AD1teHZpLz+7em45840KWQ72cXWLLVtrVyqi909e3R8ImTHefg9FB8Rl91gv43m154lzW4n59TTze/J4fdR/793aX7uMdOfJefks3FmhX8CxOd20/rlx7rY3TOm4186CjCdLiomCBHz8jP28Gh5ZRrezZvIPecCHLm5oQmmqZHaV1/GNeNV8zOtfj99jzzamuxv8yZ8LU092jIgARgA5AK1OwpwEKoALeJNfj4bzTs8A9r28X/ZUv4lGRdcSkbpftizsrqtoOJraaF53jc0Pfskvs3re7TMJHmPfcjdfYwl37Vp5UrJL4hLAAwD5u8owBLFRsS7/LYlYg21ND74N5pS00me8CtS9tgTZ2F/7OlpAem1tuLZspm27xfh+uhd/E3hqdwy4MJLTJfl3xkNixbqogdHSWcCLFZcRCLIbzsRtjbjevfNn5aztGeCFiwmTi09kL7jrXnS1O/1Uv/f6brwwbFtLWDHZTAjFReRSPLrFJvNmicp/D6GXDPFsuyvec1qPOtX6eIHR9F2Apw1bjjACMVFJLT8LKTgmpstW/oCULtgvh6BC57h7Uth7AD9UpIAhisuQvILP2kHTGSX086w7Ph+n4/q6W+oAQTPiM66wFoCIyS/MOMcVkzRzX+05LnfdppWLMe1YK4aQfAMxJj/aBdgXyBVcRGSX/iw9ylk13sfJKVvX0vPs+WTj8DhUEMIHhuBZX/bBDhYMRGSX/hw9BtE8dRpZAwZaul53HV1VD//pBpC6AzuKMBBioeQ/MJD8u7jKHnieTKHWz+vuGXW5/hbmtQYzHWDt60DVA1AIfmFgexJ5zLi0itxZlm/Qbm3pYVNTzysxmCO/h0FWKh4CMnPPPb8Qgbf/CcKDzw4YstRNs/8FK/W/oVFgAWKh5D8zNH3it8y8ISTSA6xuEJP8DQ0sPGhe9UgzNOnowD7KB5C8gsh48vtQ59zL6b/kUeRUhD5/GH9OzPwblbx0578bpWXluA0CqHmKx4imvH66V35+X3Ys3LJOfkscvcrI3fMGBxp6b3yUZrXrmXzP/6sRhHGDDBP8YgXU3jA5seWNwB7fj/smZnYs3NMH65t4df4G6pjMhS2tAzS9ikj1G0ibXY7jj59SCrsT1JuLqmDBpM+aDBp/QdY9ixv0B72eln1yD/Ar6beQ3I7CjBH8YhBfB4cA4aTcsivSCkqJnnQYJLy83Hm5WNPTsGW0vOnD9bcciNtn8yIyfAkjxzFbvc9FFeXfONHH9D04Tt67rfn5HQUYLbiEQP4/dhyC0j71Umk770v6cWjSCootPZmiOFMw290XbHZ4+LyN61Zzfo7fif5hYeMjgLUY3DRjN1OxpmXknXgwaQVl2BP1eVKuJGN5maW//mP+NtcCkZ4SAKcTkOCSYpHtKUvPpwl48g++zdk7zceR5aS9MRtCj5WPD4V17w5Ckb4SAZS2gWojQSi6adp74PIO/9iMvca2+uD7qL3WffWv6h96Sl1fcPcrwJsTsBhvEQv4xy9N/mXXkPW3vuAXZdEwObPPmHjXbdJftZ0gZOVXkQBttR08n77Z3IPPRxbcrICIgCo/nouq2+6ilCX8YgQkg4gxegPi0jj95F67NkUXnx5YDZXCIOa+fNYcc3F4PMqGBYLUPRG1peSTv4f7yX3oAlgtysgYhtbv5zFyusu6navYhEedOf1Akl7ljHo+enkHnKY5Cc69Aj8bHjvXVZeO1nyUwYYn6SfcgH9Lrsae3q6giG24XO7WfX8M1RNvVc/ihEWoAtokwyt/3XPvvpW+p52Fjbt3yA64KrayvJ776Lpo3ckP2WA8Sg/H/m3/Z28o45TLMR2VH/7Nav++Hu8m9YqGL0kQJ/xEhbR58+PkHvYEQqE2Ia7oYHVzz9DzbSH4+ZZ5Vi7BIDb2f4HxcOizO+OhyQ/0aFJ+Ng650vW3nUH3g1rJL9evBSAzwl4JEArwusn9/d3kXf4rxQLAfipr6hg7VOP0TzzfYWj93EBrvYxwFbFI7xkTp5Cn+NOUiD0Q0j9ksVseO1lGma8qkfaoqsL7GkXYL3iET5SDj+ZwnMvVGNPYHwuFzUL57Pp1Zdo/vR/gdldtYdoogl+mgWuUzzCg2PIKPpffxO2JFUYS7hkz+ejacVyqubMpvqVZ/FuXBuQnpa2RCN1HQVYo3iE42ffS+Htf8OZk6tYJEo/qq6WxpUrqf9uAbUz3sS9YvFPmZ4yvmimFsBZNHsJlWXFEmAYyJlyJ+kluyV0DFw+G954e4rL78fv89JWXY2rpobWDRtoXrGchi9n0vbd1/g9Hkkv9qjqmAFuVTx6hnPPMvJPODkqblZ3dRVtGzfg3rAeT10d3qot+F3mSql7fpwfkvyiadNyz5qVLHvwHyaqSdnwNjfh9/rw1NXgqazAvfx7sCeDs5OhDUkvFtlaWl4hAYan6+uh4PrfY09O6ZXT+71eWpYupumbcprfexvP0gXGTRm5GzPa5Afgq6um5sUnw3Ow5Ay18/iiumMGuEnxME/m+deSXjwq4uf11tdR98VM6l98Gu/yHzp0wyI76B6N8hNiJ2yQAMOALTWT/ElnRjazaWmh5v13qZt6N/6Gml7thkl+IkbZ2FGA6xQPc2RfdiNJffpG7HyNC+ez9e478C7/vte/u+Qn4iUDVCkKM9lfeha5Rx4VmazP5WLrS8/S8OS9RMMeEZKfiHHWdBTgFgLPxqUoLiFkfxdPwZmdY/l5PLU1bPjL7bR98T/JT4jwsK6jAAFWAcWKS5A4k8g55FDLT+PevIl1N16Jd+nCqPjakp+IE/l5wNgTZJPLDbBScQme9OPPIqmwn7Xy27KZdTdcIfkJEV62uc4OsP+3KwBWKC5B4veT/atjLT2Ft6GB9X+4EW/ld5KfEOFlWWl5xU8CNFiquASHfXAR6SWjrfOr18vGB+7B890cyU+I8LN8uwxQAgyNzBNPx+a0rtpLzbvv0PrfVyU/IaxhcWcCrFBcguv+Zuyzr3XCWbuGmnv+IPkJEWEBrgOaFZvusWXlkTZshGVy3fLkVHC3WXLsUDbblvxEnNJGh/mOjstgmggsDhylGHVN6uHHY0uxZrlk48L5uD54MzwH87lJPeYs0vbej+RBg3GkpgZ2gWltpW3dWlrK59D635fBkST5iURiA0YtwB0FCPCdBNg96WNLLcr+fNS8+EzPM9T0bLIvu4HcQ4/AmZfX+T/aaywcfRyeq6dQ++F71D/+d/zN9ZKfSAR+6PiXbV3gotlLABYqPt1LKmXESEsO3bJsGW2fvd2z7PSIU9jllf/S95TTu5ZfB5x5+fSddCa7vPQOKYedKPmJRGBB+xKYzjLABYpPN3haSRkwwJJD13/6Uafd0WDJvPBaCs+fbGp2OqmwH1nX/ZbajCx480VdZxHXAuw0AzT4WvHpRhSlE7GnpoX9uD5XK02vPGX6/RlnXkLhBRebXppTX19HY0sLuWedQ8pxk3ShRTzzbXcCXA9sVoy6EOCuJZbU3WtZtgx/c4Op9zr3KqPwosuwORym5dfQEDi3zeEg96xzcRSP0cUW8UgDsKRLARrjgOWKUxcCHGrN8pfWxT+afm/BVTeYzko7ym9bg0hNJfs3l4LPqwsu4o2f9XA7q50+V3HqItvKzbPkuK3zzI08pBx6POm7mcvWOpNfO6m7FpO0/0RdcBFvlHecAOlKgHMUp85x5OeH/Zh+j5u2heaS7pwTTg27/AJ9YRvpE4/UBRfxxlfBZIDfAG7FqhMBJieH/Zi+Vhe+VYtCf6O3jTQTGzHtVH7t2eXIkWC366KLeMHXWXLXWQuvQoUROknV/NhTU8N+WG9dLSSlh94d33P/kKtRBys/AEduHvZ+g3XdRbywisAkb/cCNIqjfqp4dWYFR9gP6WtzgcMZugAHDAppRjoU+W37usNG6pqLeGFmZ//jzwRoFEf9QvGKbuwh7ESX5VpDAAASvElEQVRnRn74/dj7DVCgRbzwxY4TIF11gQE+UryivEdeV2ud/ABsNvxVWhIq4oYPg8oADTYDixSzHfCGf22cPSnZ1HHd69YCfmvkZ+BZUWnCzH7szvAPFfg9HrU/YZYVdLHnUacCNBZEf6i4dcyIAnvzhhtHTi64G0OX08JZeLuRW0/l562rw7dhTeiicrtIysgI/29Pc6PaoDCd/XXW/e0uAwR4X3Hb3oC+tvAXKrWnpmIfZKICmc1By9Ilnf5fdXU9kx9A24rlpjJTR24fS/ZK9jSrVq8wTZcu606AnwMtil2Hm7CmOvxaTUoi6RfjTb23/t23O838Ghsbevy5mj/72NT70iccZU3sm5rUAIWp33LgEzMCbARmKX4dBVhjyXFT9xpn6n0t/3mZlsolYc38AFwrV9D20Tum3ps5Zk9rWvGmjWqAwgxfE1jbHJoAjXHAtxW/n3CvXmnJcdNKdjPdLd869QH8bW1hy/z8bW3U//MJsJuYyPD7ySwpsSRGrevXqwEKM7zT1fjfzjJAgOmKXwcBLq0IaWOhoAVYVIwtxVxFl7Y5H7Lyialhyfzw+6l743U835krzmDP7UvWyCJLYt+y4Fs1QGGGbh22MwGuQlWifxLg1x9ZMhNsT0sjfdIF5jIjn42q5x6nbsa/wecz/yF8Puqmv0XLa9NMHyLnxNNwWFAw1tPUiHupVmWJkKlkhz1AQhKg0Q1+S3Fs73E6adu4wZJDZ0+YGHINvlafjRZjD4/mfz5M9VOPd7s0piu8DQ1UP/Eozc8+Cpgs+Or3U3CoNSW0WjduxO9qVfsTofLv7rq/wWSA6gZvJ0A7rSuWWXLo9FGjSSqdYEp+gc9mw/Xum2y59hIav5iJb6fLRmz4mpto/PwztlxzMa73/t2jz586/hCyS0ZbEpvGlSvMjUmKROeNnf2DYJ7Cn0+gjHSx4gkt878ld4IFmY7dTt55F7H5m5mhy69jIla9hYb77qQxI4uUw44m/eAJP9vJzrVsKU2ffUrbR++aLsW/Y/Y38ILJlmwXANCwYJ4angiV1QRR3DnYgm//UjwNAX4wA7+7zZJjZ43bh+T9jzQtv+2c1NRA64xXcVX8vNy+a9EiXG+/Fh75AemHHk3eL8ZZEhOfu42GGa+p4Qkz2d9OB8V3KkBjHPAFxdMQS81mWlettObgdjsFl1/TY/lFOCIMvexqbBYVT21cvgxfsxZBi5B5aWfjf6FkgD8aXWFhs9H0jXX7RqUOH0nO9XfEiPyg/+/uJGPYMMuOX/vNN2pzIlSWEuQWv0EJUFngDlnJjH/h91q3a1qfE04mZcJxUS+/jCNOYOBxJ1qXW3o8VL+l7q8ImReCyf5CyQABXgFUkwjwLl9Ey9LF1iWZSUn0v+FmHEV7RK38kkbtycgbfoc9Kcmyc9QvrsCzYrEanAgFH/BisP84FAGuQyWyDEPZqf/wPUtP4czLp//fHqBtwPCo+/qOQcMovut+knNzLT3P1o8/1MZMIlRmAUGvVQu6dRnd4KcU3wBNr0/DU11l6TlSBw6i+MHHce4SPXtzOIcUMeqhJ0gbONDS87iqqqh57lE1NBEqTwXb/Q01AwSYQaBatHC7qPvsE8tPk7HLEEoefZqUseN7/SunjCuj5NGnSR+8i+Xn2vzxh2BT9idCog54PZQ3hNrC3MAzirMR7Sf/gTcCdepSC/sx+u8Pk3vmbywpxrBT/D5yf30xo//+MKkFhdb/tjTUs+WJh9TARKi8QIg1TEMSoNENfhLwKtbgr91CrcVjgdu6nhkZFF07haEPPIWjcGDEvqOj/2CGPTiNoquuxZmeHpFzbvrwA3x1VWpgIqTbEXg8lO6vmQwQAhUWNBnSngU+eg+eIHdo6zE2GwW/PIAxL71JwdW/w2ZiP+GgT+VwUHDNzYx54Q36lv3SssfcdqSttobND92thiVCZRbwXahvClmARhb4oOJt/OzUV1M9/c2InjMpO4ehvz6PMW9/QuF1f8CeV8DOdogL9kfUnl9A4ZTbGPPOpww9+xySsrMj+t3WvfE6vsZ6NSwRKg+Emv1BcMUQOuN/qEDCNhqm/h/ZBx1C6rARET1vSt++DDnzbAaddDJ1339PzVezqZ/+Gt6qTcFXT/F5cfTpR/aJp5O3Xxk5u+2OIzW1V+LYuHwZVY/frwYlQmUNYKqckel+TWVZ8RXAw4p9gOTxExl81z+wWbgwOKgczuulZcN6mtetw7VhPeTnk7Lb7viNyRObzYZr0XdQV0dq/wGkDR5MWv8B2By9W27K53bzw5SraJ3zmRqTCJWbgLvNZIA9EWCGYd48xT9A3s13k3/sCQqECda+9QYb//oHBUKE3AEDhpaWV5jasawnC62agKmK/0/U/PUmWlcsVyBCbcGVS9l09+0KhDDD04Dp7Rp7NLVXWVZcCKwE0nQdAjiLf8Hgh5/GkZmpYASBu6GBHy6fjHvxQgVDhNx8gJGl5RVrzB6gp0vtNxsGFgaeJfPZ9Mj9llaLiRf8Xg/LH7pf8hNmeYHAMJxpeiRAY0nMfYaJhUHL9BfY+trLCsROWPPKSzS89ZICIUzlGsDfzEx8hDMDxOgCP6vrsT31D91B7UfvKxBdsPH9/7H5gb9GbIG1iDveJLAUr0eEpfVVlhUPJVCFNUnXpWMfz0f+fdPI++UBikUHtsz6nFXXXaxACNN3FjCmtLzih54eKFzlNlahIgk/o9XvYNmUy6ia+5WCYVA1dw6rrr9EgRA94Xl2suF5RDNAIwscbGSBqbo+O5Sx9/sZct9jFB50SELHZPMnH7H6t1eo2yt6ghvYvbS8Ymk4DhbOgmtrgcd0fTrftHz1DZey/u3pvVPOqtdHAnysm/4Wq2+6UvITPWWakWiFhbC2xsqy4j7AciA7Ua9Ot3t4+H3kT76GYef/BntKSkLEw9fmYuXTT1L9z4dU4FT0lGZg19LyivXhOmC4W2QV8DfJr6ufGzvVTz9ExR9uonVL/BfWbt20iR9vuoHqaY9IfiIc3A+sD+cBw94fqSwrTgcqgF0S6cqEunubvW9/hv7xr/TZb3xcxmPrV7NZfdtN+Gq26LYV4WAzUFRaXtEQzoOGvQTIAAfu3bPSNwGnSH5d429upPbd6TS3uMkqGd1rJajCTVtdLSsee4SNd92Gv7VZt60IF9eubG6d8/qW8BYftmREurKs2A58AZRJfkH8CvUbxKAbb6Vg/wN6vSyVWfweD1tmfcG6e+7Eu3m9blcRTuYD+5SWV4T9+VLLpuQqy4r3BWYT/nHGuJJfR9LKJjD4kivIGb1b7MyW+v3U/fA9ax9/hJY5n+pWFWFvYcChVyys/HSuyxP2g1spQAjsI/wbyS8EfF4yjzudAZPOiG4RGuLb8NrLNP7n9eArUAsRGq8CZ/T0md+IC9CQYB9gMdBH8gtdMGkHTKTf6WeT94uxUTNG6G1poWbBPDa9/AItsz+2ugmJxKYeKCktr9hg1QmsFiDAZAJbaUp+JnsAjoKB5J9xLvnjf0nmiJERHyf0e700LKukevYsal59Hu/Wjbo1RSS4BnjQquzPcgEaErQBM4GYrwgQefn9HOcuI8g7cRLZe+xF5vARJOXkWHIed10tjStWULdwPrVvvY5n3QrdjiKSfAPsZ8XER0QFaEiwhMBMTsw+/hAN8tsxMwRIGVtG5vj9yRgxktT+A0jJzyc5Pz/oPYP9Hg9tNdW4qqpo2bSR5mWVNM6ZhWvebGP8UV1cEXE8QGlpecV8yxOKCH2hCuD/gDskv/D+drnmzcE1bw5V7f+zzwueNpxDdiVp19E4C/phd25/mX0eD54tm3Av+QHPmkpwJv98EkNPboje414jYYrQXRSZLDAZKAf2lPyEEN0kS2NLyytaI3GyiP3MF81e0gacRwyVz5f8hIgoXuCCSMkvogI0mB8r3WDJT4iIcw8wJ5InjPgdXllW7CTwmNx+kp8QwmAhsG9peYUrrgVoSHBXYB6QIfkJkfC0Epj1XRTpE/fWVN9S4FrJTwgB3AQs6o0T99rdbjwl8howSfITImH5L3BsaXlFr+wV0at3fGVZcY7RFR4u+QmRcKwD9iotr6jqrQ/Qq6tdL5y/vA44A2iT/IRIKLzAWb0pv14X4MwWD8Bc4DrJT4iE4vcEagT0KlFx9xsFE14AzpL8hIh73gJOLS2v8EmAP0kwg0AF6T0kPyHiliUE1vvVRcOHiZon3otmL2kCTgSqJT8h4pIG4MSX126ui5YPFG0lP5YTmBTxWHFwyU+IXsMH/Br48e8bqqPmQ0WVAItmLwH4AJgi+QkRV9wCzLCyurMZotIIxiLpR4FLJT8hYp7ngPN7a7FzzAnQkKAT+A9whOQnRMwyEzi8tLyiLRo/XFSbobKsONsI4F6SnxAxRwWwf2l5RXW0fsCornv+l6Xr6oFjgDWSnxAxxUbg6Bkbq6qj+UNGvSGM8cDRBGoI5kt+QkQ9dcAEYF60TXrEVAYI22aGfwSOBZolPyGiGhdwUizILyYE2EGCs4GTjQBLfkJEHx7gdOCTWJBfzAiwgwTfI7CY0iP5CRFV+IALgemxIr+YEmAHCf7LCLRP8hMiKvADlwDPx5L8Yk6AHST4PDAZ8El+QvS6/K4Fnoo1+UEMzAJ3RWVZMa0+2wUtPttTsShyIeJIfg/GovxiMgPsmAm2+GzT2jNBtUUhJL+EyQDbKS8tgcDEyDTAqXYphOX4gIuAf8ay/OJCgB0keArwIpCi9imEZXiA84CXYl1+cSPADhI8nEC57Qy1UyHCjovANrZvx4P84kqAHSS4H/AO0FftVYiwUQucsKXNPfPoBcvi5kvF3foRQ4IlwLvAMLVbIXrMeuAoYGG8ZH5xK8AOIhxAYNf5X6j9CmGa721w9Jsbtq7+y9qtcffl4noFcXlpSRbwCnC02rEQIfMxcEppeUVtvH7BuF5AXFpe0ZBk43jgYbVlIULiKeDIeJZf3AsQ4BdzK7zAVcBlWLTbnBBxhA+4HriotLwi7u+XhHmI9oniwYzNyTwEeB3NEAvRGbUEtqV9L94mOxJegLBthngY8CYwVu1diG18D5wIVCaK/BJOgB1EmAo8RmBFuxCJzivA5H3LK5r8CfbFE7KKSml5RStwPoHnGVvV/kWC0kZgfPys0gSUX8JmgDt0ifcCXgOKdT+IBGI5cCYwN5G6vBLgDhyQlsT9Y0ZmAY8A5+i+EAnAa8Al8b7ERQIMPRs8G5gKZCsiIg5pBK4jRqs3S4CRkeBQ4DngIEVExBFzjB5OpeQnAXbL3NISuy2wGPQOIE0RETFMm9GO70qEhc0SYHizwVHAM8B4RUTEIPMIrHZYqKxPAjQrQjuBcZM7gHRFRMQArUZ7vbe0vMKtcEiA4cgGhxNYPH2EIiKimM+Ai4ElyvokQCtEeCZwHzBAERFRxGbgt8CzEl/waD/dEDAa1ssEKk7fj6rLiN7Ha/RMSiQ/ZYCRzgbHGCKcqIiIXuruXgfMk/gkwN4SoQ04FrgXPU4nIsMK4EbgzdLyCr/CIQFGgwiTCQw+3wYUKCLCAqqB/wMeLi2vaFM4JMBo7BZnAjcAU4w/C9FTmoAHgbuAOnV3JcBYEGFf4CbgCvQ0iTBHK4EJjruBDRKfBBiLIuxviPBitJBaBEcLgU2J7gbWSnwSYLxkhNcDlwM5iorohEbgUeDvwEaJTwKMK74pLcEHWcClwNXAYEVFABuBhwiUYquV+CTARMgIk4FJwDVAqaKSkMwHHiCwuN4l8UmACcXl/XK5YEh/G4FqM1cDJwEpikxc4wZmEJjV/fzNDVv9f127VVGRAJUV2qC/Hy4AJgMjFJW4YiXwNDANWKdsTwIUXXePbcAEQ4QnoNnjWKUVeNsQ3weAT+KTAEVoMswFTgZ+DRyiaxYTfA68APwLqJb0JEDRA0Y47Lw6rhhgIHAGcBqwD+BQdKICH4EJjdeAl4A1589fyvduryIjAQqLMsOhRvf4RAIbOEmGkZfeLOAtApMay/zAvsr2JEARGZKBWQEZ5gHHGK+JBBZdi/BTDXwMvGO8qg7+uoJm1WORAEXUZIZOYG8CpfsPA8oMV4rQ8QBfAR8C7wFfA26N6UmAInaEmAocABxsdJXHoSo1XdEILABmAp8CXwDNEp4EKOJEiDZI9cPuBBZf72dki6MTtC0sBsqN15fA90CLhCcBisTKEtOBvYCxwB4ESv2XAPnE/r4xfgJjd0uAhcB3RpY3D2g69pvFbPJpEE8CFOInIWKIry9QRKDU/0jjNYzADPSAKGs/G4BVBMrFrwCWGdKrJLBjmg+2bWwlhAQoeiRIhyHBQcZ/+xnCzAf6EFjAnUOg+k2m8XIQmJDprt25DFk1EBiTawDqgVojk9tqvDYZr7XAegK7o0lwQgIUUSXKHXF00+787SLb8Q3jJDZhAf8PqGgqGSx4foAAAAAASUVORK5CYII=
+    mediatype: image/png
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - integreatly.org
+          - applicationmonitoring.integreatly.org
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projectrequests
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - list
+          - get
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resourceNames:
+          - console
+          resources:
+          - routes
+          verbs:
+          - get
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - get
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - ""
+          resourceNames:
+          - pull-secret
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resourceNames:
+          - grafana-datasources
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - get
+          - update
+          - delete
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - groups
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - groups
+          verbs:
+          - create
+        - apiGroups:
+          - user.openshift.io
+          resourceNames:
+          - rhmi-developers
+          resources:
+          - groups
+          verbs:
+          - update
+          - delete
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          verbs:
+          - watch
+          - get
+          - list
+        - apiGroups:
+          - samples.operator.openshift.io
+          resourceNames:
+          - cluster
+          resources:
+          - configs
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          - operatorgroups
+          verbs:
+          - create
+          - list
+          - get
+        - apiGroups:
+          - operators.coreos.com
+          resourceNames:
+          - rhmi-registry-cs
+          resources:
+          - catalogsources
+          verbs:
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - installplans
+          verbs:
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - identities
+          verbs:
+          - get
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - watch
+          - list
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        serviceAccountName: rhmoam-operator
+      deployments:
+      - name: rhoam-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhoam-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhoam-operator
+            spec:
+              containers:
+              - command:
+                - rhmoam-operator
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: rhoam-operator
+                - name: USE_CLUSTER_STORAGE
+                  value: "true"
+                - name: LOG_LEVEL
+                  value: info
+                - name: INSTALLATION_TYPE
+                  value: managed-api
+                image: quay.io/integreatly/managed-api-service:v0.1.0
+                imagePullPolicy: Always
+                name: rhoam-operator
+                ports:
+                - containerPort: 8090
+                resources:
+                  limits:
+                    cpu: 150m
+                    memory: 1536Mi
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                volumeMounts:
+                - mountPath: /etc/ssl/certs/webhook
+                  name: webhook-certs
+              serviceAccountName: rhoam-operator
+              volumes:
+              - emptyDir: {}
+                name: webhook-certs
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - list
+          - get
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - get
+          - create
+        - apiGroups:
+          - apps
+          resources:
+          - deployments/finalizers
+          - replicasets
+          verbs:
+          - update
+          - get
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          - subscriptions/status
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - delete
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - roles
+          - rolebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - installplans
+          verbs:
+          - get
+          - update
+          - list
+          - watch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigs
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservices
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - delete
+        serviceAccountName: rhoam-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+    - RHOAM
+    - Integration
+  labels:
+    alm-owner-rhoam: rhoam-operator
+    operated-by: rhoam-operator
+  maintainers:
+    - email: rhmi-support@redhat.com
+      name: rhmi
+  maturity: alpha
+  provider:
+    name: rhoam
+  selector:
+    matchLabels:
+      alm-owner-rhoam: rhoam-operator
+      operated-by: rhoam-operator
+  version: 0.1.0

--- a/deploy/olm-catalog/managed-api-service/managed-api-service.package.yaml
+++ b/deploy/olm-catalog/managed-api-service/managed-api-service.package.yaml
@@ -1,0 +1,5 @@
+channels:
+- currentCSV: managed-api-service.v0.1.0
+  name: rhmi
+defaultChannel: rhmi
+packageName: managed-api-service

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,16 @@
+# Scripts
+## prepare-release.sh
+This script creates a release csv for the operator under the `olm-catalog` using `operator-sdk generate csv`
+
+**Required System Variables**
+
+- SEMVER -> valid x.y.z format. Usage: `SEMVER=2.6.0`
+
+**Optional System Variables**
+
+- OLM_TYPE -> Which resource the release csv will be created under. Current Default: `integreatly-operator`.  Usage: `OLM_TYPE=managed-api-service`
+- ORG -> The quay.io org to where the images will be pushed. Setting the ORG will change the image locations specified in \<olm_type>.\<version>.clusterserviceversion.yaml under `containerImage` and `image`. Default: `integreatly`. Usage: `ORG=<user-repo>`.
+
+**Usage**
+
+`SEMVER=2.6.0 OLM_TYPE=managed-api-service ORG=<user-repo> ./prepare-release.sh`

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -2,30 +2,75 @@
 set -e
 set -o pipefail
 
-PREVIOUS_VERSION=$(grep integreatly-operator deploy/olm-catalog/integreatly-operator/integreatly-operator.package.yaml | awk -F v '{print $2}')
+if [[ -z "$OLM_TYPE" ]]; then
+  OLM_TYPE="integreatly-operator"
+fi
+
+case $OLM_TYPE in
+  "integreatly-operator")
+    PREVIOUS_VERSION=$(grep $OLM_TYPE deploy/olm-catalog/$OLM_TYPE/$OLM_TYPE.package.yaml | awk -F v '{print $2}') || echo "No previous version"
+    ;;
+  "managed-api-service")
+    PREVIOUS_VERSION=$(grep $OLM_TYPE deploy/olm-catalog/$OLM_TYPE/$OLM_TYPE.package.yaml | awk -F v '{print $3}') || echo "No previous version"
+    ;;
+  *)
+    echo "Invalid OLM_TYPE set"
+    echo "Use \"integreatly-operator\" or \"managed-api-service\""
+    exit 1
+    ;;
+esac
+
+if [[ -z "$ORG" ]]; then
+  ORG="integreatly"
+else
+  ORG="$ORG"
+fi
 
 create_new_csv() {
-  operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name integreatly-operator --csv-channel=rhmi --update-crds --from-version "$PREVIOUS_VERSION" --make-manifests=false
+
+  if [[ -z "$PREVIOUS_VERSION" ]]
+    then
+      operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name "$OLM_TYPE" --csv-channel=rhmi --update-crds --make-manifests=false
+    else
+      operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name "$OLM_TYPE" --csv-channel=rhmi --update-crds --from-version "$PREVIOUS_VERSION" --make-manifests=false
+  fi
 }
 
 update_csv() {
-  operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name integreatly-operator --csv-channel=rhmi --update-crds --make-manifests=false
+  operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name "$OLM_TYPE" --csv-channel=rhmi --update-crds --make-manifests=false
+
 }
 
 set_version() {
-  "${SED_INLINE[@]}" "s/$PREVIOUS_VERSION/$VERSION/g" Makefile
-  "${SED_INLINE[@]}" "s/$PREVIOUS_VERSION/$VERSION/g" version/version.go
+  if [[ -z "$PREVIOUS_VERSION" ]]
+    then
+      echo "No previous version please set correct values in the Makefile and version/version.go files"
+    else
+      case $OLM_TYPE in
+        "integreatly-operator")
+          "${SED_INLINE[@]}" -E "s/RHMI_TAG\s+\?=\s+$PREVIOUS_VERSION/RHMI_TAG \?= $VERSION/g" Makefile
+          "${SED_INLINE[@]}" -E "s/version\s+=\s+\"$PREVIOUS_VERSION\"/version = \"$VERSION\"/g" version/version.go
+          ;;
+        "managed-api-service")
+          "${SED_INLINE[@]}" -E "s/RHOAM_TAG\s+\?=\s+$PREVIOUS_VERSION/RHOAM_TAG \?= $VERSION/g" Makefile
+          "${SED_INLINE[@]}" -E "s/managedAPIVersion\s+=\s+\"$PREVIOUS_VERSION\"/managedAPIVersion = \"$VERSION\"/g" version/version.go
+          ;;
+        *)
+          echo "No version found for install type : $(OLM_TYPE)"
+          ;;
+      esac
+  fi
 }
 
 set_images() {
   : "${IMAGE_TAG:=v${SEMVER}}"
-  "${SED_INLINE[@]}" "s/image:.*/image: quay\.io\/integreatly\/integreatly-operator:$IMAGE_TAG/g" "deploy/olm-catalog/integreatly-operator/${VERSION}/integreatly-operator.v${VERSION}.clusterserviceversion.yaml"
-  "${SED_INLINE[@]}" "s/containerImage:.*/containerImage: quay\.io\/integreatly\/integreatly-operator:$IMAGE_TAG/g" "deploy/olm-catalog/integreatly-operator/${VERSION}/integreatly-operator.v${VERSION}.clusterserviceversion.yaml"
+  "${SED_INLINE[@]}" "s/image:.*/image: quay\.io\/$ORG\/$OLM_TYPE:$IMAGE_TAG/g" "deploy/olm-catalog/$OLM_TYPE/${VERSION}/$OLM_TYPE.v${VERSION}.clusterserviceversion.yaml"
+  "${SED_INLINE[@]}" "s/containerImage:.*/containerImage: quay\.io\/$ORG\/$OLM_TYPE:$IMAGE_TAG/g" "deploy/olm-catalog/$OLM_TYPE/${VERSION}/$OLM_TYPE.v${VERSION}.clusterserviceversion.yaml"
 }
 
 set_csv_not_service_affecting() {
   echo "Update CSV for release $SEMVER to be not service affecting"
-  yq w -i "deploy/olm-catalog/integreatly-operator/${VERSION}/integreatly-operator.v${VERSION}.clusterserviceversion.yaml" --tag '!!str' metadata.annotations.serviceAffecting "false"
+  yq w -i "deploy/olm-catalog/$OLM_TYPE/${VERSION}/$OLM_TYPE.v${VERSION}.clusterserviceversion.yaml" --tag '!!str' metadata.annotations.serviceAffecting "false"
 }
 
 if [[ -z "$SEMVER" ]]; then


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
The prepare release script now accepts more arguments with all the user to sepicfiy the `olm-catalog` resource be released. 
Also is the ability to set the quay.io org that will point to the catalogue images. This is useful when doing upgrade testing of bundles. Short readme added with a description of how to use the script and the arguments that can be set, plus the current defaults.

**JIRA** https://issues.redhat.com/browse/MGDAPI-31

**Requires https://github.com/integr8ly/delorean/pull/148 to be merged**

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer