### PR TITLE
fix: test: multi-az: add more namespaces to check

### DIFF
--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -15,6 +15,8 @@ import (
 
 var (
 	namespacesToCheck = []string{
+		common.MonitoringOperatorNamespace,
+		common.Marin3rProductNamespace,
 		common.RHSSOUserProductOperatorNamespace,
 		common.RHSSOProductNamespace,
 		common.ThreeScaleProductNamespace,


### PR DESCRIPTION
# Description
Include mw-monitoring and marin3r namespace in the test