### PR TITLE
update percentage query to produce 0 when the result is NaN.

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -281,7 +281,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(graphQueries string, dashboardVar
       "tableColumn": "",
       "targets": [
         {
-          "expr": "((sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteRequestsPerUnit) > 0 or vector(0))/(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])))*100",
+          "expr": "((sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])) - $perMinuteRequestsPerUnit) > 0 or vector(0))/(sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[1m])))*100 > 0 or vector(0)",
           "instant": true,
           "refId": "A"
         }
@@ -641,7 +641,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(graphQueries string, dashboardVar
       "tableColumn": "",
       "targets": [
         {
-          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h]))/sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))*100  ",
+          "expr": "sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_over_limit[24h]))/sum(increase(ratelimit_service_rate_limit_apicast_ratelimit_generic_key_slowpath_total_hits[24h]))*100 > 0 or vector(0)",
           "instant": true,
           "legendFormat": "",
           "refId": "A"


### PR DESCRIPTION
The result is NaN when the dividing calcuation is 0/0.
This happens in the case where there has been 0 requests
in the last minute and as such 0 rejected requests.

# Verification

Here's a screen capture of the change being tested and working:https://drive.google.com/file/d/1fnIgdo6Aq-rhOXEly78F9o3qsM0skX7r/view?usp=sharing

And a screen capture of the code change deployed to a cluster via the operator and the changes below present and in working order: https://drive.google.com/file/d/1eNKzXF9hQB-hRT6FDpXTKynlHQhMxmi8/view?usp=sharing



## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer