### PR TITLE
script for determining Az for pods in namespace

### DIFF
--- a/scripts/podsAz.sh
+++ b/scripts/podsAz.sh
@@ -14,7 +14,6 @@ echo "| Pod name | Availability Zone |"
 echo "| -------- | ----------------- |"
 while IFS= read -r pod_name; do
 node=`oc get pods/$pod_name -n $NAMESPACE -o json | jq -r '.spec.nodeName'`
-machine_name=`oc get nodes $node -o json | jq -r '.metadata.annotations["machine.openshift.io/machine"] | match("openshift-machine-api\/(.+)") | .captures[0].string'`
-zone=`oc get machines $machine_name -n openshift-machine-api -o json | jq -r '.metadata.labels["machine.openshift.io/zone"]'`
+zone=`oc get nodes $node -o json | jq -r '.metadata.labels["topology.kubernetes.io/zone"]'`
 echo "| $pod_name | $zone |"
 done <<< "$pods"

--- a/scripts/podsAz.sh
+++ b/scripts/podsAz.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Prereq:
+# - oc
+# - jq
+# Usage:
+# ./podsAz.sh <namespace>
+# Function:
+# Lists the Pods for an namespace and there Availability Zones
+
+NAMESPACE=$1
+echo "Pods distribution for '$NAMESPACE'"
+pods=`oc get pods -n $NAMESPACE -o json | jq -r '.items[].metadata.name'`
+echo "| Pod name | Availability Zone |"
+echo "| -------- | ----------------- |"
+while IFS= read -r pod_name; do
+node=`oc get pods/$pod_name -n $NAMESPACE -o json | jq -r '.spec.nodeName'`
+machine_name=`oc get nodes $node -o json | jq -r '.metadata.annotations["machine.openshift.io/machine"] | match("openshift-machine-api\/(.+)") | .captures[0].string'`
+zone=`oc get machines $machine_name -n openshift-machine-api -o json | jq -r '.metadata.labels["machine.openshift.io/zone"]'`
+echo "| $pod_name | $zone |"
+done <<< "$pods"


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Script for determining what pods are on what Availability Zone

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Verification
- deploy a multi AZ byoc cluster
- deploy managed api
- run the script for a namespace e.g. 3scale
```bash
./podsAz.sh redhat-rhmi-3scale
Pods distribution for 'redhat-rhmi-3scale'
| Pod name | Availability Zone |
| -------- | ----------------- |
| apicast-production-1-pg9zl | eu-west-1b |
| apicast-production-1-xfvt2 | eu-west-1a |
| apicast-staging-1-fv9lq | eu-west-1a |
| apicast-staging-1-szddq | eu-west-1b |
| backend-cron-1-9cdc8 | eu-west-1a |
| backend-cron-1-c7jgr | eu-west-1b |
| backend-cron-1-deploy | eu-west-1a |
| backend-listener-1-deploy | eu-west-1b |
| backend-listener-1-p6zjr | eu-west-1b |
| backend-listener-1-xrz5w | eu-west-1a |
| backend-worker-1-9jlxp | eu-west-1b |
| backend-worker-1-deploy | eu-west-1b |
| backend-worker-1-tdp5x | eu-west-1b |
| system-app-1-deploy | eu-west-1a |
| system-app-1-hook-pre | eu-west-1b |
| system-app-2-deploy | eu-west-1a |
| system-app-2-gflxj | eu-west-1b |
| system-app-2-kdggv | eu-west-1b |
| system-memcache-1-6ks54 | eu-west-1a |
| system-memcache-1-deploy | eu-west-1b |
| system-sidekiq-2-nbd6k | eu-west-1b |
| system-sidekiq-2-zhpkx | eu-west-1b |
| system-sphinx-1-5j6b4 | eu-west-1b |
| system-sphinx-1-deploy | eu-west-1a |
| zync-1-69jz6 | eu-west-1b |
| zync-1-deploy | eu-west-1a |
| zync-1-shbtd | eu-west-1a |
| zync-database-1-ndbv4 | eu-west-1b |
| zync-que-1-cn2pz | eu-west-1a |
| zync-que-1-r9tmg | eu-west-1a |
```
