### PR TITLE
MGDAPI-240: Set topology spread constraints to rate limit service

### DIFF
--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -17,6 +17,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
+var (
+	replicas int32 = 3
+)
+
 type RateLimitServiceReconciler struct {
 	Namespace       string
 	RedisSecretName string
@@ -149,6 +153,7 @@ func (r *RateLimitServiceReconciler) reconcileDeployment(ctx context.Context, cl
 			deployment.Labels = map[string]string{}
 		}
 
+		deployment.Spec.Replicas = &replicas
 		deployment.Labels["app"] = "ratelimit"
 		deployment.Spec.Selector = &v1.LabelSelector{
 			MatchLabels: map[string]string{

--- a/pkg/resources/topologyConstraints.go
+++ b/pkg/resources/topologyConstraints.go
@@ -89,3 +89,9 @@ func SelectFromDeploymentConfig(obj v1.Object) *corev1.PodTemplateSpec {
 	dc := obj.(*openshiftappsv1.DeploymentConfig)
 	return dc.Spec.Template
 }
+
+// SelectFromDeployment returns obj.Spec.Template
+func SelectFromDeployment(obj v1.Object) *corev1.PodTemplateSpec {
+	d := obj.(*appsv1.Deployment)
+	return &d.Spec.Template
+}

--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -2,8 +2,9 @@ package common
 
 import (
 	goctx "context"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -126,7 +127,7 @@ var (
 			},
 			{
 				Name:             "ratelimit",
-				ExpectedReplicas: 1,
+				ExpectedReplicas: 3,
 			},
 		},
 	}


### PR DESCRIPTION
# Description

> Link to Jira: https://issues.redhat.com/browse/MGDAPI-240

In order to enable Multi-AZ support for the rate limit service:
* Set the number of replicas to 3
* Set the Deployment topology spread constraints for multi AZ

## Steps to verify

## Short

1. Install MGDAPI from this PR
2. Once the installation completes, verify that the replicas and topologySpreadConstraints field have been set
    ```sh
    oc get deployments ratelimit -n redhat-rhmi-marin3r -o json | jq -r '{ "replicas": .spec.replicas, "topologySpreadConstraints": .spec.template.spec.topologySpreadConstraints }'    
    ```
    The output should look like:
    ```json
    {
        "replicas": 3,
        "topologyConstraints": [
            {
                "labelSelector": {
                    "matchLabels": {
                        "app": "ratelimit"
                    }
                },
                "maxSkew": 1,
                "topologyKey": "topology.kubernetes.io/zone",
                "whenUnsatisfiable": "ScheduleAnyway"
            }
        ]
    }
    ```
## Long (with multi AZ cluster)

1. Provision multi AZ cluster
1. Begin the installation
    ````sh
    make cluster/prepare/local
    export INSTALLATION_TYPE=managed-api 
    export USE_CLUSTER_STORAGE=false
    make code/run
    ````
3. Wait for the installation to complete
4. Stop the operator (`ctrl + c`)
4. Run `oc scale deployment ratelimit -n redhat-rhmi-marin3r --replicas=0 and oc scale deployment ratelimit -n redhat-rhmi-marin3r --replicas=3`
4. Navigate to Routes under redhat-rhmi-3scale namespace
4. Click on the `https://3scale-admin-apps....` route
Obtain admin credentials from `system-seed` secret
5. After logging in for the first time you will be brought to the 3scale wizard, follow the wizard to create an api
6. After creating an api click on the `integration` > `configuration` in 3Scale
7. Click on the `Promote v.1 to Production Apicast`
8. Create and run the following script: https://gist.github.com/MStokluska/78517305d5f2075bfcd3ea47ed69951b
9. Script will create a throwaway redis container to communicate with the redis aws instance, it will list 3 running rate-limiting pods ( in 2 or 3 different AZ ), then it will run for 30 minutes (updates every 15sec) and list the number of hits made against 3scale apicast production or staging, and IP numbers of envoy containers that made the connection to each rate-limiting pod. Initially there should be only 1 hit count with just 1 ip number under one of the rate-limiting pods - it is the connection that was made during creation of api by using 3scale wizard.
10. Copy the curl command from 3scale for apicast-staging
11. Run the curl command from 3scale for apicast-staging with -i flag
12. Output from the running script should increase the number of hits to match the amount of curl you have made and also, the rate-limiting envoy config IP numbers should update. You should see that each pod has accepted a connection from the envoy container.
13. Curl about 15 times and the new updated list of rate limiting pod connections and current hit count should be accurately reflected.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer