### PR TITLE
MGDAPI-810: Dynamically set expected pod count for zync in alert

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -241,7 +241,7 @@ func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
 							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
 							"message": "3Scale Zync has {{   $value  }} pods in a ready state. Expected a minimum of 2 pods.",
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("(1-absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'}) != 2", r.Config.GetNamespace())),
+						Expr:   intstr.FromString(fmt.Sprintf("(1-absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'}) != %d", r.Config.GetNamespace(), r.Config.GetReplicasConfig(r.installation)["zyncApp"])),
 						For:    "5m",
 						Labels: map[string]string{"severity": "warning"},
 					},


### PR DESCRIPTION
# Description

> Link to Jira: https://issues.redhat.com/browse/MGDAPI-810

Modify the alert reconciliation logic to use the `GetReplicasConfig` function to obtain the actual expected number of replicas of zync, and format the query with it

## Verification steps

In order to verify this PR, check that the alert query is reconciled based on the `in_prow` annotation of the RHMI CR

## With annotation

1. Install the operator from this PR
    ```sh
    git fetch upstream pull/1469/head
    INSTALLATION_TYPE=managed-api make cluster/prepare/local
    INSTALLATION_TYPE=managed-api make code/run
    ```
2. When the RHMI CR is created, add the `in_prow` annotation:
    ```yaml
    annotations:
      in_prow: 'true'
    ```
3. The operator will set the 3scale replicas to 1. Wait for the installation to complete, and verify that the query checks for 1 replica
    ```sh
    oc get prometheusrules ksm-3scale-alerts -n redhat-rhoam-3scale -o json | jq -r '.spec.groups[0].rules[] | select(.alert == "ThreeScaleZyncPodAvailability").expr'
    ```
    ```sql
    (1-absent(kube_pod_status_ready{condition='true',namespace='redhat-rhoam-3scale'} * on (pod, namespace) kube_pod_labels{namespace='redhat-rhoam-3scale', label_threescale_component='zync', label_threescale_component_element='zync'})) or count(kube_pod_status_ready{condition='true',namespace='redhat-rhoam-3scale'} * on (pod, namespace) kube_pod_labels{namespace='redhat-rhoam-3scale', label_threescale_component='zync', label_threescale_component_element='zync'}) != 1
    ```
4. Log in Prometheus and verify that the `ThreeScaleZyncPodAvailability` alert isn't firing

## Without annotation

> ⚠️ Due to current issues with cluster resources, the installation might fail or get stuck. If this happens, lower the number of replicas for 3scale components in the [`GetReplicasConfig` method](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/config/threescale.go#L106-L131)

1. Remove the `in_prow` annotation from the CR
2. Wait for the operator to reconcile the replicas and reconcile the alert
    > In order to verify that the operator reconcile the replicas, check that the value was updated in the APIManager CR
    > ```sh
    > oc get apimanagers 3scale -n redhat-rhoam-3scale -o json | jq -r '.spec.zync.appSpec.replicas'
    > ```
    > The installation will be set back to "in progress" and then to "complete" again once the changes have been propagated
3. Verify that the alert query is updated for 3 replicas
    ```sh
    oc get prometheusrules ksm-3scale-alerts -n redhat-rhoam-3scale -o json | jq -r '.spec.groups[0].rules[] | select(.alert == "ThreeScaleZyncPodAvailability").expr'
    ```
    ```sql
    (1-absent(kube_pod_status_ready{condition='true',namespace='redhat-rhoam-3scale'} * on (pod, namespace) kube_pod_labels{namespace='redhat-rhoam-3scale', label_threescale_component='zync', label_threescale_component_element='zync'})) or count(kube_pod_status_ready{condition='true',namespace='redhat-rhoam-3scale'} * on (pod, namespace) kube_pod_labels{namespace='redhat-rhoam-3scale', label_threescale_component='zync', label_threescale_component_element='zync'}) != 1
    ```
4. Log in Prometheus and verify that the `ThreeScaleZyncPodAvailability` alert isn't firing

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer