### PR TITLE
fix for 3Scale username case issue

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -897,7 +897,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 
 	added, deleted := r.getUserDiff(kcu, tsUsers.Users)
 	for _, kcUser := range added {
-		res, err := r.tsClient.AddUser(kcUser.UserName, kcUser.Email, "", *accessToken)
+		res, err := r.tsClient.AddUser(strings.ToLower(kcUser.UserName), strings.ToLower(kcUser.Email), "", *accessToken)
 		if err != nil || res.StatusCode != http.StatusCreated {
 			return integreatlyv1alpha1.PhaseInProgress, err
 		}
@@ -1213,7 +1213,7 @@ func (r *Reconciler) getUserDiff(kcUsers []keycloak.KeycloakAPIUser, tsUsers []*
 
 func kcContainsTs(kcUsers []keycloak.KeycloakAPIUser, tsUser *User) bool {
 	for _, kcu := range kcUsers {
-		if kcu.UserName == tsUser.UserDetails.Username {
+		if strings.EqualFold(kcu.UserName, tsUser.UserDetails.Username) {
 			return true
 		}
 	}
@@ -1223,7 +1223,7 @@ func kcContainsTs(kcUsers []keycloak.KeycloakAPIUser, tsUser *User) bool {
 
 func tsContainsKc(tsusers []*User, kcUser keycloak.KeycloakAPIUser) bool {
 	for _, tsu := range tsusers {
-		if tsu.UserDetails.Username == kcUser.UserName {
+		if strings.EqualFold(tsu.UserDetails.Username, kcUser.UserName) {
 			return true
 		}
 	}
@@ -1233,7 +1233,7 @@ func tsContainsKc(tsusers []*User, kcUser keycloak.KeycloakAPIUser) bool {
 
 func userIsOpenshiftAdmin(tsUser *User, adminGroup *usersv1.Group) bool {
 	for _, userName := range adminGroup.Users {
-		if tsUser.UserDetails.Username == userName {
+		if strings.EqualFold(tsUser.UserDetails.Username, userName) {
 			return true
 		}
 	}

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -386,7 +386,7 @@ func TestReconciler_syncOpenshiftAdmimMembership(t *testing.T) {
 					Id:   1,
 					Role: memberRole,
 					// User is in OS admin group. Should be promoted
-					Username: "user1",
+					Username: "User1",
 				},
 			},
 			&User{
@@ -395,7 +395,7 @@ func TestReconciler_syncOpenshiftAdmimMembership(t *testing.T) {
 					Role: adminRole,
 					// User is in OS admin group and admin in 3scale. Should
 					// be ignored
-					Username: "user2",
+					Username: "User2",
 				},
 			},
 			&User{
@@ -404,7 +404,7 @@ func TestReconciler_syncOpenshiftAdmimMembership(t *testing.T) {
 					Role: adminRole,
 					// User is not in OS admin group but is already admin.
 					// Should NOT be demoted
-					Username: "user3",
+					Username: "User3",
 				},
 			},
 		},


### PR DESCRIPTION
# Description
Depending on the origin of a ThreeScale user i.e. via sso or via rhmi threescale reconcile, the username and email fields can have a different case. This results in a potentially endless loop of creating and deleting the same user, just with different case. 
More details here: https://issues.redhat.com/browse/INTLY-9971

The fix is to always create the user with lower case and to ignore case while reconciling/syncing users between keycloak and threescale

## Verification
Create a user in GitHub with **uppercase** Email and Username
Setup a GitHub IDP. 

Test 2 Scenarios:
1. Creating the threescale user via RHMI Operator, Threescale to Keycloak user sync
2. Creating the threescale user by logging in via SSO (with operator shut down) 

Ensure in both cases the user is created with lowercase email and username and the user is not deleted and recreated. This can be verified by monitoring the initial userid created in threescale. 

**Scenario 1**
Log in via GitHub IDP. 
Wait for the rhmi operator to sync the user from Keycloak to ThreeScale
Confirm user created with lowercase username and email
Then, log in via SSO and ensure the user is not recreated / deleted. 
Wait for 3Scale to reconcile and ensure the user is not recreated / deleted. 

**Scenario 2**
Shut down RHMI operator
Log in via GitHub IDP. 
Log into 3Scale via SSO 
Confirm user created with lowercase
Start the operator and wait for 3Scale to reconcile
Confirm user is not not recreated / deleted. 
