### PR TITLE
Fix 3scale smtp flaky test

### DIFF
--- a/test/common/3Scale_user_promotion.go
+++ b/test/common/3Scale_user_promotion.go
@@ -13,8 +13,8 @@ import (
 
 func Test3ScaleUserPromotion(t *testing.T, ctx *TestingContext) {
 	var (
-		developerUser      = fmt.Sprintf("%v-%d", DefaultTestUserName, 0)
-		dedicatedAdminUser = fmt.Sprintf("%v-%d", defaultDedicatedAdminName, 0)
+		developerUser      = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+		dedicatedAdminUser = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
 	)
 
 	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {

--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	threescaleLoginUser = fmt.Sprintf("%v-%d", defaultDedicatedAdminName, 0)
+	threescaleLoginUser = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
 )
 
 // Tests that a user in group rhmi-developers can log into fuse and

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/test/resources"
 
-	appsv1 "github.com/openshift/api/apps/v1"
 	k8sv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 
@@ -42,13 +42,17 @@ var (
 	originalPassword              = ""
 	originalPort                  = ""
 	originalUsername              = ""
-	replicas                      = 2
 )
 
 //Test3ScaleSMTPConfig to confirm 3scale can send an email
 func Test3ScaleSMTPConfig(t *testing.T, ctx *TestingContext) {
+	inst, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("failed to get RHMI instance %v", err)
+	}
+
 	t.Log("Create Namespace, Deployment and Service for SMTP-Server")
-	err := createNamespace(ctx, t)
+	err = createNamespace(ctx, t)
 	if err != nil {
 		t.Logf("%v", err)
 	}
@@ -64,16 +68,20 @@ func Test3ScaleSMTPConfig(t *testing.T, ctx *TestingContext) {
 		t.Fatalf("Unable to reconcile smtp details : %v ", err)
 	}
 
-	t.Log("Restart system-app and system-sidekiq")
-	err = patchReplicationController(ctx, t)
-	if err != nil {
-		t.Log(err)
+	// Scale down system-app and system-sidekiq in order to load new smtp config
+	for _, dc := range []string{"system-app", "system-sidekiq"} {
+		t.Logf("Scalind down dc '%s' to 0 replicas in '%s' namespace", dc, threescaleNamespace)
+		err = scaleDeploymentConfig(dc, threescaleNamespace, 0, ctx.Client)
+		if err != nil {
+			t.Errorf("Failed to scale down %s: %v ", dc, err)
+		}
 	}
 
 	t.Log("Checking pods are ready")
-	err = checkThreeScaleReplicasAreReady(ctx, t, 2, retryInterval, timeout)
-	if err != nil {
-		t.Log(err)
+	threescaleConfig := config.NewThreeScale(map[string]string{})
+	replicas := threescaleConfig.GetReplicasConfig(inst)
+	if err := check3ScaleReplicasAreReady(ctx, t, replicas, retryInterval, timeout); err != nil {
+		t.Logf("Replicas not Ready within timeout: %v", err)
 	}
 
 	// Add sleep to give threescale time to reconcile the pods restarts otherwise host address will update during next steps
@@ -130,26 +138,6 @@ func checkHostAddressIsReady(ctx *TestingContext, t *testing.T, retryInterval, t
 	}
 	return nil
 
-}
-func checkThreeScaleReplicasAreReady(ctx *TestingContext, t *testing.T, replicas int64, retryInterval, timeout time.Duration) error {
-	return wait.Poll(retryInterval, timeout, func() (done bool, err error) {
-
-		for _, name := range threeScaleDeploymentConfigs {
-			deploymentConfig := &appsv1.DeploymentConfig{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: GetPrefixedNamespace("3scale")}}
-
-			err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: name, Namespace: GetPrefixedNamespace("3scale")}, deploymentConfig)
-			if err != nil {
-				t.Errorf("failed to get DeploymentConfig %s in namespace %s with error: %s", name, GetPrefixedNamespace("3scale"), err)
-			}
-
-			if deploymentConfig.Status.Replicas != int32(replicas) || deploymentConfig.Status.ReadyReplicas != int32(replicas) {
-				t.Logf("%s replicas ready %v, expected %v ", name, deploymentConfig.Status.ReadyReplicas, replicas)
-				return false, nil
-			}
-		}
-
-		return true, nil
-	})
 }
 
 func removeNamespace(ctx *TestingContext) error {
@@ -265,47 +253,6 @@ func sendTestEmail(ctx *TestingContext, t *testing.T) {
 		dumpAuthResources(ctx.Client, t)
 		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
 	}
-}
-
-func patchReplicationController(ctx *TestingContext, t *testing.T) error {
-	//Patch the deployment config so that the pods are removed.
-	//These will be automatically restarted using the new smtp details
-	replica := fmt.Sprintf(`{
-		"apiVersion": "apps.openshift.io/v1",
-		"kind": "DeploymentConfig",
-		"spec": {
-			"strategy": {
-				"type": "Recreate"
-			},
-			"replicas": %[1]v
-		}
-	}`, 0)
-
-	replicaBytes := []byte(replica)
-
-	request := ctx.ExtensionClient.RESTClient().Patch(types.MergePatchType).
-		Resource("deploymentconfigs").
-		Name("system-app").
-		Namespace(NamespacePrefix + "3scale").
-		RequestURI("/apis/apps.openshift.io/v1").Body(replicaBytes).Do()
-	_, err := request.Raw()
-
-	if err != nil {
-		return err
-	}
-
-	request = ctx.ExtensionClient.RESTClient().Patch(types.MergePatchType).
-		Resource("deploymentconfigs").
-		Name("system-sidekiq").
-		Namespace(NamespacePrefix + "3scale").
-		RequestURI("/apis/apps.openshift.io/v1").Body(replicaBytes).Do()
-	_, err = request.Raw()
-
-	if err != nil {
-		return err
-	}
-
-	return nil
 }
 
 func resetSecret(ctx *TestingContext, t *testing.T) (string, error) {

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -32,7 +32,7 @@ var (
 	s1                            = rand.NewSource(time.Now().UnixNano())
 	r1                            = rand.New(s1)
 	smtpReplicas            int32 = 1
-	threescaleLoginUserSMTP       = fmt.Sprintf("%v-%d", defaultDedicatedAdminName, 0)
+	threescaleLoginUserSMTP       = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
 	emailAddress                  = fmt.Sprintf("test%v@test.com", r1.Intn(200))
 	serviceIP                     = ""
 	emailUsername                 = "dummy"

--- a/test/common/codeready_crudl.go
+++ b/test/common/codeready_crudl.go
@@ -89,7 +89,7 @@ const (
 )
 
 var (
-	username = fmt.Sprintf("%v-0", DefaultTestUserName)
+	username = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
 	password = DefaultPassword
 )
 

--- a/test/common/fuse_crudl.go
+++ b/test/common/fuse_crudl.go
@@ -3,13 +3,14 @@ package common
 import (
 	goctx "context"
 	"fmt"
+	"testing"
+
 	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/test/resources"
-	"testing"
 )
 
 var (
-	fuseLoginUser     = fmt.Sprintf("%v-%d", DefaultTestUserName, 0)
+	fuseLoginUser     = fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
 	fuseLoginPassword = DefaultPassword
 )
 

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -19,9 +19,9 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	grafanaCredsUsername = "customer-admin-1"
-	grafanaCredsPassword = "Password1"
+var (
+	grafanaCredsUsername = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+	grafanaCredsPassword = DefaultPassword
 )
 
 func TestCustomerGrafanaExternalRouteAccessible(t *testing.T, ctx *TestingContext) {

--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -29,6 +29,8 @@ var (
 )
 
 func TestNetworkPolicyAccessNSToSVC(t *testing.T, ctx *TestingContext) {
+	dedicatedAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+
 	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
@@ -42,7 +44,7 @@ func TestNetworkPolicyAccessNSToSVC(t *testing.T, ctx *TestingContext) {
 	masterURL := rhmi.Spec.MasterURL
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -131,7 +131,7 @@ func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client
 			return false, fmt.Errorf("failed to create temporary client for idp setup: %w", err)
 		}
 
-		dedicatedAdminUsername := fmt.Sprintf("%s-%02d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins)
+		dedicatedAdminUsername := fmt.Sprintf("%s%02d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins)
 		authErr := resources.DoAuthOpenshiftUser(fmt.Sprintf("https://%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, tempHTTPClient, TestingIDPRealm, t)
 		if authErr != nil {
 			t.Logf("Error while checking IDP is setup, retrying: %+v", authErr)

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -131,7 +131,7 @@ func createTestingIDP(t *testing.T, ctx context.Context, client dynclient.Client
 			return false, fmt.Errorf("failed to create temporary client for idp setup: %w", err)
 		}
 
-		dedicatedAdminUsername := fmt.Sprintf("%s-%d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins-1)
+		dedicatedAdminUsername := fmt.Sprintf("%s-%02d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins)
 		authErr := resources.DoAuthOpenshiftUser(fmt.Sprintf("https://%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, tempHTTPClient, TestingIDPRealm, t)
 		if authErr != nil {
 			t.Logf("Error while checking IDP is setup, retrying: %+v", authErr)
@@ -168,9 +168,9 @@ func addDedicatedAdminUsers(ctx context.Context, client dynclient.Client, number
 
 	// populate admin users
 	var adminUsers []string
-	postfix := 0
-	for postfix < numberOfAdmins {
-		user := fmt.Sprintf("%s-%d", defaultDedicatedAdminName, postfix)
+	postfix := 1
+	for postfix <= numberOfAdmins {
+		user := fmt.Sprintf("%s%02d", defaultDedicatedAdminName, postfix)
 		adminUsers = append(adminUsers, user)
 		postfix++
 	}
@@ -335,24 +335,24 @@ func createClientSecret(ctx context.Context, client dynclient.Client, clientSecr
 func createKeycloakUsers(ctx context.Context, client dynclient.Client, installationName string) error {
 	// populate users to be created
 	var testUsers []TestUser
-	postfix := 0
+	postfix := 1
 	// build rhmi developer users
-	for postfix < defaultNumberOfTestUsers {
+	for postfix <= defaultNumberOfTestUsers {
 		user := TestUser{
-			UserName:  fmt.Sprintf("%s-%d", DefaultTestUserName, postfix),
+			UserName:  fmt.Sprintf("%s%02d", DefaultTestUserName, postfix),
 			FirstName: "Test",
-			LastName:  fmt.Sprintf("User %d", postfix),
+			LastName:  fmt.Sprintf("User %02d", postfix),
 		}
 		testUsers = append(testUsers, user)
 		postfix++
 	}
-	postfix = 0
+	postfix = 1
 	// build dedicated admin users
-	for postfix < defaultNumberOfDedicatedAdmins {
+	for postfix <= defaultNumberOfDedicatedAdmins {
 		user := TestUser{
-			UserName:  fmt.Sprintf("%s-%d", defaultDedicatedAdminName, postfix),
+			UserName:  fmt.Sprintf("%s%02d", defaultDedicatedAdminName, postfix),
 			FirstName: defaultDedicatedAdminName,
-			LastName:  fmt.Sprintf("User %d", postfix),
+			LastName:  fmt.Sprintf("User %02d", postfix),
 		}
 		testUsers = append(testUsers, user)
 		postfix++

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -64,6 +64,8 @@ type ExpectedPermissions struct {
 }
 
 func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
+	customerAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+
 	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
@@ -82,7 +84,7 @@ func TestDedicatedAdminUserPermissions(t *testing.T, ctx *TestingContext) {
 	}
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "customer-admin-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), customerAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -3,10 +3,11 @@ package common
 import (
 	goctx "context"
 	"fmt"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 	"time"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/google/go-querystring/query"
 	"github.com/integr8ly/integreatly-operator/test/resources"
@@ -29,6 +30,8 @@ type LogOptions struct {
 }
 
 func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
+	testUser := fmt.Sprintf("%v%02d", DefaultTestUserName, 1)
+
 	if err := createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
 		t.Fatalf("error while creating testing idp: %v", err)
 	}
@@ -49,7 +52,7 @@ func TestRHMIDeveloperUserPermissions(t *testing.T, ctx *TestingContext) {
 	t.Log("retrieved openshift-Oauth route")
 
 	// get rhmi developer user tokens
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), "test-user-1", DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 	t.Log("retrieved rhmi developer user tokens")

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -19,15 +19,14 @@ func TestIntegreatly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	installType, err := common.GetInstallType(config)
+	if err != nil {
+		t.Fatalf("failed to get install type, err: %s, %v", installType, err)
+	}
 	t.Run("Integreatly Happy Path Tests", func(t *testing.T) {
 
 		// running ALL_TESTS test cases
 		common.RunTestCases(common.ALL_TESTS, t, config)
-
-		installType, err := common.GetInstallType(config)
-		if err != nil {
-			t.Fatalf("failed to get install type, err: %s, %v", installType, err)
-		}
 
 		// get happy path test cases according to the install type
 		happyPathTestCases := common.GetHappyPathTestCases(installType)
@@ -40,10 +39,6 @@ func TestIntegreatly(t *testing.T) {
 	})
 
 	t.Run("Integreatly IDP Based Tests", func(t *testing.T) {
-		installType, err := common.GetInstallType(config)
-		if err != nil {
-			t.Fatalf("failed to get install type, err: %s, %v", installType, err)
-		}
 
 		// get IDP test cases according to the install type
 		idpTestCases := common.GetIDPBasedTestCases(installType)


### PR DESCRIPTION
# Description
* scale down "system-app" and "system-sidekiq" in order to load new smtp configuration instead of redeploying them
* use `check3ScaleReplicasAreReady` shared function instead of using the local `checkThreeScaleReplicasAreReady` func that doesn't work in OSD
* [get installtype only once when running functional test suite](https://github.com/integr8ly/integreatly-operator/commit/17187e5e94874c40d7c3092b761c35592ede4202)
* align test user & customer admin user names format with sso-idp script (i.e., test-user0x, customer-admin0x)

# To verify
1. Comment out these lines: https://github.com/integr8ly/integreatly-operator/blob/5ecb3c22a18927b39bd248c07ab6497f31500420/test/functional/integreatly_test.go#L22-L40
2. oc login to OSD cluster with RHOAM installed and SSO IDP configured with the script
```bash
DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 ./scripts/setup-sso-idp.sh
```
3. Run the tests
```
INSTALLATION_TYPE=managed-api make test/functional | tee test-results.log
```