### PR TITLE
MGDAPI-521 - Ensure 3scale deployment config rollout is ready before returning complete

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -678,6 +678,20 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 	systemEnvConfigMap.Namespace = threeScaleInstallationNamepsace
 	oauthClientSecrets.Namespace = integreatlyOperatorNamespace
 	installation.Namespace = integreatlyOperatorNamespace
+	apicastProduction.Namespace = threeScaleInstallationNamepsace
+	apicastStaging.Namespace = threeScaleInstallationNamepsace
+	backendCron.Namespace = threeScaleInstallationNamepsace
+	backendListener.Namespace = threeScaleInstallationNamepsace
+	backendWorker.Namespace = threeScaleInstallationNamepsace
+	systemApp.Namespace = threeScaleInstallationNamepsace
+	systemAppDep.Namespace = threeScaleInstallationNamepsace
+	systemMemcache.Namespace = threeScaleInstallationNamepsace
+	systemSidekiq.Namespace = threeScaleInstallationNamepsace
+	systemSidekiqDep.Namespace = threeScaleInstallationNamepsace
+	systemSphinx.Namespace = threeScaleInstallationNamepsace
+	zync.Namespace = threeScaleInstallationNamepsace
+	zyncDatabase.Namespace = threeScaleInstallationNamepsace
+	zyncQue.Namespace = threeScaleInstallationNamepsace
 
 	return []runtime.Object{
 		s3BucketSecret,


### PR DESCRIPTION
# Description
Previously 3scale phase can report complete before being truly ready. This is due to when the deployment configs changes (from adding topologySpreadConstraints, podPriority etc), there is no check that the rollout has completed before returing complete. 

This causes the products stage to become `PhaseComplete`, then back to `InProgress` before returning to `PhaseComplete` again.

Due to this, tests can run early, where 3scale is not fully ready, causing some flaky failure in tests such as product version, deployment replicas etc
  * OSDE2E - https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/osde2e-stage-aws-addon-integreatly-operator/1321421556915638272

To prevent this, we should check that the deployment config rollout has completed before returning phase complete in the 3scale reconciler

Jira:
* https://issues.redhat.com/browse/MGDAPI-521

## Verification
* Checkout this branch
* Install managed-api
```
make cluster/prepare/local
INSTALLATION_TYPE=managed-api make code/run
```
* Monitor products stage on RHMI CR and ensure it does not go back to in progress once it reported complete 
```
while true; do
	echo "products stage: $(oc get rhmi managed-api -n redhat-rhmi-operator -o template --template {{.status.stages.products.phase}})"
done
```
## Type of change
<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer