### PR TITLE
Updating RHSSO image to latest patch

### DIFF
--- a/manifests/integreatly-rhsso/10.0.0/keycloak-operator.v10.0.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/10.0.0/keycloak-operator.v10.0.0.clusterserviceversion.yaml
@@ -182,6 +182,8 @@ spec:
                   - command:
                       - keycloak-operator
                     env:
+                      - name: RELATED_IMAGE_RHSSO_OPENJDK
+                        value: registry.redhat.io/rh-sso-7/sso74-openshift-rhel8:7.4-3
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:


### PR DESCRIPTION
# Description
The following change is to update the image of RHSSO from 7.4-1 to the latest which is 7.4-3 [Jira](https://issues.redhat.com/browse/INTLY-10126)

## Type of change
Image upgrade

## Verifcation
1. install RHMI from this branch
2. Verify the env var is showing the rhsso operator
2. Verify the keycloak operator deployment in the rhsso-operator namespace is showing this new image version from 7.4-1 to 7.4-3
3. check the container associated with the 2 keycloak pods in the rhsso namespace is showing the new version to 
4. Run through the sso walkthroughs as well 

## Checklist
- [ ] Verified independently on a cluster by reviewer