### PR TITLE
add rhoam e2e makefile target

### DIFF
--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"net/http/cookiejar"
@@ -124,8 +123,6 @@ func isClusterStorage(ctx *TestingContext) (bool, error) {
 
 // returns rhmi
 func GetRHMI(client dynclient.Client, failNotExist bool) (*integreatlyv1alpha1.RHMI, error) {
-	logrus.Infof("Looking for Rhmi CR in %s namespace", RHMIOperatorNamespace)
-
 	installationList := &integreatlyv1alpha1.RHMIList{}
 	listOpts := []k8sclient.ListOption{
 		k8sclient.InNamespace(RHMIOperatorNamespace),


### PR DESCRIPTION
# Description
Add a new Makefile target to run RHOAM e2e tests.

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Verified independently on a cluster by reviewer

### Verification
- Create a fresh OSD cluster
- Wait for certs to be valid
- Login to it with oc
- run `make test/e2e/rhoam SELF_SIGNED_CERTS=false`