### PR TITLE
MGDAPI-373: Add alert for rate of rejected requests

### DIFF
--- a/pkg/products/marin3r/config/unit_conversion.go
+++ b/pkg/products/marin3r/config/unit_conversion.go
@@ -1,0 +1,73 @@
+package config
+
+import "fmt"
+
+var (
+	Second = "second"
+	Minute = "minute"
+	Hour   = "hour"
+	Day    = "day"
+)
+
+type unitConversion func(int) float64
+
+func divideBy(factor int) unitConversion {
+	return func(n int) float64 {
+		return float64(n) / float64(factor)
+	}
+}
+
+func multiplyBy(factor int) unitConversion {
+	return func(n int) float64 {
+		return float64(n * factor)
+	}
+}
+
+func identity(n int) float64 {
+	return float64(n)
+}
+
+var conversionFactors map[string]map[string]unitConversion = map[string]map[string]unitConversion{
+	Second: {
+		Second: identity,
+		Minute: multiplyBy(60),
+		Hour:   multiplyBy(3600),
+		Day:    multiplyBy(3600 * 24),
+	},
+	Minute: {
+		Second: divideBy(60),
+		Minute: identity,
+		Hour:   multiplyBy(60),
+		Day:    multiplyBy(60 * 24),
+	},
+	Hour: {
+		Second: divideBy(3600),
+		Minute: divideBy(60),
+		Hour:   identity,
+		Day:    multiplyBy(24),
+	},
+	Day: {
+		Second: divideBy(3600 * 24),
+		Minute: divideBy(60 * 24),
+		Hour:   divideBy(24),
+		Day:    identity,
+	},
+}
+
+// ConvertRate converts a rate of <value> requests/<from> to requests/<to>
+//
+// Example: ConvertRate("hour", "minute", 1200) will convert 100 requests/hour
+// to 20 requests/minute
+func ConvertRate(from string, to string, value int) (float64, error) {
+	toFuncs, ok := conversionFactors[from]
+	if !ok {
+		return 0, fmt.Errorf(`rate to convert from "%s" not supported`, from)
+	}
+
+	convert, ok := toFuncs[to]
+	if !ok {
+		return 0, fmt.Errorf(`rate to convert to "%s" not supported`, to)
+	}
+
+	return convert(value), nil
+}

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -234,6 +234,16 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	rejectedRequestsAlertReconciler, err := r.newRejectedRequestsAlertsReconciler()
+	if err != nil {
+		events.HandleError(r.recorder, installation, phase, "Failed to instantiate rejected requests alert reconciler", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if phase, err := rejectedRequestsAlertReconciler.ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile rejected requests alert", err)
+		return phase, err
+	}
+
 	if phase, err := r.newSoftLimitAlertsReconciler().ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile soft limit alerts", err)
 		return phase, err

--- a/pkg/products/marin3r/rejectedRequestsPrometheusRules.go
+++ b/pkg/products/marin3r/rejectedRequestsPrometheusRules.go
@@ -1,0 +1,47 @@
+package marin3r
+
+import (
+	"fmt"
+
+	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
+	"github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+const rejectedRequestsAlertExpr = "abs(clamp_min(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]) - %f, 0) / increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]) - (increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]) / increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))) > 0.3"
+
+func (r *Reconciler) newRejectedRequestsAlertsReconciler() (resources.AlertReconciler, error) {
+	limitPerMinute, err := config.ConvertRate(
+		r.RateLimitConfig.Unit,
+		config.Minute,
+		int(r.RateLimitConfig.RequestsPerUnit),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &resources.AlertReconcilerImpl{
+		ProductName:  "3Scale",
+		Installation: r.installation,
+		Logger:       r.logger,
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "rejected-requests",
+				GroupName: "rejected-requests.rules",
+				Namespace: r.Config.GetNamespace(),
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHOAMApiUsageRejectedRequestsMismatch",
+						Annotations: map[string]string{
+							"message": "The volume of rejected requests doesn't match the expected volume given the incoming requests and the configuration",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf(rejectedRequestsAlertExpr, limitPerMinute)),
+						Labels: map[string]string{"severity": "info"},
+						For:    "30s",
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -32,6 +32,9 @@ route:
     - match:
         alertname: RHOAMApiUsageOverLimit
       receiver: BUandCustomer
+    - match:
+        alertname: RHOAMApiUsageRejectedRequestsMismatch
+      receiver: SRECustomerBU
 receivers:
   - name: default
     email_configs:

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -338,6 +338,12 @@ func managedApiSpecificRules() []alertsTestRule {
 			},
 		},
 		{
+			File: NamespacePrefix + "marin3r-rejected-requests.yaml",
+			Rules: []string{
+				"RHOAMApiUsageRejectedRequestsMismatch",
+			},
+		},
+		{
 			File: NamespacePrefix + "operator-rhoam-installation-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMInstallationControllerIsNotReconciling",


### PR DESCRIPTION
# Description

> Link to Jira: https://issues.redhat.com/browse/MGDAPI-373

Create an alert that will fire when the rate of rejected requests doesn't match the expected rate based on the configuration

Example: The rate limit service is configured with a rate limit of `200 req/minute`, and the API is receiving `240 req/minute`. We'd expect ~16% of the requests to be rate limited. If this doesn't match, the alert will be triggered

## Verification steps

1. Install RHOAM
1. Create a 3scale application
2. Set the rate limit configuration to 200 requests per minute
3. Wait for the configuration to be propagated
4. Verify that the alert was created
    ```sh
    oc get prometheusrules rejected-requests -n redhat-rhoam-marin3r
    ```
5. Run the following script to force requests to be rate limited, and verify that the alert doesn't fire
    > It will perform requests for 5 minutes at 240 requests per minute
    ```sh
    for i in {1..1200}; do
        curl -i "<3scale API URL>" &
        sleep 0.25
    done
    ```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer