### PR TITLE
MGDAPI-242: Support rate limit configuration via SKU ConfigMap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ cluster/deploy/integreatly-rhmi-cr.yml: deploy/integreatly-rhmi-cr.yml
 	$(call wait_command, oc get RHMI $(INSTALLATION_NAME) -n $(NAMESPACE) --output=json -o jsonpath='{.status.stages.solution-explorer.phase}' | grep -q completed, solution-explorer phase, 10m, 30)
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
+cluster/prepare: cluster/prepare/project cluster/prepare/osrc cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/ratelimits cluster/prepare/delorean
 
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
@@ -241,7 +241,7 @@ cluster/prepare/crd:
 	- oc create -f deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/croaws
+cluster/prepare/local: cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/ratelimits cluster/prepare/delorean cluster/prepare/croaws
 	@oc create -f deploy/service_account.yaml
 	@oc create -f deploy/role.yaml
 	@oc create -f deploy/$(INSTALLATION_PREFIX)/role_binding.yaml -n ${NAMESPACE}
@@ -276,6 +276,10 @@ cluster/prepare/pagerduty:
 cluster/prepare/dms:
 	@-oc create secret generic $(INSTALLATION_PREFIX)-deadmanssnitch -n $(NAMESPACE) \
 		--from-literal=url=https://dms.example.com
+
+.PHONY: cluster/prepare/ratelimits
+cluster/prepare/ratelimits:
+	@-oc create -n $(NAMESPACE) -f deploy/sku-limits-configmap.yaml
 
 .PHONY: cluster/prepare/delorean
 cluster/prepare/delorean: cluster/prepare/delorean/pullsecret

--- a/deploy/sku-limits-configmap.yaml
+++ b/deploy/sku-limits-configmap.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sku-limits-managed-api-service
+data:
+  rate_limit: |-
+    {
+      "RHOAM SERVICE SKU": {
+        "unit": "minute",
+        "requests_per_unit": 20
+      }
+    }

--- a/pkg/products/marin3r/config/config.go
+++ b/pkg/products/marin3r/config/config.go
@@ -1,0 +1,74 @@
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	RateLimitConfigMapName = "sku-limits-managed-api-service"
+	ManagedApiServiceSKU   = "RHOAM SERVICE SKU"
+
+	DefaultRateLimitUnit     = "minute"
+	DefaultRateLimitRequests = 13860
+)
+
+type RateLimitConfig struct {
+	Unit            string `json:"unit"`
+	RequestsPerUnit uint32 `json:"requests_per_unit"`
+}
+
+type AlertConfig struct {
+	Name    string `json:"name"`
+	Level   string `json:"level"`
+	MinRate string `json:"minRate"`
+	MaxRate string `json:"maxRate"`
+	Period  string `json:"period"`
+}
+
+// GetRateLimitConfig retrieves the configuration for the rate limit service,
+// taken from a ConfigMap that is expected to exist in the managed api operator
+// namespace.
+func GetRateLimitConfig(ctx context.Context, client k8sclient.Client, namespace string) (*RateLimitConfig, error) {
+	sku, err := GetSKU(ctx, client)
+	if err != nil {
+		return nil, err
+	}
+
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      RateLimitConfigMapName,
+		Namespace: namespace,
+	}, configMap); err != nil {
+		return nil, err
+	}
+
+	skuConfigsJSON, ok := configMap.Data["rate_limit"]
+	if !ok {
+		return nil, fmt.Errorf("rate_limit key not found in config map")
+	}
+
+	skuConfigs := map[string]*RateLimitConfig{}
+	if err := json.Unmarshal([]byte(skuConfigsJSON), &skuConfigs); err != nil {
+		return nil, err
+	}
+
+	if result, ok := skuConfigs[sku]; ok {
+		return result, nil
+	}
+
+	return nil, fmt.Errorf("SKU %s not found in ConfigMap", sku)
+}
+
+func GetAlertConfig(ctx context.Context, client k8sclient.Client) ([]*AlertConfig, error) {
+	// TODO
+	return nil, nil
+}
+
+func GetSKU(_ context.Context, _ k8sclient.Client) (string, error) {
+	return ManagedApiServiceSKU, nil
+}

--- a/pkg/products/marin3r/config/config_test.go
+++ b/pkg/products/marin3r/config/config_test.go
@@ -1,0 +1,81 @@
+package config
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetRateLimitConfig(t *testing.T) {
+	scheme := testScheme()
+
+	scenarios := []struct {
+		Name        string
+		InitialObjs []runtime.Object
+		Namespace   string
+		Assert      func(client.Client, *RateLimitConfig, error) error
+	}{
+		{
+			Name:      "Success",
+			Namespace: "redhat-test-operator",
+			InitialObjs: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "sku-limits-managed-api-service",
+						Namespace: "redhat-test-operator",
+					},
+					Data: map[string]string{
+						"rate_limit": `
+						{
+							"RHOAM SERVICE SKU": {
+								"unit": "minute",
+								"requests_per_unit": 42
+							}
+						}
+						`,
+					},
+				},
+			},
+			Assert: func(c client.Client, config *RateLimitConfig, err error) error {
+				if err != nil {
+					return fmt.Errorf("Unexpected error: %v", err)
+				}
+
+				expectedConfig := &RateLimitConfig{
+					Unit:            "minute",
+					RequestsPerUnit: 42,
+				}
+
+				if !reflect.DeepEqual(config, expectedConfig) {
+					return fmt.Errorf("Obtained invalid config. Expected %v, but got %v", expectedConfig, config)
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client := fake.NewFakeClientWithScheme(scheme, scenario.InitialObjs...)
+			config, err := GetRateLimitConfig(context.TODO(), client, scenario.Namespace)
+
+			if err := scenario.Assert(client, config, err); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
+func testScheme() *runtime.Scheme {
+	scheme := runtime.NewScheme()
+	corev1.AddToScheme(scheme)
+	return scheme
+}

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	"gopkg.in/yaml.v2"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -19,6 +20,7 @@ type RateLimitServiceReconciler struct {
 	Namespace       string
 	RedisSecretName string
 	StatsdConfig    *StatsdConfig
+	RateLimitConfig *marin3rconfig.RateLimitConfig
 }
 
 type StatsdConfig struct {
@@ -26,8 +28,9 @@ type StatsdConfig struct {
 	Port string
 }
 
-func NewRateLimitServiceReconciler(namespace, redisSecretName string) *RateLimitServiceReconciler {
+func NewRateLimitServiceReconciler(config *marin3rconfig.RateLimitConfig, namespace, redisSecretName string) *RateLimitServiceReconciler {
 	return &RateLimitServiceReconciler{
+		RateLimitConfig: config,
 		Namespace:       namespace,
 		RedisSecretName: redisSecretName,
 	}
@@ -92,8 +95,8 @@ func (r *RateLimitServiceReconciler) reconcileConfigMap(ctx context.Context, cli
 					Key:   "generic_key",
 					Value: "slowpath",
 					RateLimit: &yamlRateLimit{
-						Unit:            "minute",
-						RequestsPerUnit: 20,
+						Unit:            r.RateLimitConfig.Unit,
+						RequestsPerUnit: r.RateLimitConfig.RequestsPerUnit,
 					},
 				},
 			},

--- a/pkg/products/marin3r/rateLimitService_test.go
+++ b/pkg/products/marin3r/rateLimitService_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -26,8 +27,11 @@ func TestRateLimitService(t *testing.T) {
 		Assert     func(k8sclient.Client, integreatlyv1alpha1.StatusPhase, error) error
 	}{
 		{
-			Name:       "Service deployed without metrics",
-			Reconciler: NewRateLimitServiceReconciler("redhat-test-marin3r", "ratelimit-redis"),
+			Name: "Service deployed without metrics",
+			Reconciler: NewRateLimitServiceReconciler(&marin3rconfig.RateLimitConfig{
+				Unit:            "minute",
+				RequestsPerUnit: 1,
+			}, "redhat-test-marin3r", "ratelimit-redis"),
 			InitObjs: []runtime.Object{
 				&corev1.Secret{
 					ObjectMeta: v1.ObjectMeta{
@@ -100,10 +104,18 @@ func TestRateLimitService(t *testing.T) {
 					},
 				},
 			},
-			Reconciler: NewRateLimitServiceReconciler("redhat-test-marin3r", "ratelimit-redis").WithStatsdConfig(StatsdConfig{
-				Host: "test-host",
-				Port: "9092",
-			}),
+			Reconciler: NewRateLimitServiceReconciler(
+				&marin3rconfig.RateLimitConfig{
+					Unit:            "minute",
+					RequestsPerUnit: 1,
+				},
+				"redhat-test-marin3r",
+				"ratelimit-redis",
+			).
+				WithStatsdConfig(StatsdConfig{
+					Host: "test-host",
+					Port: "9092",
+				}),
 			Assert: allOf(
 				assertNoError,
 				assertPhase(integreatlyv1alpha1.PhaseCompleted),
@@ -134,9 +146,12 @@ func TestRateLimitService(t *testing.T) {
 		},
 
 		{
-			Name:       "Wait for redis",
-			InitObjs:   []runtime.Object{},
-			Reconciler: NewRateLimitServiceReconciler("redhat-test-marin3r", "ratelimit-redis"),
+			Name:     "Wait for redis",
+			InitObjs: []runtime.Object{},
+			Reconciler: NewRateLimitServiceReconciler(&marin3rconfig.RateLimitConfig{
+				Unit:            "minute",
+				RequestsPerUnit: 1,
+			}, "redhat-test-marin3r", "ratelimit-redis"),
 			Assert: allOf(
 				assertNoError,
 				assertPhase(integreatlyv1alpha1.PhaseAwaitingComponents),


### PR DESCRIPTION
# Description

Add package `marin3r/config` with the functionality to retrieve the rate limit configuration from a ConfigMap that's expected to be already defined with the rate limits for multiple SKUs

Add make target to create this ConfigMap for development purposes. This ConfigMap is expected to be reconciled by hive from managed-tenants

## Verification steps

1. Begin an installation of Managed API type from this PR
3. Create the ConfigMap
    ```sh
    make cluster/prepare/ratelimits
    ```
4. Verify that the installation progresses and completes successfully
5. Open a terminal in the Rate Limit pod in the marin3r namespace, and check that the config matches the ConfigMap
    ```sh
    cat /srv/runtime_data/current/config
    ```
6. Modify the SKU Rate Limits ConfigMap to a different value
7. Wait a minute and repeat step 4 to verify that the config is updated accordingly

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer