### PR TITLE
MGDAPI-695 - fix nsPrefix not used in slo dashboards affecting counts

### DIFF
--- a/pkg/products/monitoring/dashboards/criticalSLOAlerts.go
+++ b/pkg/products/monitoring/dashboards/criticalSLOAlerts.go
@@ -4249,7 +4249,7 @@ func GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(nsPrefix string) string {
 }`
 }
 
-//GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON configured with given namespace prefix
+//GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON configured with given namespace prefix
 func GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(nsPrefix string) string {
 	return `{
   "annotations": {

--- a/pkg/products/monitoring/dashboards/criticalSLOAlerts.go
+++ b/pkg/products/monitoring/dashboards/criticalSLOAlerts.go
@@ -1,14 +1,8 @@
 package monitoring
 
 //GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON configured with given namespace prefix
-func GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(prefix string) string {
-	nsPrefix = prefix
-	return monitoringGrafanaDBCriticalSLORhmiAlertsJSON
-}
-
-var nsPrefix = ""
-
-var monitoringGrafanaDBCriticalSLORhmiAlertsJSON = `{
+func GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(nsPrefix string) string {
+	return `{
 	"annotations": {
 		"list": [{
 			"builtIn": 1,
@@ -4253,8 +4247,11 @@ var monitoringGrafanaDBCriticalSLORhmiAlertsJSON = `{
 	"uid": "eT5llOjWz",
 	"version": 440
 }`
+}
 
-var MonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON = `{
+//GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON configured with given namespace prefix
+func GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(nsPrefix string) string {
+	return `{
   "annotations": {
     "list": [
       {
@@ -6223,3 +6220,4 @@ var MonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON = `{
   "uid": "eT5llOjWz",
   "version": 440
 }`
+}

--- a/pkg/products/monitoring/dashboardsHelper.go
+++ b/pkg/products/monitoring/dashboardsHelper.go
@@ -33,7 +33,7 @@ func getSpecDetailsForDashboard(dashboard, nsPrefix string) (string, string, err
 		return monitoring.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(nsPrefix), "critical-slo-alerts.json", nil
 
 	case "critical-slo-managed-api-alerts":
-		return monitoring.MonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON, "critical-slo-alerts.json", nil
+		return monitoring.GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(nsPrefix), "critical-slo-alerts.json", nil
 
 	default:
 		return "", "", fmt.Errorf("Invalid/Unsupported Grafana Dashboard")

--- a/test-cases/tests/dashboards/e04b-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04b-verify-slo-dashboard.md
@@ -78,7 +78,7 @@ while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-rhsso-op
 ### Code #3
 
 ```bash
-while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-user-sso-operator -o json | jq '.spec.replicas' | grep 1; then     oc scale deployment keycloak-operator --replicas=0 -n redhat-rhoam-user-sso-operator;   fi;   if oc get statefulset keycloak -n redhat-rhoam-user-sso -o json | jq '.spec.replicas' | grep 2; then     oc scale statefulset keycloak --replicas=0 -n redhat-rhoam-user-sso;   fi;   sleep 5; done
+while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-user-sso-operator -o json | jq '.spec.replicas' | grep 1; then     oc scale deployment keycloak-operator --replicas=0 -n redhat-rhoam-user-sso-operator;   fi;   if oc get statefulset keycloak -n redhat-rhoam-user-sso -o json | jq '.spec.replicas' | grep 3; then     oc scale statefulset keycloak --replicas=0 -n redhat-rhoam-user-sso;   fi;   sleep 5; done
 ```
 
 ### Code #4


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
`nsPrefix` is not set in dashboard json when using as a package variable resolving to an empty string and therefore using the wrong namespace in the alerts counts for the product panels 

Jira
* https://issues.redhat.com/browse/MGDAPI-695
* https://issues.redhat.com/browse/MGDAPI-658

## Verification
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api 
make cluster/prepare/local
make code/run
```
* Once installation completes, visit middleware grafana - **Critical SLO** Dashboard
* Verify namespace prefix is used by the product panels
* Run through E04B test case from this branch, noting the script update for scaling down user sso pods
* Verify alert count is expected
  * **NOTE:** Total alert count include marin3r alerts but there is a missing panel which is why the sum total of the product alerts does not match this count
    * https://issues.redhat.com/browse/MGDAPI-498
  *  **NOTE:** Both RHSSO and USER SSO fire the same `KeycloakInstanceNotAvailable` alert so it is counted as 1 alert as part of the total but as 1 alert each in their own panels

![Screenshot from 2020-11-26 13-02-45](https://user-images.githubusercontent.com/24636860/100355623-fd63e580-2fe9-11eb-9b13-305aa866a463.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer