### PR TITLE
INTLY-9980: Add alert to check for the sendgrid smtp secret is present

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -574,7 +574,7 @@ func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha
 	}
 
 	if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) || installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged3scale) {
-		requiredSecrets := []string{installation.Spec.SMTPSecret, installation.Spec.PagerDutySecret, installation.Spec.DeadMansSnitchSecret}
+		requiredSecrets := []string{installation.Spec.PagerDutySecret, installation.Spec.DeadMansSnitchSecret}
 
 		for _, secretName := range requiredSecrets {
 			secret := &corev1.Secret{

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -282,7 +282,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = resources.CreateSmtpSecretExists(ctx, serverClient, installation)
 	logrus.Infof("Phase: %s CreateSmtpSecretExistsRule", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile SendgridSmtpSecretExists alert", err)
 		return phase, err
 	}
 

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -280,7 +280,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	// creates an alert to check for the presents of sendgrid smtp secret
 	phase, err = resources.CreateSmtpSecretExists(ctx, serverClient, installation)
-	logrus.Info("Phase: %s CreateSmtpSecretExistsRule", phase)
+	logrus.Infof("Phase: %s CreateSmtpSecretExistsRule", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
 		return phase, err

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -273,7 +273,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err = r.newAlertsReconciler().ReconcileAlerts(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcilePrometheusRule", phase)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
+		return phase, err
+	}
 
+	// creates an alert to check for the presents of sendgrid smtp secret
+	phase, err = resources.CreateSmtpSecretExists(ctx, serverClient, installation)
+    logrus.Info("Phase: %s CreateSmtpSecretExistsRule", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
 		return phase, err

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -280,7 +280,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	// creates an alert to check for the presents of sendgrid smtp secret
 	phase, err = resources.CreateSmtpSecretExists(ctx, serverClient, installation)
-    logrus.Info("Phase: %s CreateSmtpSecretExistsRule", phase)
+	logrus.Info("Phase: %s CreateSmtpSecretExistsRule", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
 		return phase, err

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -153,7 +153,7 @@ func ReconcileRedisAlerts(ctx context.Context, client k8sclient.Client, inst *v1
 // the ocm sendgrid service creates a secret automatically this is a check for when that service fails
 func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1alpha1.RHMI) (v1alpha1.StatusPhase, error) {
 	alertName := "SendgridSmtpSecretExists"
-	ruleName := "sendgrid-smtp-secrets-exists-rule"
+	ruleName := "sendgrid-smtp-secret-exists-rule"
 	alertExp := intstr.FromString(
 		fmt.Sprintf("absent(kube_secret_info{namespace='%s',secret='redhat-rhmi-smtp'} == 1)", cr.Namespace),
 	)

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -162,7 +162,7 @@ func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1
 		"severity": "warning",
 	}
 	// create the rule
-	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlSendGridSmptSecretExists, alertFor10Mins, alertExp, labels)
+	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlSendGridSmtpSecretExists, alertFor10Mins, alertExp, labels)
 	if err != nil {
 		return v1alpha1.PhaseFailed, fmt.Errorf("failed to create sendgrid smtp exists rule err: %s", err)
 	}

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -149,17 +149,17 @@ func ReconcileRedisAlerts(ctx context.Context, client k8sclient.Client, inst *v1
 	return v1alpha1.PhaseCompleted, nil
 }
 
-// createSmtpSecretExists creates a PrometheusRule to alert if the rhmi-smtp-secret is present
+// CreateSmtpSecretExists creates a PrometheusRule to alert if the rhmi-smtp-secret is present
 // the ocm sendgrid service creates a secret automatically this is a check for when that service fails
-func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1alpha1.RHMI) (v1alpha1.StatusPhase, error){
+func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1alpha1.RHMI) (v1alpha1.StatusPhase, error) {
 	alertName := "SendgridSmtpSecretExists"
 	ruleName := "sendgrid-smtp-secrets-exists-rule"
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(kube_secret_info{namespace='%s',secret='redhat-rhmi-smtp'} == 1)",cr.Namespace ),
+		fmt.Sprintf("absent(kube_secret_info{namespace='%s',secret='redhat-rhmi-smtp'} == 1)", cr.Namespace),
 	)
 	alertDescription := fmt.Sprintf("The Sendgrid SMTP secret has not been created in the %s namespace and may need to be created manualy", cr.Namespace)
 	labels := map[string]string{
-		"severity":    "warning",
+		"severity": "warning",
 	}
 	// create the rule
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlSendGridSmptSecretExists, alertFor10Mins, alertExp, labels)

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -17,5 +17,5 @@ const (
 	SopUrlEndpointAvailableAlert             = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/service_endpoint_down.asciidoc"
 	SopUrlAlertsAndTroubleshooting           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md"
 	sopUrlCloudResourceDeletionStatusFailed  = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/clean_up_cloud_resources_failed_teardown.asciidoc"
-	sopUrlSendGridSmptSecretExists           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/sendgrid_smtp_secret_not_present.asciidoc"
+	sopUrlSendGridSmtpSecretExists           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/sendgrid_smtp_secret_not_present.asciidoc"
 )

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -17,5 +17,5 @@ const (
 	SopUrlEndpointAvailableAlert             = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/service_endpoint_down.asciidoc"
 	SopUrlAlertsAndTroubleshooting           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md"
 	sopUrlCloudResourceDeletionStatusFailed  = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/clean_up_cloud_resources_failed_teardown.asciidoc"
-	sopUrlSendGridSmptSecretExists           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/install/create_cluster_smtp_configuration.md"
+	sopUrlSendGridSmptSecretExists           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/sendgrid_smtp_secret_not_present.asciidoc"
 )

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -17,4 +17,5 @@ const (
 	SopUrlEndpointAvailableAlert             = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/service_endpoint_down.asciidoc"
 	SopUrlAlertsAndTroubleshooting           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md"
 	sopUrlCloudResourceDeletionStatusFailed  = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/clean_up_cloud_resources_failed_teardown.asciidoc"
+	sopUrlSendGridSmptSecretExists           = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/install/create_cluster_smtp_configuration.md"
 )

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -401,6 +401,12 @@ var expectedRules = []alertsTestRule{
 			"RHMICSVRequirementsNotMet",
 		},
 	},
+	{
+		File: "redhat-rhmi-operator-sendgrid-smtp-secret-exists-rule.yaml",
+		Rules: []string{
+			"SendgridSmtpSecretExists",
+		},
+	},
 }
 
 var expectedAWSRules = []alertsTestRule{


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Jira: https://issues.redhat.com/browse/INTLY-9980

The ocm sendgrid service creates the sendgrid credentials and secret as such we need to add an alert to confirm the secret is setup. The pr adds an alert to check for the presents of the `redhat-rhmi-smtp` secret in the `redhat-rhmi-operator` namespace

Additional the preflight check for smtp secret is removed

## Verification
`make code/run` and `make cluster/prepare/local` have `cluster/prepare/smtp` as part of the make targets which creates dummy smtp credentials. Which we don't want, edit the make targets to remove this 
```make
.PHONY: cluster/prepare/local
cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/croaws
	@oc create -f deploy/service_account.yaml
	@oc create -f deploy/role.yaml
	@oc create -f deploy/role_binding.yaml

.PHONY: code/run
code/run: code/gen cluster/prepare/dms cluster/prepare/pagerduty setup/service_account
	@KUBECONFIG=TMP_SA_KUBECONFIG $(OPERATOR_SDK) run --local --namespace="$(NAMESPACE)"
```
run 
```bash
make cluster/prepare
oc create -f deploy/crds/examples/rhmi.cr.yaml
make code/run
```

Check the preflight checks pass and is no longer checking for the smtp secret
```
INFO[0016] Adding alerting email address to RHMI CR     
INFO[0016] Running preflight checks..                   
INFO[0016] found required secret: redhat-rhmi-pagerduty 
INFO[0016] found required secret: redhat-rhmi-deadmanssnitch 
INFO[0016] getting namespaces   
```
you should also see a warning in the logs
```
WARN[0295] Could not find credential-rhsso secret in RHMI operator namespace to copy to redhat-rhmi-rhsso 
```

Check the alert exists
![image](https://user-images.githubusercontent.com/16667688/92106481-5dc4fb80-eddc-11ea-8d45-e77e45e41286.png)

Check the alert is working delete the secret, see if the rule triggers
```bash
oc project redhat-rhmi-operator
oc delete secret redhat-rhmi-smtp
```
![image](https://user-images.githubusercontent.com/16667688/92107022-0bd0a580-eddd-11ea-87ad-179098815dd8.png)

wait 10 min and confirm that it starts alerting

![image](https://user-images.githubusercontent.com/16667688/92107188-4a666000-eddd-11ea-97a9-0f3dfb46abee.png)

create a dummy secret to confirm this stops the alert
```bash
make cluster/prepare/smtp
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [x] Verified independently on a cluster by reviewer