### PR TITLE
Moves the rate limit images registry to Quay

### DIFF
--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -226,7 +226,7 @@ func (r *RateLimitServiceReconciler) reconcileDeployment(ctx context.Context, cl
 				Containers: []corev1.Container{
 					{
 						Name:    "ratelimit",
-						Image:   "envoyproxy/ratelimit:v1.4.0",
+						Image:   "quay.io/integreatly/ratelimit:v1.4.0",
 						Command: []string{"ratelimit"},
 						VolumeMounts: []corev1.VolumeMount{
 							{

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -443,7 +443,7 @@ func (r *Reconciler) reconcilePromStatsdExporter(ctx context.Context, client k8s
 				Containers: []corev1.Container{
 					{
 						Name:  statsdHost,
-						Image: "prom/statsd-exporter:v0.18.0",
+						Image: "quay.io/integreatly/statsd-exporter:v0.18.0",
 						Ports: []corev1.ContainerPort{
 							{
 								Name:          "prom-statsd",

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -487,6 +487,7 @@ func (r *Reconciler) patchDeploymentConfig(ctx context.Context, client k8sclient
 	deploymentConfig.Spec.Template.Labels["marin3r.3scale.net/status"] = "enabled"
 	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/node-id"] = apicastRatelimiting
 	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/ports"] = "envoy-https:8443"
+	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/envoy-image"] = "quay.io/integreatly/envoy:v1.14.1"
 
 	if err := client.Update(ctx, deploymentConfig); err != nil {
 		return fmt.Errorf("failed to update deployment config: %v", err)


### PR DESCRIPTION
# Description

Moves the rate limit images registry to Quay

- quay.io/integreatly/ratelimit:v1.4.0
- quay.io/integreatly/envoy:v1.14.1
- quay.io/integreatly/statsd-exporter:v0.18.0

Jira: https://issues.redhat.com/browse/MGDAPI-580

## Verification steps

1) Install the operator from this branch 
2) Verify if the rate limit image comes from quay
```bash
$ oc get deployment ratelimit -n redhat-rhoam-marin3r -o json | jq  ".spec.template.spec.containers[0] .image"

> "quay.io/integreatly/ratelimit:v1.4.0"
```

3) Verify if the prom statsd exporter image comes from quay
```bash
oc get deployment prom-statsd-exporter -n redhat-rhoam-marin3r -o json | jq  ".spec.template.spec.containers[0] .image"

> "quay.io/integreatly/statsd-exporter:v0.18.0"
```
4) Verify if the envoy image for the sidecar containers come from quay
```bash
oc get pods -l deploymentConfig=apicast-production -n redhat-rhoam-3scale -o json | jq  ".items[] .spec.containers[1] .image"

> "quay.io/integreatly/envoy:v1.14.1"
```
5) Create an API in 3scale and verify if the requests are being limited
```bash
// verify the number of requests allowed
oc get configmap sku-limits-managed-api-service -n redhat-rhoam-operator -o json | jq ".data"
```
