### PR TITLE
MGDAPI-5: Add make target to install Managed API addon

### DIFF
--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -35,6 +35,10 @@ ocm/cluster/create:
 ocm/install/rhmi-addon:
 	@./scripts/ocm.sh install_rhmi
 
+.PHONY: ocm/install/managed-api-addon
+ocm/install/managed-api-addon:
+	@./scripts/ocm.sh install_managed_api
+
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:
 	@./scripts/ocm.sh delete_cluster


### PR DESCRIPTION
# Description

~_🚧 Marked as Work In Progress as Addon is not available yet 🚧_~

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-5

_Changes required for the Managed API addon pipeline: https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/307_

Add new `make ocm/install/managed-api-addon` target, it runs a new function in the
`ocm.sh` script that, similar to `ocm/install/rhmi-addon`, installs the addon in the
cluster and waits for the installation to finish, but uses the Managed API addon, and
relies on the products phase to decide when the installation was completed, as RHMI
relies on the Solution Explorer.

## Verification steps

1. Provision an OSD cluster and log into it
2. Save the cluster details into a file:
    ```sh
    ocm get /api/clusters_mgmt/v1/clusters/<CLUSTER ID> | jq -r  > ocm/cluster-details.json
    ```
3. Copy your kube config into the `ocm` folder
    ```sh
    # Replace "~/.kube/config" if you use a different location
    cp ~/.kube/config ocm/cluster.kubeconfig
    ```
4. Run the make target
    ```sh
    make ocm/install/managed-api-addon
    ```
5. Verify that the command works and the installation completes

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer