### PR TITLE
Fix role binding namespaces for RHOAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ ifeq ($(INSTALLATION_TYPE), managed-api)
 	NAMESPACE_PREFIX ?= redhat-rhoam-
 	APPLICATION_REPO ?= managed-api-service
 	# TODO follow on naming of this folder by INSTALLATION_PREFIX and contents of the role_binding.yaml
-	export INSTALLATION_PREFIX ?= redhat-managed-api
+	export INSTALLATION_PREFIX ?= redhat-rhoam
 	export OLM_TYPE ?= managed-api-service
 endif
 

--- a/deploy/redhat-rhoam/role_binding.yaml
+++ b/deploy/redhat-rhoam/role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: rhmi-operator
-  namespace: redhat-managed-api-operator
+  namespace: redhat-rhoam-operator
 roleRef:
   kind: Role
   name: rhmi-operator
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rhmi-operator
-    namespace: redhat-managed-api-operator
+    namespace: redhat-rhoam-operator
 roleRef:
   kind: ClusterRole
   name: rhmi-operator


### PR DESCRIPTION
# Description

Update namespace in role binding to use `redhat-rhoam-` prefix
Update directory to `redhat-rhoam`

## Verification steps

1. Start an installation from this PR on a fresh cluster
    1. Run `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
    2. Run `INSTALLATION_TYPE=managed-api make code/run`

The operator should start running with no errors in the `redhat-rhoam-operator` namespace

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer