### PR TITLE
rename from managed-3scale to managed-api

### DIFF
--- a/deploy/cro-configmaps.yaml
+++ b/deploy/cro-configmaps.yaml
@@ -15,7 +15,7 @@ objects:
         {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
       self-managed: >
         {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
-      managed-3scale: >
+      managed-api: >
         {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
 parameters:
   - name: INSTALLATION_NAMESPACE

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -25,10 +25,10 @@ var (
 	PhaseCompleted  StatusPhase = "completed"
 	PhaseFailed     StatusPhase = "failed"
 
-	InstallationTypeWorkshop      InstallationType = "workshop"
-	InstallationTypeManaged       InstallationType = "managed"
-	InstallationTypeManaged3scale InstallationType = "managed-3scale"
-	InstallationTypeSelfManaged   InstallationType = "self-managed"
+	InstallationTypeWorkshop    InstallationType = "workshop"
+	InstallationTypeManaged     InstallationType = "managed"
+	InstallationTypeManagedApi  InstallationType = "managed-api"
+	InstallationTypeSelfManaged InstallationType = "self-managed"
 
 	BootstrapStage               StageName = "bootstrap"
 	CloudResourcesStage          StageName = "cloud-resources"

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -118,12 +118,12 @@ func (r *Reconciler) checkCloudResourcesConfig(ctx context.Context, serverClient
 			cloudConfig.Data["managed"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
 			cloudConfig.Data["workshop"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
 			cloudConfig.Data["self-managed"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
-			cloudConfig.Data["managed-3scale"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
+			cloudConfig.Data["managed-api"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
 		} else {
 			cloudConfig.Data["managed"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
 			cloudConfig.Data["workshop"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
 			cloudConfig.Data["self-managed"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
-			cloudConfig.Data["managed-3scale"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
+			cloudConfig.Data["managed-api"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
 		}
 		return nil
 	}); err != nil {

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -47,6 +47,7 @@ import (
 const (
 	deletionFinalizer                = "finalizer/configmaps"
 	DefaultInstallationName          = "rhmi"
+	ManagedApiInstallationName       = "managed-api"
 	DefaultInstallationConfigMapName = "installation-config"
 	DefaultInstallationPrefix        = "redhat-rhmi-"
 	DefaultCloudResourceConfigName   = "cloud-resource-config"
@@ -159,7 +160,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 
 		installation = &integreatlyv1alpha1.RHMI{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      DefaultInstallationName,
+				Name:      getCrName(installType),
 				Namespace: namespace,
 			},
 			Spec: integreatlyv1alpha1.RHMISpec{
@@ -186,6 +187,14 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 	}
 
 	return nil
+}
+
+func getCrName(installType string) string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return ManagedApiInstallationName
+	} else {
+		return DefaultInstallationName
+	}
 }
 
 var _ reconcile.Reconciler = &ReconcileInstallation{}
@@ -573,7 +582,7 @@ func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha
 		return result, nil
 	}
 
-	if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) || installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged3scale) {
+	if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) || installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		requiredSecrets := []string{installation.Spec.PagerDutySecret, installation.Spec.DeadMansSnitchSecret}
 
 		for _, secretName := range requiredSecrets {

--- a/pkg/controller/installation/types.go
+++ b/pkg/controller/installation/types.go
@@ -12,7 +12,7 @@ type Stage struct {
 }
 
 var (
-	allManaged3scaleStages = &Type{
+	allManagedApiStages = &Type{
 		[]Stage{
 			{
 				Name: integreatlyv1alpha1.BootstrapStage,
@@ -322,8 +322,8 @@ func TypeFactory(installationType string) (*Type, error) {
 		return newWorkshopType(), nil
 	case string(integreatlyv1alpha1.InstallationTypeManaged):
 		return newManagedType(), nil
-	case string(integreatlyv1alpha1.InstallationTypeManaged3scale):
-		return newManaged3scaleType(), nil
+	case string(integreatlyv1alpha1.InstallationTypeManagedApi):
+		return newManagedApiType(), nil
 	case string(integreatlyv1alpha1.InstallationTypeSelfManaged):
 		return newSelfManagedType(), nil
 	default:
@@ -339,8 +339,8 @@ func newManagedType() *Type {
 	return allManagedStages
 }
 
-func newManaged3scaleType() *Type {
-	return allManaged3scaleStages
+func newManagedApiType() *Type {
+	return allManagedApiStages
 }
 
 func newSelfManagedType() *Type {

--- a/pkg/resources/rhmi.go
+++ b/pkg/resources/rhmi.go
@@ -1,0 +1,29 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/sirupsen/logrus"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func GetRhmiCr(client k8sclient.Client, ctx context.Context, namespace string) (*integreatlyv1alpha1.RHMI, error) {
+	logrus.Infof("Looking for rhmi CR in %s namespace", namespace)
+
+	installationList := &integreatlyv1alpha1.RHMIList{}
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(namespace),
+	}
+	err := client.List(ctx, installationList, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(installationList.Items) == 0 {
+		return nil, nil
+	}
+	if len(installationList.Items) != 1 {
+		return nil, fmt.Errorf("Unexpected number of rhmi CRs: %w", err)
+	}
+	return &installationList.Items[0], nil
+}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -411,145 +411,145 @@ var expectedRules = []alertsTestRule{
 
 var expectedAWSRules = []alertsTestRule{
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Redis-RhmiRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-backend-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-backend-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Backend-Redis-RhmiRedisCacheConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-threescale-postgres-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-threescale-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-threescale-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Redis-RhmiRedisCacheUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-threescale-backend-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-threescale-backend-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Backend-Redis-RhmiRedisCacheUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Redis-RhmiRedisResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-backend-redis-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-backend-redis-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Backend-Redis-RhmiRedisResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-threescale-postgres-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-codeready-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-codeready-postgres-rhmi.yaml",
 		Rules: []string{
 			"Codeready-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-ups-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-ups-postgres-rhmi.yaml",
 		Rules: []string{
 			"Ups-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-fuse-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-fuse-postgres-rhmi.yaml",
 		Rules: []string{
 			"Fuse-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-rhsso-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-rhsso-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhsso-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-rhssouser-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-resource-deletion-status-phase-failed-rule-rhssouser-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhssouser-Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-threescale-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-threescale-postgres-rhmi.yaml",
 		Rules: []string{
 			"Threescale-Postgres-RhmiPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-ups-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-ups-postgres-rhmi.yaml",
 		Rules: []string{
 			"Ups-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-ups-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-ups-postgres-rhmi.yaml",
 		Rules: []string{
 			"Ups-Postgres-RhmiPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-codeready-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-codeready-postgres-rhmi.yaml",
 		Rules: []string{
 			"Codeready-Postgres-RhmiPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-codeready-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-codeready-postgres-rhmi.yaml",
 		Rules: []string{
 			"Codeready-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-rhssouser-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-rhssouser-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhssouser-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-rhssouser-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-rhssouser-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhssouser-Postgres-RhmiPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-rhsso-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-rhsso-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhsso-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-rhsso-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-rhsso-postgres-rhmi.yaml",
 		Rules: []string{
 			"Rhsso-Postgres-RhmiPostgresInstanceUnavailable",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-connectivity-rule-fuse-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-connectivity-rule-fuse-postgres-rhmi.yaml",
 		Rules: []string{
 			"Fuse-Postgres-RhmiPostgresConnectionFailed",
 		},
 	},
 	{
-		File: RHMIOperatorNamespace + "-availability-rule-fuse-postgres-" + InstallationName + ".yaml",
+		File: RHMIOperatorNamespace + "-availability-rule-fuse-postgres-rhmi.yaml",
 		Rules: []string{
 			"Fuse-Postgres-RhmiPostgresInstanceUnavailable",
 		},

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -389,10 +389,10 @@ func GetInstallType(config *rest.Config) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create testing context %s", err)
 	}
-	rhmi := &integreatlyv1alpha1.RHMI{}
+	rhmi, err := getRHMI(context.Client)
 
-	if err := context.Client.Get(goctx.TODO(), types.NamespacedName{Name: "rhmi", Namespace: "redhat-rhmi-operator"}, rhmi); err != nil {
-		return "", fmt.Errorf("error getting RHMI CR: %w", err)
+	if err != nil {
+		return "", err
 	}
 
 	return rhmi.Spec.Type, nil

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -64,7 +64,7 @@ var (
 				{"F08 - Verify Replicas Scale correctly in RHSSO and user SSO", TestReplicasInRHSSOAndUserSSO},
 				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManaged3scale},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
 		},
 	}
 

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -207,7 +207,7 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		"apicurito":            "apicurito-operator",
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManaged3scale) {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		products = map[string]string{
 			"3scale": "3scale-operator",
 		}
@@ -226,7 +226,7 @@ func integreatlyManagedTest(t *testing.T, f *framework.Framework, ctx *framework
 		return err
 	}
 
-	if installType != string(integreatlyv1alpha1.InstallationTypeManaged3scale) {
+	if installType != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		// wait for solution-explorer operator to deploy
 		err = waitForProductDeployment(t, f, ctx, string(integreatlyv1alpha1.ProductSolutionExplorer), "tutorial-web-app-operator")
 		if err != nil {


### PR DESCRIPTION
# Description
rename from managed-3scale to managed-api

## Verify
**Install managed-api**
1. Install the managed-api operator and verify 
1.1 `export INSTALLATION_TYPE=managed-api`
3. Run the functional tests `make test/functional`
4. Verify all the tests in the managed api install type test suite ran

**Install rhmi**
1. Install the rhmi operator and verify 
1.1 `export INSTALLATION_TYPE=rhmi`
3. Run the functional tests `make test/functional`
4. Verify all the tests in the rhmi install type test suite ran
