### PR TITLE
Updating managed-api rolebinding to use redhat-rhmi-operator

### DIFF
--- a/deploy/redhat-managed-api/role_binding.yaml
+++ b/deploy/redhat-managed-api/role_binding.yaml
@@ -6,7 +6,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: rhmi-operator
-  namespace: redhat-managed-api-operator
+  namespace: redhat-rhmi-operator
 roleRef:
   kind: Role
   name: rhmi-operator
@@ -19,7 +19,7 @@ metadata:
 subjects:
   - kind: ServiceAccount
     name: rhmi-operator
-    namespace: redhat-managed-api-operator
+    namespace: redhat-rhmi-operator
 roleRef:
   kind: ClusterRole
   name: rhmi-operator


### PR DESCRIPTION
Before switching to a new operator namespace prefix we'll need to address a number of tasks as part of RHOAM Sprint 3.

For now, this PR reverts our rolebinding changes to work with `redhat-rhmi-operator`