### PR TITLE
add alerts for API Usage on 3Scale

### DIFF
--- a/pkg/config/marin3r.go
+++ b/pkg/config/marin3r.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Marin3r struct {
-	config ProductConfig
+	Config ProductConfig
 }
 
 func NewMarin3r(config ProductConfig) *Marin3r {
-	return &Marin3r{config: config}
+	return &Marin3r{Config: config}
 }
 
 func (m *Marin3r) GetProductName() integreatlyv1alpha1.ProductName {
@@ -20,19 +20,19 @@ func (m *Marin3r) GetProductName() integreatlyv1alpha1.ProductName {
 }
 
 func (m *Marin3r) GetOperatorNamespace() string {
-	return m.config["OPERATOR_NAMESPACE"]
+	return m.Config["OPERATOR_NAMESPACE"]
 }
 
 func (m *Marin3r) SetOperatorNamespace(newNamespace string) {
-	m.config["OPERATOR_NAMESPACE"] = newNamespace
+	m.Config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (m *Marin3r) GetNamespace() string {
-	return m.config["NAMESPACE"]
+	return m.Config["NAMESPACE"]
 }
 
 func (m *Marin3r) Read() ProductConfig {
-	return m.config
+	return m.Config
 }
 
 func (m *Marin3r) GetProductVersion() integreatlyv1alpha1.ProductVersion {
@@ -44,7 +44,7 @@ func (m *Marin3r) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
 }
 
 func (m *Marin3r) GetHost() string {
-	return m.config["HOST"]
+	return m.Config["HOST"]
 }
 
 func (m *Marin3r) GetWatchableCRDs() []runtime.Object {
@@ -59,5 +59,5 @@ func (m *Marin3r) GetWatchableCRDs() []runtime.Object {
 }
 
 func (m *Marin3r) SetNamespace(newNamespace string) {
-	m.config["NAMESPACE"] = newNamespace
+	m.Config["NAMESPACE"] = newNamespace
 }

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -1,0 +1,138 @@
+package marin3r
+
+import (
+	"errors"
+	"fmt"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	level1ApiUsageLowerThresholdPercent  = 80
+	level1ApiUsageHigherThresholdPercent = 90
+	level1ApiUsageCheckFrequencyMins     = 240
+	level2ApiUsageLowerThresholdPercent  = 90
+	level2ApiUsageHigherThresholdPercent = 95
+	level2ApiUsageCheckFrequencyMins     = 120
+	level3ApiUsageLowerThresholdPercent  = 95
+	level3ApiUsageCheckFrequencyMins     = 30
+	totalRequestsMetric                  = "ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits"
+)
+
+func (r *Reconciler) newAlertsReconciler(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (resources.AlertReconciler, error) {
+
+	requestsAllowedPerSecond, err := getRateLimitInSeconds(rateLimitUnit, rateLimitRequestsPerUnit)
+	if err != nil {
+		return nil, err
+	}
+
+	level1Rule, err := getLevel1ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+	level2Rule, err := getLevel2ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+	level3Rule, err := getLevel3ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resources.AlertReconcilerImpl{
+		ProductName:  "3Scale",
+		Installation: r.installation,
+		Logger:       r.logger,
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "api-usage-alert-level1",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level1ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level1Rule,
+				},
+			},
+			{
+				AlertName: "api-usage-alert-level2",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level2ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level2Rule,
+				},
+			},
+			{
+				AlertName: "api-usage-alert-level3",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level3ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level3Rule,
+				},
+			},
+		},
+	}, nil
+}
+
+func getLevel1ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level1ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level1ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is between 80%% and 90%% of the allowable threshold, %d requests per %s, during the last 4 hours", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
+			totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageLowerThresholdPercent, totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageHigherThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getLevel2ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level2ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level2ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is between 90%% and 95%% of the allowable threshold, %d requests per %s, during the last 2 hours", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
+			totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageLowerThresholdPercent, totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageHigherThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getLevel3ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level3ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level3ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is above 95%% of the allowable threshold, %d requests per %s, during the last 30 minutes", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d))",
+			totalRequestsMetric, level3ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level3ApiUsageLowerThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getRateLimitInSeconds(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (uint32, error) {
+	if rateLimitUnit == "seconds" {
+		return rateLimitRequestsPerUnit, nil
+	} else if rateLimitUnit == "minute" {
+		return rateLimitRequestsPerUnit * 60, nil
+	} else if rateLimitUnit == "hour" {
+		return rateLimitRequestsPerUnit * 60 * 60, nil
+	} else if rateLimitUnit == "day" {
+		return rateLimitRequestsPerUnit * 60 * 60 * 24, nil
+	} else {
+		logrus.Errorf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit)
+		return 0, errors.New(fmt.Sprintf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit))
+	}
+}

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -1,1 +1,140 @@
 package marin3r
+
+import (
+	"context"
+	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	projectv1 "github.com/openshift/api/project/v1"
+	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func getRateLimitConfigMap() *corev1.ConfigMap {
+	rateLimtCMString := `
+domain: kuard
+descriptors:
+  - key: generic_key
+    value: slowpath
+    ratelimit:
+      unit: minute
+      requestsperunit: 1`
+
+	return &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ratelimit-config",
+			Namespace: "marin3r",
+			Labels: map[string]string{
+				"app":     "ratelimit",
+				"part-of": "3scale-saas",
+			},
+		},
+		Data: map[string]string{
+			"kuard.yaml": rateLimtCMString,
+		},
+	}
+}
+
+func getBasicReconciler() *Reconciler {
+	return &Reconciler{
+		installation: getBasicInstallation(),
+		logger:       logrus.NewEntry(logrus.StandardLogger()),
+		Config: &config.Marin3r{
+			Config: config.ProductConfig{
+				"NAMESPACE": defaultInstallationNamespace,
+			},
+		},
+	}
+}
+
+func getBasicInstallation() *integreatlyv1alpha1.RHMI {
+	return &integreatlyv1alpha1.RHMI{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "installation",
+			Namespace: defaultInstallationNamespace,
+			UID:       types.UID("xyz"),
+		},
+		TypeMeta: v1.TypeMeta{
+			Kind:       integreatlyv1alpha1.SchemaGroupVersionKind.Kind,
+			APIVersion: integreatlyv1alpha1.SchemeGroupVersion.String(),
+		},
+		Spec: integreatlyv1alpha1.RHMISpec{
+			//SMTPSecret:           mockSMTPSecretName,
+			//PagerDutySecret:      mockPagerdutySecretName,
+			//DeadMansSnitchSecret: mockDMSSecretName,
+		},
+	}
+}
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := corev1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := coreosv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := prometheusmonitoringv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := projectv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	return scheme, nil
+}
+
+func TestAlertCreation(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		serverClient func() k8sclient.Client
+		reconciler   func() *Reconciler
+		installation *integreatlyv1alpha1.RHMI
+		want         integreatlyv1alpha1.StatusPhase
+		wantErr      string
+		wantFn       func(c k8sclient.Client) error
+	}{
+		{
+			name: "returns expected alerts",
+			serverClient: func() k8sclient.Client {
+				return fakeclient.NewFakeClientWithScheme(scheme, getRateLimitConfigMap())
+			},
+			reconciler: func() *Reconciler {
+				return getBasicReconciler()
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := tt.reconciler()
+			serverClient := tt.serverClient()
+
+			got, err := reconciler.reconcileAlerts(context.TODO(), serverClient, reconciler.installation)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("reconcileAlerts() error = %v, wantErr %v", err.Error(), tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileAlerts() got = %v, want %v", got, tt.want)
+			}
+			if tt.wantFn != nil {
+				if err := tt.wantFn(serverClient); err != nil {
+					t.Errorf("reconcileAlerts() error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -31,6 +31,7 @@ type AlertConfiguration struct {
 	AlertName string
 	GroupName string
 	Namespace string
+	Interval  string
 	Rules     []monitoringv1.Rule
 }
 
@@ -77,8 +78,9 @@ func (r *AlertReconcilerImpl) reconcileRule(ctx context.Context, client k8sclien
 		rule.Spec = monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name:  alert.GroupName,
-					Rules: alert.Rules,
+					Name:     alert.GroupName,
+					Rules:    alert.Rules,
+					Interval: alert.Interval,
 				},
 			},
 		}

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -17,6 +17,15 @@ route:
         alertname: DeadMansSwitch
       repeat_interval: 5m
       receiver: deadmansswitch
+    - match:
+        alertname: Level1ThreeScaleApiUsageThresholdExceeded
+      receiver: BUandCustomer
+    - match:
+        alertname: Level2ThreeScaleApiUsageThresholdExceeded
+      receiver: BUandCustomer
+    - match:
+        alertname: Level3ThreeScaleApiUsageThresholdExceeded
+      receiver: SRECustomerBU
 receivers:
   - name: default
     email_configs:
@@ -31,6 +40,14 @@ receivers:
   - name: deadmansswitch
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
+  - name: BUandCustomer
+    emailConfigs:
+      - send_resolved: True
+      to: {{ index .Params "SMTPToAddress" }}
+  - name: SRECustomerBU
+    emailConfigs:
+      - send_resolved: True
+    to: {{ index .Params "SMTPToAddress" }}
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -243,6 +243,14 @@ var rhmi2ExpectedRules = []alertsTestRule{
 // Common to all install types
 var commonExpectedRules = []alertsTestRule{
 	{
+		File: "redhat-rhmi-marin3r-3scale-api-usage-alerts.yaml",
+		Rules: []string{
+			"Level1ThreeScaleApiUsageThresholdExceeded",
+			"Level2ThreeScaleApiUsageThresholdExceeded",
+			"Level3ThreeScaleApiUsageThresholdExceeded",
+		},
+	},
+	{
 		File: NamespacePrefix + "middleware-monitoring-operator-backup-monitoring-alerts.yaml",
 		Rules: []string{
 			"JobRunningTimeExceeded",


### PR DESCRIPTION
# Description
Add Alerts for API Usage on 3Scale.
Refer to [Rate Limiting Epic ](https://docs.google.com/document/d/1S38vB_FYhGR9JKlhCK2WYs7nhzli-Cr5I3Y5VDyYG3o/edit#heading=h.i8o7bn5gd84e) for Rules on API Usage Thresholds

## How to Verify
Given the time frames under which the alert expressions apply, its best to modify them in order to test the functionality
Modify [level 1](https://github.com/briangallagher/integreatly-operator/blob/03dcdebc7a113993bc961ca5e1c579dd5fba109f/pkg/products/marin3r/apiUsagePrometheusRules.go#L15)
Modify [level 2](https://github.com/briangallagher/integreatly-operator/blob/03dcdebc7a113993bc961ca5e1c579dd5fba109f/pkg/products/marin3r/apiUsagePrometheusRules.go#L18)
Modify [level 3](https://github.com/briangallagher/integreatly-operator/blob/03dcdebc7a113993bc961ca5e1c579dd5fba109f/pkg/products/marin3r/apiUsagePrometheusRules.go#L20) 
to something more testable, for example, 3mins, 2mins, 1mins

Also modify the rate limit unit and requests per unit, modify ratelimit-config configmap

Note: The alerts are assessed in interval periods matching the frequency periods linked above. Ideally we would align requests fired with these periods however that is probably not feasible. So, compensation should be considered here. Reach out for more details on this. 

Verify that all 3 alerts fire at the appropriate times in Alert Manager
