### PR TITLE
Adding customer grafana dashboard

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -1,0 +1,606 @@
+package grafana
+
+const CustomerMonitoringGrafanaRateLimitingJSON = `{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 2,
+  "iteration": 1603968007503,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 8,
+      "panels": [],
+      "title": "RHOAM API Rate Limiting",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorPostfix": false,
+      "colorPrefix": false,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "description": "",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 1
+      },
+      "id": 4,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "$perMinuteTwentyMillion",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Minute - No. Requests",
+      "transparent": true,
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "description": "",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 1
+      },
+      "id": 6,
+      "interval": "",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h])",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "$perMinuteTwentyMillion*60*24",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Day - No. Requests",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": null,
+      "decimals": 0,
+      "fill": 1,
+      "fillGradient": 4,
+      "gridPos": {
+        "h": 10,
+        "w": 18,
+        "x": 6,
+        "y": 1
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "interval": "1m",
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "hideEmpty": false,
+        "hideZero": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null as zero",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 2,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])",
+          "instant": false,
+          "interval": "30s",
+          "legendFormat": "No. of Reqests",
+          "refId": "A"
+        },
+        {
+          "expr": "$perMinuteFiveMillion",
+          "legendFormat": "Five Million Daily SKU",
+          "refId": "B"
+        },
+        {
+          "expr": "$perMinuteTenMillion",
+          "legendFormat": "Ten Million Daily SKU",
+          "refId": "C"
+        },
+        {
+          "expr": "$perMinuteFifteenMillion",
+          "legendFormat": "Fifteen Million Daily SKU",
+          "refId": "D"
+        },
+        {
+          "expr": "$perMinuteTwentyMillion",
+          "legendFormat": "Twenty Million Daily SKU",
+          "refId": "E"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Per Minute API Requests by SKU",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": null,
+      "description": "",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 6
+      },
+      "id": 10,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m])",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": " Last Minute - Rejected",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "#299c46",
+        "rgba(237, 129, 40, 0.89)",
+        "#d44a3a"
+      ],
+      "datasource": "Prometheus",
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 3,
+        "y": 6
+      },
+      "id": 16,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false,
+        "ymax": null,
+        "ymin": null
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h])",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "thresholds": "1",
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Last Day - Rejected",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 21,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "13889",
+          "value": "13889"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "perMinuteTwentyMillion",
+        "options": [
+          {
+            "selected": true,
+            "text": "13889",
+            "value": "13889"
+          }
+        ],
+        "query": "13889",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "10417",
+          "value": "10417"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "perMinuteFifteenMillion",
+        "options": [
+          {
+            "selected": true,
+            "text": "10417",
+            "value": "10417"
+          }
+        ],
+        "query": "10417",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "6944",
+          "value": "6944"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "perMinuteTenMillion",
+        "options": [
+          {
+            "selected": true,
+            "text": "6944",
+            "value": "6944"
+          }
+        ],
+        "query": "6944",
+        "skipUrlSync": false,
+        "type": "constant"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "3472",
+          "value": "3472"
+        },
+        "hide": 2,
+        "label": null,
+        "name": "perMinuteFiveMillion",
+        "options": [
+          {
+            "selected": true,
+            "text": "3472",
+            "value": "3472"
+          }
+        ],
+        "query": "3472",
+        "skipUrlSync": false,
+        "type": "constant"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-12h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Rate Limiting",
+  "uid": "f14587491b89ba66cfb3ad51cd0e966e",
+  "version": 3
+}`

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -34,6 +34,7 @@ const (
 	manifestPackage              = "integreatly-grafana"
 	defaultGrafanaName           = "grafana"
 	defaultRoutename             = defaultGrafanaName + "-route"
+	rateLimitDashBoardName       = "rate-limit"
 )
 
 type Reconciler struct {
@@ -143,6 +144,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.reconcileGrafanaDashboards(ctx, client, rateLimitDashBoardName)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana dashboard", err)
+		return phase, err
+	}
+
 	if string(r.Config.GetProductVersion()) != string(integreatlyv1alpha1.VersionGrafana) {
 		r.Config.SetProductVersion(string(integreatlyv1alpha1.VersionGrafana))
 		r.ConfigManager.WriteConfig(r.Config)
@@ -185,6 +192,34 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, client k8sclient.Clie
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
+func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClient k8sclient.Client, dashboard string) (integreatlyv1alpha1.StatusPhase, error) {
+
+	grafanaDB := &grafanav1alpha1.GrafanaDashboard{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      dashboard,
+			Namespace: r.Config.GetOperatorNamespace(),
+		},
+	}
+
+	opRes, err := controllerutil.CreateOrUpdate(ctx, serverClient, grafanaDB, func() error {
+		grafanaDB.Labels = map[string]string{
+			"monitoring-key": "customer",
+		}
+		grafanaDB.Spec = grafanav1alpha1.GrafanaDashboardSpec{
+			Json: CustomerMonitoringGrafanaRateLimitingJSON,
+			Name: rateLimitDashBoardName,
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if opRes != controllerutil.OperationResultNone {
+		r.logger.Infof("operation result of creating/updating grafana dashboard %v was %v", grafanaDB.Name, opRes)
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
 func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
 	r.logger.Info("reconciling grafana custom resource")
 
@@ -198,7 +233,12 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "grafana",
 			Namespace: r.Config.GetOperatorNamespace(),
-		}, Spec: grafanav1alpha1.GrafanaSpec{
+		},
+	}
+
+	status, err := controllerutil.CreateOrUpdate(ctx, client, grafana, func() error {
+		owner.AddIntegreatlyOwnerAnnotations(grafana, r.installation)
+		grafana.Spec = grafanav1alpha1.GrafanaSpec{
 			Config: grafanav1alpha1.GrafanaConfig{
 				Log: &grafanav1alpha1.GrafanaConfigLog{
 					Mode:  "console",
@@ -275,12 +315,18 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 			ServiceAccount: &grafanav1alpha1.GrafanaServiceAccount{
 				Annotations: serviceAccountAnnotations,
 			},
-		},
-	}
-
-	status, err := controllerutil.CreateOrUpdate(ctx, client, grafana, func() error {
-		owner.AddIntegreatlyOwnerAnnotations(grafana, r.installation)
-
+			DashboardLabelSelector: []*metav1.LabelSelector{
+				{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{
+							Key:      "monitoring-key",
+							Operator: "In",
+							Values:   []string{"customer"},
+						},
+					},
+				},
+			},
+		}
 		return nil
 	})
 

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -26,6 +26,13 @@ var (
 		},
 		{
 			[]TestCase{
+				{"E09 - Verify customer dashboards exist", TestIntegreatlyCustomerDashboardsExist},
+				{"E10 - Verify Customer Grafana Route is accessible", TestCustomerGrafanaExternalRouteAccessible},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+		},
+		{
+			[]TestCase{
 				{"A01 - Verify that all stages in the integreatly-operator CR report completed", TestIntegreatlyStagesStatus}, // Keep test as first on the list, as it ensures that all products are reported as complete
 				{"Test RHMI installation CR metric", TestRHMICRMetrics},
 				{"A03 - Verify all namespaces have been created with the correct name", TestNamespaceCreated},
@@ -49,9 +56,9 @@ var (
 				{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
 				{"C01 - Verify Alerts are not pending or firing apart from DeadMansSwitch", TestIntegreatlyAlertsPendingOrFiring},
 				{"C04 - Verify Alerts exist", TestIntegreatlyAlertsExist},
-				{"E01 - Verify Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
+				{"E01 - Verify Middleware Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
 				{"E02 - Verify that all dashboards are installed and all the graphs are filled with data", TestDashboardsData},
-				{"E03 - Verify dashboards exist", TestIntegreatlyDashboardsExist},
+				{"E03 - Verify middleware dashboards exist", TestIntegreatlyMiddelewareDashboardsExist},
 				{"E05 - Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
 				{"F02 - Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
 				{"F05 - Verify Replicas Scale correctly in Threescale", TestReplicasInThreescale},


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/MGDAPI-91

## Type of change
Adding customer grafana dashboard
Adding tests
E06 - verify customer dashboard exists
E07 - verify customer route is accessible

## Verification.

Run the operator against an openshift cluster

Create an application in 3scale using the following steps

Navigate to `https://3scale-admin.[your_admin_domain].devshift.org/p/admin/onboarding/wizard/intro` and follow the steps outlined in the wizard to create a 3Scale service. You can get your admin domain from Routes under `redhat-rhmi-3scale` namespace, use the admin user credentials from the `system-seed` secret in the 3scale namespace
Navigate to `https://3scale-admin.[your_admin_domain].devshift.org/apiconfig/services/2/integration`
Copy curl command from API Cast staging.

Simulate load on the cluster using some loading tool, there's an example below where I'm using [wrk](https://github.com/wg/wrk)
```
wrk -t6 -c400 -d5m <copied curl command from above>
```


- Navigate to the customer grafana route and verify the dashboard is created.
 
Based on the state of the current data set. e.g. what load is being inflicted on the cluster the dashboard should look something like the below images.

Things to verify are
- the per minute dropped requests goes orange if there has been dropped requests in the last minute
- the count for the daily requests accurately reflects the amount of requests hitting the cluster

![Screenshot 2020-10-29 at 17 07 22](https://user-images.githubusercontent.com/6498727/97607740-4afc2b00-1a09-11eb-95fe-b602f95dbdac.png)

![Screenshot 2020-10-29 at 14 12 11](https://user-images.githubusercontent.com/6498727/97600745-4b90c380-1a01-11eb-805b-15a73bae2ff4.png)
![Screenshot 2020-10-29 at 12 44 07](https://user-images.githubusercontent.com/6498727/97600793-564b5880-1a01-11eb-8662-aad07d680ff2.png)
![Screenshot 2020-10-29 at 12 37 17](https://user-images.githubusercontent.com/6498727/97600823-606d5700-1a01-11eb-8bf8-3a8a158a5094.png)



Alert firing are based on alerts being added as part of [this pr](https://github.com/integr8ly/integreatly-operator/pull/1241)


- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer