### PR TITLE
Ratelimit Multi-AZ support/verification

### DIFF
--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -15,6 +15,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+var (
+	replicas int32 = 3
+)
+
 type RateLimitServiceReconciler struct {
 	Namespace       string
 	RedisSecretName string
@@ -145,6 +149,7 @@ func (r *RateLimitServiceReconciler) reconcileDeployment(ctx context.Context, cl
 			deployment.Labels = map[string]string{}
 		}
 
+		deployment.Spec.Replicas = &replicas
 		deployment.Labels["app"] = "ratelimit"
 		deployment.Spec.Selector = &v1.LabelSelector{
 			MatchLabels: map[string]string{


### PR DESCRIPTION
# Description
Address JIRA https://issues.redhat.com/browse/MGDAPI-375

# What
Scaling up the default number of rate-limiting replicas and proving that rate-limiting solution supports multi az 

# Verification
1. Provision byoc cluster ( you will need AWS credentials ) 
2. Run oc login command to log in
3. Run `make cluster/prepare/local`
4. Run `export INSTALLATION_TYPE=managed-api` and `export USE_CLUSTER_STORAGE=false`
5. Run `make code/run`
6. Wait for the installation to complete
7. `ctrl+c` operator locally
8. Navigate to `Config maps` under `redhat-rhmi-marin3r` namespace
9. Click on `ratelimit-config` > `YAML`  and edit the `data`>`apicast-ratelimiting`>`ratelimit` `unit` to `hour` and hit `save`. This will set a new rate limit configuration of 20 per hour for testing purposes. 
10. Run `oc scale deployment ratelimit -n redhat-rhmi-marin3r --replicas=0` and `oc scale deployment ratelimit -n redhat-rhmi-marin3r --replicas=3`
11. Navigate to Routes under `redhat-rhmi-3scale` namespace
12. Click on the `https://3scale-admin-apps....` route
13. Obtain admin credentials from `system-seed` secret
14. After logging in for the first time you will be brought to the 3scale wizard, follow the wizard to create an api
15. After creating an api click on the `integreation` > `configuration` in 3Scale
16. Click on the `Promote v.1 to Production Apicast`
17. Create and run the following script:  https://gist.github.com/MStokluska/78517305d5f2075bfcd3ea47ed69951b
18. Script will create a throwaway redis container to communicate with the redis aws instance, it will list 3 running rate-limiting pods ( in 2 or 3 different AZ ), then it will run for 30 minutes (updates every 15sec) and list the number of hits made against 3scale apicast production or staging, and IP numbers of envoy containers that made the connection to each rate-limiting pod. Initially there should be only 1 hit count with just 1 ip number under one of the rate-limiting pods - it is the connection that was made during creation of api by using 3scale wizard.
19. Copy the curl command from 3scale for apicast-staging
20. Run the curl command from 3scale for apicast-staging with `-i` flag
21. Output from the running script should increase the number of hits to match the amount of curl you have made and also, the rate-limiting envoy config IP numbers should update. You should see that each pod has accepted a connection from the envoy container.  
22. Curl about 15 times and the new updated list of rate limiting pod connections and current hit count should be accurately reflected. 
23. Stop the script and start the operator locally again
24. Delete managed-api CR under "redhat-rhmi-operator" namespace
25. Wait for the unistallation to complete and deprovision cluster.