### PR TITLE
Add alert for 3scale ApiCast worker process restart

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -275,6 +275,19 @@ func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
 						For:    "15m",
 						Labels: map[string]string{"severity": "warning"},
 					},
+					{
+						Alert: "ThreescaleApicastWorkerRestart",
+						Annotations: map[string]string{
+							"summary":     "A new worker process in Nginx has been started",
+							"description": "A new thread has been started. This could indicate that a worker process has died due to the memory limits being exceeded. Please investigate the memory pressure on pod (instance {{ $labels.instance }})",
+							"sop_url":     "https://github.com/3scale/3scale-Operations/blob/master/sops/alerts/apicast_worker_restart.adoc",
+						},
+						Expr: intstr.FromString(fmt.Sprintf(`changes(worker_process{kubernetes_namespace='%s', kubernetes_pod_name=~'apicast-production.*'}[5m]) > 0`, r.Config.GetNamespace())),
+						For:  "5m",
+						Labels: map[string]string{
+							"severity": "critical",
+						},
+					},
 				},
 			},
 		},

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -400,6 +400,7 @@ func commonExpectedRules() []alertsTestRule {
 				"ThreeScaleContainerHighCPU",
 				"ThreeScaleZyncPodAvailability",
 				"ThreeScaleZyncDatabasePodAvailability",
+				"ThreescaleApicastWorkerRestart",
 			},
 		},
 		{


### PR DESCRIPTION
# Description

Add an alert to detect when 3scale apicast worker restarts

Jira: https://issues.redhat.com/browse/MGDAPI-322

PS.: this PR is in WIP because the existing SOP to troubleshoot the alert but it needs to be improved with more details on how to fix the issue in case the alert start firing and be approved by SRE. 

## Verification steps

1) Install the operator from this branch
2) Check if the alert is created in prometheus
3) Go to one of the production APICast pod and run the command below to restart nginx worker
```for k in /proc/[0-9]*; do grep -i "^nginx: worker process" $k/cmdline 2>&1 >/dev/null; if [[ $? == 0 ]]; then echo ${k##*/}; fi; done | xargs kill -9```
4) Verify if the alert is in a pending state
