### PR TITLE
MGDAPI-368 - capture monitoring stack metrics

### DIFF
--- a/scripts/capture_resource_metrics.sh
+++ b/scripts/capture_resource_metrics.sh
@@ -49,11 +49,13 @@ IDLE_QUERIES=(\
   "avg_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-marin3r', pod!='', container=''}) [15m:10s])/1024/1024"\
   "avg_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-user-sso', pod!='', container=''}) [15m:10s])/1024/1024"\
   "avg_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-rhsso', pod!='', container=''}) [15m:10s])/1024/1024"\
+  "avg_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-middleware-monitoring-operator', pod!='', container=''}) [15m:10s])/1024/1024"\
   "avg_over_time(sum(container_memory_working_set_bytes{namespace=~'redhat-rhmi-.*', pod!='', container=''}) [15m:10s])/1024/1024"\
   "avg_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-3scale'} [15m])"\
   "avg_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-marin3r'} [15m])"\
   "avg_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-user-sso'} [15m])"\
   "avg_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-rhsso'} [15m])"\
+  "avg_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-middleware-monitoring-operator'} [15m])"\
   "sum(avg_over_time(namespace:container_cpu_usage:sum{namespace=~'redhat-rhmi-.*'} [15m]))"\
 )
 
@@ -63,11 +65,13 @@ LOAD_QUERIES=(\
   "max_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-marin3r',container='', pod!=''}) [${testDuration}s:10s])/1024/1024"\
   "max_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-user-sso',container='', pod!=''}) [${testDuration}s:10s])/1024/1024"\
   "max_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-rhsso',container='', pod!=''}) [${testDuration}s:10s])/1024/1024"\
+  "max_over_time(sum(container_memory_working_set_bytes{namespace='redhat-rhmi-middleware-monitoring-operator',container='', pod!=''}) [${testDuration}s:10s])/1024/1024"\
   "max_over_time(sum(container_memory_working_set_bytes{namespace=~'redhat-rhmi-.*',container='', pod!=''}) [${testDuration}s:10s])/1024/1024"\
   "max_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-3scale'} [${testDuration}s])"\
   "max_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-marin3r'} [${testDuration}s])"\
   "max_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-user-sso'} [${testDuration}s])"\
   "max_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-rhsso'} [${testDuration}s])"\
+  "max_over_time(namespace:container_cpu_usage:sum{namespace='redhat-rhmi-middleware-monitoring-operator'} [${testDuration}s])"\
   "sum(max_over_time(namespace:container_cpu_usage:sum{namespace=~'redhat-rhmi-.*'} [${testDuration}s]))"\
 )
 


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/MGDAPI-368

Monitoring stack metrics should be captured separately based on suggestion from Craig.
[The spreadsheet](https://docs.google.com/spreadsheets/d/1v_bZIk8B_thZi93hGBNiOOnbSix0gmpwy3LV_s4WFPw/edit#gid=231944674) has been updated to reflect this change.

Current script output:
```
$ ./scripts/capture_resource_metrics.sh 
60
36
370.32443618774414
278.5992774963379
7209.878211805554
116.46827256944448
1981.523480902778
2518.197352430556
2486.900868055555
14831.480555555558
0.45457553151360897
0.022072775865353913
0.021481257596153224
5.356680045147766
0.06664203723568832
6.000041681219844
7574.71875
116.45703125
1981.671875
2525.53515625
2575.02734375
15181.6328125
0.4640411898223442
0.02274905165420596
0.021607092761040114
5.913627247923801
0.09203584063716518
6.59870026037486
```