### PR TITLE
fix: remove c16 from rhoam

### DIFF
--- a/test-cases/tests/alerts/c16-verify-ocm-sendgrid-service-alerts.md
+++ b/test-cases/tests/alerts/c16-verify-ocm-sendgrid-service-alerts.md
@@ -4,14 +4,8 @@ products:
   - name: rhmi
     environments:
       - osd-post-upgrade
-    tags:
-      - per-release
-  - name: rhoam
-    environments:
-      - osd-post-upgrade
-      - osd-fresh-install
-tags:
-  - per-release
+    targets:
+      - 2.7.0
 ---
 
 # C16 - Verify OCM SendGrid Service alerts


### PR DESCRIPTION
# Motivation

This test case is no longer tight to RHOAM or RHMI releases