### PR TITLE
MGDAPI-92 Reconcile rate limit service

### DIFF
--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -1,0 +1,285 @@
+package marin3r
+
+import (
+	"context"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"gopkg.in/yaml.v2"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+type RateLimitServiceReconciler struct {
+	Namespace       string
+	RedisSecretName string
+}
+
+func NewRateLimitServiceReconciler(namespace, redisSecretName string) *RateLimitServiceReconciler {
+	return &RateLimitServiceReconciler{
+		Namespace:       namespace,
+		RedisSecretName: redisSecretName,
+	}
+}
+
+// Config types, taken from unexported types in ratelimit service:
+// https://github.com/envoyproxy/ratelimit/blob/master/src/config/config_impl.go#L15-L44
+
+type yamlRateLimit struct {
+	RequestsPerUnit uint32 `yaml:"requests_per_unit"`
+	Unit            string
+}
+
+type yamlDescriptor struct {
+	Key         string
+	Value       string
+	RateLimit   *yamlRateLimit `yaml:"rate_limit"`
+	Descriptors []yamlDescriptor
+}
+
+type yamlRoot struct {
+	Domain      string
+	Descriptors []yamlDescriptor
+}
+
+// ReconcileRateLimitService creates the resources to deploy the rate limit service
+// It reconciles a ConfigMap to configure the service, a Deployment to run it, and
+// exposes it as a Service
+func (r *RateLimitServiceReconciler) ReconcileRateLimitService(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	phase, err := r.reconcileConfigMap(ctx, client)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	phase, err = r.reconcileDeployment(ctx, client)
+	if phase != integreatlyv1alpha1.PhaseCompleted {
+		return phase, err
+	}
+
+	return r.reconcileService(ctx, client)
+}
+
+func (r *RateLimitServiceReconciler) reconcileConfigMap(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	cm := &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ratelimit-config",
+			Namespace: r.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, cm, func() error {
+		configYaml := yamlRoot{
+			Domain: "kuard",
+			Descriptors: []yamlDescriptor{
+				{
+					Key:   "generic_key",
+					Value: "slowpath",
+					RateLimit: &yamlRateLimit{
+						Unit:            "minute",
+						RequestsPerUnit: 1,
+					},
+				},
+			},
+		}
+		configYamlMarshalled, err := yaml.Marshal(configYaml)
+		if err != nil {
+			return fmt.Errorf("failed to marshall rate limit config: %v", err)
+		}
+
+		if cm.Data == nil {
+			cm.Data = map[string]string{}
+		}
+		if cm.Labels == nil {
+			cm.Labels = map[string]string{}
+		}
+
+		cm.Data["kuard.yaml"] = string(configYamlMarshalled)
+		cm.Labels["app"] = "ratelimit"
+		cm.Labels["part-of"] = "3scale-saas"
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *RateLimitServiceReconciler) reconcileDeployment(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	redisSecret, err := r.getRedisSecret(ctx, client)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+		} else {
+			return integreatlyv1alpha1.PhaseFailed, err
+		}
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ratelimit",
+			Namespace: r.Namespace,
+		},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, client, deployment, func() error {
+		if deployment.Labels == nil {
+			deployment.Labels = map[string]string{}
+		}
+
+		deployment.Labels["app"] = "ratelimit"
+		deployment.Spec.Selector = &v1.LabelSelector{
+			MatchLabels: map[string]string{
+				"app": "ratelimit",
+			},
+		}
+		deployment.Spec.Strategy = appsv1.DeploymentStrategy{
+			Type: appsv1.RecreateDeploymentStrategyType,
+		}
+		deployment.Spec.Template = corev1.PodTemplateSpec{
+			ObjectMeta: v1.ObjectMeta{
+				Labels: map[string]string{
+					"app": "ratelimit",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:    "ratelimit",
+						Image:   "envoyproxy/ratelimit:v1.4.0",
+						Command: []string{"ratelimit"},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								MountPath: "/srv/runtime_data/current/config",
+								Name:      "runtime-config",
+							},
+						},
+						Ports: []corev1.ContainerPort{
+							{
+								Name:          "http",
+								ContainerPort: 8080,
+							},
+							{
+								Name:          "grpc",
+								ContainerPort: 8081,
+							},
+							{
+								Name:          "debug",
+								ContainerPort: 6070,
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  "REDIS_SOCKET_TYPE",
+								Value: "tcp",
+							},
+							{
+								Name:  "REDIS_URL",
+								Value: string(redisSecret.Data["URL"]),
+							},
+							{
+								Name:  "USE_STATSD",
+								Value: "false",
+							},
+							{
+								Name:  "RUNIME_ROOT",
+								Value: "/srv/runtime_data/current",
+							},
+							{
+								Name:  "RUNTIME_SUBDIRECTORY",
+								Value: "/",
+							},
+							{
+								Name:  "RUNTIME_IGNOREDOTFILES",
+								Value: "true",
+							},
+						},
+					},
+				},
+				Volumes: []corev1.Volume{
+					{
+						Name: "runtime-config",
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{
+									Name: "ratelimit-config",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *RateLimitServiceReconciler) reconcileService(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	service := &corev1.Service{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ratelimit",
+			Namespace: r.Namespace,
+		},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, client, service, func() error {
+		if service.Labels == nil {
+			service.Labels = map[string]string{}
+		}
+
+		service.Labels["app"] = "ratelimit"
+		service.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       "http",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       8080,
+				TargetPort: intstr.FromInt(8080),
+			},
+			{
+				Name:       "debug",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       6070,
+				TargetPort: intstr.FromInt(6070),
+			},
+			{
+				Name:       "grpc",
+				Protocol:   corev1.ProtocolTCP,
+				Port:       8081,
+				TargetPort: intstr.FromInt(8081),
+			},
+		}
+		service.Spec.Selector = map[string]string{
+			"app": "ratelimit",
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *RateLimitServiceReconciler) getRedisSecret(ctx context.Context, client k8sclient.Client) (*corev1.Secret, error) {
+	secret := &corev1.Secret{}
+	err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      r.RedisSecretName,
+		Namespace: r.Namespace,
+	}, secret)
+
+	return secret, err
+}

--- a/pkg/products/marin3r/rateLimitService_test.go
+++ b/pkg/products/marin3r/rateLimitService_test.go
@@ -1,0 +1,144 @@
+package marin3r
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/pkg/errors"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestRateLimitService(t *testing.T) {
+	scheme := newScheme()
+
+	scenarios := []struct {
+		Name       string
+		Reconciler *RateLimitServiceReconciler
+		InitObjs   []runtime.Object
+		Assert     func(k8sclient.Client, integreatlyv1alpha1.StatusPhase, error) error
+	}{
+		{
+			Name:       "Service deployed",
+			Reconciler: NewRateLimitServiceReconciler("redhat-test-marin3r", "ratelimit-redis"),
+			InitObjs: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "ratelimit-redis",
+						Namespace: "redhat-test-marin3r",
+					},
+					Data: map[string][]byte{
+						"URL": []byte("test-url"),
+					},
+				},
+			},
+			Assert: func(client k8sclient.Client, phase integreatlyv1alpha1.StatusPhase, reconcileError error) error {
+				if reconcileError != nil {
+					return fmt.Errorf("unexpected error: %v", reconcileError)
+				}
+
+				if phase != integreatlyv1alpha1.PhaseCompleted {
+					return fmt.Errorf("unexpected phase. Expected PhaseCompleted, got %s", phase)
+				}
+
+				configMap := &corev1.ConfigMap{}
+				if err := client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "ratelimit-config",
+					Namespace: "redhat-test-marin3r",
+				}, configMap); err != nil {
+					return fmt.Errorf("failed to obtain expected ConfigMap: %v", err)
+				}
+
+				deployment := &appsv1.Deployment{}
+				if err := client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "ratelimit",
+					Namespace: "redhat-test-marin3r",
+				}, deployment); err != nil {
+					return fmt.Errorf("failed to obtain expected deployment: %v", err)
+				}
+
+				envs := deployment.Spec.Template.Spec.Containers[0].Env
+				url, err := func() (string, error) {
+					for _, env := range envs {
+						if env.Name == "REDIS_URL" {
+							return env.Value, nil
+						}
+					}
+
+					return "", errors.Errorf("REDIS_URL not found in environment variables")
+				}()
+
+				if err != nil {
+					return err
+				}
+				if url != "test-url" {
+					return fmt.Errorf("unexpected value for REDIS_URL: %s", url)
+				}
+
+				service := &corev1.Service{}
+				if err := client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "ratelimit",
+					Namespace: "redhat-test-marin3r",
+				}, service); err != nil {
+					return fmt.Errorf("failed to obtain expected service: %v", err)
+				}
+
+				return nil
+			},
+		},
+
+		{
+			Name:       "Wait for redis",
+			InitObjs:   []runtime.Object{},
+			Reconciler: NewRateLimitServiceReconciler("redhat-test-marin3r", "ratelimit-redis"),
+			Assert: func(client k8sclient.Client, phase integreatlyv1alpha1.StatusPhase, reconcileError error) error {
+				if reconcileError != nil {
+					return fmt.Errorf("unexpected error: %v", reconcileError)
+				}
+
+				if phase != integreatlyv1alpha1.PhaseAwaitingComponents {
+					return fmt.Errorf("unexpected phase. Expected %s, got %s",
+						integreatlyv1alpha1.PhaseAwaitingComponents,
+						phase,
+					)
+				}
+
+				deployment := &appsv1.Deployment{}
+				if err := client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "ratelimit",
+					Namespace: "redhat-test-marin3r",
+				}, deployment); !k8serrors.IsNotFound(err) {
+					return fmt.Errorf("expected deployment not found error, got: %v", err)
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client := fake.NewFakeClientWithScheme(scheme, scenario.InitObjs...)
+			phase, err := scenario.Reconciler.ReconcileRateLimitService(context.TODO(), client)
+
+			if err := scenario.Assert(client, phase, err); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func newScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	appsv1.AddToScheme(scheme)
+
+	return scheme
+}


### PR DESCRIPTION
# Description

Create RateLimitServiceReconciler component to reconcile the resources for the rate limit service. It expects a secret that points to the Redis instance to be used by the service, and creates a ConfigMap, Deployment and Service to configure, run and expose this service.

Create unit tests for reconciler.

## Verification steps

### 1. Include the marin3r reconciler

Uncomment the line with the `integreatlyv1alpha1.ProductMarin3r` reconciler to include the product in the ManagedAPI installation:
https://github.com/integr8ly/integreatly-operator/blob/master/pkg/controller/installation/types.go#L48

### 2. Install the Managed API Operator

```sh
make cluster/prepare/local
make code/run
```

### 3. Create Redis instance

> This step will be automated by [MGDAPI-88](https://issues.redhat.com/browse/MGDAPI-88). Meanwhile, create the in-cluster Redis instance and a Service to expose it

```sh
cat << EOF | oc create -f - -n redhat-rhmi-operator
apiVersion: integreatly.org/v1alpha1
kind: Redis
metadata:  
  name: rate-limit
spec:
  secretRef:
    name: rate-limit-redis
  tier: production
  type: managed-api
EOF
```

Wait for the CRO to reconcile the Redis CR and set it to complete. Then create a Secret in the `redhat-rhmi-marin3r` namespace referencing the Redis Service:

```sh
REDIS_URL=$(oc get secret/rate-limit-redis -n redhat-rhmi-operator -o json | jq -r '.data.uri' | base64 --decode):$(oc get secret/rate-limit-redis -n redhat-rhmi-operator -o json | jq -r '.data.port' | base64 --decode)
oc create secret generic redis -n redhat-rhmi-marin3r --from-literal=URL=$REDIS_URL
```

### 4. Check resources are reconciled

Once the secret with the Redis URL is created, the operator will finish reconciling the resources. Check that the following resources exist and are in good state:

* Rate limit configuration ConfigMap
    ```sh
    oc get configmaps/ratelimit-config -n redhat-rhmi-marin3r
    ```
* Rate limit service Deployment
    ```sh
    oc get deployments/ratelimit -n redhat-rhmi-marin3r
    ```
* Exposed service
    ```sh
    oc get services/ratelimit -n redhat-rhmi-marin3r
    ```
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer