### PR TITLE
Increases ThreeScaleZyncPodAvailability alert firing time

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -239,10 +239,10 @@ func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
 						Alert: "ThreeScaleZyncPodAvailability",
 						Annotations: map[string]string{
 							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "3Scale Zync has {{   $value  }} pods in a ready state. Expected a minimum of 2 pods.",
+							"message": fmt.Sprintf("3Scale Zync has {{   $value  }} pods in a ready state. Expected %d of pods.", r.Config.GetReplicasConfig(r.installation)["zyncApp"]),
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("(1-absent(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'})) or count(kube_pod_status_ready{condition='true',namespace='%[1]v'} * on (pod, namespace) kube_pod_labels{namespace='%[1]v', label_threescale_component='zync', label_threescale_component_element='zync'}) != %d", r.Config.GetNamespace(), r.Config.GetReplicasConfig(r.installation)["zyncApp"])),
-						For:    "5m",
+						For:    "15m",
 						Labels: map[string]string{"severity": "warning"},
 					},
 					{


### PR DESCRIPTION
# Description

With the increase of replicas for [3scale zync pods to 3](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/config/threescale.go#L128), the time for all the pods to become ready has increased which is making the alert `ThreeScaleZyncPodAvailability` fire. We need to extend the length of time for this alert to avoid it from fire prior the installation is completed

https://issues.redhat.com/browse/MGDAPI-913

## Verification steps

1) install the operator from this branch in a multi AZ cluster
2) verify that `ThreeScaleZyncPodAvailability` is not firing during the installation of 3scale. 
