### PR TITLE
Rate-limiting alerts

### DIFF
--- a/pkg/products/grafana/prometheusRules.go
+++ b/pkg/products/grafana/prometheusRules.go
@@ -1,0 +1,73 @@
+package grafana
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
+	return &resources.AlertReconcilerImpl{
+		Installation: r.installation,
+		Logger:       r.logger,
+		ProductName:  "Grafana",
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "ksm-endpoint-alerts",
+				GroupName: "grafana-operator-endpoint.rules",
+				Namespace: r.Config.GetOperatorNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "GrafanaOperatorRhmiRegistryCsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%[1]v'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "GrafanaServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString("kube_endpoint_address_available{endpoint='grafana-service'} * on(namespace) group_left() kube_namespace_labels{label_monitoring_key='middleware'} < 1"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+			{
+				AlertName: "ksm-grafana-alerts",
+				GroupName: "general.rules",
+				Namespace: r.Config.GetOperatorNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "GrafanaOperatorPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Grafana Operator has no pods in ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_name='grafana-operator',namespace='%[1]v'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_name='grafana-operator',namespace='%[1]v'}) < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "GrafanaServicePod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Grafana Service has no pods in ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='grafana',namespace='%[1]v'})) or count(kube_pod_status_ready{condition='true',namespace=`%[1]v`} * on(pod, namespace) kube_pod_labels{label_app='grafana',namespace='%[1]v'}) < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -148,6 +148,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		r.ConfigManager.WriteConfig(r.Config)
 	}
 
+	alertsReconciler := r.newAlertReconciler()
+	if phase, err := alertsReconciler.ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana alerts", err)
+		return phase, err
+	}
+
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()

--- a/pkg/products/marin3r/prometheusRules.go
+++ b/pkg/products/marin3r/prometheusRules.go
@@ -1,0 +1,148 @@
+package marin3r
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
+	return &resources.AlertReconcilerImpl{
+		Installation: r.installation,
+		Logger:       r.logger,
+		ProductName:  "Marin3r",
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "ksm-endpoint-alerts",
+				GroupName: "marin3r-endpoint.rules",
+				Namespace: r.Config.GetNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "Marin3rDiscoveryServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetNamespace()),
+						},
+						Expr:   intstr.FromString("kube_endpoint_address_available{endpoint='marin3r-instance'} * on(namespace) group_left() kube_namespace_labels{label_monitoring_key='middleware'} < 1"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rPromstatsdExporterServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetNamespace()),
+						},
+						Expr:   intstr.FromString("kube_endpoint_address_available{endpoint='prom-statsd-exporter'} * on(namespace) group_left() kube_namespace_labels{label_monitoring_key='middleware'} < 1"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rRateLimitServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetNamespace()),
+						},
+						Expr:   intstr.FromString("kube_endpoint_address_available{endpoint='ratelimit'} * on(namespace) group_left() kube_namespace_labels{label_monitoring_key='middleware'} < 1"),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+			{
+				AlertName: "ksm-endpoint-alerts",
+				GroupName: "marin3r-operator-endpoint.rules",
+				Namespace: r.Config.GetOperatorNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "Marin3rOperatorRhmiRegistryCsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%[1]v'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+			{
+				AlertName: "ksm-marin3r-alerts",
+				GroupName: "general.rules",
+				Namespace: r.Config.GetOperatorNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "Marin3rOperatorPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Marin3r operator has no pods in ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='marin3r-operator',namespace='%[1]v'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='marin3r-operator',namespace='%[1]v'}) < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+			{
+				AlertName: "ksm-marin3r-alerts",
+				GroupName: "general.rules",
+				Namespace: r.Config.GetNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "Marin3rDiscoveryServicePod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Marin3r Discovery Service has no pods in ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app_kubernetes_io_component='discovery-service',namespace='%[1]v'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app_kubernetes_io_component='discovery-service',namespace='%[1]v'}) < 1", r.Config.GetNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rPromstatsdExporterPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Marin3r Promstatsd Exporter has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='prom-statsd-exporter',namespace='%[1]v'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='prom-statsd-exporter',namespace='%[1]v'}) < 1", r.Config.GetNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rRateLimitPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "Marin3r Rate Limit has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on(pod, namespace) kube_pod_labels{label_app='ratelimit',namespace='%[1]v'}))", r.Config.GetNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rEnvoyApicastStagingContainerDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "3Scale apicast-staging pods have no ratelimiting sidecar container attached.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_container_status_running{container='envoy-sidecar'} * on (pod,namespace) kube_pod_labels{label_deploymentconfig='apicast-staging',namespace='%[1]v3scale'})) < 1", global.NamespacePrefix)),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+					{
+						Alert: "Marin3rEnvoyApicastProductionContainerDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "3Scale apicast-production pods have no ratelimiting sidecar container attached.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_container_status_running{container='envoy-sidecar'} * on (pod,namespace) kube_pod_labels{label_deploymentconfig='apicast-production',namespace='%[1]v3scale'})) < 1", global.NamespacePrefix)),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+					},
+				},
+			},
+		},
+	}
+}

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -198,6 +198,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	alertsReconciler := r.newAlertReconciler()
+	if phase, err := alertsReconciler.ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile Marin3r alerts", err)
+		return phase, err
+	}
+
 	product.Host = r.Config.GetHost()
 	product.Version = r.Config.GetProductVersion()
 	product.OperatorVersion = r.Config.GetOperatorVersion()

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -240,6 +240,54 @@ var rhmi2ExpectedRules = []alertsTestRule{
 	},
 }
 
+// Managed-Api-Service rules
+var managedApiSpecificRules = []alertsTestRule{
+	{
+		File: NamespacePrefix + "marin3r-ksm-endpoint-alerts.yaml",
+		Rules: []string{
+			"Marin3rDiscoveryServiceEndpointDown",
+			"Marin3rPromstatsdExporterServiceEndpointDown",
+			"Marin3rRateLimitServiceEndpointDown",
+		},
+	},
+	{
+		File: NamespacePrefix + "marin3r-operator-ksm-endpoint-alerts.yaml",
+		Rules: []string{
+			"Marin3rOperatorRhmiRegistryCsServiceEndpointDown",
+		},
+	},
+	{
+		File: NamespacePrefix + "marin3r-operator-ksm-marin3r-alerts.yaml",
+		Rules: []string{
+			"Marin3rOperatorPod",
+		},
+	},
+	{
+		File: NamespacePrefix + "marin3r-ksm-marin3r-alerts.yaml",
+		Rules: []string{
+			"Marin3rDiscoveryServicePod",
+			"Marin3rPromstatsdExporterPod",
+			"Marin3rRateLimitPod",
+			"Marin3rEnvoyApicastStagingContainerDown",
+			"Marin3rEnvoyApicastProductionContainerDown",
+		},
+	},
+	{
+		File: NamespacePrefix + "customer-monitoring-operator-ksm-endpoint-alerts.yaml",
+		Rules: []string{
+			"GrafanaOperatorRhmiRegistryCsServiceEndpointDown",
+			"GrafanaServiceEndpointDown",
+		},
+	},
+	{
+		File: NamespacePrefix + "customer-monitoring-operator-ksm-grafana-alerts.yaml",
+		Rules: []string{
+			"GrafanaOperatorPod",
+			"GrafanaServicePod",
+		},
+	},
+}
+
 // Common to all install types
 var commonExpectedRules = []alertsTestRule{
 	{
@@ -862,7 +910,7 @@ func getExpectedAWSRules(installType string) []alertsTestRule {
 
 func getExpectedRules(installType string) []alertsTestRule {
 	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
-		return commonExpectedRules
+		return append(commonExpectedRules, managedApiSpecificRules...)
 	} else {
 		return append(commonExpectedRules, rhmi2ExpectedRules...)
 	}

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -32,6 +32,13 @@ type alertsFiringError struct {
 }
 
 var (
+	// Applicable to RHOAM
+	rhoamExpectedPodNamespaces = []string{
+		Marin3rOperatorNamespace,
+		Marin3rProductNamespace,
+		CustomerGrafanaNamespace,
+	}
+
 	// Applicable to all install types
 	commonPodNamespaces = []string{
 		RHMIOperatorNamespace,
@@ -186,7 +193,7 @@ func podLogs(t *testing.T, ctx *TestingContext) {
 
 func getPodNamespaces(installType string) []string {
 	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
-		return commonPodNamespaces
+		return append(commonPodNamespaces, rhoamExpectedPodNamespaces...)
 	} else {
 		return append(commonPodNamespaces, rhmi2PodNamespaces...)
 	}


### PR DESCRIPTION
# Description
This PR implements identified alerts for rate-limiting service in https://issues.redhat.com/browse/MGDAPI-106, addresses ticket https://issues.redhat.com/browse/MGDAPI-107.

# Why
With the implementation of the rate-limiting service, there is a set of alerts required that will monitor the state of each individual component and trigger in case of component failure.

# List of added alerts

## Marin3r Alerts
- Marin3rDiscoveryServiceEndpointDown
- Marin3rPromstatsdExporterServiceEndpointDown
- Marin3rRateLimitServiceEndpointDown
- Marin3rOperatorRhmiRegistryCsServiceEndpointDown
- Marin3rOperatorPod
- Marin3rDiscoveryServicePod
- Marin3rPromstatsdExporterPod
- Marin3rRateLimitPod
- Marin3rEnvoyApicastStagingContainerDown
- Marin3rEnvoyApicastProductionContainerDown

## Grafana Alerts
- GrafanaOperatorRhmiRegistryCsServiceEndpointDown
- GrafanaServiceEndpointDown
- GrafanaOperatorPod
- GrafanaServicePod

# Verification
## Prerequisites
- Cluster provisioned
- Login to your cluster via ocm
- Run `make cluster/prepare/local`
- Run `export INSTALLATION_TYPE=managed-api`
- Run `make code/run`
- Wait for the installation to complete, you can verify that the installation has completed by navigating to managed-api CR under `redhat-rhmi-operator` namespace. Once `status` > `stage` reports `completed` proceed with the next steps.
- Navigate to `Networking` > `Routes` under `redhat-rhmi-middleware-monitoring-operator` and click on the `promtheus-route` route
- Login to Prometheus with Openshift credentials, and click on `Alerts`
- Verify that all the alerts from the list of added alerts above exist and are not firing ( only DMS alert should be triggered )
- Leave the Prometheus tab opened

## Marin3r alerts verification
- Stop the `RHMI-Operator` locally by `ctrl+c` in the terminal where you have run the `make code/run` command 

### Marin3rOperatorPod Alert
- Under `redhat-rhmi-marin3r-operator` namespace go to `Deployments` and click on `marin3r-operator`
- Scale down the deployment by clicking on the down arrow
- The `Marin3rOperatorPod` alert should trigger in the next few minutes. Wait for the alert to trigger and proceed with the next steps but do not scale the `marin3r-operator` back up just yet

### Marin3rDiscoveryServicePod & Marin3rDiscoveryServiceEndpointDown
- Go to `Deployments` under `redhat-rhmi-marin3r` namespace and click on the deployment of `marin3r-instance` - which is our Discovery Service
- Click on the down arrow to scale down the deployment of `marin3r-instance`
- Both, Marin3rDiscoveryServicePod & Marin3rDiscoveryServiceEndpointDown alerts should trigger in next few minutes. Confirm alerts are firing and scale the deployment back up by clicking on the up arrow. When both alerts stop firing continue with next step

### Marin3rPromstatsdExporterPod & Marin3rPromstatsdExporterServiceEndpointDown
- Go to `Deployments` under `redhat-rhmi-marin3r` namespace and click on the deployment of `prom-statsd-exporter` and scale down the deployment by clicking on the down arrow. Both alerts should fire in prometheus in couple of minutes
- Once alerts are confirmed firing, scale the `prom-statsd-exporter` back up, wait for both alerts to stop firing and continue with the next step

### Marin3rRateLimitPod & Marin3rRateLimitServiceEndpointDown
- Go to `Deployments` under `redhat-rhmi-marin3r` namespace and click on the deployment of `ratelimit` and scale down the deployment by clicking on the down arrow. Both alerts should fire in prometheus in couple of minutes
- Once alerts are confirmed firing, scale the `ratelimit` back up, wait for both alerts to stop firing and continue with the next step

### Marin3rEnvoyApicastStagingContainerDown & Marin3rEnvoyApicastProductionContainerDown
- Go to the `Deployment Configuration` of `apicast-production`
- Click on `YAML`
- Under `spec` > `template` > `labels` find and delete the `marin3r.3scale.net/status=enabled`
- Do the same steps for `apicast-staging`
- Both alerts should trigger in Prometheus
- Once both alerts are verified triggering run the rhmi operator locally to add the labels, it will take a couple of minutes before alarms are back to normal state
- Scale `mariner-operator` back up to 1 and verify that no alerts are triggered apart from the DMS alert.

## Grafana alerts verification
- Shut down RHMI Operator locally by using `ctrl+c` in the terminal where you RHMI is running

### GrafanaOperatorPod
- In the `Deployments` under `redhat-rhmi-customer-monitoring-operator` click on the `grafana-operator` and scale down the deployment by clicking on down arrow
- After couple of minutes the alert should trigger in Prometheus
- Leave the Grafana operator scaled down for now

### GrafanaServicePod & GrafanaServiceEndpointDown
- In the `Deployments` under `redhat-rhmi-customer-monitoring-operator` click on `grafana` and scale down the deployment by clicking on the down arrow.
- After few minutes both alerts should be triggered

- Scale back the Grafana Operator pod and Grafana pod
- Run the RHMI operator locally
- After a couple of minutes confirm that no alerts are firing apart from DMS alert 

