### PR TITLE
Fix podPriorityClassName variable

### DIFF
--- a/pkg/products/rhssocommon/reconciler.go
+++ b/pkg/products/rhssocommon/reconciler.go
@@ -499,6 +499,7 @@ func (r *Reconciler) ReconcilePodPriority(ctx context.Context, serverClient k8sc
 			},
 			resources.SelectFromStatefulSet,
 			keycloakStatefulSet,
+			r.Installation.Spec.PriorityClassName,
 		)
 	}
 	return integreatlyv1alpha1.PhaseCompleted, nil

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -406,7 +406,7 @@ func (r *Reconciler) reconcilePodPriority(ctx context.Context, serverClient k8sc
 		ns := global.NamespacePrefix + defaultInstallationNamespace
 		for _, name := range threeScaleDeploymentConfigs {
 			deploymentConfig := &appsv1.DeploymentConfig{}
-			_, err := resources.ReconcilePodPriority(ctx, serverClient, k8sclient.ObjectKey{Name: name, Namespace: ns}, resources.SelectFromDeploymentConfig, deploymentConfig)
+			_, err := resources.ReconcilePodPriority(ctx, serverClient, k8sclient.ObjectKey{Name: name, Namespace: ns}, resources.SelectFromDeploymentConfig, deploymentConfig, r.installation.Spec.PriorityClassName)
 			if err != nil {
 				return integreatlyv1alpha1.PhaseInProgress, err
 			}


### PR DESCRIPTION
# Description
This fixes a hard coded pod priority class name value. 

to validate :
1. install this branch as a `managed-api` type
2. Confirm podPriority class exists with the name `rhoam-pod-priority`
3. Confirm the RHSSO/UserSSO keycloak stateful sets have the priority class name set
4. Confirm the threescale deployment configs have the priority class name set

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)