### PR TITLE
MGDAPI-532: Include anti affinity rules for Multi-AZ support

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -2,9 +2,11 @@ package installation
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -593,6 +595,16 @@ func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha
 
 	eventRecorder := r.mgr.GetEventRecorderFor("Preflight Checks")
 
+	// Validate the env vars used by the operator
+	if err := checkEnvVars(map[string]func(string, bool) error{
+		resources.AntiAffinityRequiredEnvVar: optionalEnvVar(func(s string) error {
+			_, err := strconv.ParseBool(s)
+			return err
+		}),
+	}); err != nil {
+		return result, err
+	}
+
 	if strings.ToLower(installation.Spec.UseClusterStorage) != "true" && strings.ToLower(installation.Spec.UseClusterStorage) != "false" {
 		installation.Status.PreflightStatus = integreatlyv1alpha1.PreflightFail
 		installation.Status.PreflightMessage = "Spec.useClusterStorage must be set to either 'true' or 'false' to continue"
@@ -851,6 +863,37 @@ func (r *ReconcileInstallation) addCustomInformer(crd runtime.Object, namespace 
 
 	logrus.Infof("Cache synced. A %s watch in %s namespace successfully initialized.", gvk, namespace)
 	return nil
+}
+
+func checkEnvVars(checks map[string]func(string, bool) error) error {
+	for env, check := range checks {
+		value, exists := os.LookupEnv(env)
+		if err := check(value, exists); err != nil {
+			return fmt.Errorf("validation failure for env var %s: %w", env, err)
+		}
+	}
+
+	return nil
+}
+
+func optionalEnvVar(check func(string) error) func(string, bool) error {
+	return func(value string, ok bool) error {
+		if !ok {
+			return nil
+		}
+
+		return check(value)
+	}
+}
+
+func requiredEnvVar(check func(string) error) func(string, bool) error {
+	return func(value string, ok bool) error {
+		if !ok {
+			return errors.New("required env var not present")
+		}
+
+		return check(value)
+	}
 }
 
 type multiErr struct {

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -270,9 +270,12 @@ func (r *RateLimitServiceReconciler) reconcileDeployment(ctx context.Context, cl
 			},
 		}
 
-		if err := resources.SetZoneTopologySpreadConstraints(
+		if err := resources.SetPodTemplate(
 			resources.SelectFromDeployment,
-			"app",
+			resources.AllMutationsOf(
+				resources.MutateZoneTopologySpreadConstraints("app"),
+				resources.MutateMultiAZAntiAffinity(ctx, client, "app"),
+			),
 			deployment,
 		); err != nil {
 			return fmt.Errorf("failed to set zone topology spread constraints: %w", err)

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -167,7 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.ReconcilePodPriority(ctx, serverClient, r.Config.RHSSOCommon, installation)
+	phase, err = r.ReconcileStatefulSet(ctx, serverClient, r.Config.RHSSOCommon)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconsile RHSSO pod priority", err)
 		return phase, err
@@ -198,12 +198,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.newAlertsReconciler().ReconcileAlerts(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile alerts", err)
-		return phase, err
-	}
-
-	phase, err = r.ReconcileZoneTopologySpreadConstraints(ctx, serverClient, r.Config.RHSSOCommon)
-	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile topology spread constraints", err)
 		return phase, err
 	}
 

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -200,7 +200,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.ReconcilePodPriority(ctx, serverClient, r.Config.RHSSOCommon, installation)
+	phase, err = r.ReconcileStatefulSet(ctx, serverClient, r.Config.RHSSOCommon)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconsile RHSSO pod priority", err)
 		return phase, err
@@ -231,12 +231,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.newAlertsReconciler().ReconcileAlerts(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile alerts", err)
-		return phase, err
-	}
-
-	phase, err = r.ReconcileZoneTopologySpreadConstraints(ctx, serverClient, r.Config.RHSSOCommon)
-	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile topology spread constraints", err)
 		return phase, err
 	}
 

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	"github.com/sirupsen/logrus"
 
 	openshiftv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -177,6 +178,7 @@ func TestThreeScale(t *testing.T) {
 			}
 
 			tsReconciler, err := NewReconciler(configManager, scenario.Installation, scenario.FakeAppsV1Client, scenario.FakeOauthClient, scenario.FakeThreeScaleClient, scenario.MPM, scenario.Recorder)
+			tsReconciler.logger = logrus.NewEntry(logrus.New())
 			if err != nil {
 				t.Fatalf("Error creating new reconciler %s: %v", constants.ThreeScaleSubscriptionName, err)
 			}
@@ -251,6 +253,7 @@ func TestReconciler_reconcileBlobStorage(t *testing.T) {
 			r := &Reconciler{
 				ConfigManager: tt.fields.ConfigManager,
 				Config:        tt.fields.Config,
+				logger:        logrus.NewEntry(logrus.New()),
 				mpm:           tt.fields.mpm,
 				installation:  tt.fields.installation,
 				tsClient:      tt.fields.tsClient,
@@ -333,6 +336,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			r := &Reconciler{
 				ConfigManager: tt.fields.ConfigManager,
 				Config:        tt.fields.Config,
+				logger:        logrus.NewEntry(logrus.New()),
 				mpm:           tt.fields.mpm,
 				installation:  tt.fields.installation,
 				tsClient:      tt.fields.tsClient,

--- a/pkg/resources/podAntiAffinity.go
+++ b/pkg/resources/podAntiAffinity.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strconv"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// ZoneLabel is the label that specifies the zone where a node is
+	ZoneLabel = "topology.kubernetes.io/zone"
+	// AntiAffinityRequiredEnvVar is an environment variable that, when set to
+	// true, makes the product pod replicas use "required" anti affinity rules
+	// by AZ
+	AntiAffinityRequiredEnvVar = "FORCE_ZONE_DISTRIBUTION"
+)
+
+// MutateMultiAZAntiAffinity returns a PodTemplateMutation that sets the anti
+// affinity by AZ on the label labelMatch. It checks if the affinity rule is
+// required or not, and sets the required or preferred affinity based on it
+func MutateMultiAZAntiAffinity(ctx context.Context, client k8sclient.Client, labelMatch string) PodTemplateMutation {
+	isRequired, err := IsAntiAffinityRequired(ctx, client)
+	if err != nil {
+		isRequired = false
+	}
+
+	return func(obj metav1.Object, podTemplate *corev1.PodTemplateSpec) error {
+		labels := obj.GetLabels()
+		labelValue, ok := labels[labelMatch]
+		if !ok {
+			return fmt.Errorf("label %s not found in object", labelMatch)
+		}
+
+		podTemplate.Spec.Affinity = SelectAntiAffinityForCluster(isRequired, map[string]string{
+			labelMatch: labelValue,
+		})
+
+		return nil
+	}
+}
+
+// MultiAZAntiAffinityPreferred returns the affinity configuration to set the
+// preferred anti affinity by AZ on the given matchLabels
+func MultiAZAntiAffinityPreferred(matchLabels map[string]string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+
+			PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{
+				{
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &v1.LabelSelector{
+							MatchLabels: matchLabels,
+						},
+						TopologyKey: ZoneLabel,
+					},
+					Weight: 100,
+				},
+			},
+		},
+	}
+}
+
+// MultiAZAntiAffinityRequired returns the affinity configuration to set the
+// required anti affinity by AZ on the given matchLabels
+func MultiAZAntiAffinityRequired(matchLabels map[string]string) *corev1.Affinity {
+	return &corev1.Affinity{
+		PodAntiAffinity: &corev1.PodAntiAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{
+				{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					TopologyKey: ZoneLabel,
+				},
+			},
+		},
+	}
+}
+
+// SelectAntiAffinityForCluster returns the affinity configuration for a cluster
+// given whether the rule is required or preferred
+func SelectAntiAffinityForCluster(required bool, matchLabels map[string]string) *corev1.Affinity {
+	if required {
+		return MultiAZAntiAffinityRequired(matchLabels)
+	}
+
+	return MultiAZAntiAffinityPreferred(matchLabels)
+}
+
+// IsAntiAffinityRequired checks whether the anti affinity rule must be set
+// to required or preferred.
+//
+// It currently checks the value of the FORCE_ZONE_DISTRIBUTION bool env var
+func IsAntiAffinityRequired(_ context.Context, _ k8sclient.Client) (bool, error) {
+	envValue, ok := os.LookupEnv(AntiAffinityRequiredEnvVar)
+	if !ok {
+		return false, nil
+	}
+
+	return strconv.ParseBool(envValue)
+}
+
+// IsMultiAZCluster checks if the cluster runs in multiple AZs, by retrieving
+// the nodes and checking that the `topology.kubernetes.io/zone` label is
+// the same across all
+func IsMultiAZCluster(ctx context.Context, client k8sclient.Client) (bool, error) {
+	// Get the list of nodes
+	nodeList := &corev1.NodeList{}
+	if err := client.List(ctx, nodeList); err != nil {
+		return false, err
+	}
+
+	// If there's no nodes, fail
+	if len(nodeList.Items) == 0 {
+		return false, fmt.Errorf("no nodes found")
+	}
+
+	// If there's only one node, directly return false
+	if len(nodeList.Items) == 1 {
+		return false, nil
+	}
+
+	// Get the zone of the first node. In order to be multi AZ there has
+	// to be at least one node with a different zone
+	firstZone := nodeList.Items[0].Labels[ZoneLabel]
+
+	// Iterate through the tail of the list and check if there's any difference
+	// in the zones
+	for i := 1; i < len(nodeList.Items); i++ {
+		zone := nodeList.Items[i].Labels[ZoneLabel]
+		if zone != firstZone {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/resources/podPriority.go
+++ b/pkg/resources/podPriority.go
@@ -1,44 +1,13 @@
 package resources
 
 import (
-	"context"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func ReconcilePodPriority(ctx context.Context, client client.Client, objKey client.ObjectKey, templateSelector PodTemplateSelector, obj runtime.Object, priorityClassName string) (integreatlyv1alpha1.StatusPhase, error) {
-	err := client.Get(ctx, objKey, obj)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return integreatlyv1alpha1.PhaseAwaitingComponents, nil
-		}
-
-		return integreatlyv1alpha1.PhaseFailed, err
+func MutatePodPriority(priorityClassName string) PodTemplateMutation {
+	return func(_ metav1.Object, podTemplate *corev1.PodTemplateSpec) error {
+		podTemplate.Spec.PriorityClassName = priorityClassName
+		return nil
 	}
-
-	if err := UpdatePodPriority(ctx, client, templateSelector, obj, priorityClassName); err != nil {
-		return integreatlyv1alpha1.PhaseFailed, err
-	}
-
-	return integreatlyv1alpha1.PhaseCompleted, nil
-}
-
-func UpdatePodPriority(ctx context.Context, client client.Client, templateSelector PodTemplateSelector, obj runtime.Object, priorityClassName string) error {
-	if err := SetPodPriority(templateSelector, obj.(v1.Object), priorityClassName); err != nil {
-		return err
-	}
-
-	return client.Update(ctx, obj)
-}
-
-func SetPodPriority(templateSelector PodTemplateSelector, obj v1.Object, priorityClassName string) error {
-	podTemplate := templateSelector(obj)
-
-	podTemplate.Spec.PriorityClassName = priorityClassName
-
-	return nil
 }

--- a/pkg/resources/podTemplate.go
+++ b/pkg/resources/podTemplate.go
@@ -1,0 +1,79 @@
+package resources
+
+import (
+	"context"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	openshiftappsv1 "github.com/openshift/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PodTemplateMutation represents a mutating function over a PodTemplate.
+// The function receives the object that the PodTemplate belongs to, and
+// the PodTemplate itself
+type PodTemplateMutation func(metav1.Object, *corev1.PodTemplateSpec) error
+
+// PodTemplateSelector is a function that obtains the PodTemplateSpec from a resource
+// that contains it
+type PodTemplateSelector func(v1.Object) *corev1.PodTemplateSpec
+
+// SelectFromStatefulSet returns obj.Spec.Template
+func SelectFromStatefulSet(obj v1.Object) *corev1.PodTemplateSpec {
+	ss := obj.(*appsv1.StatefulSet)
+	return &ss.Spec.Template
+}
+
+// SelectFromDeploymentConfig returns obj.Spec.Template
+func SelectFromDeploymentConfig(obj v1.Object) *corev1.PodTemplateSpec {
+	dc := obj.(*openshiftappsv1.DeploymentConfig)
+	return dc.Spec.Template
+}
+
+// SelectFromDeployment returns obj.Spec.Template
+func SelectFromDeployment(obj v1.Object) *corev1.PodTemplateSpec {
+	d := obj.(*appsv1.Deployment)
+	return &d.Spec.Template
+}
+
+// UpdatePodTemplateIfExists updates the template retrieved by templateSelector
+// on obj by applying the given mutation. If the object obj is not found, it
+// returns InProgress and no error
+func UpdatePodTemplateIfExists(ctx context.Context, client client.Client, templateSelector PodTemplateSelector, mutation PodTemplateMutation, obj metav1.Object) (integreatlyv1alpha1.StatusPhase, error) {
+	mutateFn := func() error {
+		podTemplate := templateSelector(obj)
+		return mutation(obj, podTemplate)
+	}
+
+	return UpdateIfExists(ctx, client, mutateFn, obj.(runtime.Object))
+}
+
+// SetPodTemplate updates the template retrieved by templateSelector
+// on obj by applying the given mutation.
+func SetPodTemplate(templateSelector PodTemplateSelector, mutation PodTemplateMutation, obj metav1.Object) error {
+	podTemplate := templateSelector(obj)
+	return mutation(obj, podTemplate)
+}
+
+// AllMutationsOf composes a list of PodTemplateMutations by applying them
+// sequentially
+func AllMutationsOf(mutations ...PodTemplateMutation) PodTemplateMutation {
+	return func(obj metav1.Object, podTemplate *corev1.PodTemplateSpec) error {
+		for _, mutation := range mutations {
+			if err := mutation(obj, podTemplate); err != nil {
+				return err
+			}
+		}
+
+		return nil
+	}
+}
+
+// NoopMutate is a PodTemplateMutation that doesn't perform any changes
+func NoopMutate(_ metav1.Object, _ *corev1.PodTemplateSpec) error {
+	return nil
+}

--- a/pkg/resources/topologyConstraints.go
+++ b/pkg/resources/topologyConstraints.go
@@ -1,97 +1,40 @@
 package resources
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	openshiftappsv1 "github.com/openshift/api/apps/v1"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// PodTemplateSelector is a function that obtains the PodTemplateSpec from a resource
-// that contains it
-type PodTemplateSelector func(v1.Object) *corev1.PodTemplateSpec
-
-// ReconcileZoneTopologySpreadConstraints populates obj with the resource found by
-// the objKey. If it's not found it returns PhaseAwaitingComponents. If it is
-// found, it updates the CR, setting the TopologySpreadConstraints for AZ spreading
-func ReconcileZoneTopologySpreadConstraints(ctx context.Context, client client.Client, objKey client.ObjectKey, templateSelector PodTemplateSelector, labelMatch string, obj runtime.Object) (integreatlyv1alpha1.StatusPhase, error) {
-	err := client.Get(ctx, objKey, obj)
-	if err != nil {
-		if k8serr.IsNotFound(err) {
-			return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+// MutateZoneTopologySpreadConstraints creates a PodTemplateMutation that
+// sets the TopologySpreadConstraints for Multi AZ
+func MutateZoneTopologySpreadConstraints(labelMatch string) PodTemplateMutation {
+	return func(obj metav1.Object, podTemplate *corev1.PodTemplateSpec) error {
+		labels := obj.GetLabels()
+		if labels == nil {
+			return errors.New("object has no labels")
 		}
 
-		return integreatlyv1alpha1.PhaseFailed, err
-	}
+		labelValue, ok := labels[labelMatch]
+		if !ok {
+			return fmt.Errorf("label %s not found in object", labelMatch)
+		}
 
-	if err := UpdateZoneTopologySpreadConstraints(ctx, client, templateSelector, labelMatch, obj); err != nil {
-		return integreatlyv1alpha1.PhaseFailed, err
-	}
-
-	return integreatlyv1alpha1.PhaseCompleted, nil
-}
-
-// UpdateZoneTopologySpreadConstraints updates the topologySpreadConstraints
-// on obj to spread the pods among multiple zones
-func UpdateZoneTopologySpreadConstraints(ctx context.Context, client client.Client, templateSelector PodTemplateSelector, labelMatch string, obj runtime.Object) error {
-	if err := SetZoneTopologySpreadConstraints(templateSelector, labelMatch, obj.(v1.Object)); err != nil {
-		return err
-	}
-
-	return client.Update(ctx, obj)
-}
-
-func SetZoneTopologySpreadConstraints(templateSelector PodTemplateSelector, labelMatch string, obj v1.Object) error {
-	podTemplate := templateSelector(obj)
-
-	labels := obj.GetLabels()
-	if labels == nil {
-		return errors.New("object has no labels")
-	}
-
-	labelValue, ok := labels[labelMatch]
-	if !ok {
-		return fmt.Errorf("label %s not found in object", labelMatch)
-	}
-
-	podTemplate.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
-		{
-			MaxSkew:           1,
-			TopologyKey:       "topology.kubernetes.io/zone",
-			WhenUnsatisfiable: corev1.ScheduleAnyway,
-			LabelSelector: &v1.LabelSelector{
-				MatchLabels: map[string]string{
-					labelMatch: labelValue,
+		podTemplate.Spec.TopologySpreadConstraints = []corev1.TopologySpreadConstraint{
+			{
+				MaxSkew:           1,
+				TopologyKey:       ZoneLabel,
+				WhenUnsatisfiable: corev1.ScheduleAnyway,
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						labelMatch: labelValue,
+					},
 				},
 			},
-		},
+		}
+
+		return nil
 	}
-
-	return nil
-}
-
-// SelectFromStatefulSet returns obj.Spec.Template
-func SelectFromStatefulSet(obj v1.Object) *corev1.PodTemplateSpec {
-	ss := obj.(*appsv1.StatefulSet)
-	return &ss.Spec.Template
-}
-
-// SelectFromDeploymentConfig returns obj.Spec.Template
-func SelectFromDeploymentConfig(obj v1.Object) *corev1.PodTemplateSpec {
-	dc := obj.(*openshiftappsv1.DeploymentConfig)
-	return dc.Spec.Template
-}
-
-// SelectFromDeployment returns obj.Spec.Template
-func SelectFromDeployment(obj v1.Object) *corev1.PodTemplateSpec {
-	d := obj.(*appsv1.Deployment)
-	return &d.Spec.Template
 }


### PR DESCRIPTION
# Description

Add logic to include anti affinity rules in the products pod templates (SSO, User SSO, Rate limit and 3scale)
Refactor logic that updates pod template of product components by unifying into a `UpdatePodTemplateIfExists` function that receives composable mutations.
Add anti affinity rules to 3scale APIManager CR to delegate this logic in the 3scale operator

## Verification steps

The behaviour of the operator in regards to the anti affinity rules is different depending on whether the `FORCE_ZONE_DISTRIBUTIO` env var is set. Install the operator and run it with both combinations

1. Install RHOAM from this PR
    1. Preferred
        > By default the pod affinity rule will be set to preferred
        ```sh
        INSTALLATION_TYPE=managed-api make code/run
        ```
    2. Required
        ```sh
        FORCE_ZONE_DISTRIBUTION=true INSTALLATION_TYPE=managed-api make code/run
        ```

2. For each of the following components, check that the `podAntiAffinity` field is added to the pod template:
    > 1.  Required
    >     ```yaml
    >     affinity:
    >      podAntiAffinity:
    >        requiredDuringSchedulingIgnoredDuringExecution:
    >          - labelSelector:
    >              matchLabels: # set of labels that identify the set of pod replicas
    >            topologyKey: topology.kubernetes.io/zone
    >     ```
    >
    > 2. Preferred
    >     ```yaml
    >     affinity:
    >       podAntiAffinity:
    >         preferredDuringSchedulingIgnoredDuringExecution:
    >           - weight: 100
    >             podAffinityTerm:
    >               labelSelector:
    >                 matchLabels: # set of labels that identify the set of pod replicas
    >               topologyKey: topology.kubernetes.io/zone
    >     ```

    | Namespace | Kind | Components |
    | --------------- | ------- | ---------------- |
    | `redhat-rhmi-rhsso` | `StatefulSet` | `keycloak` |
    | `redhat-rhmi-usersso` | `StatefulSet` | `keycloak` |
    | `redhat-rhmi-marin3r` | `Deployment` | `ratelimit` |
    | `redhat-rhmi-3scale` | `DeploymentConfig` | `apicast-production`, `apicast-staging`, `backend-cron`, `backend-listener`, `backend-worker`, `system-app`, `system-sidekiq`, `zync`, `zync-que` |

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer