### PR TITLE
MGDAPI-179 Adding Managed-API version

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,7 +61,7 @@ func init() {
 }
 
 func printVersion() {
-	log.Info(fmt.Sprintf("Operator Version: %s", version.Version))
+	log.Info(fmt.Sprintf("Operator Version: %s", version.GetVersion()))
 	log.Info(fmt.Sprintf("Go Version: %s", runtime.Version()))
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 	log.Info(fmt.Sprintf("Version of operator-sdk: %v", sdkVersion.Version))

--- a/pkg/controller/subscription/rhmiConfigs/main_test.go
+++ b/pkg/controller/subscription/rhmiConfigs/main_test.go
@@ -360,7 +360,7 @@ func TestApproveUpgrade(t *testing.T) {
 				{
 					Resource: olmv1alpha1.StepResource{
 						Kind:     "ClusterServiceVersion",
-						Manifest: fmt.Sprintf("{\"kind\":\"ClusterServiceVersion\",    \"spec\": {      \"version\": \"%s\"}}", version.Version),
+						Manifest: fmt.Sprintf("{\"kind\":\"ClusterServiceVersion\",    \"spec\": {      \"version\": \"%s\"}}", version.GetVersion()),
 					},
 				},
 			},

--- a/pkg/controller/subscription/subscription_controller.go
+++ b/pkg/controller/subscription/subscription_controller.go
@@ -250,7 +250,7 @@ func (r *ReconcileSubscription) HandleUpgrades(ctx context.Context, rhmiSubscrip
 	}
 
 	isInstallPlanDeleted := false
-	currentOperatorVersionName := fmt.Sprintf("%s.v%s", CSVNamePrefix, version.Version)
+	currentOperatorVersionName := fmt.Sprintf("%s.v%s", CSVNamePrefix, version.GetVersion())
 	if csvFromCatalogSource.Spec.Replaces != currentOperatorVersionName {
 
 		if csvFromCatalogSource.Spec.Replaces != latestRHMICSV.Spec.Replaces {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -16,8 +16,8 @@ var (
 			Name: "integreatly_version_info",
 			Help: "Integreatly operator information",
 			ConstLabels: prometheus.Labels{
-				"operator_version": version.Version,
-				"version":          version.IntegreatlyVersion,
+				"operator_version": version.GetVersion(),
+				"version":          version.GetVersion(),
 			},
 		},
 	)

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -369,7 +369,7 @@ func (r *Reconciler) ReconcileCustomResource(ctx context.Context, installation *
 			paramOpenShiftVersion:     "4",
 			paramClusterType:          "osd",
 			paramInstalledServices:    installedServices,
-			paramIntegreatlyVersion:   version.IntegreatlyVersion,
+			paramIntegreatlyVersion:   version.GetVersion(),
 			paramWalkthroughLocations: defaultWalkthroughsLoc,
 			paramRoutingSubdomain:     installation.Spec.RoutingSubdomain,
 			paramInstallationType:     installation.Spec.Type,

--- a/version/version.go
+++ b/version/version.go
@@ -3,11 +3,16 @@ package version
 import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/sirupsen/logrus"
+	"os"
+)
+
+const (
+	installTypeEnvName = "INSTALLATION_TYPE"
 )
 
 var (
-	Version            = "2.7.0"
-	IntegreatlyVersion = "2.7.0"
+	version           = "2.7.0"
+	managedAPIVersion = "1.0.0"
 )
 
 func VerifyProductAndOperatorVersion(product integreatlyv1alpha1.RHMIProductStatus, expectedProductVersion string, expectedOpVersion string) bool {
@@ -23,4 +28,14 @@ func VerifyProductAndOperatorVersion(product integreatlyv1alpha1.RHMIProductStat
 		return false
 	}
 	return true
+}
+
+func GetVersion() string {
+	installTypeEnv, _ := os.LookupEnv(installTypeEnvName)
+
+	if installTypeEnv == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return managedAPIVersion
+	} else {
+		return version
+	}
 }


### PR DESCRIPTION
# What

PR addressing ticket https://issues.redhat.com/browse/MGDAPI-179 and other 2 issues discovered.

Currently, 
1. Managed-API CR version is the same for managed-api and managed installation
2. We are setting our `version` field as soon as one of the product reports completed ( monitoring is usually marked as completed first ) and removing the `toVersion`. 
3. Grafana Reconciler was reporting `completed` although it did not finish the installation and it did not complete, the `operatorVersion`, `version` and `host` fields in the managed-api CR were not set.

# How
- added managed-api version field in version.go, version is now returned when version.GetVersion() is called
- added a check for `productVersionMismatch` - once all of the products report completed - the `version` is set and `toVersion` removed
- added logic to Grafana reconciler to save and use `operator version`, `version` and `host` fields

# How to verify
1. Provision cluster and run oc login to use your cluster
2. Run 
```
export INSTALLATION_TYPE=managed-api
```
3. Prepare cluster:
```
make cluster/prepare/local
```
4. Run operator locally
```
make code/run
```
5. Verify that during installation `toVersion` is present and set to `1.0.0` and once installation completes, `toVersion` is gone and `version` field is present with version 1.0.0

6. Delete Managed-API CR and wait for deletion
7. Run
```
export INSTALLATION_TYPE=managed
```
8. Run operator locally:
```
make code/run
```
9.  Verify that during installation `toVersion` is present and set to `2.7.0` and once installation completes, `toVersion` is gone and `version` field is present with version 2.7.0