### PR TITLE
add redis to rate limiting service

### DIFF
--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -298,7 +298,7 @@ func (r *Reconciler) preUpgradeBackupExecutor() backup.BackupExecutor {
 
 	return backup.NewAWSBackupExecutor(
 		r.installation.Namespace,
-		externalRedisSecretName,
+		fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, r.installation.Name),
 		backup.RedisSnapshotType,
 	)
 }

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -3,6 +3,11 @@ package marin3r
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
+	croUtil "github.com/integr8ly/cloud-resource-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	marin3r "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
@@ -140,6 +145,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.reconcileRedis(ctx, client)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if phase == integreatlyv1alpha1.PhaseAwaitingComponents {
+		return phase, nil
+	}
+
 	phase, err = NewRateLimitServiceReconciler(productNamespace, externalRedisSecretName).
 		ReconcileRateLimitService(ctx, client)
 	if err != nil {
@@ -151,6 +164,68 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) reconcileRedis(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	logrus.Info("Creating backend redis instance in marine3r reconcile")
+
+	ns := r.installation.Namespace
+
+	redisName := fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, r.installation.Name)
+	rateLimitRedis, err := croUtil.ReconcileRedis(ctx, client, defaultInstallationNamespace, r.installation.Spec.Type, croUtil.TierProduction, redisName, ns, redisName, ns, func(cr metav1.Object) error {
+		owner.AddIntegreatlyOwnerAnnotations(cr, r.installation)
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile backend redis request: %w", err)
+	}
+
+	// wait for the redis cr to reconcile
+	if rateLimitRedis.Status.Phase != types.PhaseComplete {
+		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	// get the secret created by the cloud resources operator
+	// containing system redis connection details
+	systemCredSec := &corev1.Secret{}
+	err = client.Get(ctx, k8sclient.ObjectKey{Name: rateLimitRedis.Status.SecretRef.Name, Namespace: rateLimitRedis.Status.SecretRef.Namespace}, systemCredSec)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to get system redis credential secret: %w", err)
+	}
+
+	// create system redis external connection secret needed for the 3scale apimanager
+	redisSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      externalRedisSecretName,
+			Namespace: r.Config.GetNamespace(),
+		},
+		Data: map[string][]byte{},
+	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, redisSecret, func() error {
+		uri := systemCredSec.Data["uri"]
+		port := systemCredSec.Data["port"]
+
+		conn := fmt.Sprintf("%s:%s", uri, port)
+		redisSecret.Data["URL"] = []byte(conn)
+
+		return nil
+	})
+
+	phase, err := resources.ReconcileRedisAlerts(ctx, client, r.installation, rateLimitRedis)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile redis alerts: %w", err)
+	}
+	if phase != integreatlyv1alpha1.PhaseCompleted {
+		return phase, nil
+	}
+
+	// create Redis Cpu Usage High alert
+	err = resources.CreateRedisCpuUsageAlerts(ctx, client, r.installation, rateLimitRedis)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create rate limit redis prometheus Cpu usage high alerts for threescale: %s", err)
+	}
+
+	return phase, nil
 }
 
 func (r *Reconciler) reconcileDiscoveryService(ctx context.Context, client k8sclient.Client, productNamespace string, namespacePrefix string) (integreatlyv1alpha1.StatusPhase, error) {
@@ -220,6 +295,10 @@ func (r *Reconciler) preUpgradeBackupExecutor() backup.BackupExecutor {
 	if r.installation.Spec.UseClusterStorage != "false" {
 		return backup.NewNoopBackupExecutor()
 	}
-	//todo add backup for redis once it's added to the reconciler
-	return backup.NewNoopBackupExecutor()
+
+	return backup.NewAWSBackupExecutor(
+		r.installation.Namespace,
+		externalRedisSecretName,
+		backup.RedisSnapshotType,
+	)
 }

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -351,7 +351,7 @@ var postgresSec = &corev1.Secret{
 
 var redis = &crov1.Redis{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "threescale-redis-test-installation",
+		Name:      "threescale-redis-rhmi",
 		Namespace: "integreatly-operator-ns",
 	},
 	Status: crov1.RedisStatus{
@@ -379,7 +379,7 @@ var redisSec = &corev1.Secret{
 
 var backendRedis = &crov1.Redis{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      "threescale-backend-redis-test-installation",
+		Name:      "threescale-backend-redis-rhmi",
 		Namespace: "integreatly-operator-ns",
 	},
 	Status: crov1.RedisStatus{

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -703,7 +703,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	// setup backend redis custom resource
 	// this will be used by the cloud resources operator to provision a redis instance
 	logrus.Info("Creating backend redis instance")
-	backendRedisName := fmt.Sprintf("%s%s", constants.ThreeScaleBackendRedisPrefix, r.installation.Name)
+	backendRedisName := fmt.Sprintf("%s%s", constants.ThreeScaleBackendRedisPrefix, "rhmi")
 	backendRedis, err := croUtil.ReconcileRedis(ctx, serverClient, defaultInstallationNamespace, r.installation.Spec.Type, croUtil.TierProduction, backendRedisName, ns, backendRedisName, ns, func(cr metav1.Object) error {
 		owner.AddIntegreatlyOwnerAnnotations(cr, r.installation)
 		return nil
@@ -715,7 +715,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	// setup system redis custom resource
 	// this will be used by the cloud resources operator to provision a redis instance
 	logrus.Info("Creating system redis instance")
-	systemRedisName := fmt.Sprintf("%s%s", constants.ThreeScaleSystemRedisPrefix, r.installation.Name)
+	systemRedisName := fmt.Sprintf("%s%s", constants.ThreeScaleSystemRedisPrefix, "rhmi")
 	systemRedis, err := croUtil.ReconcileRedis(ctx, serverClient, defaultInstallationNamespace, r.installation.Spec.Type, croUtil.TierProduction, systemRedisName, ns, systemRedisName, ns, func(cr metav1.Object) error {
 		owner.AddIntegreatlyOwnerAnnotations(cr, r.installation)
 		return nil

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -90,7 +90,7 @@ type ThreeScaleTestScenario struct {
 func getTestInstallation() *integreatlyv1alpha1.RHMI {
 	return &integreatlyv1alpha1.RHMI{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test",
+			Name:      "rhmi",
 			Namespace: "test",
 		},
 		Spec: integreatlyv1alpha1.RHMISpec{
@@ -106,7 +106,7 @@ func getTestInstallation() *integreatlyv1alpha1.RHMI {
 func getTestBlobStorage() *crov1.BlobStorage {
 	return &crov1.BlobStorage{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "threescale-blobstorage-test",
+			Name:      "threescale-blobstorage-rhmi",
 			Namespace: "test",
 		},
 		Status: crov1.BlobStorageStatus{

--- a/pkg/resources/constants/croConstants.go
+++ b/pkg/resources/constants/croConstants.go
@@ -5,6 +5,7 @@ const (
 	ThreeScaleBackendRedisPrefix = "threescale-backend-redis-"
 	ThreeScaleSystemRedisPrefix  = "threescale-redis-"
 	ThreeScalePostgresPrefix     = "threescale-postgres-"
+	RateLimitRedisPrefix         = "ratelimit-service-redis-"
 	RHSSOPostgresPrefix          = "rhsso-postgres-"
 	RHSSOUserProstgresPrefix     = "rhssouser-postgres-"
 	UPSPostgresPrefix            = "ups-postgres-"

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -718,6 +718,15 @@ var rhmi2ExpectedAWSRules = []alertsTestRule{
 	},
 }
 
+var managedApiAwsExpectedRules = []alertsTestRule{
+	{
+		File: NamespacePrefix + "operator-resource-status-phase-failed-rule-ratelimit-service-redis-managed-api.yaml",
+		Rules: []string{
+			"Ratelimit-Service-Redis-Managed-ApiRedisResourceStatusPhaseFailed",
+		},
+	},
+}
+
 func TestIntegreatlyAlertsExist(t *testing.T, ctx *TestingContext) {
 	isClusterStorage, err := isClusterStorage(ctx)
 	if err != nil {
@@ -847,7 +856,7 @@ func getExpectedAWSRules(installType string) []alertsTestRule {
 	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		return commonExpectedAWSRules
 	} else {
-		return append(commonExpectedAWSRules, rhmi2ExpectedAWSRules...)
+		return append(append(commonExpectedAWSRules, rhmi2ExpectedAWSRules...), managedApiAwsExpectedRules...)
 	}
 }
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

## How to Verify

- Install manged-api and verify it's as expected 

- Verify that the rate-limiting Deployment exists
`oc get deployments/ratelimit -n redhat-rhmi-marin3r`

- Verify redis installed
`oc get redis ratelimit-service-redis-managed-api`

- Check the Pod logs of rate-limiting service and confirm no error when it connects to redis.


