### PR TITLE
Mgdapi 585

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -1,6 +1,19 @@
 package grafana
 
-const CustomerMonitoringGrafanaRateLimitingJSON = `{
+// This dashboard json is dynamically configured
+// Search for %s to see where there are values passed
+// At the time of writing there are two places that are dynamically configured
+// 1. Dashboard Variables
+// 2. Rate Limit Graph Queries
+// In both cases these are configured based on soft limits provided in the sku-limits-managed-api-servic config map
+// present in the operator namespace for RHOAM installations
+// For example if there are softLimits provided of [500000,10000000,15000000] Five, Ten and Fifteen Million per day
+// Then there are 3 Dashboard variables configured, in addition to a static 2000000, TwentyMillion Variable representing
+// the cluster hard limit.
+// Each of these soft limits are then dynamically added as queries to the Rate Limit Graph.
+//
+// Each of the static hard limit and dynamic soft limit are calculated to a perMinute amount.
+var CustomerMonitoringGrafanaRateLimitingJSON = `{
   "annotations": {
     "list": [
       {
@@ -81,9 +94,9 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -113,7 +126,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "title": "Last 1 Minute - No. Requests",
       "transparent": true,
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -167,9 +180,9 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -198,7 +211,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 1 Minute - Rejected",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -251,10 +264,10 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
-      "postfix": "%",
-      "postfixFontSize": "50%",
+      "postfix": "%%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -283,7 +296,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 1 Minute - Rejected/Requests",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -345,27 +358,8 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
           "interval": "30s",
           "legendFormat": "No. of Requests",
           "refId": "A"
-        },
-        {
-          "expr": "$perMinuteFiveMillion",
-          "legendFormat": "Five Million Daily Requests",
-          "refId": "B"
-        },
-        {
-          "expr": "$perMinuteTenMillion",
-          "legendFormat": "Ten Million Daily Requests",
-          "refId": "C"
-        },
-        {
-          "expr": "$perMinuteFifteenMillion",
-          "legendFormat": "Fifteen Million Daily Requests",
-          "refId": "D"
-        },
-        {
-          "expr": "$perMinuteTwentyMillion",
-          "legendFormat": "Twenty Million Daily Requests",
-          "refId": "E"
         }
+        %s
       ],
       "thresholds": [],
       "timeFrom": null,
@@ -453,9 +447,9 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -484,7 +478,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 24 Hours - No. Requests",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -538,9 +532,9 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -570,7 +564,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 24 Hours - Rejected",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -623,10 +617,10 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
-      "postfix": "%",
-      "postfixFontSize": "50%",
+      "postfix": "%%",
+      "postfixFontSize": "50%%",
       "prefix": "",
-      "prefixFontSize": "50%",
+      "prefixFontSize": "50%%",
       "rangeMaps": [
         {
           "from": "null",
@@ -656,7 +650,7 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 24 Hours -  Rejected/Requests",
       "type": "singlestat",
-      "valueFontSize": "80%",
+      "valueFontSize": "80%%",
       "valueMaps": [
         {
           "op": "=",
@@ -692,68 +686,9 @@ const CustomerMonitoringGrafanaRateLimitingJSON = `{
         "query": "13889",
         "skipUrlSync": false,
         "type": "constant"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "10417",
-          "value": "10417"
-        },
-        "hide": 2,
-        "label": null,
-        "name": "perMinuteFifteenMillion",
-        "options": [
-          {
-            "selected": true,
-            "text": "10417",
-            "value": "10417"
-          }
-        ],
-        "query": "10417",
-        "skipUrlSync": false,
-        "type": "constant"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "6944",
-          "value": "6944"
-        },
-        "hide": 2,
-        "label": null,
-        "name": "perMinuteTenMillion",
-        "options": [
-          {
-            "selected": true,
-            "text": "6944",
-            "value": "6944"
-          }
-        ],
-        "query": "6944",
-        "skipUrlSync": false,
-        "type": "constant"
-      },
-      {
-        "current": {
-          "selected": false,
-          "text": "3472",
-          "value": "3472"
-        },
-        "hide": 2,
-        "label": null,
-        "name": "perMinuteFiveMillion",
-        "options": [
-          {
-            "selected": true,
-            "text": "3472",
-            "value": "3472"
-          }
-        ],
-        "query": "3472",
-        "skipUrlSync": false,
-        "type": "constant"
       }
-    ]
+		%s
+	]
   },
   "time": {
     "from": "now-12h",

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -85,7 +85,7 @@ func mapAlertsConfiguration(logger *logrus.Entry, namespace, rateLimitUnit strin
 			}
 			annotations := map[string]string{
 				"message": fmt.Sprintf(
-					"Total API usage in your API Management service is between %s%% and %s%% of the allowable threshold, %d requests per %s, during the last %s",
+					"Total API usage in your API Management service is between %s and %s of the allowable threshold, %d requests per %s, during the last %s",
 					alertConfig.Threshold.MinRate, upperMessage, rateLimitRequestsPerUnit, rateLimitUnit, alertConfig.Period,
 				),
 				"grafanaConsole": grafanaDashboardURL,

--- a/pkg/products/marin3r/config/config.go
+++ b/pkg/products/marin3r/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -54,7 +55,7 @@ func GetRateLimitConfig(ctx context.Context, client k8sclient.Client, namespace 
 		RateLimitConfigMapName, namespace, "rate_limit",
 		&skuConfigs,
 	); err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, fmt.Sprintf("could not read rate_limit config from %s config map", RateLimitConfigMapName))
 	}
 
 	sku, err := GetSKU(ctx, client)

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -29,6 +29,9 @@ route:
     - match_re:
         alertname: RHOAMApiUsageSoftLimitReachedTier[0-9]+
       receiver: BU
+    - match:
+        alertname: RHOAMApiUsageOverLimit
+      receiver: BUandCustomer
 receivers:
   - name: default
     email_configs:


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/MGDAPI-585

## Change

Addressing Feedback from https://github.com/integr8ly/integreatly-operator/pull/1368

Updating Grafana Dashboard to dynamically create variables and graph queries based on array of soft limits provided in the operator namespace.

## Verification

1. Verify that the soft limits are loaded as expected from the default copy of the `sku-limits-managed-api-service` config map.

1.1 Install RHOAM

`INSTALLATION_TYPE=managed-api make cluster/prepare/local `
`INSTALLATION_TYPE=managed-api make code/run/service_account`

1.2 Verify that the dashboard is created

Wait for the grafana stage to complete
Navigate to `http://<grafana-route>/d/66ab72e0d012aacf34f907be9d81cd9e/rate-limiting`

1.3 Verify that the Dashboard Variables have been dynamically loaded
Log in as admin using the credentials from `grafana-admin-credentials` secret
Navigate to `Dashboard Settings` (top right - cog)
Navigate to Variables 
They should appear as below

![Screenshot 2020-11-20 at 13 11 04](https://user-images.githubusercontent.com/6498727/99803780-e7f64380-2b31-11eb-8639-050a666eeda5.png)


1.4 verify the dashboard rate limit graph has each soft limit represented on the graph and in the queries as per the image below
![Screenshot 2020-11-20 at 13 08 59](https://user-images.githubusercontent.com/6498727/99803597-a5cd0200-2b31-11eb-86c2-bebfe90231cb.png)
![Screenshot 2020-11-20 at 13 09 04](https://user-images.githubusercontent.com/6498727/99803614-ad8ca680-2b31-11eb-9656-731508ef0b8e.png)



2. Verify that updating the soft limits in the config map gets reflected in the grafana dashboard

2.1 update the `sku-limits-managed-api-service` config map soft_limits entry with additional daily limits. Try to put them out of order e.g. 
```
"soft_daily_limits": [
          18000000,
          5000000,
          15000000,
          10000000
        ]
```


2.2 verify the variables in the dashboard look like this, they should be in increasing order

![Screenshot 2020-11-20 at 12 45 38](https://user-images.githubusercontent.com/6498727/99801745-710b7b80-2b2e-11eb-86ec-0ea99df816b3.png)

2.3 verify the dashboard rate limit graph has each soft limit represented on the graph and in the queries as per the image below - they should be in increasing order

![Screenshot 2020-11-20 at 12 48 28](https://user-images.githubusercontent.com/6498727/99801938-bb8cf800-2b2e-11eb-8e06-bdee97e7ebe0.png)

3. Verify that adding incorrect values or additional commas to the array returns an informative error to the rhmi cr and reports stage failure

Update the `sku-limits-managed-api-service` config map soft_limits entry with daily limits that are malformated. e.g. with an addtional comma at the end
```
"soft_daily_limits": [
          18000000,
          5000000,
          15000000,
          10000000,
        ]
```

Waif for a rereconcile and verify that the rhmi reports phase failed: 

![Screenshot 2020-11-20 at 13 16 22](https://user-images.githubusercontent.com/6498727/99804251-9d28fb80-2b32-11eb-879f-c60a8f4a4187.png)

4. Verify alerts don't have the additional % symbol in them - fix from related pr.

Naviagate to prometheus and check the alert message string looks like the below without the additional % symbol
![Screenshot 2020-11-20 at 13 18 34](https://user-images.githubusercontent.com/6498727/99804500-0446b000-2b33-11eb-9127-c457edb28ae3.png)

5. Verify that the alert `RHOAMApiUsageOverLimit` is present in alert manager with reciever BUAndCustomer
Navigate to AlertManager in the monitoring namespace
http://<alert-manager-route>/#/status

![Screenshot 2020-11-20 at 13 24 06](https://user-images.githubusercontent.com/6498727/99804956-b2eaf080-2b33-11eb-8923-b6d5b0d36cc8.png)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer