### PR TITLE
[WIP] Added affinity to AMO spec

### DIFF
--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -9,7 +9,12 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
+func (r *Reconciler) newAlertsReconciler(antiAffinityRequired bool) resources.AlertReconciler {
+	monitoringExpectedPodCount := 7
+	if antiAffinityRequired {
+		monitoringExpectedPodCount = 11
+	}
+
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "monitoring",
 		Installation: r.installation,
@@ -197,9 +202,9 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						Alert: "MiddlewareMonitoringPodCount",
 						Annotations: map[string]string{
 							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "Pod count for namespace {{ $labels.namespace }} is {{ $value }}. Expected exactly 7 pods.",
+							"message": fmt.Sprintf("Pod count for namespace {{ $labels.namespace }} is {{ $value }}. Expected exactly %d pods.", monitoringExpectedPodCount),
 						},
-						Expr:   intstr.FromString("(1 - absent(kube_pod_status_ready{condition='true',namespace='" + global.NamespacePrefix + "middleware-monitoring-operator'})) or sum(kube_pod_status_ready{condition='true',namespace='" + global.NamespacePrefix + "middleware-monitoring-operator'}) != 7"),
+						Expr:   intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='"+global.NamespacePrefix+"middleware-monitoring-operator'})) or sum(kube_pod_status_ready{condition='true',namespace='"+global.NamespacePrefix+"middleware-monitoring-operator'}) != %d", monitoringExpectedPodCount)),
 						For:    "5m",
 						Labels: map[string]string{"severity": "critical"},
 					},

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -203,6 +203,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	antiAffinityRequired, err := resources.IsAntiAffinityRequired(ctx, serverClient)
+	if err != nil {
+		r.Logger.Errorf("error when deciding if monitoring pod anti affinity is required. Defaulted to false: %v", err)
+	}
+
 	phase, err = r.ReconcileNamespace(ctx, operatorNamespace, installation, serverClient)
 	logrus.Infof("Phase: %s ReconcileNamespace", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
@@ -220,7 +225,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.reconcileComponents(ctx, serverClient)
+	phase, err = r.reconcileComponents(ctx, serverClient, antiAffinityRequired)
 	logrus.Infof("Phase: %s reconcileComponents", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile components", err)
@@ -279,7 +284,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.newAlertsReconciler().ReconcileAlerts(ctx, serverClient)
+	phase, err = r.newAlertsReconciler(antiAffinityRequired).ReconcileAlerts(ctx, serverClient)
 	logrus.Infof("Phase: %s reconcilePrometheusRule", phase)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)
@@ -549,7 +554,7 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 	return err
 }
 
-func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8sclient.Client, antiAffinityRequired bool) (integreatlyv1alpha1.StatusPhase, error) {
 	r.Logger.Info("Reconciling Monitoring Components")
 	m := &monitoring.ApplicationMonitoring{
 		ObjectMeta: metav1.ObjectMeta{
@@ -568,6 +573,10 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 			AlertmanagerInstanceNamespaces:   r.Config.GetOperatorNamespace(),
 			PrometheusInstanceNamespaces:     r.Config.GetOperatorNamespace(),
 			SelfSignedCerts:                  r.installation.Spec.SelfSignedCerts,
+			Affinity: resources.SelectAntiAffinityForCluster(antiAffinityRequired, map[string]string{
+				"prometheus":   "application-monitoring",
+				"alertmanager": "application-monitoring",
+			}),
 		}
 		r.monitoring = m
 		return nil


### PR DESCRIPTION
# Description
[MGDAPI-187](https://issues.redhat.com/browse/MGDAPI-187)

These change updates the AMO spec include the affinity rules which were created as part of [this](https://github.com/obrienrobert/application-monitoring-operator/tree/MGDAPI-187) PR. It also updates the `MiddlewareMonitoringPodCount` alert by setting the expected number of pods depending on if the cluster is multi-AZ or not.

This PR **_should not_** be merged until a new release of the AMO has been created, and the Integreatly-Operator updated to include the new release of the AMO. I'll add verification steps once this is complete. Code reviews are welcome though! 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer