### PR TITLE
Updating OverLimit and Grafana queries

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -201,7 +201,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]))",
+          "expr": "(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteTwentyMillion) > 0 or vector(0)",
           "instant": true,
           "refId": "A"
         }
@@ -286,7 +286,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]))/sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))*100",
+          "expr": "((sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteTwentyMillion) > 0 or vector(0))/(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])))*100",
           "instant": true,
           "refId": "A"
         }

--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -353,6 +353,13 @@ func getCustomerMonitoringGrafanaRateLimitJSON(graphQueries string, dashboardVar
           "interval": "30s",
           "legendFormat": "No. of Requests",
           "refId": "A"
+        },
+		{
+          "expr": "$perMinuteRequestsPerUnit",
+          "instant": false,
+          "interval": "30s",
+          "legendFormat": "Hard Limit - ` + requestsPerUnit + ` per minute",
+          "refId": "B"
         }
         ` + graphQueries + `
       ],

--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -115,7 +115,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]) * (60 - 30) / 60)",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))",
           "instant": true,
           "refId": "A"
         }
@@ -201,7 +201,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]) * (60 - 30) / 60)",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[1m]))",
           "instant": true,
           "refId": "A"
         }
@@ -353,7 +353,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "steppedLine": false,
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]) * (60 - 30) / 60)",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))",
           "instant": false,
           "interval": "30s",
           "legendFormat": "No. of Requests",

--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -1,19 +1,14 @@
 package grafana
 
-// This dashboard json is dynamically configured
-// Search for %s to see where there are values passed
-// At the time of writing there are two places that are dynamically configured
-// 1. Dashboard Variables
-// 2. Rate Limit Graph Queries
-// In both cases these are configured based on soft limits provided in the sku-limits-managed-api-servic config map
+// This dashboard json is dynamically configured based on soft limits and perUnitRequests provided in the sku-limits-managed-api-servic config map
 // present in the operator namespace for RHOAM installations
 // For example if there are softLimits provided of [500000,10000000,15000000] Five, Ten and Fifteen Million per day
-// Then there are 3 Dashboard variables configured, in addition to a static 2000000, TwentyMillion Variable representing
-// the cluster hard limit.
 // Each of these soft limits are then dynamically added as queries to the Rate Limit Graph.
 //
-// Each of the static hard limit and dynamic soft limit are calculated to a perMinute amount.
-var CustomerMonitoringGrafanaRateLimitingJSON = `{
+// Each of the hard limit and soft limits are calculated to a perMinute amount.
+
+func getCustomerMonitoringGrafanaRateLimitJSON(graphQueries string, dashboardVariables string, requestsPerUnit string) string {
+	return `{
   "annotations": {
     "list": [
       {
@@ -94,9 +89,9 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -120,13 +115,13 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
           "refId": "A"
         }
       ],
-      "thresholds": "$perMinuteTwentyMillion",
+      "thresholds": "$perMinuteRequestsPerUnit",
       "timeFrom": null,
       "timeShift": null,
       "title": "Last 1 Minute - No. Requests",
       "transparent": true,
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -180,9 +175,9 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -201,7 +196,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteTwentyMillion) > 0 or vector(0)",
+          "expr": "(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteRequestsPerUnit) > 0 or vector(0)",
           "instant": true,
           "refId": "A"
         }
@@ -211,7 +206,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 1 Minute - Rejected",
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -264,10 +259,10 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
-      "postfix": "%%",
-      "postfixFontSize": "50%%",
+      "postfix": "%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -286,7 +281,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "tableColumn": "",
       "targets": [
         {
-          "expr": "((sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteTwentyMillion) > 0 or vector(0))/(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])))*100",
+          "expr": "((sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteRequestsPerUnit) > 0 or vector(0))/(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])))*100",
           "instant": true,
           "refId": "A"
         }
@@ -296,7 +291,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 1 Minute - Rejected/Requests",
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -359,7 +354,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
           "legendFormat": "No. of Requests",
           "refId": "A"
         }
-        %s
+        ` + graphQueries + `
       ],
       "thresholds": [],
       "timeFrom": null,
@@ -447,9 +442,9 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -473,12 +468,12 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
           "refId": "A"
         }
       ],
-      "thresholds": "$perMinuteTwentyMillion*60*24",
+      "thresholds": "$perMinuteRequestsPerUnit*60*24",
       "timeFrom": null,
       "timeShift": null,
       "title": "Last 24 Hours - No. Requests",
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -532,9 +527,9 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullText": null,
       "options": {},
       "postfix": "",
-      "postfixFontSize": "50%%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -564,7 +559,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 24 Hours - Rejected",
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -617,10 +612,10 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "nullPointMode": "connected",
       "nullText": null,
       "options": {},
-      "postfix": "%%",
-      "postfixFontSize": "50%%",
+      "postfix": "%",
+      "postfixFontSize": "50%",
       "prefix": "",
-      "prefixFontSize": "50%%",
+      "prefixFontSize": "50%",
       "rangeMaps": [
         {
           "from": "null",
@@ -650,7 +645,7 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       "timeShift": null,
       "title": "Last 24 Hours -  Rejected/Requests",
       "type": "singlestat",
-      "valueFontSize": "80%%",
+      "valueFontSize": "80%",
       "valueMaps": [
         {
           "op": "=",
@@ -670,24 +665,24 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
       {
         "current": {
           "selected": false,
-          "text": "13889",
-          "value": "13889"
+          "text": "` + requestsPerUnit + `",
+          "value": "` + requestsPerUnit + `"
         },
         "hide": 2,
         "label": null,
-        "name": "perMinuteTwentyMillion",
+        "name": "perMinuteRequestsPerUnit",
         "options": [
           {
             "selected": true,
-            "text": "13889",
-            "value": "13889"
+            "text": "` + requestsPerUnit + `",
+            "value": "` + requestsPerUnit + `"
           }
         ],
-        "query": "13889",
+        "query": "` + requestsPerUnit + `",
         "skipUrlSync": false,
         "type": "constant"
       }
-		%s
+		` + dashboardVariables + `
 	]
   },
   "time": {
@@ -713,5 +708,6 @@ var CustomerMonitoringGrafanaRateLimitingJSON = `{
   "uid": "66ab72e0d012aacf34f907be9d81cd9e",
   "version": 1
 }`
+}
 
 // The UID above is used to construct the url for the grafana dashboard in customer alerts. Please do not edit this value.

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -498,7 +498,7 @@ func GetGrafanaConsoleURL(ctx context.Context, serverClient k8sclient.Client, in
 
 func buildGrafanaDashboardStrings(softLimits []uint32) (string, string) {
 	//todo improve this line
-	refID := []string{"B", "C", "D", "E", "F", "G", "H", "I", "J", "K"}
+	refID := []string{"C", "D", "E", "F", "G", "H", "I", "J", "K", "L"}
 	graphQueries := ""
 	dashboardVariables := ""
 	for i, limit := range softLimits {

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -150,7 +150,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	phase, err = r.reconcileGrafanaDashboards(ctx, client, rateLimitDashBoardName, rateLimitConfig.SoftDailyLimits)
+	phase, err = r.reconcileGrafanaDashboards(ctx, client, rateLimitDashBoardName, rateLimitConfig)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana dashboard", err)
 		return phase, err
@@ -199,7 +199,7 @@ func (r *Reconciler) reconcileSecrets(ctx context.Context, client k8sclient.Clie
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClient k8sclient.Client, dashboard string, softLimits []uint32) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClient k8sclient.Client, dashboard string, limitConfig *marin3rconfig.RateLimitConfig) (integreatlyv1alpha1.StatusPhase, error) {
 
 	grafanaDB := &grafanav1alpha1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{
@@ -216,10 +216,11 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 		// sorting the array from smallest to largest
 		// this array is loaded from a config map which can be edited by human
 		// the order of the queries on the graph are important for the visualisation
+		softLimits := limitConfig.SoftDailyLimits
 		sort.Slice(softLimits, func(i, j int) bool { return softLimits[i] < softLimits[j] })
 		graphQueries, dashboardVariables := buildGrafanaDashboardStrings(softLimits)
 		grafanaDB.Spec = grafanav1alpha1.GrafanaDashboardSpec{
-			Json: fmt.Sprintf(CustomerMonitoringGrafanaRateLimitingJSON, graphQueries, dashboardVariables),
+			Json: getCustomerMonitoringGrafanaRateLimitJSON(graphQueries, dashboardVariables, fmt.Sprintf("%d", limitConfig.RequestsPerUnit)),
 			Name: rateLimitDashBoardName,
 		}
 		return nil
@@ -509,8 +510,8 @@ func buildGrafanaDashboardStrings(softLimits []uint32) (string, string) {
                      "refId": "%s"
                     }`, limitVariableName, limit, refID[i])
 		graphQueries = fmt.Sprintf("%s%s", graphQueries, graphQuery)
-		// caluclating the per minute value of each of the soft limits
-		// the values shown in the dashboad are based on the per minute limits
+		// calculating the per minute value of each of the soft limits
+		// the values shown in the dashboard are based on the per minute limits
 		perMinuteValue := limit / 24 / 60
 		dashboardVariable := fmt.Sprintf(`,
 							{

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -48,7 +48,7 @@ func mapAlertsConfiguration(logger *logrus.Entry, namespace, rateLimitUnit strin
 		switch alertConfig.Type {
 		case marin3rconfig.AlertTypeSpike:
 			expr := fmt.Sprintf(
-				"max_over_time((increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))[%s:]) /2 > %d",
+				"max_over_time((increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m]))[%s:]) > %d",
 				alertConfig.Period, rateLimitRequestsPerUnit)
 			annotations := map[string]string{
 				"message":        fmt.Sprintf("hard limit of %d breached at least once in the last %s", rateLimitRequestsPerUnit, alertConfig.Period),


### PR DESCRIPTION
# Description
An issue was found with the OverLimit alert and supporting Grafana queries where we don't need to compensate for the prometheus signalling issue when dealing with higher request counters (counts are not being doubled).

The purpose of this PR is to update the queries to not half the reported count

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

# Validation
1. Configure a cluster to support 20M requests per day (13860 requests per minute)
2. Run load tests against the cluster and verify that Grafana dashboard counters are accurate and that the OverLimit alert triggers when exceeding the upper limit