### PR TITLE
Fix marin3r namespace not removed on uninstall

### DIFF
--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -115,7 +115,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err := r.ReconcileFinalizer(ctx, client, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {
 		phase, err := ratelimit.DeleteEnvoyConfigsInNamespaces(ctx, client, enabledNamespaces...)
-		if err != nil || phase != integreatlyv1alpha1.PhaseFailed {
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Marin3r namespaces are not removed during uninstall

This is due to checking for the wrong phase returned by `DeleteEnvoyConfigsInNamespaces` function

## Verification
* Checkout this branch
* Install managed-api
```
INSTALLATION_TYPE=managed-api make code/run
```
* Once installation completed, trigger uninstall by deleting RHMI CR
* Verify `redhat-rhmi-marin3r-operator`  and `redhat-rhmi-marin3r` are deleted during uninstall
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer