### PR TITLE
MGDAPI-193: Only reconcile backups blob storage on Managed type

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -276,6 +276,10 @@ func (r *Reconciler) cleanupResources(ctx context.Context, installation *integre
 }
 
 func (r *Reconciler) reconcileBackupsStorage(ctx context.Context, installation *integreatlyv1alpha1.RHMI, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	if r.installation.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManaged) {
+		return integreatlyv1alpha1.PhaseCompleted, nil
+	}
+
 	blobStorageName := fmt.Sprintf("%s%s", constants.BackupsBlobStoragePrefix, installation.Name)
 	blobStorage, err := croUtil.ReconcileBlobStorage(ctx, client, defaultInstallationNamespace, installation.Spec.Type, croUtil.TierProduction, blobStorageName, installation.Namespace, r.ConfigManager.GetBackupsSecretName(), installation.Namespace, func(cr metav1.Object) error {
 		return nil

--- a/test/common/cro_cr_success.go
+++ b/test/common/cro_cr_success.go
@@ -3,8 +3,9 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1"
 	croTypes "github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
@@ -47,11 +48,20 @@ func getRedisToCheck(installationName string) []string {
 	}
 }
 
-func getBlobStorageToCheck(installationName string) []string {
-	return []string{
-		fmt.Sprintf("%s%s", constants.BackupsBlobStoragePrefix, installationName),
+func getBlobStorageToCheck(installType, installationName string) []string {
+	common := []string{
 		fmt.Sprintf("%s%s", constants.ThreeScaleBlobStoragePrefix, installationName),
 	}
+
+	rhmi2 := []string{
+		fmt.Sprintf("%s%s", constants.BackupsBlobStoragePrefix, installationName),
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return common
+	}
+
+	return append(common, rhmi2...)
 }
 
 func TestCROPostgresSuccessfulState(t *testing.T, ctx *TestingContext) {
@@ -116,7 +126,7 @@ func TestCROBlobStorageSuccessfulState(t *testing.T, ctx *TestingContext) {
 	if err != nil {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
-	blobStorageToCheck := getBlobStorageToCheck(rhmi.Name)
+	blobStorageToCheck := getBlobStorageToCheck(rhmi.Spec.Type, rhmi.Name)
 
 	for _, blobStorageName := range blobStorageToCheck {
 		blobStorage := &crov1.BlobStorage{}


### PR DESCRIPTION
# Description

Add condition in CRO reconciler to only reconcile the backups blob storage when
the InstallationType is `managed`.

Modify e2e test to not check for this blob storage when the installation type
is `managed-api`

## Verification steps

1. Install the Managed API Operator
2. Check that the installation completes successfully
3. Check that only the 3scale blobstorage has been created:
    ```sh
    $ oc get blobstorages -n redhat-rhmi-operator

    NAME                                 AGE
    threescale-blobstorage-managed-api   17h
    ```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer