### PR TITLE
Updates grafana image from dockerhub to quay

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -5,6 +5,8 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"sort"
+
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
@@ -26,7 +28,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sort"
 )
 
 const (
@@ -269,6 +270,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 					Enabled: &[]bool{true}[0],
 				},
 			},
+			BaseImage: fmt.Sprintf("%s:%s", constants.GrafanaImage, constants.GrafanaVersion),
 			Containers: []v1.Container{
 				{Name: "grafana-proxy",
 					Image: "quay.io/openshift/origin-oauth-proxy:4.2",

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -318,6 +318,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 	}
 
+	grafana := &grafanav1alpha1.Grafana{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "grafana",
+			Namespace: defaultInstallationNamespace,
+		},
+	}
+
 	installation := basicInstallation()
 
 	smtpSecret := &corev1.Secret{
@@ -383,7 +390,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			FakeClient: moqclient.NewSigsClientMoqWithScheme(scheme, ns, operatorNS, federationNs,
 				grafanadatasourcesecret, installation, smtpSecret, pagerdutySecret,
-				dmsSecret, alertmanagerRoute),
+				dmsSecret, alertmanagerRoute, grafana),
 			FakeConfig: &config.ConfigReadWriterMock{
 				ReadMonitoringFunc: func() (ready *config.Monitoring, e error) {
 					return config.NewMonitoring(config.ProductConfig{

--- a/pkg/resources/constants/grafanaConstants.go
+++ b/pkg/resources/constants/grafanaConstants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	GrafanaImage   = "quay.io/integreatly/grafana"
+	GrafanaVersion = "7.1.1"
+)


### PR DESCRIPTION
# Description

One of the requirements for RHOAM GA is that all images used in the product should be hosted in quay, so this PR updates the granafa image from dockerhub to quay

https://issues.redhat.com/browse/MGDAPI-809

## Verification steps

1) install the operator from this branch
2) check if the granafa image used in AMO and `redhat-rhoam-customer-monitoring-operator` namespaces use the image from quay `quay.io/integreatly/grafana:7.1.1`