### PR TITLE
[WIP] Updated alertmanager and prometheus route names

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -52,7 +52,7 @@ const (
 	manifestPackage              = "integreatly-monitoring"
 
 	// alert manager configuration
-	alertManagerRouteName            = "alertmanager-route"
+	alertManagerRouteName            = "alertmanager"
 	alertManagerConfigSecretName     = "alertmanager-application-monitoring"
 	alertManagerConfigSecretFileName = "alertmanager.yaml"
 	alertManagerConfigTemplatePath   = "alertmanager/alertmanager-application-monitoring.yaml"

--- a/test-cases/tests/alerts/c03-verify-that-alerting-mechanism-works.md
+++ b/test-cases/tests/alerts/c03-verify-that-alerting-mechanism-works.md
@@ -17,7 +17,7 @@ oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:644
 ```
 
 2. Go to the OpenShift cluster Console URL and login as a user with **cluster-admin** role (kubeadmin).
-3. Open RHMI Prometheus UI and RHMI Alertmanager (in OpenShift Console, go to `Networking -> Routes` and open `alertmanager-route` URL and `prometheus-route` URL and login using the kubeadmin credentials)
+3. Open RHMI Prometheus UI and RHMI Alertmanager (in the OpenShift Console, go to `Networking -> Routes`, open the `alertmanager` and `prometheus` URL and login using the kubeadmin credentials)
 
 ## Steps
 

--- a/test-cases/tests/alerts/c14-verify-3scale-uibbt-alerts.md
+++ b/test-cases/tests/alerts/c14-verify-3scale-uibbt-alerts.md
@@ -22,5 +22,5 @@ More info: <https://issues.redhat.com/browse/INTLY-9043>
 2. Check that all `ThreeScale**UIBBT` alerts are firing
    1. **Networking > Routes**
    2. Select `redhat-rhmi-middleware-monitoring-operator` project
-   3. Open route for `alertmanager-route`
+   3. Open route for `alertmanager`
       > `ThreeScale**UIBBT` should be firing

--- a/test-cases/tests/uninstallation/o01-verify-cloud-resources-can-be-properly-cleaned-up-in-case-of.md
+++ b/test-cases/tests/uninstallation/o01-verify-cloud-resources-can-be-properly-cleaned-up-in-case-of.md
@@ -66,7 +66,7 @@ oc delete redis --all -n redhat-rhmi-operator
 6. Go to alert manager
 
 ```bash
-open "https://$(oc get routes alertmanager-route -n redhat-rhmi-middleware-monitoring-operator -o jsonpath='{.spec.host}')"
+open "https://$(oc get routes alertmanager -n redhat-rhmi-middleware-monitoring-operator -o jsonpath='{.spec.host}')"
 ```
 
 > Verify that all Postgres-RhmiPostgresResourceDeletionStatusPhaseFailed and Redis-RhmiRedisResourceDeletionStatusPhaseFailed alerts (8 in total) go into a pending state and then they start firing (it should take 5 minutes for these alerts to go from pending to firing state)

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -84,7 +84,7 @@ var (
 
 	middlewareMonitoringRoutes = []ExpectedRoute{
 		ExpectedRoute{
-			Name:  "alertmanager-route",
+			Name:  "alertmanager",
 			isTLS: true,
 		},
 		ExpectedRoute{
@@ -92,7 +92,7 @@ var (
 			isTLS: true,
 		},
 		ExpectedRoute{
-			Name:  "prometheus-route",
+			Name:  "prometheus",
 			isTLS: true,
 		},
 	}


### PR DESCRIPTION
# Description

[MGDAPI-117](https://issues.redhat.com/browse/MGDAPI-117)

As part of an update to the Application Monitoring Operator [(pull/148)](https://github.com/integr8ly/application-monitoring-operator/pull/148), both the Alertmanager and Prometheus route names were renamed. This PR contains the required changes to update both route names within the Integreatly Operator. 

**NOTE**: This PR _shouldn't_ be merged until [pull/148](https://github.com/integr8ly/application-monitoring-operator/pull/148) has been verified and new release of the AMO created.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer