### PR TITLE
MGDAPI-378: Support rate limit alerts configuration via ConfigMap

### DIFF
--- a/pkg/config/marin3r.go
+++ b/pkg/config/marin3r.go
@@ -8,11 +8,11 @@ import (
 )
 
 type Marin3r struct {
-	config ProductConfig
+	Config ProductConfig
 }
 
 func NewMarin3r(config ProductConfig) *Marin3r {
-	return &Marin3r{config: config}
+	return &Marin3r{Config: config}
 }
 
 func (m *Marin3r) GetProductName() integreatlyv1alpha1.ProductName {
@@ -20,19 +20,19 @@ func (m *Marin3r) GetProductName() integreatlyv1alpha1.ProductName {
 }
 
 func (m *Marin3r) GetOperatorNamespace() string {
-	return m.config["OPERATOR_NAMESPACE"]
+	return m.Config["OPERATOR_NAMESPACE"]
 }
 
 func (m *Marin3r) SetOperatorNamespace(newNamespace string) {
-	m.config["OPERATOR_NAMESPACE"] = newNamespace
+	m.Config["OPERATOR_NAMESPACE"] = newNamespace
 }
 
 func (m *Marin3r) GetNamespace() string {
-	return m.config["NAMESPACE"]
+	return m.Config["NAMESPACE"]
 }
 
 func (m *Marin3r) Read() ProductConfig {
-	return m.config
+	return m.Config
 }
 
 func (m *Marin3r) GetProductVersion() integreatlyv1alpha1.ProductVersion {
@@ -44,7 +44,7 @@ func (m *Marin3r) GetOperatorVersion() integreatlyv1alpha1.OperatorVersion {
 }
 
 func (m *Marin3r) GetHost() string {
-	return m.config["HOST"]
+	return m.Config["HOST"]
 }
 
 func (m *Marin3r) GetWatchableCRDs() []runtime.Object {
@@ -59,5 +59,5 @@ func (m *Marin3r) GetWatchableCRDs() []runtime.Object {
 }
 
 func (m *Marin3r) SetNamespace(newNamespace string) {
-	m.config["NAMESPACE"] = newNamespace
+	m.Config["NAMESPACE"] = newNamespace
 }

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -207,26 +207,29 @@ func (r *Reconciler) checkRateLimitAlertsConfig(ctx context.Context, serverClien
 			return nil
 		}
 
+		maxRate1 := "90%"
+		maxRate2 := "95%"
+
 		defaultConfig := map[string]*marin3rconfig.AlertConfig{
 			"api-usage-alert-level1": {
 				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "80%",
-				MaxRate:  "90%",
+				MaxRate:  &maxRate1,
 				Period:   "4h",
 			},
 			"api-usage-alert-level2": {
 				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "90%",
-				MaxRate:  "95%",
+				MaxRate:  &maxRate2,
 				Period:   "2h",
 			},
 			"api-usage-alert-level3": {
 				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "95%",
-				MaxRate:  "100%",
+				MaxRate:  nil,
 				Period:   "30m",
 			},
 		}

--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	routev1 "github.com/openshift/api/route/v1"
@@ -102,6 +103,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.checkRateLimitAlertsConfig(ctx, serverClient)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to check rate limit alert config settings", err)
+		return phase, err
+	}
+
 	events.HandleStageComplete(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
 
 	metrics.SetRHMIInfo(installation)
@@ -172,6 +179,65 @@ func (r *Reconciler) checkRateLimitsConfig(ctx context.Context, serverClient k8s
 		}
 
 		rlConfig.Data["rate_limit"] = string(defaultConfigJSON)
+
+		return nil
+	}); err != nil {
+		return integreatlyv1alpha1.PhaseInProgress, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) checkRateLimitAlertsConfig(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	alertsConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      marin3rconfig.AlertConfigMapName,
+			Namespace: r.installation.Namespace,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, serverClient, alertsConfig, func() error {
+		owner.AddIntegreatlyOwnerAnnotations(alertsConfig, r.installation)
+
+		if alertsConfig.Data == nil {
+			alertsConfig.Data = map[string]string{}
+		}
+
+		if _, ok := alertsConfig.Data["alerts"]; ok {
+			return nil
+		}
+
+		defaultConfig := map[string]*marin3rconfig.AlertConfig{
+			"api-usage-alert-level1": {
+				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "80%",
+				MaxRate:  "90%",
+				Period:   "4h",
+			},
+			"api-usage-alert-level2": {
+				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "90%",
+				MaxRate:  "95%",
+				Period:   "2h",
+			},
+			"api-usage-alert-level3": {
+				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "95%",
+				MaxRate:  "100%",
+				Period:   "30m",
+			},
+		}
+
+		defaultConfigJSON, err := json.MarshalIndent(defaultConfig, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		alertsConfig.Data["alerts"] = string(defaultConfigJSON)
+
 		return nil
 	}); err != nil {
 		return integreatlyv1alpha1.PhaseInProgress, err

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/version"
 
+	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
 	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
 	"k8s.io/apimachinery/pkg/labels"
@@ -134,6 +135,13 @@ func add(mgr manager.Manager, r ReconcileInstallation) error {
 	if err != nil {
 		return err
 	}
+
+	// Watch the SKU rate limits config map
+	err = c.Watch(
+		&source.Kind{Type: &corev1.ConfigMap{}},
+		enqueueAllInstallations,
+		newObjectPredicate(isName(marin3rconfig.RateLimitConfigMapName)),
+	)
 
 	return nil
 }

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -126,6 +126,15 @@ func add(mgr manager.Manager, r ReconcileInstallation) error {
 		return err
 	}
 
+	// Watch for changes to rate limit alerts config
+	err = c.Watch(
+		&source.Kind{Type: &corev1.ConfigMap{}},
+		&EnqueueIntegreatlyOwner{},
+	)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 

--- a/pkg/controller/installation/watch.go
+++ b/pkg/controller/installation/watch.go
@@ -7,7 +7,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -39,4 +41,42 @@ func (m installationMapper) Map(mo handler.MapObject) []reconcile.Request {
 	}
 
 	return requests
+}
+
+// objectPredicate implements the predicate.Predicate interface, which is used
+// to filter watch events. This implementation will filter out events where
+// the object doesn't fullfil the predicate in the Predicate field
+type objectPredicate struct {
+	Predicate func(mo handler.MapObject) bool
+}
+
+func newObjectPredicate(predicate func(mo handler.MapObject) bool) *objectPredicate {
+	return &objectPredicate{
+		Predicate: predicate,
+	}
+}
+
+var _ predicate.Predicate = &objectPredicate{}
+
+func (p *objectPredicate) Create(e event.CreateEvent) bool {
+	return p.Predicate(handler.MapObject{Meta: e.Meta, Object: e.Object})
+}
+
+func (p *objectPredicate) Delete(e event.DeleteEvent) bool {
+	return p.Predicate(handler.MapObject{Meta: e.Meta, Object: e.Object})
+}
+
+func (p *objectPredicate) Update(e event.UpdateEvent) bool {
+	return p.Predicate(handler.MapObject{Meta: e.MetaNew, Object: e.ObjectNew})
+}
+
+func (p *objectPredicate) Generic(e event.GenericEvent) bool {
+	return p.Predicate(handler.MapObject{Meta: e.Meta, Object: e.Object})
+}
+
+// isName creates a predicate that returns true if the object name matches name
+func isName(name string) func(handler.MapObject) bool {
+	return func(mo handler.MapObject) bool {
+		return mo.Meta.GetName() == name
+	}
 }

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -3,123 +3,88 @@ package marin3r
 import (
 	"errors"
 	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var (
-	level1ApiUsageLowerThresholdPercent  = 80
-	level1ApiUsageHigherThresholdPercent = 90
-	level1ApiUsageCheckFrequencyMins     = 240
-	level2ApiUsageLowerThresholdPercent  = 90
-	level2ApiUsageHigherThresholdPercent = 95
-	level2ApiUsageCheckFrequencyMins     = 120
-	level3ApiUsageLowerThresholdPercent  = 95
-	level3ApiUsageCheckFrequencyMins     = 30
-	totalRequestsMetric                  = "ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits"
+	totalRequestsMetric = "ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits"
 )
 
-func (r *Reconciler) newAlertsReconciler(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (resources.AlertReconciler, error) {
+func (r *Reconciler) newAlertsReconciler() (resources.AlertReconciler, error) {
 
-	requestsAllowedPerSecond, err := getRateLimitInSeconds(rateLimitUnit, rateLimitRequestsPerUnit)
+	requestsAllowedPerSecond, err := getRateLimitInSeconds(r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit)
 	if err != nil {
 		return nil, err
 	}
 
-	level1Rule, err := getLevel1ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	alerts, err := mapAlertsConfiguration(r.Config.GetNamespace(), r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit, requestsAllowedPerSecond, r.AlertsConfig)
 	if err != nil {
-		return nil, err
-	}
-	level2Rule, err := getLevel2ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
-	if err != nil {
-		return nil, err
-	}
-	level3Rule, err := getLevel3ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
-	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to create alerts from configuration: %w", err)
 	}
 
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "3Scale",
 		Installation: r.installation,
 		Logger:       r.logger,
-		Alerts: []resources.AlertConfiguration{
-			{
-				AlertName: "api-usage-alert-level1",
-				Namespace: r.Config.GetNamespace(),
-				GroupName: "api-usage.rules",
-				Interval:  fmt.Sprintf("%dm", level1ApiUsageCheckFrequencyMins),
-				Rules: []monitoringv1.Rule{
-					*level1Rule,
-				},
-			},
-			{
-				AlertName: "api-usage-alert-level2",
-				Namespace: r.Config.GetNamespace(),
-				GroupName: "api-usage.rules",
-				Interval:  fmt.Sprintf("%dm", level2ApiUsageCheckFrequencyMins),
-				Rules: []monitoringv1.Rule{
-					*level2Rule,
-				},
-			},
-			{
-				AlertName: "api-usage-alert-level3",
-				Namespace: r.Config.GetNamespace(),
-				GroupName: "api-usage.rules",
-				Interval:  fmt.Sprintf("%dm", level3ApiUsageCheckFrequencyMins),
-				Rules: []monitoringv1.Rule{
-					*level3Rule,
-				},
-			},
-		},
+		Alerts:       alerts,
 	}, nil
 }
 
-func getLevel1ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+// mapAlertsConfiguration maps each value from alertsConfig into a
+// resources.AlertConfiguration object, resulting into a list of the
+// prometheus alerts to be created
+func mapAlertsConfiguration(namespace, rateLimitUnit string, rateLimitRequestsPerUnit, requestsAllowedPerSecond uint32, alertsConfig map[string]*marin3rconfig.AlertConfig) ([]resources.AlertConfiguration, error) {
+	result := make([]resources.AlertConfiguration, 0, len(alertsConfig))
 
-	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level1ApiUsageCheckFrequencyMins) * 60
+	for alertName, alertConfig := range alertsConfig {
+		usageFrequencyMins, err := intervalToMinutes(alertConfig.Period)
+		if err != nil {
+			return nil, err
+		}
+		requestsAllowedOverTimePeriod := requestsAllowedPerSecond * usageFrequencyMins * 60
 
-	return &monitoringv1.Rule{
-		Alert: "Level1ThreeScaleApiUsageThresholdExceeded",
-		Annotations: map[string]string{
-			"message": fmt.Sprintf("3Scale API usage is between 80%% and 90%% of the allowable threshold, %d requests per %s, during the last 4 hours", rateLimitRequestsPerUnit, rateLimitUnit),
-		},
-		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
-			totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageLowerThresholdPercent, totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageHigherThresholdPercent)),
-		Labels: map[string]string{"severity": "informational"},
-	}, nil
-}
+		minRateValue, maxRateValue, err := parsePercenteageRange(
+			alertConfig.MinRate,
+			alertConfig.MaxRate,
+		)
+		if err != nil {
+			return nil, err
+		}
 
-func getLevel2ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+		alert := resources.AlertConfiguration{
+			AlertName: alertName,
+			GroupName: "api-usage.rules",
+			Interval:  alertConfig.Period,
+			Namespace: namespace,
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: alertConfig.RuleName,
+					Annotations: map[string]string{
+						"message": fmt.Sprintf(
+							"3Scale API usage is between %s and %s of the allowable threshold, %d requests per %s, during the last %s",
+							alertConfig.MinRate, alertConfig.MaxRate, rateLimitRequestsPerUnit, rateLimitUnit, alertConfig.Period,
+						),
+					},
+					Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%s]) >= (%d / 100 * %d)) and (increase(%s[%s]) <=  (%d / 100 * %d))",
+						totalRequestsMetric, alertConfig.Period, requestsAllowedOverTimePeriod, minRateValue, totalRequestsMetric, alertConfig.Period, requestsAllowedOverTimePeriod, maxRateValue,
+					)),
+					Labels: map[string]string{"severity": alertConfig.Level},
+				},
+			},
+		}
 
-	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level2ApiUsageCheckFrequencyMins) * 60
+		result = append(result, alert)
+	}
 
-	return &monitoringv1.Rule{
-		Alert: "Level2ThreeScaleApiUsageThresholdExceeded",
-		Annotations: map[string]string{
-			"message": fmt.Sprintf("3Scale API usage is between 90%% and 95%% of the allowable threshold, %d requests per %s, during the last 2 hours", rateLimitRequestsPerUnit, rateLimitUnit),
-		},
-		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
-			totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageLowerThresholdPercent, totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageHigherThresholdPercent)),
-		Labels: map[string]string{"severity": "informational"},
-	}, nil
-}
-
-func getLevel3ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
-
-	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level3ApiUsageCheckFrequencyMins) * 60
-
-	return &monitoringv1.Rule{
-		Alert: "Level3ThreeScaleApiUsageThresholdExceeded",
-		Annotations: map[string]string{
-			"message": fmt.Sprintf("3Scale API usage is above 95%% of the allowable threshold, %d requests per %s, during the last 30 minutes", rateLimitRequestsPerUnit, rateLimitUnit),
-		},
-		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d))",
-			totalRequestsMetric, level3ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level3ApiUsageLowerThresholdPercent)),
-		Labels: map[string]string{"severity": "informational"},
-	}, nil
+	return result, nil
 }
 
 func getRateLimitInSeconds(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (uint32, error) {
@@ -135,4 +100,80 @@ func getRateLimitInSeconds(rateLimitUnit string, rateLimitRequestsPerUnit uint32
 		logrus.Errorf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit)
 		return 0, errors.New(fmt.Sprintf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit))
 	}
+}
+
+// intervalToMinutes parses an interval string made up from a number and a unit
+// that can be "m" for minutes, or "h" for hours, and returns the value in minutes
+// or an error if the string representation is invalid
+func intervalToMinutes(interval string) (uint32, error) {
+	re := regexp.MustCompile(`(?m)([0-9]+)([a-zA-Z])$`)
+	matches := re.FindAllStringSubmatch(interval, -1)
+
+	if len(matches) == 0 || len(matches[0]) != 3 {
+		return 0, fmt.Errorf("invalid value for interval %s", interval)
+	}
+
+	intervalValueStr := matches[0][1]
+	intervalUnit := matches[0][2]
+
+	var multiplier int
+	switch strings.ToLower(intervalUnit) {
+	case "m":
+		multiplier = 1
+		break
+	case "h":
+		multiplier = 60
+		break
+	default:
+		return 0, fmt.Errorf("invalid value for interval unit %s, must be m or h", intervalUnit)
+	}
+
+	intervalValue, err := strconv.Atoi(intervalValueStr)
+	if err != nil {
+		return 0, err
+	}
+
+	return uint32(intervalValue * multiplier), nil
+}
+
+// parsePercenteage parses and validates a percenteage string by extracting
+// the numeric value and validating that it's in a correct value for a percenteage
+func parsePercenteage(percenteage string) (int, error) {
+	var re = regexp.MustCompile(`(?m)([0-9]+)%$`)
+	matches := re.FindAllStringSubmatch(percenteage, -1)
+
+	if len(matches) == 0 || len(matches[0]) != 2 {
+		return 0, fmt.Errorf("invalid value for percenteage %s", percenteage)
+	}
+
+	result, err := strconv.Atoi(matches[0][1])
+	if err != nil {
+		return 0, nil
+	}
+
+	if result < 0 || result > 100 {
+		return 0, fmt.Errorf("%d is an invalid percenteage", result)
+	}
+
+	return result, nil
+}
+
+// parsePercenteageRange parses both min and max as percenteages, and validates
+// that min is less than or equal to max
+func parsePercenteageRange(min, max string) (int, int, error) {
+	minValue, err := parsePercenteage(min)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	maxValue, err := parsePercenteage(max)
+	if err != nil {
+		return 0, 0, err
+	}
+
+	if minValue > maxValue {
+		return 0, 0, fmt.Errorf("min value %d must be less than or equal to max value %d", minValue, maxValue)
+	}
+
+	return minValue, maxValue, nil
 }

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -1,0 +1,138 @@
+package marin3r
+
+import (
+	"errors"
+	"fmt"
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var (
+	level1ApiUsageLowerThresholdPercent  = 80
+	level1ApiUsageHigherThresholdPercent = 90
+	level1ApiUsageCheckFrequencyMins     = 240
+	level2ApiUsageLowerThresholdPercent  = 90
+	level2ApiUsageHigherThresholdPercent = 95
+	level2ApiUsageCheckFrequencyMins     = 120
+	level3ApiUsageLowerThresholdPercent  = 95
+	level3ApiUsageCheckFrequencyMins     = 30
+	totalRequestsMetric                  = "ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits"
+)
+
+func (r *Reconciler) newAlertsReconciler(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (resources.AlertReconciler, error) {
+
+	requestsAllowedPerSecond, err := getRateLimitInSeconds(rateLimitUnit, rateLimitRequestsPerUnit)
+	if err != nil {
+		return nil, err
+	}
+
+	level1Rule, err := getLevel1ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+	level2Rule, err := getLevel2ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+	level3Rule, err := getLevel3ApiUsageAlert(rateLimitUnit, rateLimitRequestsPerUnit, requestsAllowedPerSecond)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resources.AlertReconcilerImpl{
+		ProductName:  "3Scale",
+		Installation: r.installation,
+		Logger:       r.logger,
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "api-usage-alert-level1",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level1ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level1Rule,
+				},
+			},
+			{
+				AlertName: "api-usage-alert-level2",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level2ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level2Rule,
+				},
+			},
+			{
+				AlertName: "api-usage-alert-level3",
+				Namespace: r.Config.GetNamespace(),
+				GroupName: "api-usage.rules",
+				Interval:  fmt.Sprintf("%dm", level3ApiUsageCheckFrequencyMins),
+				Rules: []monitoringv1.Rule{
+					*level3Rule,
+				},
+			},
+		},
+	}, nil
+}
+
+func getLevel1ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level1ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level1ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is between 80%% and 90%% of the allowable threshold, %d requests per %s, during the last 4 hours", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
+			totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageLowerThresholdPercent, totalRequestsMetric, level1ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level1ApiUsageHigherThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getLevel2ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level2ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level2ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is between 90%% and 95%% of the allowable threshold, %d requests per %s, during the last 2 hours", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d)) and (increase(%s[%dm]) <=  (%d / 100 * %d))",
+			totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageLowerThresholdPercent, totalRequestsMetric, level2ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level2ApiUsageHigherThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getLevel3ApiUsageAlert(rateLimitUnit string, rateLimitRequestsPerUnit uint32, requestsAllowedPerSecond uint32) (*monitoringv1.Rule, error) {
+
+	requestsAllowedOverTimePeriod := requestsAllowedPerSecond * uint32(level3ApiUsageCheckFrequencyMins) * 60
+
+	return &monitoringv1.Rule{
+		Alert: "Level3ThreeScaleApiUsageThresholdExceeded",
+		Annotations: map[string]string{
+			"message": fmt.Sprintf("3Scale API usage is above 95%% of the allowable threshold, %d requests per %s, during the last 30 minutes", rateLimitRequestsPerUnit, rateLimitUnit),
+		},
+		Expr: intstr.FromString(fmt.Sprintf("(increase(%s[%dm]) >= (%d / 100 * %d))",
+			totalRequestsMetric, level3ApiUsageCheckFrequencyMins, requestsAllowedOverTimePeriod, level3ApiUsageLowerThresholdPercent)),
+		Labels: map[string]string{"severity": "informational"},
+	}, nil
+}
+
+func getRateLimitInSeconds(rateLimitUnit string, rateLimitRequestsPerUnit uint32) (uint32, error) {
+	if rateLimitUnit == "seconds" {
+		return rateLimitRequestsPerUnit, nil
+	} else if rateLimitUnit == "minute" {
+		return rateLimitRequestsPerUnit * 60, nil
+	} else if rateLimitUnit == "hour" {
+		return rateLimitRequestsPerUnit * 60 * 60, nil
+	} else if rateLimitUnit == "day" {
+		return rateLimitRequestsPerUnit * 60 * 60 * 24, nil
+	} else {
+		logrus.Errorf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit)
+		return 0, errors.New(fmt.Sprintf("Unexpected Rate Limit Unit %v, while creating 3scale api usage alerts", rateLimitUnit))
+	}
+}

--- a/pkg/products/marin3r/config/config.go
+++ b/pkg/products/marin3r/config/config.go
@@ -11,6 +11,7 @@ import (
 
 const (
 	RateLimitConfigMapName = "sku-limits-managed-api-service"
+	AlertConfigMapName     = "rate-limit-alerts"
 	ManagedApiServiceSKU   = "RHOAM SERVICE SKU"
 
 	DefaultRateLimitUnit     = "minute"
@@ -23,37 +24,28 @@ type RateLimitConfig struct {
 }
 
 type AlertConfig struct {
-	Name    string `json:"name"`
-	Level   string `json:"level"`
-	MinRate string `json:"minRate"`
-	MaxRate string `json:"maxRate"`
-	Period  string `json:"period"`
+	RuleName string `json:"ruleName"`
+	Level    string `json:"level"`
+	MinRate  string `json:"minRate"`
+	MaxRate  string `json:"maxRate"`
+	Period   string `json:"period"`
 }
 
 // GetRateLimitConfig retrieves the configuration for the rate limit service,
 // taken from a ConfigMap that is expected to exist in the managed api operator
 // namespace.
 func GetRateLimitConfig(ctx context.Context, client k8sclient.Client, namespace string) (*RateLimitConfig, error) {
+	skuConfigs := map[string]*RateLimitConfig{}
+	if err := getFromJSONConfigMap(
+		ctx, client,
+		RateLimitConfigMapName, namespace, "rate_limit",
+		&skuConfigs,
+	); err != nil {
+		return nil, err
+	}
+
 	sku, err := GetSKU(ctx, client)
 	if err != nil {
-		return nil, err
-	}
-
-	configMap := &corev1.ConfigMap{}
-	if err := client.Get(ctx, k8sclient.ObjectKey{
-		Name:      RateLimitConfigMapName,
-		Namespace: namespace,
-	}, configMap); err != nil {
-		return nil, err
-	}
-
-	skuConfigsJSON, ok := configMap.Data["rate_limit"]
-	if !ok {
-		return nil, fmt.Errorf("rate_limit key not found in config map")
-	}
-
-	skuConfigs := map[string]*RateLimitConfig{}
-	if err := json.Unmarshal([]byte(skuConfigsJSON), &skuConfigs); err != nil {
 		return nil, err
 	}
 
@@ -64,11 +56,34 @@ func GetRateLimitConfig(ctx context.Context, client k8sclient.Client, namespace 
 	return nil, fmt.Errorf("SKU %s not found in ConfigMap", sku)
 }
 
-func GetAlertConfig(ctx context.Context, client k8sclient.Client) ([]*AlertConfig, error) {
-	// TODO
-	return nil, nil
+func GetAlertConfig(ctx context.Context, client k8sclient.Client, namespace string) (map[string]*AlertConfig, error) {
+	alertsConfig := map[string]*AlertConfig{}
+	err := getFromJSONConfigMap(
+		ctx, client,
+		AlertConfigMapName, namespace, "alerts",
+		&alertsConfig,
+	)
+
+	return alertsConfig, err
 }
 
 func GetSKU(_ context.Context, _ k8sclient.Client) (string, error) {
 	return ManagedApiServiceSKU, nil
+}
+
+func getFromJSONConfigMap(ctx context.Context, client k8sclient.Client, cmName, namespace, configkey string, v interface{}) error {
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      cmName,
+		Namespace: namespace,
+	}, configMap); err != nil {
+		return err
+	}
+
+	configJSON, ok := configMap.Data[configkey]
+	if !ok {
+		return fmt.Errorf("%s not found in %s ConfigMap data", configkey, cmName)
+	}
+
+	return json.Unmarshal([]byte(configJSON), v)
 }

--- a/pkg/products/marin3r/config/config.go
+++ b/pkg/products/marin3r/config/config.go
@@ -24,11 +24,11 @@ type RateLimitConfig struct {
 }
 
 type AlertConfig struct {
-	RuleName string `json:"ruleName"`
-	Level    string `json:"level"`
-	MinRate  string `json:"minRate"`
-	MaxRate  string `json:"maxRate"`
-	Period   string `json:"period"`
+	RuleName string  `json:"ruleName"`
+	Level    string  `json:"level"`
+	MinRate  string  `json:"minRate"`
+	MaxRate  *string `json:"maxRate,omitempty"`
+	Period   string  `json:"period"`
 }
 
 // GetRateLimitConfig retrieves the configuration for the rate limit service,

--- a/pkg/products/marin3r/config/config_test.go
+++ b/pkg/products/marin3r/config/config_test.go
@@ -74,6 +74,78 @@ func TestGetRateLimitConfig(t *testing.T) {
 	}
 }
 
+func TestGetAlertConfig(t *testing.T) {
+	scheme := testScheme()
+
+	scenarios := []struct {
+		Name        string
+		InitialObjs []runtime.Object
+		Namespace   string
+		Assert      func(client.Client, map[string]*AlertConfig, error) error
+	}{
+		{
+			Name:      "Success",
+			Namespace: "redhat-test-operator",
+			InitialObjs: []runtime.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "rate-limit-alerts",
+						Namespace: "redhat-test-operator",
+					},
+					Data: map[string]string{
+						"alerts": `
+						{
+							"alert-1": {
+								"ruleName": "Rule1",
+								"level": "warning",
+								"minRate": "80%",
+								"maxRate": "90%",
+								"period": "2h"
+							}
+						}
+						`,
+					},
+				},
+			},
+			Assert: func(c client.Client, config map[string]*AlertConfig, err error) error {
+				if err != nil {
+					return fmt.Errorf("Unexpected error: %v", err)
+				}
+
+				alertConfig, ok := config["alert-1"]
+				if !ok {
+					return fmt.Errorf("expected key alert-1 not found in resulting config")
+				}
+
+				expectedConfig := &AlertConfig{
+					RuleName: "Rule1",
+					Level:    "warning",
+					MaxRate:  "90%",
+					MinRate:  "80%",
+					Period:   "2h",
+				}
+
+				if !reflect.DeepEqual(alertConfig, expectedConfig) {
+					return fmt.Errorf("Obtained invalid config. Expected %v, but got %v", expectedConfig, alertConfig)
+				}
+
+				return nil
+			},
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			client := fake.NewFakeClientWithScheme(scheme, scenario.InitialObjs...)
+			config, err := GetAlertConfig(context.TODO(), client, scenario.Namespace)
+
+			if err := scenario.Assert(client, config, err); err != nil {
+				t.Error(err)
+			}
+		})
+	}
+}
+
 func testScheme() *runtime.Scheme {
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)

--- a/pkg/products/marin3r/config/config_test.go
+++ b/pkg/products/marin3r/config/config_test.go
@@ -117,10 +117,12 @@ func TestGetAlertConfig(t *testing.T) {
 					return fmt.Errorf("expected key alert-1 not found in resulting config")
 				}
 
+				maxRate := "90%"
+
 				expectedConfig := &AlertConfig{
 					RuleName: "Rule1",
 					Level:    "warning",
-					MaxRate:  "90%",
+					MaxRate:  &maxRate,
 					MinRate:  "80%",
 					Period:   "2h",
 				}

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	prometheus "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/ghodss/yaml"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	croUtil "github.com/integr8ly/cloud-resource-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
@@ -204,12 +205,44 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	// Reconcile API usage alerts
+	phase, err = r.reconcileAlerts(ctx, client, installation)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
+		return phase, err
+	}
+
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()
 
 	events.HandleProductComplete(r.recorder, installation, integreatlyv1alpha1.ProductsStage, r.Config.GetProductName())
 	logrus.Infof("%s installation is reconciled successfully", r.Config.GetProductName())
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) reconcileAlerts(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
+
+	cm := &corev1.ConfigMap{}
+	err := client.Get(context.TODO(), k8sclient.ObjectKey{Name: "ratelimit-config", Namespace: r.Config.GetNamespace()}, cm)
+	if err != nil {
+		logrus.Infof("didn't find ratelimit-config config map in %s", r.Config.GetNamespace())
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	cmYamlData := yamlRoot{}
+	yaml.Unmarshal([]byte(cm.Data["kuard.yaml"]), &cmYamlData)
+
+	alertReconciler, err := r.newAlertsReconciler(cmYamlData.Descriptors[0].RateLimit.Unit, cmYamlData.Descriptors[0].RateLimit.RequestsPerUnit)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	phase, err := alertReconciler.ReconcileAlerts(ctx, client)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
+		return phase, err
+	}
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -58,21 +58,20 @@ func getBasicReconciler() *Reconciler {
 				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "80%",
-				MaxRate:  "90%",
+				MaxRate:  strPtr("90%"),
 				Period:   "4h",
 			},
 			"api-usage-alert-level2": {
 				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "90%",
-				MaxRate:  "95%",
+				MaxRate:  strPtr("95%"),
 				Period:   "2h",
 			},
 			"api-usage-alert-level3": {
 				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "95%",
-				MaxRate:  "100%",
 				Period:   "30m",
 			},
 		},
@@ -166,4 +165,8 @@ func TestAlertCreation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func strPtr(str string) *string {
+	return &str
 }

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -1,1 +1,140 @@
 package marin3r
+
+import (
+	"context"
+	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	projectv1 "github.com/openshift/api/project/v1"
+	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func getRateLimitConfigMap() *corev1.ConfigMap {
+	rateLimtCMString := `
+domain: kuard
+descriptors:
+  - key: generic_key
+    value: slowpath
+    ratelimit:
+      unit: minute
+      requestsperunit: 1`
+
+	return &corev1.ConfigMap{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ratelimit-config",
+			Namespace: "marin3r",
+			Labels: map[string]string{
+				"app":     "ratelimit",
+				"part-of": "3scale-saas",
+			},
+		},
+		Data: map[string]string{
+			"kuard.yaml": rateLimtCMString,
+		},
+	}
+}
+
+func getBasicReconciler() *Reconciler {
+	return &Reconciler{
+		installation: getBasicInstallation(),
+		logger:       logrus.NewEntry(logrus.StandardLogger()),
+		Config: &config.Marin3r{
+			Config: config.ProductConfig{
+				"NAMESPACE": defaultInstallationNamespace,
+			},
+		},
+	}
+}
+
+func getBasicInstallation() *integreatlyv1alpha1.RHMI {
+	return &integreatlyv1alpha1.RHMI{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "installation",
+			Namespace: defaultInstallationNamespace,
+			UID:       types.UID("xyz"),
+		},
+		TypeMeta: v1.TypeMeta{
+			Kind:       integreatlyv1alpha1.SchemaGroupVersionKind.Kind,
+			APIVersion: integreatlyv1alpha1.SchemeGroupVersion.String(),
+		},
+		Spec: integreatlyv1alpha1.RHMISpec{
+			//SMTPSecret:           mockSMTPSecretName,
+			//PagerDutySecret:      mockPagerdutySecretName,
+			//DeadMansSnitchSecret: mockDMSSecretName,
+		},
+	}
+}
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := corev1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := coreosv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := prometheusmonitoringv1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := projectv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	return scheme, nil
+}
+
+func TestAlertCreation(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		serverClient func() k8sclient.Client
+		reconciler   func() *Reconciler
+		installation *integreatlyv1alpha1.RHMI
+		want         integreatlyv1alpha1.StatusPhase
+		wantErr      string
+		wantFn       func(c k8sclient.Client) error
+	}{
+		{
+			name: "returns expected alerts",
+			serverClient: func() k8sclient.Client {
+				return fakeclient.NewFakeClientWithScheme(scheme, getRateLimitConfigMap())
+			},
+			reconciler: func() *Reconciler {
+				return getBasicReconciler()
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reconciler := tt.reconciler()
+			serverClient := tt.serverClient()
+
+			got, err := reconciler.reconcileAlerts(context.TODO(), serverClient, reconciler.installation)
+			if tt.wantErr != "" && err.Error() != tt.wantErr {
+				t.Errorf("reconcileAlerts() error = %v, wantErr %v", err.Error(), tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileAlerts() got = %v, want %v", got, tt.want)
+			}
+			if tt.wantFn != nil {
+				if err := tt.wantFn(serverClient); err != nil {
+					t.Errorf("reconcileAlerts() error = %v", err)
+				}
+			}
+		})
+	}
+}

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -2,9 +2,12 @@ package marin3r
 
 import (
 	"context"
+	"testing"
+
 	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	projectv1 "github.com/openshift/api/project/v1"
 	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	"github.com/sirupsen/logrus"
@@ -14,7 +17,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 )
 
 func getRateLimitConfigMap() *corev1.ConfigMap {
@@ -50,6 +52,33 @@ func getBasicReconciler() *Reconciler {
 			Config: config.ProductConfig{
 				"NAMESPACE": defaultInstallationNamespace,
 			},
+		},
+		AlertsConfig: map[string]*marin3rconfig.AlertConfig{
+			"api-usage-alert-level1": {
+				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "80%",
+				MaxRate:  "90%",
+				Period:   "4h",
+			},
+			"api-usage-alert-level2": {
+				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "90%",
+				MaxRate:  "95%",
+				Period:   "2h",
+			},
+			"api-usage-alert-level3": {
+				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
+				Level:    "warning",
+				MinRate:  "95%",
+				MaxRate:  "100%",
+				Period:   "30m",
+			},
+		},
+		RateLimitConfig: &marin3rconfig.RateLimitConfig{
+			Unit:            "minute",
+			RequestsPerUnit: 1,
 		},
 	}
 }

--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -31,6 +31,7 @@ type AlertConfiguration struct {
 	AlertName string
 	GroupName string
 	Namespace string
+	Interval  string
 	Rules     []monitoringv1.Rule
 }
 
@@ -77,8 +78,9 @@ func (r *AlertReconcilerImpl) reconcileRule(ctx context.Context, client k8sclien
 		rule.Spec = monitoringv1.PrometheusRuleSpec{
 			Groups: []monitoringv1.RuleGroup{
 				{
-					Name:  alert.GroupName,
-					Rules: alert.Rules,
+					Name:     alert.GroupName,
+					Rules:    alert.Rules,
+					Interval: alert.Interval,
 				},
 			},
 		}

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -17,6 +17,15 @@ route:
         alertname: DeadMansSwitch
       repeat_interval: 5m
       receiver: deadmansswitch
+    - match:
+        alertname: Level1ThreeScaleApiUsageThresholdExceeded
+      receiver: BUandCustomer
+    - match:
+        alertname: Level2ThreeScaleApiUsageThresholdExceeded
+      receiver: BUandCustomer
+    - match:
+        alertname: Level3ThreeScaleApiUsageThresholdExceeded
+      receiver: SRECustomerBU
 receivers:
   - name: default
     email_configs:
@@ -31,6 +40,14 @@ receivers:
   - name: deadmansswitch
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
+  - name: BUandCustomer
+    emailConfigs:
+      - send_resolved: True
+      to: {{ index .Params "SMTPToAddress" }}
+  - name: SRECustomerBU
+    emailConfigs:
+      - send_resolved: True
+    to: {{ index .Params "SMTPToAddress" }}
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -43,11 +43,11 @@ receivers:
   - name: BUandCustomer
     emailConfigs:
       - send_resolved: True
-      to: {{ index .Params "SMTPToAddress" }}
+        to: {{ index .Params "SMTPToAddress" }}
   - name: SRECustomerBU
     emailConfigs:
       - send_resolved: True
-    to: {{ index .Params "SMTPToAddress" }}
+        to: {{ index .Params "SMTPToAddress" }}
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -2,9 +2,10 @@ package common
 
 import (
 	"encoding/json"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"strings"
 	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
@@ -286,18 +287,28 @@ var managedApiSpecificRules = []alertsTestRule{
 			"GrafanaServicePod",
 		},
 	},
+	{
+		File: NamespacePrefix + "marin3r-api-usage-alert-level1.yaml",
+		Rules: []string{
+			"Level1ThreeScaleApiUsageThresholdExceeded",
+		},
+	},
+	{
+		File: NamespacePrefix + "marin3r-api-usage-alert-level2.yaml",
+		Rules: []string{
+			"Level2ThreeScaleApiUsageThresholdExceeded",
+		},
+	},
+	{
+		File: NamespacePrefix + "marin3r-api-usage-alert-level3.yaml",
+		Rules: []string{
+			"Level3ThreeScaleApiUsageThresholdExceeded",
+		},
+	},
 }
 
 // Common to all install types
 var commonExpectedRules = []alertsTestRule{
-	{
-		File: "redhat-rhmi-marin3r-3scale-api-usage-alerts.yaml",
-		Rules: []string{
-			"Level1ThreeScaleApiUsageThresholdExceeded",
-			"Level2ThreeScaleApiUsageThresholdExceeded",
-			"Level3ThreeScaleApiUsageThresholdExceeded",
-		},
-	},
 	{
 		File: NamespacePrefix + "middleware-monitoring-operator-backup-monitoring-alerts.yaml",
 		Rules: []string{

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -291,6 +291,14 @@ var managedApiSpecificRules = []alertsTestRule{
 // Common to all install types
 var commonExpectedRules = []alertsTestRule{
 	{
+		File: "redhat-rhmi-marin3r-3scale-api-usage-alerts.yaml",
+		Rules: []string{
+			"Level1ThreeScaleApiUsageThresholdExceeded",
+			"Level2ThreeScaleApiUsageThresholdExceeded",
+			"Level3ThreeScaleApiUsageThresholdExceeded",
+		},
+	},
+	{
 		File: NamespacePrefix + "middleware-monitoring-operator-backup-monitoring-alerts.yaml",
 		Rules: []string{
 			"JobRunningTimeExceeded",


### PR DESCRIPTION
# Description

Modify AlertReconciler instantiation for the marin3r product to create the AlertConfiguration items from the marin3rconfig.AlertConfig elements that are obtained from a ConfigMap.
Modify bootstrap phase to create this ConfigMap with default values, as well as owner annotations to trigger a reconciliation when the ConfigMap is updated.

## Verification steps

1. Begin an installation from this PR
2. Once the bootstrap phase is complete, check that the alerts ConfigMap has been created
    ```sh
    oc get cm rate-limit-alerts -n redhat-rhmi-operator
    ```
3. Wait for the installation to complete
4. Check that the alerts have been reconciled
   ```sh
    oc get prometheusrules -n redhat-rhmi-marin3r

        NAME                     AGE
    api-usage-alert-level1   123m
    api-usage-alert-level2   123m
    api-usage-alert-level3   123m
    ```
5. Modify the alerts ConfigMap
6. A reconciliation should be triggered
7. Verify that the PrometheusRules CRs are updated with the changes

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer