### PR TITLE
MGDAPI-172: script for firing/pending alerts

### DIFF
--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# USAGE
+# ./alerts-during-perf-testing.sh <optional product-name>
+# ^C to break
+# Generates two files for firing and pending alerts
+#
+# PREREQUISITES
+# - jq
+# - oc (logged in at the cmd line in order to get the bearer token)
+PRODUCT_NAME=$1
+
+# If no args are passed in then run for all products
+if (( $# == 0 )); then
+  while :; do
+    # generate a report
+    curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
+    $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
+    | jq '.data.alerts[]| select(.state=="pending") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+
+    curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
+    $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
+    | jq '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+
+    # sort command to remove duplicate alert
+     sort -t, -k1 -u tmp-alert-firing-during-perf-testing-report.csv > alert-firing-during-perf-testing-report.csv
+     sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > alert-pending-during-perf-testing-report.csv
+
+     CHECK_NO_ALERTS
+  done
+fi
+
+# Check the product namespaces
+PRODUCT_NAME=`echo $PRODUCT_NAME | grep "3scale\|user-sso\|rhsso\|marin3r"`
+
+if [ -z "$PRODUCT_NAME" ]; then
+  echo Command line args excepted for individual products alerts
+  echo - "3scale"
+  echo - "user-sso"
+  echo - "rhsso"
+  echo - "marin3r"
+  break
+else
+  echo "Check $1 args product namespace and operator namespace for alerts"
+  while :; do
+    curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
+    $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
+    | jq '.data.alerts[]| select(.state=="pending" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname,.labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+
+    curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
+    $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
+    | jq '.data.alerts[]| select(.state=="firing" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname,.labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+
+    # sort command to remove duplicate alert
+    sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-pending-during-perf-testing-report.csv
+    sort -t, -k1 -u tmp-alert-firing-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-firing-during-perf-testing-report.csv
+
+    CHECK_NO_ALERTS
+  done
+fi
+
+# function to check if there are no alerts firing bar deadmansnitch and remove the temp files
+function CHECK_NO_ALERTS(){
+    if [[ $(wc -l  tmp-alert-firing-during-perf-testing-report.csv) = 1  && $(wc -l  tmp-alert-pending-during-perf-testing-report.csv) = 1 ]] ; then
+      echo Only alert firing is DeadMansSwitch
+      date
+    fi
+    rm tmp-alert-firing-during-perf-testing-report.csv
+    rm tmp-alert-pending-during-perf-testing-report.csv
+  done
+}

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -71,7 +71,6 @@ else
       curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
       | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
     fi
-    set -
     # sort command to remove duplicate alert
     sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-pending-during-perf-testing-report.csv
     sort -t, -k1 -u tmp-alert-firing-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-firing-during-perf-testing-report.csv

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -11,13 +11,12 @@ PRODUCT_NAME=$1
 
 # function to check if there are no alerts firing bar deadmansnitch and remove the temp files
 function CHECK_NO_ALERTS(){
-    if [[ $(wc -l  tmp-alert-firing-during-perf-testing-report.csv) = 1  && $(wc -l  tmp-alert-pending-during-perf-testing-report.csv) = 1 ]] ; then
+    if [[ $(wc -l  tmp-alert-firing-during-perf-testing-report.csv) = 1 ]] ; then
       echo Only alert firing is DeadMansSwitch
       date
     fi
     rm tmp-alert-firing-during-perf-testing-report.csv
     rm tmp-alert-pending-during-perf-testing-report.csv
-  done
 }
 
 # If no args are passed in then run for all products

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -9,6 +9,17 @@
 # - oc (logged in at the cmd line in order to get the bearer token)
 PRODUCT_NAME=$1
 
+# function to check if there are no alerts firing bar deadmansnitch and remove the temp files
+function CHECK_NO_ALERTS(){
+    if [[ $(wc -l  tmp-alert-firing-during-perf-testing-report.csv) = 1  && $(wc -l  tmp-alert-pending-during-perf-testing-report.csv) = 1 ]] ; then
+      echo Only alert firing is DeadMansSwitch
+      date
+    fi
+    rm tmp-alert-firing-during-perf-testing-report.csv
+    rm tmp-alert-pending-during-perf-testing-report.csv
+  done
+}
+
 # If no args are passed in then run for all products
 if (( $# == 0 )); then
   while :; do
@@ -58,13 +69,3 @@ else
   done
 fi
 
-# function to check if there are no alerts firing bar deadmansnitch and remove the temp files
-function CHECK_NO_ALERTS(){
-    if [[ $(wc -l  tmp-alert-firing-during-perf-testing-report.csv) = 1  && $(wc -l  tmp-alert-pending-during-perf-testing-report.csv) = 1 ]] ; then
-      echo Only alert firing is DeadMansSwitch
-      date
-    fi
-    rm tmp-alert-firing-during-perf-testing-report.csv
-    rm tmp-alert-pending-during-perf-testing-report.csv
-  done
-}

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -15,8 +15,7 @@ function CHECK_NO_ALERTS(){
       echo Only alert firing is DeadMansSwitch
       date
     fi
-    rm tmp-alert-firing-during-perf-testing-report.csv
-    rm tmp-alert-pending-during-perf-testing-report.csv
+    rm tmp-alert-firing-during-perf-testing-report.csv tmp-alert-pending-during-perf-testing-report.csv
 }
 
 # If no args are passed in then run for all products
@@ -25,11 +24,11 @@ if (( $# == 0 )); then
     # generate a report
     curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
     $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
-    | jq '.data.alerts[]| select(.state=="pending") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+    | jq -r '.data.alerts[]| select(.state=="pending") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
 
     curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
     $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
-    | jq '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+    | jq -r '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
 
     # sort command to remove duplicate alert
      sort -t, -k1 -u tmp-alert-firing-during-perf-testing-report.csv > alert-firing-during-perf-testing-report.csv
@@ -54,11 +53,11 @@ else
   while :; do
     curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
     $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
-    | jq '.data.alerts[]| select(.state=="pending" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname,.labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+    | jq -r '.data.alerts[]| select(.state=="pending" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
 
     curl -s -H "Authorization: Bearer $(oc whoami --show-token)" \
     $(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts \
-    | jq '.data.alerts[]| select(.state=="firing" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname,.labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+    | jq -r '.data.alerts[]| select(.state=="firing" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
 
     # sort command to remove duplicate alert
     sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-pending-during-perf-testing-report.csv

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -8,11 +8,12 @@
 # - jq
 # - oc (logged in at the cmd line in order to get the bearer token)
 # VARIABLES
+NAMESPACE_PREFIX=redhat-rhmi-
 RHSSO="rhsso"
 USER_SSO="user-sso"
 THREESCALE="3scale"
 TOKEN=$(oc whoami --show-token)
-MONITORING_ROUTE=$(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts
+MONITORING_ROUTE=$(echo "https://$(oc get route prometheus-route -n ${NAMESPACE_PREFIX}middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts
 
 # remove tmp files on ctrl-c
 trap "rm tmp-alert-firing-during-perf-testing-report.csv tmp-alert-pending-during-perf-testing-report.csv" EXIT
@@ -57,19 +58,19 @@ else
   while :; do
     if [ $PRODUCT_NAME == $RHSSO ] || [ $PRODUCT_NAME == $USER_SSO ]; then
       curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
       curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
     elif [ $PRODUCT_NAME == $THREESCALE ]; then
      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-     | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+     | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-     | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+     | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
    else
       curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
       curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
     fi
     # sort command to remove duplicate alert
     sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-pending-during-perf-testing-report.csv

--- a/scripts/alerts-during-perf-testing.sh
+++ b/scripts/alerts-during-perf-testing.sh
@@ -8,6 +8,9 @@
 # - jq
 # - oc (logged in at the cmd line in order to get the bearer token)
 # VARIABLES
+RHSSO="rhsso"
+USER_SSO="user-sso"
+THREESCALE="3scale"
 TOKEN=$(oc whoami --show-token)
 MONITORING_ROUTE=$(echo "https://$(oc get route prometheus-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')")/api/v1/alerts
 
@@ -16,7 +19,7 @@ trap "rm tmp-alert-firing-during-perf-testing-report.csv tmp-alert-pending-durin
 
 # function to check if there are no alerts firing bar deadmansnitch
 function CHECK_NO_ALERTS(){
-    if [[ $(curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE | jq -r '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt ] | @csv' | wc -l) == 1 ]] ; then
+    if [[ $(curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE | jq -r '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt ] | @csv' | wc -l  | xargs ) == 1 ]] ; then
       echo Only alert firing is DeadMansSwitch
       date
     fi
@@ -50,14 +53,25 @@ if [ -z "$PRODUCT_NAME" ]; then
   echo - "rhsso"
   echo - "marin3r"
 else
-  echo "Check $1 product namespace and operator namespace for alerts"
+  echo "Check $PRODUCT_NAME product namespace and operator namespace for alerts"
   while :; do
-    curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-    | jq -r '.data.alerts[]| select(.state=="pending" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
-
-    curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-    | jq -r '.data.alerts[]| select(.state=="firing" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator") | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
-
+    if [ $PRODUCT_NAME == $RHSSO ] || [ $PRODUCT_NAME == $USER_SSO ]; then
+      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+    elif [ $PRODUCT_NAME == $THREESCALE ]; then
+     curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+     | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+     curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+     | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+   else
+      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-during-perf-testing-report.csv
+      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
+      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'" or .labels.namespace=="redhat-rhmi-'$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-firing-during-perf-testing-report.csv
+    fi
+    set -
     # sort command to remove duplicate alert
     sort -t, -k1 -u tmp-alert-pending-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-pending-during-perf-testing-report.csv
     sort -t, -k1 -u tmp-alert-firing-during-perf-testing-report.csv > ${PRODUCT_NAME}-alert-firing-during-perf-testing-report.csv


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Script to determine what alerts fire during a performance test

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Verification
- deploy managed api
- log into oc on the command line
- clone this branch
- run the script
```bash
./scripts/alerts-during-perf-testing.sh
```
- scale down the user-sso operator
- scale down the user-sso statefulSet pods
- wait for the alerts to fire
- you should get 2 csv files for firing and pending alerts
with the alert that is triggered and a time stamp e.g.
```csv
"DeadMansSwitch","firing","2020-10-12T08:06:05.755551085Z"
```
- scale backup the user-sso statfulSet pods and the user-sso operator
- once alerts stop firing confirm that the two file still contain the alerts data gathered during the downtime.

- you can test the Passing in an arg with the script
it does accept 
```
- 3scale
- user-sso
- rhsso
- marin3r
```
e.g. 
```bash
./script/alerts-during-perf-testing.sh user-sso
```
This will return any alerts firing that are linked to the namespace and the operator namespace for the product. 