### PR TITLE
MGDAPI-565: Modify API Usage queries for statsd pod restart support

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -102,7 +102,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))",
           "instant": true,
           "refId": "A"
         }
@@ -188,7 +188,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m])",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]))",
           "instant": true,
           "refId": "A"
         }
@@ -273,7 +273,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m])/increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))*100",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]))/sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))*100",
           "instant": true,
           "refId": "A"
         }
@@ -340,7 +340,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))",
           "instant": false,
           "interval": "30s",
           "legendFormat": "No. of Reqests",
@@ -474,7 +474,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h])",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))",
           "instant": true,
           "refId": "A"
         }
@@ -559,7 +559,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h])",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h]))",
           "format": "time_series",
           "instant": true,
           "refId": "A"
@@ -645,7 +645,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h])/increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))*100  ",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h]))/sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))*100  ",
           "instant": false,
           "legendFormat": "",
           "refId": "A"

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -103,7 +103,7 @@ func increaseExpr(totalRequestsMetric, period string, comparisonOperator string,
 	}
 
 	result := fmt.Sprintf(
-		"(increase(%s[%s]) %s (%f / 100 * %d))",
+		"(sum(increase(%s[%s]) %s (%f / 100 * %d)))",
 		totalRequestsMetric, period, comparisonOperator, requestsAllowedOverTimePeriod, *percenteageLimit,
 	)
 

--- a/pkg/products/marin3r/softLimitPrometheusRules.go
+++ b/pkg/products/marin3r/softLimitPrometheusRules.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	softLimitAlertQuery = "vector(scalar(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits or on() vector(0))" +
-		" - " +
-		"scalar((ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits " +
-		"offset 1d) or on() vector(0))) > %d"
+	// softLimitAlertQuery = "vector(scalar(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits or on() vector(0))" +
+	// 	" - " +
+	// 	"scalar((ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits " +
+	// 	"offset 1d) or on() vector(0))) > %d"
+	softLimitAlertQuery = "floor(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))) > %d"
 )
 
 func (r *Reconciler) newSoftLimitAlertsReconciler() resources.AlertReconciler {


### PR DESCRIPTION
# Description

> Link to Jira: https://issues.redhat.com/browse/MGDAPI-565

The metrics exposed by the rate limiting service include in their labels information about the statsd Pod such as it's host and Pod name. When the statsd Pod is restarted, a different vector is exposed with the counter restarted to 0, which affects the Grafana dashboard as well as the alerts that rely on these metrics.
Wrap the `increase()` function calls to `sum()`. When the metric is not exposed anymore the value of `increase()` will remain and, by using `sum()`, the values of the different vectors will be added up.

## Verification steps

This PR modifies the promql queries for the Grafana dashboard, the API Usage alerts, and the soft limit alerts. In order to verify this, verify that the alerts still work and the Grafana dashboard works after restarting the statsd Pod

1. ### Restart the statsd Pod
    1. Create a 3scale application.
    2. Produce some traffic
    3. In Prometheus, check that there is some data present for the query
        ```python
        increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h])
        ```
    4. Restart the prom-stats-d-exporter pod in the redhat-rhoam-marin3r namespace. 
    5. Scale down the rate-limit Deployment, scale it up again and wait a minute for it to be deployed
2. ### Verify API Usage alerts
    Follow the verification steps from https://github.com/integr8ly/integreatly-operator/pull/1319
    > The queries use the `increase()` function now. Verify that they work the same with the following format
    > ```python
    > floor(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))) > <soft limit>
    > ```

3. ### Verify soft limits alerts
    Follow the steps in the manual test case to verify it still works:
    https://github.com/integr8ly/integreatly-operator/blob/master/test-cases/tests/alerts/c18-validate-api-usage-alerts.md#steps
    
4. ### Verify Grafana dashboard
    Navigate to the Grafana dashboard and verify that the figures make sense and no error is shown.
    > A value of `"NaN%"` for "Last 1 Minute Rejected/Requests" is acceptable, as if there's no requests it's a division by 0
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer