### PR TITLE
Sync OpenShift-IDP client secret

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -309,6 +309,12 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 	r.Logger.Infof("Authentication flow added to %s IDP", idpAlias)
 
+	err = r.SyncOpenshiftIDPClientSecret(ctx, serverClient, authenticated, r.Config, keycloakRealmName)
+	if err != nil {
+		r.Logger.Infof("failed to sync openshift idp client secret: %v", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to sync openshift idp client secret: %w", err)
+	}
+
 	// Get all currently existing keycloak users
 	keycloakUsers, err := GetKeycloakUsers(ctx, serverClient, r.Config.GetNamespace())
 	if err != nil {

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -659,10 +659,12 @@ func getMoqKeycloakClientFactory() keycloakCommon.KeycloakClientFactory {
 					return &keycloak.KeycloakIdentityProvider{
 						Alias:                     "babla",
 						FirstBrokerLoginFlowAlias: "authdelay",
+						Config:                    map[string]string{},
 					}, nil
 				}, CreateAuthenticatorConfigFunc: func(authenticatorConfig *keycloak.AuthenticatorConfig, realmName string, executionID string) (string, error) {
 					return "", nil
 				},
+				UpdateIdentityProviderFunc:               keycloakInterfaceMock.UpdateIdentityProvider,
 				AddExecutionToAuthenticatonFlowFunc:      keycloakInterfaceMock.AddExecutionToAuthenticatonFlow,
 				CreateAuthenticationFlowFunc:             keycloakInterfaceMock.CreateAuthenticationFlow,
 				FindAuthenticationFlowByAliasFunc:        keycloakInterfaceMock.FindAuthenticationFlowByAlias,
@@ -729,6 +731,10 @@ func createKeycloakInterfaceMock() (keycloakCommon.KeycloakInterface, *mockClien
 			return []*keycloakCommon.AuthenticationFlow{}, nil
 		}
 		return context.AuthenticationFlow[realmName], nil
+	}
+
+	updateIdentityProviderFunc := func(specIdentityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error {
+		return nil
 	}
 
 	findAuthenticationFlowByAliasFunc := func(flowAlias, realmName string) (*keycloakCommon.AuthenticationFlow, error) {
@@ -831,5 +837,6 @@ func createKeycloakInterfaceMock() (keycloakCommon.KeycloakInterface, *mockClien
 		FindAuthenticationExecutionForFlowFunc:   findAuthenticationExecutionForFlowFunc,
 		UpdateAuthenticationExecutionForFlowFunc: updateAuthenticationExecutionForFlowFunc,
 		ListAuthenticationFlowsFunc:              listAuthenticationFlowsFunc,
+		UpdateIdentityProviderFunc:               updateIdentityProviderFunc,
 	}, &context
 }


### PR DESCRIPTION
# Description
Reconcile OpenShift IDP client secret. This is required to cover the accidental changing of this secret through
the Keycloak GUI. This scenario happened for a customer in production. See below.

JIRA: [INTLY-10308](https://issues.redhat.com/browse/INTLY-10308)
Production Issue: [OHSS-2019](https://issues.redhat.com/browse/OHSS-2019)

# To Verify:
- Install RHMI and verify 3Scale SSO works.
- Modify the Openshift-v4 IDP Client Secret. In rhsso , browse to Identity Providers in the OpenShift Realm. Select openshift-v4 and modify the client secret.
- Verify Login to 3Scale SSO failing
- Wait for a RHSSO Reconcile to run
- Verify Login to 3Scale SSO working
