### PR TITLE
Adds a productised envoy image

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -493,7 +493,7 @@ func (r *Reconciler) patchDeploymentConfig(ctx context.Context, client k8sclient
 	deploymentConfig.Spec.Template.Labels["marin3r.3scale.net/status"] = "enabled"
 	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/node-id"] = apicastRatelimiting
 	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/ports"] = "envoy-https:8443"
-	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/envoy-image"] = "quay.io/integreatly/envoy:v1.14.1"
+	deploymentConfig.Spec.Template.Annotations["marin3r.3scale.net/envoy-image"] = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0"
 
 	if err := client.Update(ctx, deploymentConfig); err != nil {
 		return fmt.Errorf("failed to update deployment config: %v", err)


### PR DESCRIPTION
# Description

Adds productised envoy image 

https://issues.redhat.com/browse/MGDAPI-701

## Verification steps

1) Install the operator from this branch 

2) Verify if the envoy image for the sidecar containers is the productised one
```bash
oc get pods -l deploymentConfig=apicast-production -n redhat-rhoam-3scale -o json | jq  ".items[] .spec.containers[1] .image"

> "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.0"
```

3) Create an API in 3scale and verify if the requests are being limited
```bash
// verify the number of requests allowed
oc get configmap sku-limits-managed-api-service -n redhat-rhoam-operator -o json | jq ".data"
```
