### PR TITLE
Removes validation for maximum days for upgrade schedule

### DIFF
--- a/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
@@ -56,6 +56,8 @@ spec:
                     until it's approved
                   nullable: true
                   type: integer
+                schedule:
+                  type: boolean
                 waitForMaintenance:
                   description: If this value is true, upgrades will be approved in
                     the next maintenance window n days after the upgrade is made available.

--- a/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmiconfig_types.go
@@ -41,7 +41,7 @@ const (
 	DefaultWaitForMaintenance = true
 
 	// Maximum allowed number of days to schedule an upgrade via `NotBeforeDays`
-	MaxUpgradeDays = 14
+	// MaxUpgradeDays = 14
 )
 
 // RHMIConfigSpec defines the desired state of RHMIConfig
@@ -105,6 +105,8 @@ type Upgrade struct {
 	// +optional
 	// +nullable
 	NotBeforeDays *int `json:"notBeforeDays,omitempty"`
+
+	Schedule *bool `json:"schedule,omitempty"`
 }
 
 type Maintenance struct {
@@ -166,9 +168,6 @@ func (c *RHMIConfig) ValidateUpdate(old runtime.Object) error {
 
 		if notBeforeDays < 0 {
 			return errors.New("Value of spec.Upgrade.NotBeforeDays must be greater or equal to zero")
-		}
-		if notBeforeDays > MaxUpgradeDays {
-			return fmt.Errorf("Value of spec.Upgrade.NotBeforeDays must be less than or equal to %d", MaxUpgradeDays)
 		}
 	}
 
@@ -252,6 +251,7 @@ func (h *rhmiConfigMutatingHandler) Handle(ctx context.Context, request admissio
 func (u *Upgrade) DefaultIfEmpty() {
 	u.NotBeforeDays = either(u.NotBeforeDays, DefaultNotBeforeDays).(*int)
 	u.WaitForMaintenance = either(u.WaitForMaintenance, DefaultWaitForMaintenance).(*bool)
+	u.Schedule = either(u.Schedule, false).(*bool)
 }
 
 func init() {

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.deepcopy.go
@@ -365,6 +365,11 @@ func (in *Upgrade) DeepCopyInto(out *Upgrade) {
 		*out = new(int)
 		**out = **in
 	}
+	if in.Schedule != nil {
+		in, out := &in.Schedule, &out.Schedule
+		*out = new(bool)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/controller/rhmiconfig/helpers/update_status.go
+++ b/pkg/controller/rhmiconfig/helpers/update_status.go
@@ -13,6 +13,13 @@ import (
 const WINDOW = 6
 
 func UpdateStatus(ctx context.Context, client k8sclient.Client, config *integreatlyv1alpha1.RHMIConfig) error {
+
+	// removes the upgrade schedule time from the CR, if Upgrade.Schedule is set to false
+	if *config.Spec.Upgrade.Schedule == false {
+		config.Status.Upgrade.Scheduled = nil
+		return client.Status().Update(ctx, config)
+	}
+
 	// Calculate the next maintenance window based on the maintenance schedule
 	if config.Spec.Maintenance.ApplyFrom != "" {
 		mtStart, _, err := getWeeklyWindowFromNow(config.Spec.Maintenance.ApplyFrom, time.Hour*WINDOW)

--- a/pkg/controller/rhmiconfig/helpers/update_status_test.go
+++ b/pkg/controller/rhmiconfig/helpers/update_status_test.go
@@ -2,11 +2,12 @@ package helpers
 
 import (
 	"context"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
 	"reflect"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
@@ -70,6 +71,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						NotBeforeDays:      intPtr(8),
 						WaitForMaintenance: boolPtr(true),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
@@ -101,6 +103,9 @@ func TestUpdateStatus(t *testing.T) {
 					Maintenance: integreatlyv1alpha1.Maintenance{
 						ApplyFrom: strings.ToLower(nowOffset(-1).Format("Mon 15:04")),
 					},
+					Upgrade: integreatlyv1alpha1.Upgrade{
+						Schedule: boolPtr(true),
+					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
 					UpgradeAvailable: &integreatlyv1alpha1.UpgradeAvailable{
@@ -129,6 +134,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						NotBeforeDays:      intPtr(0),
 						WaitForMaintenance: boolPtr(false),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
@@ -152,6 +158,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						NotBeforeDays:      intPtr(0),
 						WaitForMaintenance: boolPtr(true),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
@@ -180,6 +187,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						WaitForMaintenance: boolPtr(true),
 						NotBeforeDays:      intPtr(3),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
@@ -206,6 +214,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						WaitForMaintenance: boolPtr(true),
 						NotBeforeDays:      intPtr(6),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{
@@ -227,6 +236,7 @@ func TestUpdateStatus(t *testing.T) {
 					Upgrade: integreatlyv1alpha1.Upgrade{
 						NotBeforeDays:      intPtr(3),
 						WaitForMaintenance: boolPtr(false),
+						Schedule:           boolPtr(true),
 					},
 				},
 				Status: integreatlyv1alpha1.RHMIConfigStatus{

--- a/test/common/rhmi_config.go
+++ b/test/common/rhmi_config.go
@@ -113,17 +113,14 @@ var upgradeSectionStates = map[v1alpha1.Upgrade]func(*testing.T) func(error){
 
 	{
 		NotBeforeDays: intPtr(-1),
+		Schedule:      boolPtr(true),
 	}: assertValidationError,
 
 	{
 		NotBeforeDays:      intPtr(7),
 		WaitForMaintenance: boolPtr(true),
+		Schedule:           boolPtr(true),
 	}: assertNoError,
-
-	{
-		NotBeforeDays:      intPtr(365),
-		WaitForMaintenance: boolPtr(true),
-	}: assertValidationError,
 }
 
 // TestRHMIConfigCRs tests that the RHMIConfig CR is created successfuly and


### PR DESCRIPTION
# Description

Removes the maximum days validation for upgrade schedule

https://issues.redhat.com/browse/INTLY-10150

## Verification Step

1. Install the operator from this index `quay.io/jjaferson/integreatly-index:2.8.0`
2. Change the catalogsource to point to `quay.io/jjaferson/integreatly-index:2.9.0` 
3. Modify the schedule field in the RHMIConfig CR to true 
```
spec:
  upgrade:
    schedule: true
```
4. Change the notBeforeDays field to a number grater than 14 
```
spec:
  upgrade:
    notBeforeDays: 30
```
5. Verify if the upgrade is scheduled for a date equivalent to the number of days defined in the `notBeforeDays`
```
status:
  upgrade: {}
```
6. Change the schedule field in the RHMIConfig CR to false
```
spec:
  upgrade:
    schedule: false
```
7. Check if the scheduled date for the upgrade is removed from the status clock
```
status:
  upgrade: {}
```