### PR TITLE
INTLY-10307 ThreeScaleSystemAdminUIBBT alert update

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -231,7 +231,7 @@ func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
 							"sop_url": resources.SopUrlThreeScaleSystemAdminUIBBT,
 							"message": "3Scale System Admin UI Blackbox Target: If this console is unavailable, the client is unable to perform Account Management,Analytics or Billing.",
 						},
-						Expr:   intstr.FromString("absent(probe_success{job='blackbox',service='3scale-system-admin-ui'} == 1)"),
+						Expr:   intstr.FromString("probe_success{job='blackbox', service='3scale-system-admin-ui'} == 0 and up{job='blackbox', service='3scale-system-admin-ui'} ==1"),
 						For:    "5m",
 						Labels: map[string]string{"severity": "critical"},
 					},


### PR DESCRIPTION
# Description
This alert fired in production while 3scale admin ui was still responding correctly. Route cause is that the blackbox exporter didnt scrap metrics for a period of time. This update will check for when the exporter returns 0 rather than nothing

# Validation
To validate 1. remove the url from the blackbox target and the alert should not fire. Once confirmed. replace the url and move on to step 2.
2. stop 3scale operator and scale down system-app replicas until the alert fires. 