### PR TITLE
Reconcile webhooks before preflight checks

### DIFF
--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -341,6 +341,11 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		return reconcile.Result{}, err
 	}
 
+	// Reconcile the webhooks
+	if err := webhooks.Config.Reconcile(context.TODO(), r.client, installation); err != nil {
+		return reconcile.Result{}, err
+	}
+
 	if !resources.Contains(installation.GetFinalizers(), deletionFinalizer) && installation.GetDeletionTimestamp() == nil {
 		installation.SetFinalizers(append(installation.GetFinalizers(), deletionFinalizer))
 	}
@@ -383,11 +388,6 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 	_, err = r.newAlertsReconciler(logrus.NewEntry(logrus.StandardLogger()), installation).ReconcileAlerts(context.TODO(), alertsClient)
 	if err != nil {
 		logrus.Infof("Error reconciling alerts for the rhmi installation: %v", err)
-	}
-
-	// Reconcile the webhooks
-	if err := webhooks.Config.Reconcile(context.TODO(), r.client, installation); err != nil {
-		return reconcile.Result{}, err
 	}
 
 	for _, stage := range installType.GetInstallStages() {


### PR DESCRIPTION
# Description

Webhooks were only being reconciled after the preflight checks had passed. A webhook was set up to delete the operator
Subscription when the RHMI CR is deleted, however; in the chance that the CR is deleted before the preflight checks have passed (example: the `useClusterStorage` field hasn't been set), the webhook won't be in place and the Subscription won't be deleted.
This change ensures that the webhooks are created before the preflight checks

## Verification steps

In order to verify this, install the add-on and use an image from this PR, then delete the add-on and check that the subscription is deleted

1. Create an image from this PR
2. Install the add-on
3. Update the operator CSV to reference the custom image
4. Wait for the operator Pod to be restarted
5. Uninstall the add-on
6. Verify that the RHMI CR is deleted and the Subscription is deleted as well

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer