### PR TITLE
MGDAPI-495 - Add rhoam version metric

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,6 +61,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIInfo)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatus)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	integreatlymetrics.OperatorVersion.Add(1)
 }
 

--- a/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmiconfigs_crd.yaml
@@ -17,10 +17,14 @@ spec:
       description: RHMIConfig is the Schema for the rhmiconfigs API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -30,28 +34,34 @@ spec:
             backup:
               properties:
                 applyOn:
-                  description: 'apply-on: string, day time. Format: "DDD hh:mm" > "wed 20:00". UTC time'
+                  description: 'apply-on: string, day time. Format: "DDD hh:mm" >
+                    "wed 20:00". UTC time'
                   type: string
               type: object
             maintenance:
               properties:
                 applyFrom:
-                  description: 'apply-from: string, day time. Currently this is a 6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                  description: 'apply-from: string, day time. Currently this is a
+                    6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
                   type: string
               type: object
             upgrade:
               properties:
                 contacts:
-                  description: 'contacts: list of contacts which are comma separated "user1@example.com,user2@example.com"'
+                  description: 'contacts: list of contacts which are comma separated
+                    "user1@example.com,user2@example.com"'
                   type: string
                 notBeforeDays:
-                  description: Minimum of days since an upgrade is made available until it's approved
+                  description: Minimum of days since an upgrade is made available
+                    until it's approved
                   nullable: true
                   type: integer
                 schedule:
                   type: boolean
                 waitForMaintenance:
-                  description: If this value is true, upgrades will be approved in the next maintenance window n days after the upgrade is made available. Being n the value of `notBeforeDays`.
+                  description: If this value is true, upgrades will be approved in
+                    the next maintenance window n days after the upgrade is made available.
+                    Being n the value of `notBeforeDays`.
                   nullable: true
                   type: boolean
               type: object
@@ -60,7 +70,10 @@ spec:
           description: RHMIConfigStatus defines the observed state of RHMIConfig
           properties:
             maintenance:
-              description: "status block reflects the current configuration of the cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00 \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 - 17 Jan 1980\""
+              description: "status block reflects the current configuration of the
+                cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00
+                \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 -
+                17 Jan 1980\""
               properties:
                 applyFrom:
                   type: string
@@ -70,17 +83,20 @@ spec:
             upgrade:
               properties:
                 scheduled:
-                  description: Scheduled contains the information on the next upgrade schedule
+                  description: Scheduled contains the information on the next upgrade
+                    schedule
                   properties:
                     for:
-                      description: For is the calculated time when the upgrade is scheduled for, in format "2 Jan 2006 15:04"
+                      description: For is the calculated time when the upgrade is
+                        scheduled for, in format "2 Jan 2006 15:04"
                       type: string
                   type: object
               type: object
             upgradeAvailable:
               properties:
                 availableAt:
-                  description: 'Time of new update becoming available Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                  description: 'Time of new update becoming available Format: "DDD
+                    hh:mm" > "sun 23:00". UTC time'
                   format: date-time
                   type: string
                 targetVersion:

--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -17,10 +17,14 @@ spec:
       description: RHMI is the Schema for the RHMI API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -40,17 +44,25 @@ spec:
               - cssre
               type: object
             deadMansSnitchSecret:
-              description: "DeadMansSnitchSecret is the name of a secret in the installation namespace containing connection details for Dead Mans Snitch. The secret must contain the following fields: \n url"
+              description: "DeadMansSnitchSecret is the name of a secret in the installation
+                namespace containing connection details for Dead Mans Snitch. The
+                secret must contain the following fields: \n url"
               type: string
             masterURL:
               type: string
             namespacePrefix:
               type: string
             operatorsInProductNamespace:
-              description: OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.
+              description: OperatorsInProductNamespace is a flag that decides if the
+                product operators should be installed in the product namespace (when
+                set to true) or in standalone namespace (when set to false, default).
+                Standalone namespace will be used only for those operators that support
+                it.
               type: boolean
             pagerDutySecret:
-              description: "PagerDutySecret is the name of a secret in the installation namespace containing PagerDuty account details. The secret must contain the following fields: \n serviceKey"
+              description: "PagerDutySecret is the name of a secret in the installation
+                namespace containing PagerDuty account details. The secret must contain
+                the following fields: \n serviceKey"
               type: string
             priorityClassName:
               type: string
@@ -69,10 +81,15 @@ spec:
             selfSignedCerts:
               type: boolean
             smtpSecret:
-              description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields: \n host port tls username password"
+              description: "SMTPSecret is the name of a secret in the installation
+                namespace containing SMTP connection details. The secret must contain
+                the following fields: \n host port tls username password"
               type: string
             type:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
             useClusterStorage:
               type: string
@@ -130,7 +147,10 @@ spec:
                 - name
                 - phase
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: object
             toVersion:
               type: string

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -68,6 +68,18 @@ var (
 			"stage",
 		},
 	)
+
+	RHOAMVersion = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhoam_version",
+			Help: "RHOAM versions",
+		},
+		[]string{
+			"stage",
+			"version",
+			"to_version",
+		},
+	)
 )
 
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
@@ -95,4 +107,7 @@ func SetRHMIStatus(installation *integreatlyv1alpha1.RHMI) {
 func SetRhmiVersions(stage string, version string, toVersion string, firstInstallTimestamp int64) {
 	RHMIVersion.Reset()
 	RHMIVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
+
+	RHOAMVersion.Reset()
+	RHOAMVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
 }


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Add RHOAM version metric

Jira:
* https://issues.redhat.com/browse/MGDAPI-495

## Verification
* Install using prebuilt image from this branch
```
make cluster/prepare/local
cat << EOF | oc create -f - -n redhat-rhmi-operator                              
  apiVersion: apps/v1
  kind: Deployment
  metadata:
    name: rhmi-operator
  spec:
    replicas: 1
    selector:
      matchLabels:
        name: rhmi-operator
    template:
      metadata:
        labels:
          name: rhmi-operator
      spec:
        serviceAccountName: rhmi-operator
        volumes:
        - name: webhook-certs
          emptyDir: {}
        containers:
          - name: rhmi-operator
            # Replace this with the built image name
            image:  quay.io/kevfan/integreatly-operator:MGAPI-495
            ports:
              - containerPort: 8090
            command:
            - rhmi-operator
            imagePullPolicy: Always
            resources:
              limits:
                memory: 1536Mi
                cpu: 150m
              requests:
                memory: 64Mi
                cpu: 100m
            volumeMounts:
            - name: webhook-certs
              mountPath: "/etc/ssl/certs/webhook"
            env:
              - name: WATCH_NAMESPACE
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.namespace
              - name: POD_NAME
                valueFrom:
                  fieldRef:
                    fieldPath: metadata.name
              - name: OPERATOR_NAME
                value: "rhmi-operator"
              - name: USE_CLUSTER_STORAGE
                value: "true"
              - name: LOG_LEVEL
                value: "info"
              - name: INSTALLATION_TYPE
                value: "managed-api"
EOF
```
* Once monitoring stage completes, visit the middleware prometheus
* Verify `rhoam_version` metric is exposed

![image](https://user-images.githubusercontent.com/24636860/97886261-493fa980-1d20-11eb-9e3c-6ad3e8fdef40.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer