### PR TITLE
Scale the 3scale components to 3 pods

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -80,7 +80,7 @@ const (
 	externalBackendRedisSecretName = "backend-redis"
 	externalPostgresSecretName     = "system-database"
 
-	numberOfReplicas              int64 = 2
+	numberOfReplicas              int64 = 3
 	apicastStagingName                  = "apicast-staging"
 	apicastProductionName               = "apicast-production"
 	systemSeedSecretName                = "system-seed"
@@ -953,8 +953,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		apim.Spec.PodDisruptionBudget = &threescalev1.PodDisruptionBudgetSpec{Enabled: true}
 		apim.Spec.Monitoring = &threescalev1.MonitoringSpec{Enabled: false}
 
-		if *apim.Spec.System.AppSpec.Replicas < 2 {
-			*apim.Spec.System.AppSpec.Replicas = 2
+		if *apim.Spec.System.AppSpec.Replicas < numberOfReplicas {
+			*apim.Spec.System.AppSpec.Replicas = numberOfReplicas
 		}
 		if *apim.Spec.System.SidekiqSpec.Replicas < numberOfReplicas {
 			*apim.Spec.System.SidekiqSpec.Replicas = numberOfReplicas
@@ -962,8 +962,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		if *apim.Spec.Apicast.ProductionSpec.Replicas < 6 {
 			*apim.Spec.Apicast.ProductionSpec.Replicas = 6
 		}
-		if *apim.Spec.Apicast.StagingSpec.Replicas < 3 {
-			*apim.Spec.Apicast.StagingSpec.Replicas = 3
+		if *apim.Spec.Apicast.StagingSpec.Replicas < numberOfReplicas {
+			*apim.Spec.Apicast.StagingSpec.Replicas = numberOfReplicas
 		}
 		if *apim.Spec.Backend.ListenerSpec.Replicas < 5 {
 			*apim.Spec.Backend.ListenerSpec.Replicas = 5
@@ -971,8 +971,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		if *apim.Spec.Backend.WorkerSpec.Replicas < 4 {
 			*apim.Spec.Backend.WorkerSpec.Replicas = 4
 		}
-		if *apim.Spec.Backend.CronSpec.Replicas < numberOfReplicas {
-			*apim.Spec.Backend.CronSpec.Replicas = numberOfReplicas
+		if *apim.Spec.Backend.CronSpec.Replicas != 1 {
+			*apim.Spec.Backend.CronSpec.Replicas = 1
 		}
 		if *apim.Spec.Zync.AppSpec.Replicas < numberOfReplicas {
 			*apim.Spec.Zync.AppSpec.Replicas = numberOfReplicas

--- a/test/common/scale_up_replicas_threescale.go
+++ b/test/common/scale_up_replicas_threescale.go
@@ -15,7 +15,7 @@ import (
 )
 
 var (
-	numberOfReplicas  int64 = 2
+	numberOfReplicas  int64 = 3
 	scaleUpReplicas   int64 = 3
 	scaleDownReplicas int64 = 1
 	name                    = "3scale"
@@ -173,27 +173,27 @@ func checkNumberOfReplicasAgainstValue(apim threescalev1.APIManager, ctx *Testin
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil
 		}
-		if *apim.Spec.Apicast.ProductionSpec.Replicas != numberOfRequiredReplicas {
+		if *apim.Spec.Apicast.ProductionSpec.Replicas != 6 {
 			t.Logf("Number of replicas for apim.Spec.Apicast.ProductionSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Apicast.ProductionSpec.Replicas, numberOfRequiredReplicas)
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil
 		}
-		if *apim.Spec.Apicast.StagingSpec.Replicas != numberOfRequiredReplicas {
+		if *apim.Spec.Apicast.StagingSpec.Replicas != 3 {
 			t.Logf("Number of replicas for apim.Spec.Apicast.StagingSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Apicast.StagingSpec.Replicas, numberOfRequiredReplicas)
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil
 		}
-		if *apim.Spec.Backend.ListenerSpec.Replicas != numberOfRequiredReplicas {
+		if *apim.Spec.Backend.ListenerSpec.Replicas != 5 {
 			t.Logf("Number of replicas for apim.Spec.Backend.ListenerSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.ListenerSpec.Replicas, numberOfRequiredReplicas)
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil
 		}
-		if *apim.Spec.Backend.WorkerSpec.Replicas != numberOfRequiredReplicas {
+		if *apim.Spec.Backend.WorkerSpec.Replicas != 4 {
 			t.Logf("Number of replicas for apim.Spec.Backend.WorkerSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.WorkerSpec.Replicas, numberOfRequiredReplicas)
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil
 		}
-		if *apim.Spec.Backend.CronSpec.Replicas != numberOfRequiredReplicas {
+		if *apim.Spec.Backend.CronSpec.Replicas != 1 {
 			t.Logf("Number of replicas for apim.Spec.Backend.CronSpec is not correct : Replicas - %v, Expected - %v", *apim.Spec.Backend.CronSpec.Replicas, numberOfRequiredReplicas)
 			t.Logf("retrying in : %v seconds", retryInterval)
 			return false, nil


### PR DESCRIPTION
# Description

We need to increase the number of pods of most of the 3scale components to 3 to spread across the AZs

https://issues.redhat.com/browse/MGDAPI-718

## Verification steps

1) install the operator from this branch 
2) verify the deployment config has the following number of pods:

```System.AppSpec: 3
System.SidekiqSpec: 3
Apicast.ProductionSpec: 6
Apicast.StagingSpec: 3
Backend.ListenerSpec: 5
Backend.WorkerSpec: 4
Backend.CronSpec: 1
Zync.AppSpec: 3
Zync.QueSpec: 3
```