### PR TITLE
MGDAPI-543: Automatic uninstall operator in OLM

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -67,6 +67,7 @@ rules:
       - list
       - watch
       - update
+      - delete
 
   # Monitoring resources ar not covered by namespace "admin" permissions
   - apiGroups:
@@ -105,6 +106,16 @@ rules:
       - list
       - watch
       - delete
+
+  # Allow operator to delete its own CSV
+  - apiGroups:
+      - operators.coreos.com
+    resources:
+      - clusterserviceversions
+    verbs:
+      - delete
+      - get
+      - list
 
   # Permissions needed to be able to grant to prometheus-k8s SA from openshift-monitoring NS
   - apiGroups:

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -4,10 +4,15 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
+const (
+	ManagedAPIService = "managed-api-service"
+	RHMI              = "rhmi"
+)
+
 var (
 	addonNames = map[integreatlyv1alpha1.InstallationType]string{
-		integreatlyv1alpha1.InstallationTypeManagedApi: "managed-api-service",
-		integreatlyv1alpha1.InstallationTypeManaged:    "rhmi",
+		integreatlyv1alpha1.InstallationTypeManagedApi: ManagedAPIService,
+		integreatlyv1alpha1.InstallationTypeManaged:    RHMI,
 	}
 )
 
@@ -15,7 +20,7 @@ var (
 func GetName(installationType integreatlyv1alpha1.InstallationType) string {
 	addonName, ok := addonNames[installationType]
 	if !ok {
-		return "rhmi"
+		return RHMI
 	}
 
 	return addonName

--- a/pkg/addon/operator_run.go
+++ b/pkg/addon/operator_run.go
@@ -1,0 +1,118 @@
+package addon
+
+import (
+	"context"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// OperatorRunType is used to indicate how the operator is being currently
+// run
+type OperatorRunType string
+
+// AddonRunType represents when the operator is run by an add-on installation
+var AddonRunType OperatorRunType = "Addon"
+
+// OLMRunType represents when the operator is run by a non-add-on OLM installation
+var OLMRunType OperatorRunType = "OLM"
+
+// ClusterRunType represents when the operator is run by a non-OLM in-cluster
+// deployment
+var ClusterRunType OperatorRunType = "Cluster"
+
+// LocalRunType represents when the operator is run locally
+var LocalRunType OperatorRunType = "Local"
+
+var runTypesBySubscription map[string]OperatorRunType = map[string]OperatorRunType{
+	// RHOAM - Add-on
+	addonPrefixed(ManagedAPIService): AddonRunType,
+	// RHOAM - OLM
+	ManagedAPIService: OLMRunType,
+
+	// RHMI - Add-on
+	addonPrefixed(RHMI): AddonRunType,
+	// RHMI - OLM
+	"integreatly": OLMRunType,
+}
+
+// InferOperatorRunType infers how the operator is being run
+func InferOperatorRunType(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (OperatorRunType, error) {
+	subscription, err := GetSubscription(ctx, client, installation)
+	if err != nil {
+		return "", err
+	}
+
+	if subscription != nil {
+		return runTypesBySubscription[subscription.Name], nil
+	}
+
+	isCluster, err := IsClusterRunType(ctx, client, installation)
+	if err != nil {
+		return "", err
+	}
+
+	if isCluster {
+		return ClusterRunType, nil
+	}
+
+	return LocalRunType, nil
+}
+
+// OperatorInstalledViaOLM checks if the operator was installed through OLM
+func OperatorInstalledViaOLM(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (bool, error) {
+	runType, err := InferOperatorRunType(ctx, client, installation)
+	if err != nil {
+		return false, err
+	}
+
+	return runType == AddonRunType || runType == OLMRunType, nil
+}
+
+// IsClusterRunType checks if the operator is run on a cluster
+func IsClusterRunType(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (bool, error) {
+	deploymentPrefix := "rhmi"
+	if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		deploymentPrefix = "rhoam"
+	}
+
+	deployment := &appsv1.Deployment{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-operator", deploymentPrefix),
+			Namespace: installation.Namespace,
+		},
+	}
+
+	return resources.Exists(ctx, client, deployment)
+}
+
+// GetSubscription attempts to find the subscription that installed the operator.
+// If the subscription is not found, `nil` is returned
+func GetSubscription(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) (*operatorsv1alpha1.Subscription, error) {
+	for subscriptionName := range runTypesBySubscription {
+		subscription := &operatorsv1alpha1.Subscription{}
+		err := client.Get(ctx, k8sclient.ObjectKey{
+			Name:      subscriptionName,
+			Namespace: installation.Namespace,
+		}, subscription)
+		if err != nil && errors.IsNotFound(err) {
+			continue
+		} else if err != nil {
+			return nil, err
+		}
+
+		return subscription, nil
+	}
+
+	return nil, nil
+}
+
+func addonPrefixed(name string) string {
+	return fmt.Sprintf("addon-%s", name)
+}

--- a/pkg/addon/operator_run_test.go
+++ b/pkg/addon/operator_run_test.go
@@ -1,0 +1,104 @@
+package addon
+
+import (
+	"context"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestGetSubscription(t *testing.T) {
+	scheme := runtime.NewScheme()
+	integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme)
+	operatorsv1alpha1.AddToScheme(scheme)
+
+	scenarios := []struct {
+		Name                    string
+		InstallType             integreatlyv1alpha1.InstallationType
+		SubscriptionName        *string
+		ExpectSubscriptionFound bool
+	}{
+		{
+			Name:                    "RHOAM Add-on",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManagedApi,
+			SubscriptionName:        existingSubscription("addon-managed-api-service"),
+			ExpectSubscriptionFound: true,
+		},
+		{
+			Name:                    "RHMI Add-on",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManaged,
+			SubscriptionName:        existingSubscription("addon-rhmi"),
+			ExpectSubscriptionFound: true,
+		},
+		{
+			Name:                    "OLM Installation / RHOAM",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManagedApi,
+			SubscriptionName:        existingSubscription("integreatly"),
+			ExpectSubscriptionFound: true,
+		},
+		{
+			Name:                    "OLM Installation / RHMI",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManaged,
+			SubscriptionName:        existingSubscription("integreatly"),
+			ExpectSubscriptionFound: true,
+		},
+		{
+			Name:                    "Local run / RHOAM",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManagedApi,
+			SubscriptionName:        noSubscription(),
+			ExpectSubscriptionFound: false,
+		},
+		{
+			Name:                    "Local run / RHMI",
+			InstallType:             integreatlyv1alpha1.InstallationTypeManaged,
+			SubscriptionName:        noSubscription(),
+			ExpectSubscriptionFound: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			installation := &integreatlyv1alpha1.RHMI{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "installation",
+					Namespace: "rhmi-test-operator",
+				},
+			}
+
+			initObjs := []runtime.Object{
+				installation,
+			}
+			if scenario.SubscriptionName != nil {
+				initObjs = append(initObjs, &operatorsv1alpha1.Subscription{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      *scenario.SubscriptionName,
+						Namespace: "rhmi-test-operator",
+					},
+				})
+			}
+
+			client := fake.NewFakeClientWithScheme(scheme, initObjs...)
+
+			subscription, err := GetSubscription(context.TODO(), client, installation)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if (subscription != nil) != scenario.ExpectSubscriptionFound {
+				t.Errorf("unexpeted subscription presence. Expected %t, but got %t", scenario.ExpectSubscriptionFound, subscription != nil)
+			}
+		})
+	}
+}
+
+func existingSubscription(name string) *string {
+	return &name
+}
+
+func noSubscription() *string {
+	return nil
+}

--- a/pkg/addon/uninstall.go
+++ b/pkg/addon/uninstall.go
@@ -1,0 +1,118 @@
+package addon
+
+import (
+	"context"
+	"net/http"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/sirupsen/logrus"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// UninstallOperator uninstalls the RHMI operator by deleting the subscription
+// and CSV. If the subscription is not found, it doesn't do anything, as the
+// operator might not be run through OLM
+func UninstallOperator(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI) error {
+	// Get the operator subscription
+	subscription, err := GetSubscription(ctx, client, installation)
+	if err != nil {
+		return err
+	}
+
+	// If the subscription is not found, finish: the operator might have been
+	// running locally
+	if subscription == nil {
+		return nil
+	}
+
+	logrus.Infof("deleting subscription %s", subscription.Name)
+
+	// Declare the deleting subscription function
+	deleteSubscription := func() error {
+		return client.Delete(ctx, subscription)
+	}
+
+	// Retrieve the operator CSV
+	csv := &operatorsv1alpha1.ClusterServiceVersion{}
+	err = client.Get(ctx, k8sclient.ObjectKey{
+		Name:      subscription.Status.InstalledCSV,
+		Namespace: installation.Namespace,
+	}, csv)
+	// If there's an unexpected error, return it
+	if err != nil && !k8serr.IsNotFound(err) {
+		return err
+	}
+
+	// If the CSV wasn't found, just delete the subscription
+	if k8serr.IsNotFound(err) {
+		return deleteSubscription()
+	}
+
+	logrus.Infof("Deleting operator CSV %s", csv.Name)
+
+	// Delete the CSV
+	if err := client.Delete(ctx, csv); err != nil {
+		return err
+	}
+
+	// Delete the subscription
+	return deleteSubscription()
+}
+
+type deleteRHMIHandler struct {
+	decoder    *admission.Decoder
+	restConfig *rest.Config
+	client     k8sclient.Client
+}
+
+var _ admission.Handler = &deleteRHMIHandler{}
+var _ admission.DecoderInjector = &deleteRHMIHandler{}
+
+func NewDeleteRHMIHandler(config *rest.Config) admission.Handler {
+	return &deleteRHMIHandler{
+		restConfig: config,
+	}
+}
+
+func (h *deleteRHMIHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *deleteRHMIHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
+	rhmi := &integreatlyv1alpha1.RHMI{}
+	if err := h.decoder.DecodeRaw(request.OldObject, rhmi); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	if len(rhmi.Finalizers) != 0 {
+		return admission.Allowed("RHMI Has finalizers")
+	}
+
+	client, err := h.getClient()
+	if err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	if err := UninstallOperator(ctx, client, rhmi); err != nil {
+		return admission.Errored(http.StatusInternalServerError, err)
+	}
+
+	return admission.Allowed("RHMI Uninstalled")
+}
+
+func (h *deleteRHMIHandler) getClient() (k8sclient.Client, error) {
+	if h.client == nil {
+		c, err := k8sclient.New(h.restConfig, k8sclient.Options{})
+		if err != nil {
+			return nil, err
+		}
+		h.client = c
+	}
+
+	return h.client, nil
+}

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/version"
 
-	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/global"
 	"github.com/integr8ly/integreatly-operator/pkg/webhooks"
@@ -22,6 +21,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/metrics"
@@ -570,6 +570,11 @@ func (r *ReconcileInstallation) handleUninstall(installation *integreatlyv1alpha
 
 		err = r.client.Update(context.TODO(), installation)
 		if err != nil {
+			merr.Add(err)
+			return retryRequeue, merr
+		}
+
+		if err := addon.UninstallOperator(context.TODO(), r.client, installation); err != nil {
 			merr.Add(err)
 			return retryRequeue, merr
 		}


### PR DESCRIPTION
# Description
Add logic to uninstall the operator (delete the CSV and Subscription) when
the uninstallation has finished.
Include utility logic to interact with the addon (infer if the operator is run via an addon installation, in-cluster, or local)

## Verification steps
In order to verify this PR, install the operator with the add-on, replace the image in the CSV from an image based on this PR, delete the installation and verify that the operator is uninsalled when the CR is deleted

1. ### Install add-on

    1. On a fresh cluster, install the Managed API Service add-on. Fill the parameters with dummy data (e.g. `10.1.0.0/23` for the CIDR)
        > The installation via the add-on is curently broken. In order to progress it for the sake of this PR take the following steps:
        >  1. Replace the operator image in the CSV for `quay.io/sfrancog/managed-api-service:mgdapi-543`
        >  2. Create the DMS secret
        >     ```sh
        >     oc create secret generic redhat-rhoam-deadmanssnitch -n redhat-rhoam-operator \                       
        >        --from-literal=url=https://dms.example.com
        >     ```
        > 3. Modify the references to the DMS and PagerDuty secrets to use the `rhoam` prefix in the RHMI CR
    2. The add-on installation doesn't include the role changes in this PR. Manually perform the changes in the Role named `managed-api-service.v0.7.0-rhoam-operator-*`

        > [Link to changes to the role](https://github.com/integr8ly/integreatly-operator/pull/1363/files#diff-dd2b7f73672812f28eaeefd88568f005bc349b4647e015a36b2789ad29b5221f)           

    The installation should progress normally.

2. ### Trigger uninstallation
    Verify that the uninstall is triggered both when the CR has finalizers or not (if it has finalizers it will be uninstalled as part of the finalizer execution. If not, as a webhook). Re-install the add-on between verifications, as the operator will have been uninstalled    
    1. #### Without finalizers
        Before the operator has added finalizers to the CR, delete it, and verify that the Subscription and CSV have been removed

    2. #### With finalizers
        Wait for the operator to complete the installation and delete the CR. Verify that the uninstall progresses until the CR is deleted, and verify that the Subscription and CSV are deleted at the end
 
### _*Re-installing add-on_

Once the operator is uninstalled, you must re-install the add-on in order to verify the alternative path (with/without finalizers). 
1. Uninstall the add-on

    > Add-on uninstallation is not yet supported in the UI. Take note of your cluster ID and run the following OCM command
    ```sh
    ocm delete /api/clusters_mgmt/v1/clusters/<cluster ID>/addons/managed-api-service
    ```
2. Install the add-on and follow step 1 again


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer