### PR TITLE
Attempt to clear EnvoyConfig only in ManagedApi install

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -182,12 +182,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	productNamespace := r.Config.GetNamespace()
 
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {
-		phase, err := ratelimit.DeleteEnvoyConfigsInNamespaces(ctx, serverClient, productNamespace)
-		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-			return phase, err
+		if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+			phase, err := ratelimit.DeleteEnvoyConfigsInNamespaces(ctx, serverClient, productNamespace)
+			if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+				return phase, err
+			}
 		}
 
-		phase, err = resources.RemoveNamespace(ctx, installation, serverClient, productNamespace)
+		phase, err := resources.RemoveNamespace(ctx, installation, serverClient, productNamespace)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			return phase, err
 		}


### PR DESCRIPTION
# Description

The finalizer for 3scale attempts to delete the EnvoyConfig CR without checking the installation type. If the installation type is not Managed API, it will try to delete a CR that has no CRD so will fail with a "no match for kind" error. Wrap the deletion in an `if` block to do it only in Managed API installations

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer