### PR TITLE
Fix errors around permissions on objects due to operator-sdk version bump metrics change

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,7 +270,7 @@ cluster/prepare/olm: cluster/prepare cluster/prepare/olm/subscription cluster/ch
 
 .PHONY: cluster/prepare/smtp
 cluster/prepare/smtp:
-	@-oc create secret generic $(INSTALLATION_PREFIX)-smtp -n $(NAMESPACE) \
+	@-oc create secret generic $(NAMESPACE_PREFIX)smtp -n $(NAMESPACE) \
 		--from-literal=host=smtp.example.com \
 		--from-literal=username=dummy \
 		--from-literal=password=dummy \
@@ -279,12 +279,12 @@ cluster/prepare/smtp:
 
 .PHONY: cluster/prepare/pagerduty
 cluster/prepare/pagerduty:
-	@-oc create secret generic $(INSTALLATION_PREFIX)-pagerduty -n $(NAMESPACE) \
+	@-oc create secret generic $(NAMESPACE_PREFIX)pagerduty -n $(NAMESPACE) \
 		--from-literal=serviceKey=test
 
 .PHONY: cluster/prepare/dms
 cluster/prepare/dms:
-	@-oc create secret generic $(INSTALLATION_PREFIX)-deadmanssnitch -n $(NAMESPACE) \
+	@-oc create secret generic $(NAMESPACE_PREFIX)deadmanssnitch -n $(NAMESPACE) \
 		--from-literal=url=https://dms.example.com
 
 .PHONY: cluster/prepare/ratelimits
@@ -304,7 +304,7 @@ endif
 
 .PHONY: cluster/cleanup
 cluster/cleanup:
-	@-oc delete -f deploy/integreatly-rhmi-cr.yml --timeout=240s --wait
+	@-oc delete -f deploy/crds/examples/integreatly-rhmi-cr.yml --timeout=240s --wait
 	@-oc delete namespace $(NAMESPACE) --timeout=60s --wait
 	@-oc delete -f deploy/role.yaml
 	@-oc delete -f deploy/$(INSTALLATION_PREFIX)/role_binding.yaml -n ${NAMESPACE}

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -4,9 +4,9 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: rhmi-operator
 subjects:
-- kind: ServiceAccount
-  name: rhmi-operator
-  namespace: redhat-rhmi-operator
+  - kind: ServiceAccount
+    name: rhmi-operator
+    namespace: redhat-rhmi-operator
 roleRef:
   kind: Role
   name: rhmi-operator

--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -50,7 +50,7 @@ func (r *AlertReconcilerImpl) ReconcileAlerts(ctx context.Context, client k8scli
 		if or, err := r.reconcileRule(ctx, client, monitoringConfig, alert); err != nil {
 			return integreatlyv1alpha1.PhaseFailed, err
 		} else if or != controllerutil.OperationResultNone {
-			r.Logger.Infof("The opreation result for %s %s was %s",
+			r.Logger.Infof("The operation result for %s %s was %s",
 				r.ProductName,
 				alert.AlertName,
 				or,


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/MGDAPI-326

## Verification

On a clean cluster - please uninstall any previous installation and delete any integreatly-operator namespaces.
In the Makefile ->
Update `NAMESPACE_PREFIX=redhat-mgdapi-`
Update `export INSTALLATION_TYPE   ?= managed-api`
Update `export INSTALLATION_PREFIX ?= redhat-managed-api`
Run `make cluster/prepare/local`
Run `yq w -i deploy/operator.yaml 'spec.template.spec.containers[0].image' quay.io/laurafitzgerald/integreatly-operator:v2.8.6`
Run `oc apply -f deploy/operator.yaml -n redhat-mgdapi-operator`

Verify that the errors faced in [this gist ](https://gist.github.com/psturc/86df94fd4fac09c3d32a3e94e3c7d806)are no longer present.

Please go to prometheus and ensure no alerts are firing. There's a change include which fixes an issue with alert manager.


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer