### PR TITLE
Automate backup and restore for rhsso

### DIFF
--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Import the test function
+. ./postgres.sh --source-only
+
+# Set the parameters
+AWS_DB_ID=$(oc get secret/keycloak-db-secret -o go-template --template="{{.data.POSTGRES_EXTERNAL_ADDRESS|base64decode}}" -n redhat-rhmi-rhsso | awk -F\. '{print $1}')
+POSTGRES_CR_NAME=rhsso-postgres-rhmi
+DATABASE_SECRET=rhsso-postgres-rhmi
+
+# Perform the test
+test_postgres_backup $POSTGRES_CR_NAME $DATABASE_SECRET $AWS_DB_ID


### PR DESCRIPTION
# Description
I've used a script recently created by @sergioifg94 to also automate rhsso Postgres backup and restore.
Addresses ticket https://issues.redhat.com/browse/INTLY-9981

# Verification steps
## Pre-requisites:
  - BYOC cluster
  - The AWS CLI configured with the credentials for the cluster

## Perform the following steps
- Install RHMI with `useClusterStorage` set to false
- Wait for installation to complete
- Create the testing IdP

```
 PASSWORD=Password1 ./scripts/setup-sso-idp.sh
```
Perform the J07 test and verify that it's completed successfully