### PR TITLE
add test containers for managed apis

### DIFF
--- a/test-containers-managed-api.yaml
+++ b/test-containers-managed-api.yaml
@@ -1,0 +1,9 @@
+---
+tests:
+  - name: 3scale-test
+    image: quay.io/rh_integration/3scale-testsuite:2.9.0
+    timeout: 3600
+    imagePullSecretEnvVar: "RH_INTEGRATION"
+    envVars:
+      - name: NAMESPACE
+        value: redhat-rhmi-3scale


### PR DESCRIPTION
# Description
add a new test containers config specifically for managed apis. Only contains reference to 3scale at the moment. RHSSO can be added in future. 

