### PR TITLE
MGDAPI-428 - Enable 3scale monitoring

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -965,7 +965,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		apim.Spec.APIManagerCommonSpec.WildcardDomain = r.installation.Spec.RoutingSubdomain
 		apim.Spec.System.FileStorageSpec = fss
 		apim.Spec.PodDisruptionBudget = &threescalev1.PodDisruptionBudgetSpec{Enabled: true}
-		apim.Spec.Monitoring = &threescalev1.MonitoringSpec{Enabled: false}
+		apim.Spec.Monitoring = &threescalev1.MonitoringSpec{Enabled: true}
 
 		if *apim.Spec.System.AppSpec.Replicas < numberOfReplicas {
 			*apim.Spec.System.AppSpec.Replicas = numberOfReplicas

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -10,6 +10,14 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
+    # Manually lower severity of some 3scale 2.9 Monitoring alerts
+    - match:
+        alertname: ThreescaleBackendWorkerJobsCountRunningHigh
+      receiver: default
+    - match:
+        alertname: SystemSidekiqZyncRuntime
+      receiver: default
+    # End lower severity of 3scale alerts
     - match:
         severity: critical
       receiver: critical

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -481,6 +481,63 @@ var commonExpectedRules = []alertsTestRule{
 			"SendgridSmtpSecretExists",
 		},
 	},
+	{
+		File: fmt.Sprintf("%s3scale-zync-que.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescaleZyncQueJobDown",
+			"ThreescaleZyncQueScheduledJobCountHigh",
+			"ThreescaleZyncQueFailedJobCountHigh",
+			"ThreescaleZyncQueReadyJobCountHigh",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-zync.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescaleZyncJobDown",
+			"ThreescaleZync5XXRequestsHigh",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-apicast.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescaleApicastJobDown",
+			"ThreescaleApicastRequestTime",
+			"ThreescaleApicastHttp4xxErrorRate",
+			"ThreescaleApicastLatencyHigh",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-threescale-kube-state-metrics.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescalePodCrashLooping",
+			"ThreescalePodNotReady",
+			"ThreescaleReplicationControllerReplicasMismatch",
+			"ThreescaleContainerWaiting",
+			"ThreescaleContainerCPUHigh",
+			"ThreescaleContainerMemoryHigh",
+			"ThreescaleContainerCPUThrottlingHigh",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-system-sidekiq.yaml", NamespacePrefix),
+		Rules: []string{
+			"SystemSidekiqZyncRuntime",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-backend-listener.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescaleBackendListener5XXRequestsHigh",
+			"ThreescaleBackendListenerJobDown",
+		},
+	},
+	{
+		File: fmt.Sprintf("%s3scale-backend-worker.yaml", NamespacePrefix),
+		Rules: []string{
+			"ThreescaleBackendWorkerJobsCountRunningHigh",
+			"ThreescaleBackendWorkerJobDown",
+		},
+	},
 }
 
 // common aws rules applicable to all install types

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -3,6 +3,7 @@ package common
 import (
 	goctx "context"
 	"encoding/json"
+	"fmt"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"strings"
 	"testing"
@@ -41,6 +42,27 @@ var commonExpectedDashboards = []dashboardsTestRule{
 	},
 	{
 		Title: "Critical SLO summary",
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / Backend", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / Apicast Services", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / Kubernetes / Compute Resources / Namespace (Pods)", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / Kubernetes / Compute Resources / Pod", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / System", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale / 3scale / Zync", NamespacePrefix),
+	},
+	{
+		Title: fmt.Sprintf("%s3scale/ 3scale / Apicast", NamespacePrefix),
 	},
 }
 

--- a/test/e2e/integreatly_test.go
+++ b/test/e2e/integreatly_test.go
@@ -36,7 +36,7 @@ const (
 	cloudResourcesStageTimeout   = time.Minute * 10
 	monitoringStageTimeout       = time.Minute * 10
 	authenticationStageTimeout   = time.Minute * 30
-	productsStageTimout          = time.Minute * 30
+	productsStageTimout          = time.Minute * 45
 	solutionExplorerStageTimeout = time.Minute * 10
 	artifactsDirEnv              = "ARTIFACT_DIR"
 )


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Jira:
* https://issues.redhat.com/browse/MGDAPI-428

## Verification
* Check out this branch
* Install managed api
```
export INSTALLATION_TYPE=managed-api 
make cluster/prepare/local
make code/run
```
* Once installation is complete, visit middleware prometheus
* Verify the following 3scale monitoring alerts are available:
  * ThreescaleApicastHttp4xxErrorRate
  * ThreescaleApicastJobDown
  * ThreescaleApicastLatencyHigh
  * ThreescaleApicastRequestTime
  * ThreescaleBackendListener5XXRequestsHigh
  * ThreescaleBackendListenerJobDown
  * ThreescaleBackendWorkerJobDown
  * ThreescaleBackendWorkerJobsCountRunningHigh
  * SystemSidekiqZyncRuntime
  * ThreescaleContainerCPUHigh
  * ThreescaleContainerCPUThrottlingHigh
  * ThreescaleContainerMemoryHigh
  * ThreescaleContainerWaiting
  * ThreescalePodCrashLooping
  * ThreescalePodNotReady
  * ThreescaleReplicationControllerReplicasMismatch
  * ThreescaleZyncQueFailedJobCountHigh
  * ThreescaleZyncQueJobDown
  * ThreescaleZyncQueReadyJobCountHigh
  * ThreescaleZyncQueScheduledJobCountHigh
  * ThreescaleZyncJobDown
  * ThreescaleZync5XXRequestsHigh 

![Screenshot from 2020-11-05 09-55-12](https://user-images.githubusercontent.com/24636860/98226195-9bb1dd80-1f4d-11eb-8500-7acfe1a0ce00.png)

* Visit middlware grafana
* Verify the following dashboards are available:
  * redhat-rhmi-3scale / 3scale / Backend
  * redhat-rhmi-3scale / 3scale / Apicast Services
  * redhat-rhmi-3scale / 3scale / Kubernetes / Compute Resources / Namespace (Pods)
  * redhat-rhmi-3scale / 3scale / Kubernetes / Compute Resources / Pod
  * redhat-rhmi-3scale / 3scale / System
  * redhat-rhmi-3scale / 3scale / Zync
  * redhat-rhmi-3scale/ 3scale / Apicast

![Screenshot from 2020-11-05 09-58-59](https://user-images.githubusercontent.com/24636860/98226163-948acf80-1f4d-11eb-9415-bd865d0b8d05.png)

* Check the alertmanager-config secret in the middleware monitoring namespace
* Verify the following alerts has a `route` included to sent the alert to the `default` receiver
  *  ThreescaleBackendWorkerJobsCountRunningHigh
  * SystemSidekiqZyncRuntime


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer