### PR TITLE
set version based on install type

### DIFF
--- a/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
@@ -17,14 +17,10 @@ spec:
       description: RHMIConfig is the Schema for the rhmiconfigs API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -34,32 +30,26 @@ spec:
             backup:
               properties:
                 applyOn:
-                  description: 'apply-on: string, day time. Format: "DDD hh:mm" >
-                    "wed 20:00". UTC time'
+                  description: 'apply-on: string, day time. Format: "DDD hh:mm" > "wed 20:00". UTC time'
                   type: string
               type: object
             maintenance:
               properties:
                 applyFrom:
-                  description: 'apply-from: string, day time. Currently this is a
-                    6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                  description: 'apply-from: string, day time. Currently this is a 6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
                   type: string
               type: object
             upgrade:
               properties:
                 contacts:
-                  description: 'contacts: list of contacts which are comma separated
-                    "user1@example.com,user2@example.com"'
+                  description: 'contacts: list of contacts which are comma separated "user1@example.com,user2@example.com"'
                   type: string
                 notBeforeDays:
-                  description: Minimum of days since an upgrade is made available
-                    until it's approved
+                  description: Minimum of days since an upgrade is made available until it's approved
                   nullable: true
                   type: integer
                 waitForMaintenance:
-                  description: If this value is true, upgrades will be approved in
-                    the next maintenance window n days after the upgrade is made available.
-                    Being n the value of `notBeforeDays`.
+                  description: If this value is true, upgrades will be approved in the next maintenance window n days after the upgrade is made available. Being n the value of `notBeforeDays`.
                   nullable: true
                   type: boolean
               type: object
@@ -68,10 +58,7 @@ spec:
           description: RHMIConfigStatus defines the observed state of RHMIConfig
           properties:
             maintenance:
-              description: "status block reflects the current configuration of the
-                cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00
-                \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 -
-                17 Jan 1980\""
+              description: "status block reflects the current configuration of the cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00 \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 - 17 Jan 1980\""
               properties:
                 applyFrom:
                   type: string
@@ -81,20 +68,17 @@ spec:
             upgrade:
               properties:
                 scheduled:
-                  description: Scheduled contains the information on the next upgrade
-                    schedule
+                  description: Scheduled contains the information on the next upgrade schedule
                   properties:
                     for:
-                      description: For is the calculated time when the upgrade is
-                        scheduled for, in format "2 Jan 2006 15:04"
+                      description: For is the calculated time when the upgrade is scheduled for, in format "2 Jan 2006 15:04"
                       type: string
                   type: object
               type: object
             upgradeAvailable:
               properties:
                 availableAt:
-                  description: 'Time of new update becoming available Format: "DDD
-                    hh:mm" > "sun 23:00". UTC time'
+                  description: 'Time of new update becoming available Format: "DDD hh:mm" > "sun 23:00". UTC time'
                   format: date-time
                   type: string
                 targetVersion:

--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -17,14 +17,10 @@ spec:
       description: RHMI is the Schema for the RHMI API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -34,25 +30,17 @@ spec:
             alertingEmailAddress:
               type: string
             deadMansSnitchSecret:
-              description: "DeadMansSnitchSecret is the name of a secret in the installation
-                namespace containing connection details for Dead Mans Snitch. The
-                secret must contain the following fields: \n url"
+              description: "DeadMansSnitchSecret is the name of a secret in the installation namespace containing connection details for Dead Mans Snitch. The secret must contain the following fields: \n url"
               type: string
             masterURL:
               type: string
             namespacePrefix:
               type: string
             operatorsInProductNamespace:
-              description: OperatorsInProductNamespace is a flag that decides if the
-                product operators should be installed in the product namespace (when
-                set to true) or in standalone namespace (when set to false, default).
-                Standalone namespace will be used only for those operators that support
-                it.
+              description: OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.
               type: boolean
             pagerDutySecret:
-              description: "PagerDutySecret is the name of a secret in the installation
-                namespace containing PagerDuty account details. The secret must contain
-                the following fields: \n serviceKey"
+              description: "PagerDutySecret is the name of a secret in the installation namespace containing PagerDuty account details. The secret must contain the following fields: \n serviceKey"
               type: string
             pullSecret:
               properties:
@@ -69,15 +57,10 @@ spec:
             selfSignedCerts:
               type: boolean
             smtpSecret:
-              description: "SMTPSecret is the name of a secret in the installation
-                namespace containing SMTP connection details. The secret must contain
-                the following fields: \n host port tls username password"
+              description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields: \n host port tls username password"
               type: string
             type:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
             useClusterStorage:
               type: string
@@ -135,10 +118,7 @@ spec:
                 - name
                 - phase
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: object
             toVersion:
               type: string

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	k8s.io/apiextensions-apiserver v0.18.6
 	k8s.io/apimachinery v0.18.6
 	k8s.io/client-go v12.0.0+incompatible
+	k8s.io/helm v2.16.3+incompatible
 	k8s.io/kube-openapi v0.0.0-20200410145947-61e04a5be9a6
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -29,13 +29,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/integreatly/v1alpha1/.RHMI":       schema_apis_integreatly_v1alpha1__RHMI(ref),
-		"./pkg/apis/integreatly/v1alpha1/.RHMISpec":   schema_apis_integreatly_v1alpha1__RHMISpec(ref),
-		"./pkg/apis/integreatly/v1alpha1/.RHMIStatus": schema_apis_integreatly_v1alpha1__RHMIStatus(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMI":       schema_pkg_apis_integreatly_v1alpha1_RHMI(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec":   schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus": schema_pkg_apis_integreatly_v1alpha1_RHMIStatus(ref),
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMI(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMI(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -63,23 +63,23 @@ func schema_apis_integreatly_v1alpha1__RHMI(ref common.ReferenceCallback) common
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMISpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMIStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.RHMISpec", "./pkg/apis/integreatly/v1alpha1/.RHMIStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec", "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -119,7 +119,7 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 					},
 					"pullSecret": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.PullSecretSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"),
 						},
 					},
 					"useClusterStorage": {
@@ -167,11 +167,11 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.PullSecretSpec"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"},
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMIStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -186,7 +186,7 @@ func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) 
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMIStageStatus"),
+										Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStageStatus"),
 									},
 								},
 							},
@@ -245,6 +245,6 @@ func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.RHMIStageStatus"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStageStatus"},
 	}
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,9 +1,10 @@
 package version
 
 import (
+	"os"
+
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/sirupsen/logrus"
-	"os"
 )
 
 const (
@@ -12,7 +13,7 @@ const (
 
 var (
 	version           = "2.7.0"
-	managedAPIVersion = "1.0.0"
+	managedAPIVersion = "0.1.0"
 )
 
 func VerifyProductAndOperatorVersion(product integreatlyv1alpha1.RHMIProductStatus, expectedProductVersion string, expectedOpVersion string) bool {
@@ -33,7 +34,11 @@ func VerifyProductAndOperatorVersion(product integreatlyv1alpha1.RHMIProductStat
 func GetVersion() string {
 	installTypeEnv, _ := os.LookupEnv(installTypeEnvName)
 
-	if installTypeEnv == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	return GetVersionByType(installTypeEnv)
+}
+
+func GetVersionByType(installType string) string {
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		return managedAPIVersion
 	} else {
 		return version


### PR DESCRIPTION
# Description
Updated logic around updating version number in RHMI CR.

Cleaned  up logic at end of main reconcile as it was getting confusing to read.

Testing I performed locally:
- installing: toVersion: 0.1.0, version: ""
- Installed: toVersion: "", Version: 0.1.0
- Slow Upgrade pending: toVersion: 0.2.0, Version: 0.1.0
- Slow Upgrade complete: toVersion: "", Version: 0.2.0
- Fast Upgrade pending: --- too fast ---
- Fast Upgrade complete: toVersion: "", Version: 0.3.0

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Verified independently on a cluster by reviewer