### PR TITLE
Expose Grafana URL in API usage notifications

### DIFF
--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -9,6 +9,7 @@ import (
 	prometheus "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/integr8ly/cloud-resource-operator/pkg/apis/integreatly/v1alpha1/types"
 	croUtil "github.com/integr8ly/cloud-resource-operator/pkg/client"
+	grafana "github.com/integr8ly/integreatly-operator/pkg/products/grafana"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 	appsv1 "k8s.io/api/apps/v1"
@@ -242,7 +243,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 }
 
 func (r *Reconciler) reconcileAlerts(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (integreatlyv1alpha1.StatusPhase, error) {
-	alertReconciler, err := r.newAlertsReconciler()
+
+	granafaConsoleURL, err := grafana.GetGrafanaConsoleURL(ctx, client, installation)
+	if err != nil {
+		logrus.Errorf("failed to get Grafana console URL %w", err)
+	}
+
+	alertReconciler, err := r.newAlertsReconciler(granafaConsoleURL)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}


### PR DESCRIPTION
# Description

Expose the Grafana URL in the alert notifications for the API usage

https://issues.redhat.com/browse/MGDAPI-228

## Verification steps

1) Install the operator locally from this branch
2) Get the Prometheus Rules CRs
```oc get prometheusrules -n redhat-rhmi-marin3r``` 
3)  Verify if the `grafanaConsole` is present in the annotation block of the Prometheus Rules CRs
```oc get prometheusrules [prometheus_rule_cr_name]  -o json -n redhat-rhmi-marin3r | jq .spec.groups[0].rules[0].annotations[0].grafanaConsole```


## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)
