### PR TITLE
MGDAPI-564 RHOAM/RHMI Installation/upgrade/reconciler alerts

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -65,6 +65,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
 	integreatlymetrics.OperatorVersion.Add(1)
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -80,6 +80,16 @@ var (
 			"to_version",
 		},
 	)
+
+	RHOAMStatus = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhoam_status",
+			Help: "RHOAM status of an installation",
+		},
+		[]string{
+			"stage",
+		},
+	)
 )
 
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
@@ -101,6 +111,11 @@ func SetRHMIStatus(installation *integreatlyv1alpha1.RHMI) {
 	RHMIStatus.Reset()
 	if string(installation.Status.Stage) != "" {
 		RHMIStatus.With(prometheus.Labels{"stage": string(installation.Status.Stage)}).Set(float64(1))
+	}
+
+	RHOAMStatus.Reset()
+	if string(installation.Status.Stage) != "" {
+		RHOAMStatus.With(prometheus.Labels{"stage": string(installation.Status.Stage)}).Set(float64(1))
 	}
 }
 

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -242,6 +242,13 @@ func rhmi2ExpectedRules() []alertsTestRule {
 				"RHMIUPSUnifiedpushProxyServiceEndpointDown",
 			},
 		},
+		{
+			File: NamespacePrefix + "operator-rhmi-installation-controller-alerts.yaml",
+			Rules: []string{
+				"RHMIInstallationControllerIsNotReconciling",
+				"RHMIInstallationControllerStoppedReconciling",
+			},
+		},
 	}
 }
 
@@ -317,6 +324,13 @@ func managedApiSpecificRules() []alertsTestRule {
 				"RHOAMApiUsageSoftLimitReachedTier1",
 				"RHOAMApiUsageSoftLimitReachedTier2",
 				"RHOAMApiUsageSoftLimitReachedTier3",
+			},
+		},
+		{
+			File: NamespacePrefix + "operator-rhoam-installation-controller-alerts.yaml",
+			Rules: []string{
+				"RHOAMInstallationControllerIsNotReconciling",
+				"RHOAMInstallationControllerStoppedReconciling",
 			},
 		},
 	}
@@ -475,13 +489,6 @@ func commonExpectedRules() []alertsTestRule {
 			Rules: []string{
 				"RHMIUserRhssoOperatorRhmiRegistryCsMetricsServiceEndpointDown",
 				"RHMIUserRhssoKeycloakOperatorMetricsServiceEndpointDown",
-			},
-		},
-		{
-			File: NamespacePrefix + "operator-rhmi-installation-controller-alerts.yaml",
-			Rules: []string{
-				"RHMIInstallationControllerIsNotReconciling",
-				"RHMIInstallationControllerStoppedReconciling",
 			},
 		},
 		{


### PR DESCRIPTION
# Description
Addresses https://issues.redhat.com/browse/MGDAPI-564.
Currently, when RHOAM is installed and/or running the following alerts could trigger:
```
RHMIInstallationControllerIsNotReconciling
RHMIInstallationControllerStoppedReconciling
```
and the following alerts triggers and don't go away after installation completes:
```
RHMIOperatorInstallDelayed
RHMIUpgradeExpectedDurationExceeded
```
The reason for it is because the alerts expect rhmi_status and rhmi_version present, while we are having rhoam installed. 

# What
Both `RHMIOperatorInstallDelayed` and `RHOAMUpgradeExpectedDurationExceeded` fired during installation and remained in firing state after installation reports completed. The reason for it is because we were checking RHMI installation stage status instead of RHOAM.

# How
Added metrics for RHOAM status and edited the alerts to be flexible so that alerts names and queries are built based on the install type

# Verification
Both RHMI and RHOAM must be verified.

## RHOAM

- install RHOAM from this branch via OLM ( you can follow steps in https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md )
- during installation following alert should be pending:
```
RHOAMOperatorInstallDelayed
```
- and the following alerts will fire:
```
RHOAMUpgradeExpectedDurationExceeded
```
The reason for the RHOAMUpgradeExpectedDurationExceeded alert firing is that this alert aims to monitor upgrade time, so the `version` field during initial installation is not present, and thus, the alert fires. 
- when the installation completes, confirm that none of the following alerts are triggered:
```
1. RHOAMOperatorInstallDelayed
2. RHOAMInstallationControllerIsNotReconciling
3. RHOAMInstallationControllerStoppedReconciling
4. RHOAMUpgradeExpectedDurationExceeded
```

## RHMI

- install RHMI from this branch via OLM ( you can follow steps in https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md )
- during installation following alert should be pending:
```
RHMIOperatorInstallDelayed
```
- and the following alerts will fire:
```
RHMIUpgradeExpectedDurationExceeded
```
- when the installation completes, confirm that none of the following alerts are triggered:
```
1. RHMIOperatorInstallDelayed
2. RHMIInstallationControllerIsNotReconciling
3. RHMIInstallationControllerStoppedReconciling
4. RHMIUpgradeExpectedDurationExceeded
```


