### PR TITLE
Renaming API usage alerts to reference RHOAM

### DIFF
--- a/pkg/controller/installation/bootstrapReconciler.go
+++ b/pkg/controller/installation/bootstrapReconciler.go
@@ -241,21 +241,21 @@ func (r *Reconciler) checkRateLimitAlertsConfig(ctx context.Context, serverClien
 
 		defaultConfig := map[string]*marin3rconfig.AlertConfig{
 			"api-usage-alert-level1": {
-				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel1ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "80%",
 				MaxRate:  &maxRate1,
 				Period:   "4h",
 			},
 			"api-usage-alert-level2": {
-				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel2ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "90%",
 				MaxRate:  &maxRate2,
 				Period:   "2h",
 			},
 			"api-usage-alert-level3": {
-				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel3ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "95%",
 				MaxRate:  nil,

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -80,7 +80,7 @@ func mapAlertsConfiguration(namespace, rateLimitUnit string, rateLimitRequestsPe
 					Alert: alertConfig.RuleName,
 					Annotations: map[string]string{
 						"message": fmt.Sprintf(
-							"3Scale API usage is between %s and %s of the allowable threshold, %d requests per %s, during the last %s",
+							"RHOAM API usage is between %s and %s of the allowable threshold, %d requests per %s, during the last %s",
 							alertConfig.MinRate, upperMessage, rateLimitRequestsPerUnit, rateLimitUnit, alertConfig.Period,
 						),
 						"grafanaConsole": string(grafanaConsoleURL),

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -55,21 +55,21 @@ func getBasicReconciler() *Reconciler {
 		},
 		AlertsConfig: map[string]*marin3rconfig.AlertConfig{
 			"api-usage-alert-level1": {
-				RuleName: "Level1ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel1ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "80%",
 				MaxRate:  strPtr("90%"),
 				Period:   "4h",
 			},
 			"api-usage-alert-level2": {
-				RuleName: "Level2ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel2ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "90%",
 				MaxRate:  strPtr("95%"),
 				Period:   "2h",
 			},
 			"api-usage-alert-level3": {
-				RuleName: "Level3ThreeScaleApiUsageThresholdExceeded",
+				RuleName: "RHOAMApiUsageLevel3ThresholdExceeded",
 				Level:    "warning",
 				MinRate:  "95%",
 				Period:   "30m",

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -18,13 +18,13 @@ route:
       repeat_interval: 5m
       receiver: deadmansswitch
     - match:
-        alertname: Level1ThreeScaleApiUsageThresholdExceeded
+        alertname: RHOAMApiUsageLevel1ThresholdExceeded
       receiver: BUandCustomer
     - match:
-        alertname: Level2ThreeScaleApiUsageThresholdExceeded
+        alertname: RHOAMApiUsageLevel2ThresholdExceeded
       receiver: BUandCustomer
     - match:
-        alertname: Level3ThreeScaleApiUsageThresholdExceeded
+        alertname: RHOAMApiUsageLevel3ThresholdExceeded
       receiver: SRECustomerBU
 receivers:
   - name: default

--- a/test-cases/tests/alerts/c18-validate-api-usage-alerts.md
+++ b/test-cases/tests/alerts/c18-validate-api-usage-alerts.md
@@ -75,21 +75,21 @@ and insert the following data:
 ```json
 {
   "api-usage-alert-level1": {
-    "ruleName": "Level1ThreeScaleApiUsageThresholdExceeded",
+    "ruleName": "RHOAMApiUsageLevel1ThresholdExceeded",
     "level": "warning",
     "minRate": "80%",
     "maxRate": "90%",
     "period": "1m"
   },
   "api-usage-alert-level2": {
-    "ruleName": "Level2ThreeScaleApiUsageThresholdExceeded",
+    "ruleName": "RHOAMApiUsageLevel2ThresholdExceeded",
     "level": "warning",
     "minRate": "90%",
     "maxRate": "95%",
     "period": "1m"
   },
   "api-usage-alert-level3": {
-    "ruleName": "Level3ThreeScaleApiUsageThresholdExceeded",
+    "ruleName": "RHOAMApiUsageLevel3ThresholdExceeded",
     "level": "warning",
     "minRate": "95%",
     "period": "1m"
@@ -134,9 +134,9 @@ and insert the following data:
 
     | Alert to fire                             | `numRequests` | `interval` |
     | ----------------------------------------- | ------------- | ---------- |
-    | Level1ThreeScaleApiUsageThresholdExceeded | 170           | 0.71       |
-    | Level2ThreeScaleApiUsageThresholdExceeded | 186           | 0.645      |
-    | Level3ThreeScaleApiUsageThresholdExceeded | 240           | 0.5        |
+    | RHOAMApiUsageLevel1ThresholdExceeded | 170           | 0.71       |
+    | RHOAMApiUsageLevel2ThresholdExceeded | 186           | 0.645      |
+    | RHOAMApiUsageLevel3ThresholdExceeded | 240           | 0.5        |
 
     > Only the requests for level 3 should be eventually failing with a `429 Too Many Requests` status code
     > due to the rate limit being exceeded

--- a/test-cases/tests/alerts/c18-validate-api-usage-alerts.md
+++ b/test-cases/tests/alerts/c18-validate-api-usage-alerts.md
@@ -132,8 +132,8 @@ and insert the following data:
     > - `numRequests = expected rate x minutes to keep the alert firing`
     > - `interval = 60 / expected rate`
 
-    | Alert to fire                             | `numRequests` | `interval` |
-    | ----------------------------------------- | ------------- | ---------- |
+    | Alert to fire                        | `numRequests` | `interval` |
+    | ------------------------------------ | ------------- | ---------- |
     | RHOAMApiUsageLevel1ThresholdExceeded | 170           | 0.71       |
     | RHOAMApiUsageLevel2ThresholdExceeded | 186           | 0.645      |
     | RHOAMApiUsageLevel3ThresholdExceeded | 240           | 0.5        |

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -3,9 +3,10 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"strings"
 	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
@@ -290,19 +291,19 @@ var managedApiSpecificRules = []alertsTestRule{
 	{
 		File: NamespacePrefix + "marin3r-api-usage-alert-level1.yaml",
 		Rules: []string{
-			"Level1ThreeScaleApiUsageThresholdExceeded",
+			"RHOAMApiUsageLevel1ThresholdExceeded",
 		},
 	},
 	{
 		File: NamespacePrefix + "marin3r-api-usage-alert-level2.yaml",
 		Rules: []string{
-			"Level2ThreeScaleApiUsageThresholdExceeded",
+			"RHOAMApiUsageLevel2ThresholdExceeded",
 		},
 	},
 	{
 		File: NamespacePrefix + "marin3r-api-usage-alert-level3.yaml",
 		Rules: []string{
-			"Level3ThreeScaleApiUsageThresholdExceeded",
+			"RHOAMApiUsageLevel3ThresholdExceeded",
 		},
 	},
 }


### PR DESCRIPTION
# Description
Renaming the following API usage alerts:
```
Level1ThreeScaleApiUsageThresholdExceeded -> RHOAMApiUsageLevel1ThresholdExceeded
Level2ThreeScaleApiUsageThresholdExceeded -> RHOAMApiUsageLevel2ThresholdExceeded
Level3ThreeScaleApiUsageThresholdExceeded -> RHOAMApiUsageLevel3ThresholdExceeded
```
This ensures consistency with what we've done with RHMI in the past

## Verification
1. Install RHOAM from this branch on an OSD cluster
2. Login to the middleware-monitoring prometheus instance
3. Verify that the new alert names are in place and that the old ones are not listed

## Checklist
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes
- [ ] Verified independently on a cluster by reviewer