### PR TITLE
test: pod distribution on Multi-AZ cluster

### DIFF
--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -39,15 +39,6 @@ func TestIntegreatly(t *testing.T) {
 		common.RunTestCases(FUNCTIONAL_TESTS, t, config)
 	})
 
-	t.Run("Integreatly Destructive Tests", func(t *testing.T) {
-		// Do not execute these tests unless DESTRUCTIVE is set to true
-		if os.Getenv("DESTRUCTIVE") != "true" {
-			t.Skip("Skipping Destructive tests as DESTRUCTIVE env var is not set to true")
-		}
-
-		common.RunTestCases(common.DESTRUCTIVE_TESTS, t, config)
-	})
-
 	t.Run("API Managed Multi-AZ Tests", func(t *testing.T) {
 		// Do not execute these tests unless MULTIAZ is set to true
 		if os.Getenv("MULTIAZ") != "true" {
@@ -55,5 +46,14 @@ func TestIntegreatly(t *testing.T) {
 		}
 
 		common.RunTestCases(MULTIAZ_TESTS, t, config)
+	})
+
+	t.Run("Integreatly Destructive Tests", func(t *testing.T) {
+		// Do not execute these tests unless DESTRUCTIVE is set to true
+		if os.Getenv("DESTRUCTIVE") != "true" {
+			t.Skip("Skipping Destructive tests as DESTRUCTIVE env var is not set to true")
+		}
+
+		common.RunTestCases(common.DESTRUCTIVE_TESTS, t, config)
 	})
 }

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -47,4 +47,13 @@ func TestIntegreatly(t *testing.T) {
 
 		common.RunTestCases(common.DESTRUCTIVE_TESTS, t, config)
 	})
+
+	t.Run("API Managed Multi-AZ Tests", func(t *testing.T) {
+		// Do not execute these tests unless DESTRUCTIVE is set to true
+		if os.Getenv("MULTIAZ_TESTS") != "true" {
+			t.Skip("Skipping Multi-AZ tests as MULTIAZ_TESTS env var is not set to true")
+		}
+
+		common.RunTestCases(MULTIAZ_TESTS, t, config)
+	})
 }

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -49,9 +49,9 @@ func TestIntegreatly(t *testing.T) {
 	})
 
 	t.Run("API Managed Multi-AZ Tests", func(t *testing.T) {
-		// Do not execute these tests unless DESTRUCTIVE is set to true
-		if os.Getenv("MULTIAZ_TESTS") != "true" {
-			t.Skip("Skipping Multi-AZ tests as MULTIAZ_TESTS env var is not set to true")
+		// Do not execute these tests unless MULTIAZ is set to true
+		if os.Getenv("MULTIAZ") != "true" {
+			t.Skip("Skipping Multi-AZ tests as MULTIAZ env var is not set to true")
 		}
 
 		common.RunTestCases(MULTIAZ_TESTS, t, config)

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -1,0 +1,137 @@
+package functional
+
+import (
+	goctx "context"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/test/common"
+	v1 "k8s.io/api/core/v1"
+	"math"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+)
+
+var (
+	namespacesToCheck = []string{
+		common.RHSSOUserProductOperatorNamespace,
+		common.RHSSOProductNamespace,
+		common.ThreeScaleProductNamespace,
+	}
+	availableZones = map[string]bool{}
+)
+
+type podDistribution struct {
+	zones     map[string]int
+	podsTotal int
+}
+
+func TestMultiAZPodDistribution(t *testing.T, ctx *common.TestingContext) {
+	pods := &v1.PodList{}
+	nodes := &v1.NodeList{}
+
+	ctx.Client.List(goctx.TODO(), nodes)
+
+	availableZones = getAZ(nodes)
+
+	for _, ns := range namespacesToCheck {
+		distributionPerOwner := make(map[string]*podDistribution)
+		// Get a list of pods per namespace
+		ctx.Client.List(goctx.TODO(), pods, k8sclient.InNamespace(ns))
+		for _, pod := range pods.Items {
+			// Skip pods with status "Completed"
+			if pod.Status.Phase == "Succeeded" {
+				continue
+			}
+			// Get an owner of the pod (ReplicationController, StatefulSet, ...)
+			podOwnerName := pod.OwnerReferences[0].Name
+			// Get a pod's AZ it is currently running in
+			podsAz := getPodZone(pod, nodes)
+			// Save
+			if _, ok := distributionPerOwner[podOwnerName]; ok == false {
+				distributionPerOwner[podOwnerName] = &podDistribution{zones: map[string]int{podsAz: 1}, podsTotal: 1}
+			} else {
+				distributionPerOwner[podOwnerName].podsTotal++
+				distributionPerOwner[podOwnerName].zones[podsAz]++
+			}
+
+		}
+		testErrors := testCorrectPodDistribution(distributionPerOwner)
+
+		if len(testErrors) != 0 {
+			t.Fatalf("Error when verifying the pod distribution: %s", testErrors)
+		}
+	}
+}
+
+func getAZ(nodes *v1.NodeList) map[string]bool {
+	zones := make(map[string]bool)
+	for _, node := range nodes.Items {
+		if isNodeWorkerAndReady(node) {
+			for labelName, labelValue := range node.Labels {
+				if labelName == "topology.kubernetes.io/zone" {
+					zones[labelValue] = true
+				}
+			}
+		}
+	}
+	return zones
+}
+
+func isNodeWorkerAndReady(node v1.Node) bool {
+	var isWorker bool
+
+	for annKey, annValue := range node.Annotations {
+		if annKey == "machine.openshift.io/machine" && strings.Contains(annValue, "worker") {
+			isWorker = true
+			break
+		}
+	}
+
+	if isWorker {
+		for _, cond := range node.Status.Conditions {
+			if cond.Type == "Ready" && cond.Status == "True" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func getPodZone(pod v1.Pod, nodes *v1.NodeList) string {
+	for _, node := range nodes.Items {
+		if pod.Spec.NodeName == node.Name {
+			for labelName, labelValue := range node.Labels {
+				if labelName == "topology.kubernetes.io/zone" {
+					return labelValue
+				}
+
+			}
+		}
+	}
+	return ""
+}
+
+func testCorrectPodDistribution(dist map[string]*podDistribution) []string {
+	var testErrors []string
+	for podOwner, pd := range dist {
+		minPodsPerZone, maxPodsPerZone := getAllowedNumberOfPodsPerZone(pd.podsTotal)
+		for _, n := range pd.zones {
+			if n == minPodsPerZone || n == maxPodsPerZone {
+				continue
+			}
+			testErrors = append(testErrors, fmt.Sprintf("Pods are not distributed correctly in %s.", podOwner))
+		}
+	}
+	return testErrors
+}
+
+func getAllowedNumberOfPodsPerZone(podsTotal int) (min int, max int) {
+	if podsTotal%len(availableZones) == 0 {
+		min = podsTotal / len(availableZones)
+		max = min
+		return
+	}
+	min = int(math.Floor(float64(podsTotal) / float64(len(availableZones))))
+	max = min + 1
+	return
+}

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -147,7 +147,7 @@ func testCorrectPodDistribution(dist map[string]*podDistribution) []string {
 			if n == minPodsPerZone || n == maxPodsPerZone {
 				continue
 			}
-			testErrors = append(testErrors, fmt.Sprintf("Pod owner '%s' pods are not distributed correctly. %+v\n", podOwner, dist))
+			testErrors = append(testErrors, fmt.Sprintf("Pod owner '%s' pods are not distributed correctly. %+v\n", podOwner, pd))
 		}
 	}
 	return testErrors

--- a/test/functional/tests.go
+++ b/test/functional/tests.go
@@ -10,5 +10,6 @@ var (
 		{Description: "A25 - Verify standalone RHMI VPC exists and is configured properly", Test: TestStandaloneVPCExists},
 		{Description: "N06 - Verify Legacy cluster VPC is configured properly", Test: TestLegacyClusterVPC},
 		{Description: "F04 - Verify AWS s3 blob storage resources exist", Test: TestAWSs3BlobStorageResourcesExist},
+		{"F09 - Verify correct pod distribution on Multi-AZ cluster", TestMultiAZPodDistribution},
 	}
 )

--- a/test/functional/tests.go
+++ b/test/functional/tests.go
@@ -10,6 +10,8 @@ var (
 		{Description: "A25 - Verify standalone RHMI VPC exists and is configured properly", Test: TestStandaloneVPCExists},
 		{Description: "N06 - Verify Legacy cluster VPC is configured properly", Test: TestLegacyClusterVPC},
 		{Description: "F04 - Verify AWS s3 blob storage resources exist", Test: TestAWSs3BlobStorageResourcesExist},
-		{"F09 - Verify correct pod distribution on Multi-AZ cluster", TestMultiAZPodDistribution},
+	}
+	MULTIAZ_TESTS = []common.TestCase{
+		{Description: "F09 - Verify correct pod distribution on Multi-AZ cluster", Test: TestMultiAZPodDistribution},
 	}
 )


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/MGDAPI-59

# Comments
* this test verifies the correct pod distribution of 3scale, User SSO and RHSSO services (by default)
* it allows to test a pod distribution in a custom namespace (by passing in an env var with the list of namespaces)

# Verification steps
1. Clone this branch
2. Target multi-az cluster with managed-api installed (ping me if you need such cluster)

### Verify: Tests passes

1. Run
```
go clean -testcache && MULTIAZ=true go test -v ./test/functional -run="//^F09"
```
2. Verify that the test has passed (see something like `--- PASS: TestIntegreatly/API_Managed_Multi-AZ_Tests/F09_-_Verify_correct_pod_distribution_on_Multi-AZ_cluster (3.16s)` in the log)

### Verify: Test wasn't run

1. Run
```
go clean -testcache && go test -v ./test/functional -run="//^F09"
```
2. Verify that the test wasn't run because the env var `MULTIAZ` was't defined (see `--- SKIP: TestIntegreatly/API_Managed_Multi-AZ_Tests (0.00s)` in the log)

### Verify: `NAMESPACES_TO_CHECK` env var works

1. Uncomment [this line](https://github.com/integr8ly/integreatly-operator/pull/1201/files#diff-e7a8d8d902bb6b36f0482f7895b49926R145) to log the detailed information about the pod distribution per pods' owner
2. Run
```
go clean -testcache && MULTIAZ=true NAMESPACES_TO_CHECK=redhat-rhmi-operator,redhat-rhmi-3scale-operator go test -v ./test/functional -run="//^F09"
```
3. You should see something like this in the test output log
```
Pods distribution in rhmi-operator-688f6fdccb: &{zones:map[eu-central-1a:1] podsTotal:1 namespace:redhat-rhmi-operator}
Pods distribution in rhmi-registry-cs: &{zones:map[eu-central-1c:1] podsTotal:1 namespace:redhat-rhmi-3scale-operator}
```

### Verify: Pod distribution check works, even when an invalid namespace is passed

1. Run
```
go clean -testcache && MULTIAZ=true NAMESPACES_TO_CHECK=invalid-namespace,redhat-rhmi-operator go test -v ./test/functional -run="//^F09"
```
2. You should see an error in the log mentioning the "invalid-namespace", but there should be also a log mentioning the pod distribution in redhat-rhmi-operator

### Verify: test works after changing the amount of replicas for a service
1. Scale down 3scale operator and scale up apicast-production
```
oc scale deployment --replicas 0 3scale-operator -n redhat-rhmi-3scale-operator
oc scale dc --replicas 5 apicast-production -n redhat-rhmi-3scale
```
2. Wait until all pods belonging to apicast-production dc are running
```
watch oc get pods -n redhat-rhmi-3scale -l deploymentConfig=apicast-production
```
3. Run the test
```
go clean -testcache && MULTIAZ=true go test -v ./test/functional -run="//^F09"
```
4. You should see something like this in the test output
```
Pods distribution in apicast-production-1: &{zones:map[eu-central-1a:2 eu-central-1b:1 eu-central-1c:2] podsTotal:5 namespace:redhat-rhmi-3scale}
```
indicating that the total number of pods changed to 5 and they are distributed evenly across the AZs