### PR TITLE
disabling AZ script

### DIFF
--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -93,7 +93,7 @@ else
   echo "Re-enable AvailabilityZone"
   for SUBNETID in $(aws ec2 describe-subnets --region ${AZ%?} | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
   do
-    aws ec2 describe-network-acls --region ${AZ:?} | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
+    aws ec2 describe-network-acls --region ${AZ%?} | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
   done
 
   # Restore the subnets to the original ACL's

--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+
+# prereq jq
+# DISABLE=$1
+# if [ -z "$DISABLE" ]; then
+# 	echo No option set expect prama true/false, the default option is disable which is true
+# 	$DISABLE=true
+# fi
+
+
+AZ=eu-west-1c
+
+# function changeAcl takes two params for disable or enable
+# $1 should be NetworkAclAssociationId filename
+# $2 should be NetworkAclId filename
+function changeAcl() {
+	count=1
+	cat $1 | while read NetworkAclAssociationId
+	do
+		echo $count
+		echo $(sed -n "${count}p" < NetworkAclId.tmp)
+		echo $NetworkAclAssociationId
+		aws ec2 replace-network-acl-association --association-id $NetworkAclAssociationId --network-acl-id $(sed -n "${count}p" < $2)
+	    ((count=count+1))
+	done
+}
+
+# use the subnetId to get the NetworkAclAssociationId to create the new acl accociation and get the NetworkAclId so can revert the change
+for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+do
+	aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId.tmp
+    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclId' >> NetworkAclId-restore.tmp
+done
+
+
+# if [[ $DISABLE ]]
+
+# create two the dummy ACL and create a file containing the NetworkAclId for the dummy ACL
+for VPCID in $(aws ec2 describe-subnets | jq -r ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.VpcId')
+do
+	aws ec2 create-network-acl --vpc-id $VPCID | jq -r '.NetworkAcl.NetworkAclId' >> NetworkAclId.tmp
+done
+
+
+
+# create new disable ACL accociation
+changeAcl NetworkAclAssociationId.tmp NetworkAclId.tmp
+
+
+sleep 1m
+for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+do
+	aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
+done
+
+# Restore the subnets to the orignal ACL's
+changeAcl NetworkAclAssociationId-restore.tmp NetworkAclId-restore.tmp
+
+# delete the dummy ACL's
+cat NetworkAclId.tmp | while read deleteNetworkAclId
+do
+	aws ec2 delete-network-acl --network-acl-id $deleteNetworkAclId
+done
+
+# remove the tmp files
+rm *.tmp

--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -69,7 +69,7 @@ if $DISABLE; then
     echo "Removing existing NetworkAclId-restore.tmp file"
     rm NetworkAclId-restore.tmp
   fi
-  if [ -f "NetworkAclId.tmp"];  then
+  if [ -f "NetworkAclId.tmp" ];  then
     echo "Removing existing NetworkAclId.tmp file"
     rm NetworkAclId.tmp
   fi

--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -1,23 +1,30 @@
 #!/bin/bash
 
-# prereq jq
-# DISABLE=$1
-# if [ -z "$DISABLE" ]; then
-# 	echo No option set expect prama true/false, the default option is disable which is true
-# 	$DISABLE=true
-# fi
+# Usage: disable and renable an AZ
+#
+# prereq
+#  - jq
+#  - aws-cli
 
-
+# AZ to disable
 AZ=eu-west-1c
 
-# function changeAcl takes two params for disable or enable
+# Checks the command line params true/nothing to disable and false to re-enable
+DISABLE=$1
+if [ -z "$DISABLE" ]; then
+ 	echo "No option set expect params true/false, the default option is disable which is true"
+ 	echo "true - disable the AvailabilityZone"
+ 	echo "false - restore the original configuration (run only after a successful disable)"
+ 	DISABLE=true
+fi
+
+# Function changeAcl takes two params for disable or enable
 # $1 should be NetworkAclAssociationId filename
 # $2 should be NetworkAclId filename
-function changeAcl() {
+function ChangeAcl() {
 	count=1
 	cat $1 | while read NetworkAclAssociationId
 	do
-		echo $count
 		echo $(sed -n "${count}p" < NetworkAclId.tmp)
 		echo $NetworkAclAssociationId
 		aws ec2 replace-network-acl-association --association-id $NetworkAclAssociationId --network-acl-id $(sed -n "${count}p" < $2)
@@ -25,42 +32,41 @@ function changeAcl() {
 	done
 }
 
-# use the subnetId to get the NetworkAclAssociationId to create the new acl accociation and get the NetworkAclId so can revert the change
-for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
-do
-	aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId.tmp
-    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclId' >> NetworkAclId-restore.tmp
-done
+if $DISABLE
+then
+  echo "Disabling AvailabilityZone"
+  # use the subnetId to get the NetworkAclAssociationId to create the new acl association and get the NetworkAclId so can revert the change
+  for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+  do
+    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId.tmp
+      aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclId' >> NetworkAclId-restore.tmp
+  done
+
+  # create two the dummy ACL and create a file containing the NetworkAclId for the dummy ACL
+  for VPCID in $(aws ec2 describe-subnets | jq -r ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.VpcId')
+  do
+    aws ec2 create-network-acl --vpc-id $VPCID | jq -r '.NetworkAcl.NetworkAclId' >> NetworkAclId.tmp
+  done
+
+  # create new disable ACL association
+  ChangeAcl NetworkAclAssociationId.tmp NetworkAclId.tmp
+else
+    echo "Re-enable AvailabilityZone"
+  for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+  do
+    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
+  done
+
+  # Restore the subnets to the original ACL's
+  ChangeAcl NetworkAclAssociationId-restore.tmp NetworkAclId-restore.tmp
 
 
-# if [[ $DISABLE ]]
+  # delete the dummy ACL's
+  cat NetworkAclId.tmp | while read deleteNetworkAclId
+  do
+    aws ec2 delete-network-acl --network-acl-id $deleteNetworkAclId
+  done
 
-# create two the dummy ACL and create a file containing the NetworkAclId for the dummy ACL
-for VPCID in $(aws ec2 describe-subnets | jq -r ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.VpcId')
-do
-	aws ec2 create-network-acl --vpc-id $VPCID | jq -r '.NetworkAcl.NetworkAclId' >> NetworkAclId.tmp
-done
-
-
-
-# create new disable ACL accociation
-changeAcl NetworkAclAssociationId.tmp NetworkAclId.tmp
-
-
-sleep 1m
-for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
-do
-	aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
-done
-
-# Restore the subnets to the orignal ACL's
-changeAcl NetworkAclAssociationId-restore.tmp NetworkAclId-restore.tmp
-
-# delete the dummy ACL's
-cat NetworkAclId.tmp | while read deleteNetworkAclId
-do
-	aws ec2 delete-network-acl --network-acl-id $deleteNetworkAclId
-done
-
-# remove the tmp files
-rm *.tmp
+  # remove the tmp files
+  rm *.tmp
+fi

--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -1,24 +1,52 @@
 #!/bin/bash
 
 # Usage: disable and renable an AZ
-#
+# ./disableAz.sh <true/false> <aws availability zone>
 # prereq
 #  - jq
 #  - aws-cli
 
-# AZ to disable
-AZ=eu-west-1a
-
-# Checks the command line params true/nothing to disable and false to re-enable
-DISABLE=$1
-if [ -z "$DISABLE" ]; then
- 	echo "No option set expect params true/false, the default option is disable which is true"
- 	echo "true - disable the AvailabilityZone"
- 	echo "false - restore the original configuration (run only after a successful disable)"
- 	DISABLE=true
+# check the correct command line args are passed two expected
+if (( $# < 2 ))
+then
+  echo "Incorrect amount of arguments passed in"
+ 	echo "usage ./disableAz.sh <true/false> <aws az>"
+ 	exit 1
 fi
 
-# Function changeAcl takes two params for disable or enable
+# Checks the command line args $1 true to disable and false to re-enable
+DISABLE=$1
+if [[ "$DISABLE" == "true" ]] || [[ "$DISABLE" == "false" ]]
+then
+  echo "Arg $1 accepted"
+else
+ 	echo "Incorrect option for first arg expect true/false"
+ 	echo "usage ./disableAz.sh <true/false> <aws az>"
+ 	echo "- true - disable the AvailabilityZone"
+ 	echo "- false - restore the original configuration (run only after a successful disable)"
+ 	exit 1
+fi
+
+# Sets the command line args $2 for the availability zone
+AZ=$2
+# check $2 for matching az string
+AZCHECK=`echo $AZ | grep "eu-west-\|eu-central-\|eu-north-\|eu-south-\|us-east-\|us-west-\|ap-northeast-\|ap-south-\|ap-southeast-|\sa-east-\|ca-central-"`
+# if the $2 arg does not match the stings above then
+if [ -z "$AZCHECK" ]; then
+ 	echo "Incorrect availability zone in args"
+ 	echo "AvailabilityZone examples"
+ 	echo "- eu-west-1a"
+ 	echo "- eu-west-1b"
+ 	echo "- eu-west-1c"
+ 	echo "- eu-central-1a"
+ 	echo "etc ...."
+ 	echo " "
+ 	echo "usage ./disableAz.sh <true/false> <aws az>"
+ 	exit 1
+fi
+
+
+# Function changeAcl takes two arguments for disable or enable
 # $1 should be NetworkAclAssociationId filename
 # $2 should be NetworkAclId filename
 function ChangeAcl() {
@@ -27,7 +55,7 @@ function ChangeAcl() {
 	do
 		echo $(sed -n "${count}p" < NetworkAclId.tmp)
 		echo $NetworkAclAssociationId
-		aws ec2 replace-network-acl-association --association-id $NetworkAclAssociationId --network-acl-id $(sed -n "${count}p" < $2)
+		aws ec2 replace-network-acl-association --region ${AZ:0:-1} --association-id $NetworkAclAssociationId --network-acl-id $(sed -n "${count}p" < $2)
 	    ((count=count+1))
 	done
 }
@@ -36,25 +64,25 @@ if $DISABLE
 then
   echo "Disabling AvailabilityZone"
   # use the subnetId to get the NetworkAclAssociationId to create the new acl association and get the NetworkAclId so can revert the change
-  for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+  for SUBNETID in $(aws ec2 describe-subnets --region ${AZ:0:-1}| jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")"  | jq -r '.SubnetId')
   do
-    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId.tmp
-      aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclId' >> NetworkAclId-restore.tmp
+    aws ec2 describe-network-acls --region ${AZ:0:-1}| jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId.tmp
+    aws ec2 describe-network-acls --region ${AZ:0:-1}| jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclId' >> NetworkAclId-restore.tmp
   done
 
   # create two the dummy ACL and create a file containing the NetworkAclId for the dummy ACL
-  for VPCID in $(aws ec2 describe-subnets | jq -r ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.VpcId')
+  for VPCID in $(aws ec2 describe-subnets --region ${AZ:0:-1} | jq -r ".Subnets[] | select(.AvailabilityZone==\"$AZ\")"  | jq -r '.VpcId')
   do
-    aws ec2 create-network-acl --vpc-id $VPCID | jq -r '.NetworkAcl.NetworkAclId' >> NetworkAclId.tmp
+    aws ec2 create-network-acl --vpc-id $VPCID --region ${AZ:0:-1} | jq -r '.NetworkAcl.NetworkAclId' >> NetworkAclId.tmp
   done
 
   # create new disable ACL association
   ChangeAcl NetworkAclAssociationId.tmp NetworkAclId.tmp
 else
   echo "Re-enable AvailabilityZone"
-  for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
+  for SUBNETID in $(aws ec2 describe-subnets --region ${AZ:0:-1} | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
   do
-    aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
+    aws ec2 describe-network-acls --region ${AZ:0:-1} | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp
   done
 
   # Restore the subnets to the original ACL's
@@ -64,7 +92,7 @@ else
   # delete the dummy ACL's
   cat NetworkAclId.tmp | while read deleteNetworkAclId
   do
-    aws ec2 delete-network-acl --network-acl-id $deleteNetworkAclId
+    aws ec2 delete-network-acl --network-acl-id $deleteNetworkAclId --region ${AZ:0:-1}
   done
 
   # remove the tmp files

--- a/scripts/disableAz.sh
+++ b/scripts/disableAz.sh
@@ -7,7 +7,7 @@
 #  - aws-cli
 
 # AZ to disable
-AZ=eu-west-1c
+AZ=eu-west-1a
 
 # Checks the command line params true/nothing to disable and false to re-enable
 DISABLE=$1
@@ -51,7 +51,7 @@ then
   # create new disable ACL association
   ChangeAcl NetworkAclAssociationId.tmp NetworkAclId.tmp
 else
-    echo "Re-enable AvailabilityZone"
+  echo "Re-enable AvailabilityZone"
   for SUBNETID in $(aws ec2 describe-subnets | jq ".Subnets[] | select(.AvailabilityZone==\"$AZ\")" | jq -r '.SubnetId')
   do
     aws ec2 describe-network-acls | jq -r ".[] | .[].Associations[] | select(.SubnetId==\"$SUBNETID\")" | jq -r '.NetworkAclAssociationId' >> NetworkAclAssociationId-restore.tmp


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Jira: https://issues.redhat.com/browse/MGDAPI-53
Need a method to disable an aws availability zone. This script creates dummy ACL(deny all traffic) on aws and points all subnets on a particular AZ to these dummy ACL. 

## Type of change
Script to disable and AZ and re-enable again
<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
## Verification
### Setup
- Deploy a multi AZ byoc
- Change the rhmi cr to deploy `type: managed-api` and `useClusterStorage: 'false'` 
- run `make cluster/prepare/local`
- run ` oc create -f deploy/crds/examples/rhmi.cr.yaml`
- run `make code/run`
### Test the script
Before running the script check the ACL for the account 
should look something like
![image](https://user-images.githubusercontent.com/16667688/93768989-247cf000-fc12-11ea-943e-3d7dc3aacf47.png)


Disable AZ
```bash
./disableAz.sh
No option set expect params true/false, the default option is disable which is true
true - disable the AvailabilityZone
false - restore the original configuration (run only after a successful disable)
Disabling AvailabilityZone
acl-0e6064637db103dbd
aclassoc-0ae2f313cd55928f3
{
    "NewAssociationId": "aclassoc-04218d21fb9162c71"
}
acl-0230cb9b94f332966
aclassoc-013c5e171044eb352
{
    "NewAssociationId": "aclassoc-0867d96a9057fe41c"
}
acl-0344cf512e041926c
aclassoc-0966c189592afdd8a
{
    "NewAssociationId": "aclassoc-00cec7884f9acc1e5"
}
```
Check the ACL after running the command and you should see the new associations
![image](https://user-images.githubusercontent.com/16667688/93769166-58581580-fc12-11ea-90a4-1b0402238fed.png)

You can also check the machineSet although these can take a while to change
```bash
 oc get machineset -n openshift-machine-api
NAME                                      DESIRED   CURRENT   READY   AVAILABLE   AGE
mw-collab-multi-zmvv6-infra-eu-west-1a    1         1         1       1           3d
mw-collab-multi-zmvv6-infra-eu-west-1b    1         1         1       1           3d
mw-collab-multi-zmvv6-infra-eu-west-1c    1         1                             3d
mw-collab-multi-zmvv6-worker-eu-west-1a   3         3         3       3           3d1h
mw-collab-multi-zmvv6-worker-eu-west-1b   3         3         3       3           3d1h
mw-collab-multi-zmvv6-worker-eu-west-1c   3         3                             3d1h

```

Re-enable the AZ
```bash
./disableAz.sh false
Re-enable AvailabilityZone
acl-0e6064637db103dbd
aclassoc-04218d21fb9162c71
{
    "NewAssociationId": "aclassoc-091984c33350a6634"
}
acl-0230cb9b94f332966
aclassoc-0867d96a9057fe41c
{
    "NewAssociationId": "aclassoc-0d876901f17655855"
}
acl-0344cf512e041926c
aclassoc-00cec7884f9acc1e5
{
    "NewAssociationId": "aclassoc-05d59a48b57dd5ba8"
}
```
recheck the ACL after running should see them return to normal
![image](https://user-images.githubusercontent.com/16667688/93769232-6efe6c80-fc12-11ea-8452-8e406aa1678d.png)

you can also check the MachineSet but these take a while to reconcile
```bash
oc get machineset -n openshift-machine-api
NAME                                      DESIRED   CURRENT   READY   AVAILABLE   AGE
mw-collab-multi-zmvv6-infra-eu-west-1a    1         1         1       1           3d
mw-collab-multi-zmvv6-infra-eu-west-1b    1         1         1       1           3d
mw-collab-multi-zmvv6-infra-eu-west-1c    1         1         1       1           3d
mw-collab-multi-zmvv6-worker-eu-west-1a   3         3         3       3           3d1h
mw-collab-multi-zmvv6-worker-eu-west-1b   3         3         3       3           3d1h
mw-collab-multi-zmvv6-worker-eu-west-1c   3         3         3       3           3d1h
```


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer