### PR TITLE
fix: tests: A18, A25

### DIFF
--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -274,4 +275,19 @@ func putStrategyForResource(configMap *v1.ConfigMap, stratMap *strategyMap, reso
 	}
 	configMap.Data[resourceType] = string(updatedRawStrategyMapping)
 	return nil
+}
+
+// GetClustersAvailableZones returns a map containing zone names that are currently available
+func GetClustersAvailableZones(nodes *v1.NodeList) map[string]bool {
+	zones := make(map[string]bool)
+	for _, node := range nodes.Items {
+		if isNodeWorkerAndReady(node) {
+			for labelName, labelValue := range node.Labels {
+				if labelName == "topology.kubernetes.io/zone" {
+					zones[labelValue] = true
+				}
+			}
+		}
+	}
+	return zones
 }

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -3,13 +3,14 @@ package functional
 import (
 	goctx "context"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/test/common"
-	v1 "k8s.io/api/core/v1"
 	"math"
 	"os"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strings"
 	"testing"
+
+	"github.com/integr8ly/integreatly-operator/test/common"
+	v1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var (
@@ -34,7 +35,7 @@ func TestMultiAZPodDistribution(t *testing.T, ctx *common.TestingContext) {
 
 	ctx.Client.List(goctx.TODO(), nodes)
 
-	availableZones = getAZ(nodes)
+	availableZones = GetClustersAvailableZones(nodes)
 
 	// If "NAMESPACES_TO_CHECK" env var contains a list of namespaces, use that instead of the predefined list
 	namespacesFromEnvVar := os.Getenv("NAMESPACES_TO_CHECK")
@@ -82,21 +83,6 @@ func TestMultiAZPodDistribution(t *testing.T, ctx *common.TestingContext) {
 	if len(testErrors) != 0 {
 		t.Fatalf("\nError when verifying the pod distribution: \n%s", testErrors)
 	}
-}
-
-// Returns a map containing zone names that are currently available
-func getAZ(nodes *v1.NodeList) map[string]bool {
-	zones := make(map[string]bool)
-	for _, node := range nodes.Items {
-		if isNodeWorkerAndReady(node) {
-			for labelName, labelValue := range node.Labels {
-				if labelName == "topology.kubernetes.io/zone" {
-					zones[labelValue] = true
-				}
-			}
-		}
-	}
-	return zones
 }
 
 // Returns true if the node is a "worker" (compute node)


### PR DESCRIPTION
# Description

Fix (workaround) for a flaky tests A18 and A25
https://issues.redhat.com/browse/MGDAPI-395
https://issues.redhat.com/browse/MGDAPI-394

## A18
This test sometimes fails on an error:
```
    TestIntegreatly/Integreatly_Happy_Path_Tests/A18_-_Verify_RHMI_Config_CRs_Successful: rhmi_config.go:310: Expected error to be nil. Got Operation cannot be fulfilled on rhmiconfigs.integreatly.org "test-rhmi-config": the object has been modified; please apply your changes to the latest version and try again
```
that happens between the mutations of RHMIconfig CR

### Fix description
I've put the `verifyRHMIConfigValidation` function calls inside `wait.Poll` method to keep retrying the mutation until it finally passed without an error.

## A25
This test was failing on multi-az cluster due to hardcoded number of route tables a cluster VPC should have

### Fix description
Fixed by determining the number of route tables by summing up number of AZs the cluster is using (1 private route table per AZ) + 1 public route table

![Screenshot 2020-10-27 at 15 10 39](https://user-images.githubusercontent.com/4881144/97313167-9cb88000-1866-11eb-8ecb-9b6e235335fb.png)


# Verification
```
go clean -testcache && MULTIAZ=true go test -v ./test/functional -run="//(^A18)|(^A25)"
```
(already tested against single-az and multi-az cluster)