### PR TITLE
Fix testing IDP issues with new keycloa-operator version

### DIFF
--- a/scripts/testing-idp-template.yml
+++ b/scripts/testing-idp-template.yml
@@ -30,7 +30,6 @@ objects:
         matchLabels:
           sso: ${REALM}
       client:
-        id: openshift
         clientId: openshift
         rootUrl: ${OAUTH_URL}
         secret: ${CLIENT_SECRET}


### PR DESCRIPTION
# Description
@philbrookes  cc

Removal of the id field from client spec is a workaround for keycloak-operator behavior.
Currently, if id is set, then the set secret is ignored.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer