### PR TITLE
MGDAPI-497, MGDAPI-500 - fix alert manager recievers

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -696,10 +696,16 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 	}
 
 	// only set the to address to a real value for managed deployments
-	smtpToAddress := fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host)
-	smtpToAddressCRDVal := r.installation.Spec.AlertingEmailAddresses.CSSRE
-	if smtpToAddressCRDVal != "" {
-		smtpToAddress = smtpToAddressCRDVal
+	smtpToSREAddress := fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host)
+	smtpToSREAddressCRVal := r.installation.Spec.AlertingEmailAddresses.CSSRE
+	if smtpToSREAddressCRVal != "" {
+		smtpToSREAddress = smtpToSREAddressCRVal
+	}
+
+	smtpToBUAddress := fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host)
+	smtpToBUAddressCRVal := r.installation.Spec.AlertingEmailAddresses.BusinessUnit
+	if smtpToBUAddressCRVal != "" {
+		smtpToBUAddress = smtpToBUAddressCRVal
 	}
 
 	// parse the config template into a secret object
@@ -709,7 +715,8 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 		"AlertManagerRoute":   alertmanagerRoute.Spec.Host,
 		"SMTPUsername":        string(smtpSecret.Data["username"]),
 		"SMTPPassword":        string(smtpSecret.Data["password"]),
-		"SMTPToAddress":       smtpToAddress,
+		"SMTPToSREAddress":    smtpToSREAddress,
+		"SMTPToBUAddress":     smtpToBUAddress,
 		"PagerDutyServiceKey": pagerDutySecret,
 		"DeadMansSnitchURL":   dmsSecret,
 	})

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -40,10 +40,11 @@ import (
 )
 
 const (
-	mockSMTPSecretName       = "test-smtp"
-	mockPagerdutySecretName  = "test-pd"
-	mockDMSSecretName        = "test-dms"
-	mockAlertingEmailAddress = "noreply-test@rhmi-redhat.com"
+	mockSMTPSecretName         = "test-smtp"
+	mockPagerdutySecretName    = "test-pd"
+	mockDMSSecretName          = "test-dms"
+	mockAlertingEmailAddress   = "noreply-test@rhmi-redhat.com"
+	mockBUAlertingEmailAddress = "noreply-bu-test@rhmi-redhat.com"
 )
 
 func basicInstallation() *integreatlyv1alpha1.RHMI {
@@ -69,6 +70,7 @@ func basicInstallation() *integreatlyv1alpha1.RHMI {
 func basicInstallationWithAlertEmailAddress() *integreatlyv1alpha1.RHMI {
 	installation := basicInstallation()
 	installation.Spec.AlertingEmailAddresses.CSSRE = mockAlertingEmailAddress
+	installation.Spec.AlertingEmailAddresses.BusinessUnit = mockBUAlertingEmailAddress
 	return installation
 }
 
@@ -683,7 +685,8 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 		"SMTPPassword":        string(smtpSecret.Data["password"]),
 		"PagerDutyServiceKey": string(pagerdutySecret.Data["serviceKey"]),
 		"DeadMansSnitchURL":   string(dmsSecret.Data["url"]),
-		"SMTPToAddress":       fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
+		"SMTPToSREAddress":    fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
+		"SMTPToBUAddress":     fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
 	})
 
 	testSecretData, err := templateUtil.loadTemplate(alertManagerConfigTemplatePath)
@@ -834,7 +837,8 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 					"SMTPPassword":        string(smtpSecret.Data["password"]),
 					"PagerDutyServiceKey": string(pagerdutySecret.Data["serviceKey"]),
 					"DeadMansSnitchURL":   string(dmsSecret.Data["url"]),
-					"SMTPToAddress":       mockAlertingEmailAddress,
+					"SMTPToSREAddress":    mockAlertingEmailAddress,
+					"SMTPToBUAddress":     mockBUAlertingEmailAddress,
 				})
 
 				testSecretData, err := templateUtil.loadTemplate(alertManagerConfigTemplatePath)

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -41,11 +41,11 @@ receivers:
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
   - name: BUandCustomer
-    emailConfigs:
+    email_configs:
       - send_resolved: True
         to: {{ index .Params "SMTPToAddress" }}
   - name: SRECustomerBU
-    emailConfigs:
+    email_configs:
       - send_resolved: True
         to: {{ index .Params "SMTPToAddress" }}
 inhibit_rules:

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -30,24 +30,24 @@ receivers:
   - name: default
     email_configs:
       - send_resolved: true
-        to: {{ index .Params "SMTPToAddress" }}
+        to: {{ index .Params "SMTPToSREAddress" }}
   - name: critical
     pagerduty_configs:
       - service_key: {{ index .Params "PagerDutyServiceKey" }}
     email_configs:
       - send_resolved: true
-        to: {{ index .Params "SMTPToAddress" }}
+        to: {{ index .Params "SMTPToSREAddress" }}
   - name: deadmansswitch
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
   - name: BUandCustomer
     email_configs:
       - send_resolved: True
-        to: {{ index .Params "SMTPToAddress" }}
+        to: '{{ index .Params "SMTPToBUAddress" }}'
   - name: SRECustomerBU
     email_configs:
       - send_resolved: True
-        to: {{ index .Params "SMTPToAddress" }}
+        to: '{{ index .Params "SMTPToSREAddress" }}, {{ index .Params "SMTPToBUAddress" }}'
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'


### PR DESCRIPTION
# Description
JIRAs: 
https://issues.redhat.com/browse/MGDAPI-497
https://issues.redhat.com/browse/MGDAPI-500

After this change, alert manager receivers config looks like this:
```
receivers:
  - name: default
    email_configs:
      - send_resolved: true
        to: cssre-noreply@redhat-rhmi.com
  - name: critical
    pagerduty_configs:
      - service_key: test
    email_configs:
      - send_resolved: true
        to: cssre-noreply@redhat-rhmi.com
  - name: deadmansswitch
    webhook_configs:
      - url: https://dms.example.com
  - name: BUandCustomer
    email_configs:
      - send_resolved: True
        to: 'bu-noreply@redhat-rhmi.com'
  - name: SRECustomerBU
    email_configs:
      - send_resolved: True
        to: 'cssre-noreply@redhat-rhmi.com, bu-noreply@redhat-rhmi.com'
```
Notice that it now has correct name for the "emails_config" field and it contains BU email address.

For verification, you can check this config in the "alertmanager-application-monitoring" Secret in "redhat-rhmi-middleware-monitoring-operator" namespace OR in the "Status" page of the AlertManager.  


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer