### PR TITLE
Fix e2e tests around IDP

### DIFF
--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -3,7 +3,9 @@ package common
 import (
 	goctx "context"
 	"fmt"
+	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/test/resources"
@@ -40,8 +42,8 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
 		dumpAuthResources(ctx.Client, t)
-		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
-		//t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+		// t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
 	}
 
 	// Make sure 3Scale is available
@@ -50,8 +52,11 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 		t.Fatal(err)
 	}
 
+	s1 := rand.NewSource(time.Now().UnixNano())
+	r1 := rand.New(s1)
+
 	// Create a product
-	productId, err := tsClient.CreateProduct("dummy-product")
+	productId, err := tsClient.CreateProduct(fmt.Sprintf("dummy-product-%v", r1.Intn(100000)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -249,8 +249,8 @@ func sendTestEmail(ctx *TestingContext, t *testing.T) {
 	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
 		dumpAuthResources(ctx.Client, t)
-		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
-		//t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+		// t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/INTLY-10087")
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
 	}
 
 	// Make sure 3Scale is available

--- a/test/common/authdelay_first_broker_login.go
+++ b/test/common/authdelay_first_broker_login.go
@@ -68,8 +68,8 @@ func TestAuthDelayFirstBrokerLogin(t *testing.T, ctx *TestingContext) {
 	err = loginToThreeScale(t, tsHost, testUser.UserName, DefaultPassword, TestingIDPRealm, httpClient)
 	if err != nil {
 		dumpAuthResources(ctx.Client, t)
-		t.Skip("Skipping due to known flaky behavior, reported in Jira: https://issues.redhat.com/browse/INTLY-10087")
-		//t.Fatalf("[%s] error logging in to three scale: %v", getTimeStampPrefix(), err)
+		// t.Skip("Skipping due to known flaky behavior, reported in Jira: https://issues.redhat.com/browse/INTLY-10087")
+		t.Fatalf("[%s] error logging in to three scale: %v", getTimeStampPrefix(), err)
 	}
 }
 

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -458,7 +458,7 @@ func createKeycloakClient(ctx context.Context, client dynclient.Client, oauthURL
 				},
 			},
 			Client: &v1alpha1.KeycloakAPIClient{
-				ID:                      "openshift",
+				// ID:                      "openshift",
 				ClientID:                "openshift",
 				Enabled:                 true,
 				ClientAuthenticatorType: "client-secret",

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -2,10 +2,11 @@ package common
 
 import (
 	"fmt"
-	k8errors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/client-go/rest"
 	"testing"
 	"time"
+
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/rest"
 
 	"github.com/integr8ly/integreatly-operator/test/resources"
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
@@ -48,6 +49,13 @@ type TestUser struct {
 
 // creates testing idp
 func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client, kubeConfig *rest.Config, hasSelfSignedCerts bool) error {
+
+	// checks if the IDP is created already
+	if hasIDPCreated(ctx, client, t) {
+		t.Log("not creating IDP, it's already created")
+		return nil
+	}
+
 	rhmiCR, err := GetRHMI(client, true)
 	if err != nil {
 		return fmt.Errorf("error occurred while getting rhmi cr: %w", err)
@@ -138,12 +146,13 @@ func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client
 }
 
 func waitForOauthDeployment(ctx context.Context, client dynclient.Client) error {
-	err := wait.PollImmediate(time.Second*5, time.Minute*5, func() (done bool, err error) {
+	err := wait.PollImmediate(time.Second*5, time.Minute*1, func() (done bool, err error) {
 		oauthDeployment := &appsv1.Deployment{}
 		if err := client.Get(ctx, types.NamespacedName{Name: "oauth-openshift", Namespace: "openshift-authentication"}, oauthDeployment); err != nil {
 			return true, fmt.Errorf("error occurred while getting dedicated admin group")
 		}
-		if oauthDeployment.Status.UnavailableReplicas == 0 {
+
+		if oauthDeployment.Status.AvailableReplicas > 0 {
 			return true, nil
 		}
 		return false, nil
@@ -657,6 +666,25 @@ func setupDedicatedAdminGroup(ctx context.Context, client dynclient.Client) erro
 		return fmt.Errorf("error occurred while creating or updating dedicated admin cluster role binding: %w", err)
 	}
 	return nil
+}
+
+func hasIDPCreated(ctx context.Context, client dynclient.Client, t *testing.T) bool {
+	clusterOauth := &configv1.OAuth{}
+	if err := client.Get(ctx, types.NamespacedName{Name: "cluster"}, clusterOauth); err != nil {
+		t.Logf("error occurred while getting cluster oauth: %w", err)
+	}
+
+	idpExists := false
+	identityProviders := clusterOauth.Spec.IdentityProviders
+	if identityProviders != nil {
+		for _, providers := range identityProviders {
+			if providers.Name == TestingIDPRealm {
+				idpExists = true
+			}
+		}
+	}
+
+	return idpExists
 }
 
 // checks to see if a dedicated admin group exists


### PR DESCRIPTION
# Description

Fixes IDP issues causing flakiness in e2e tests

https://issues.redhat.com/browse/MGDAPI-557
https://issues.redhat.com/browse/MGDAPI-558

## Verification steps

1) Install the operator with the install type for rhoam
```bash
 INSTALLATION_TYPE=managed-api make cluster/prepare/local && INSTALLATION_TYPE=managed-api make code/run
```
2) Run the functional e2e tests
```bash
INSTALLATION_TYPE=managed-api make test/functional
```
3) Verify if all the IDP based e2e tests `IDP_BASED_TESTS` pass 
