### PR TITLE
Add pod distribution check and balance

### DIFF
--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -17,10 +17,14 @@ spec:
       description: RHMI is the Schema for the RHMI API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
@@ -40,17 +44,25 @@ spec:
               - cssre
               type: object
             deadMansSnitchSecret:
-              description: "DeadMansSnitchSecret is the name of a secret in the installation namespace containing connection details for Dead Mans Snitch. The secret must contain the following fields: \n url"
+              description: "DeadMansSnitchSecret is the name of a secret in the installation
+                namespace containing connection details for Dead Mans Snitch. The
+                secret must contain the following fields: \n url"
               type: string
             masterURL:
               type: string
             namespacePrefix:
               type: string
             operatorsInProductNamespace:
-              description: OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.
+              description: OperatorsInProductNamespace is a flag that decides if the
+                product operators should be installed in the product namespace (when
+                set to true) or in standalone namespace (when set to false, default).
+                Standalone namespace will be used only for those operators that support
+                it.
               type: boolean
             pagerDutySecret:
-              description: "PagerDutySecret is the name of a secret in the installation namespace containing PagerDuty account details. The secret must contain the following fields: \n serviceKey"
+              description: "PagerDutySecret is the name of a secret in the installation
+                namespace containing PagerDuty account details. The secret must contain
+                the following fields: \n serviceKey"
               type: string
             priorityClassName:
               type: string
@@ -69,13 +81,20 @@ spec:
             selfSignedCerts:
               type: boolean
             smtpSecret:
-              description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields: \n host port tls username password"
+              description: "SMTPSecret is the name of a secret in the installation
+                namespace containing SMTP connection details. The secret must contain
+                the following fields: \n host port tls username password"
               type: string
             type:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                Important: Run "operator-sdk generate k8s" to regenerate code after
+                modifying this file Add custom validation using kubebuilder tags:
+                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
             useClusterStorage:
               type: string
+            rebalancePods:
+              type: boolean
           required:
           - namespacePrefix
           - type
@@ -130,7 +149,10 @@ spec:
                 - name
                 - phase
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state
+                of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                code after modifying this file Add custom validation using kubebuilder
+                tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: object
             toVersion:
               type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -52,3 +52,5 @@ spec:
               value: "info"
             - name: INSTALLATION_TYPE
               value: "managed"
+            - name: REBALANCE_PODS
+              value: "true"

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -131,6 +131,7 @@ type RHMISpec struct {
 	RoutingSubdomain       string                 `json:"routingSubdomain,omitempty"`
 	MasterURL              string                 `json:"masterURL,omitempty"`
 	NamespacePrefix        string                 `json:"namespacePrefix"`
+	RebalancePods          bool                   `json:"rebalancePods,omitempty"`
 	SelfSignedCerts        bool                   `json:"selfSignedCerts,omitempty"`
 	PullSecret             PullSecretSpec         `json:"pullSecret,omitempty"`
 	UseClusterStorage      string                 `json:"useClusterStorage,omitempty"`

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -29,13 +29,13 @@ import (
 
 func GetOpenAPIDefinitions(ref common.ReferenceCallback) map[string]common.OpenAPIDefinition {
 	return map[string]common.OpenAPIDefinition{
-		"./pkg/apis/integreatly/v1alpha1/.RHMI":       schema_apis_integreatly_v1alpha1__RHMI(ref),
-		"./pkg/apis/integreatly/v1alpha1/.RHMISpec":   schema_apis_integreatly_v1alpha1__RHMISpec(ref),
-		"./pkg/apis/integreatly/v1alpha1/.RHMIStatus": schema_apis_integreatly_v1alpha1__RHMIStatus(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMI":       schema_pkg_apis_integreatly_v1alpha1_RHMI(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec":   schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref),
+		"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus": schema_pkg_apis_integreatly_v1alpha1_RHMIStatus(ref),
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMI(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMI(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -63,23 +63,23 @@ func schema_apis_integreatly_v1alpha1__RHMI(ref common.ReferenceCallback) common
 					},
 					"spec": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMISpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec"),
 						},
 					},
 					"status": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMIStatus"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus"),
 						},
 					},
 				},
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.RHMISpec", "./pkg/apis/integreatly/v1alpha1/.RHMIStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMISpec", "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStatus", "k8s.io/apimachinery/pkg/apis/meta/v1.ObjectMeta"},
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -111,6 +111,12 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 							Format: "",
 						},
 					},
+					"rebalancePods": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"boolean"},
+							Format: "",
+						},
+					},
 					"selfSignedCerts": {
 						SchemaProps: spec.SchemaProps{
 							Type:   []string{"boolean"},
@@ -119,7 +125,7 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 					},
 					"pullSecret": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.PullSecretSpec"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"),
 						},
 					},
 					"useClusterStorage": {
@@ -142,7 +148,7 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 					},
 					"alertingEmailAddresses": {
 						SchemaProps: spec.SchemaProps{
-							Ref: ref("./pkg/apis/integreatly/v1alpha1/.AlertingEmailAddresses"),
+							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.AlertingEmailAddresses"),
 						},
 					},
 					"operatorsInProductNamespace": {
@@ -178,11 +184,11 @@ func schema_apis_integreatly_v1alpha1__RHMISpec(ref common.ReferenceCallback) co
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.AlertingEmailAddresses", "./pkg/apis/integreatly/v1alpha1/.PullSecretSpec"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.AlertingEmailAddresses", "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.PullSecretSpec"},
 	}
 }
 
-func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
+func schema_pkg_apis_integreatly_v1alpha1_RHMIStatus(ref common.ReferenceCallback) common.OpenAPIDefinition {
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
@@ -197,7 +203,7 @@ func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) 
 								Allows: true,
 								Schema: &spec.Schema{
 									SchemaProps: spec.SchemaProps{
-										Ref: ref("./pkg/apis/integreatly/v1alpha1/.RHMIStageStatus"),
+										Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStageStatus"),
 									},
 								},
 							},
@@ -256,6 +262,6 @@ func schema_apis_integreatly_v1alpha1__RHMIStatus(ref common.ReferenceCallback) 
 			},
 		},
 		Dependencies: []string{
-			"./pkg/apis/integreatly/v1alpha1/.RHMIStageStatus"},
+			"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.RHMIStageStatus"},
 	}
 }

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/poddistribution"
 	"os"
 	"reflect"
 	"strconv"
@@ -171,6 +172,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 	// Creates installation CR in case there is none
 	if len(installationList.Items) == 0 {
 		useClusterStorage, _ := os.LookupEnv("USE_CLUSTER_STORAGE")
+		rebalancePods := getRebalancePods()
 		cssreAlertingEmailAddress, _ := os.LookupEnv(alertingEmailAddressEnvName)
 		buAlertingEmailAddress, _ := os.LookupEnv(buAlertingEmailAddressEnvName)
 
@@ -209,6 +211,7 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 			Spec: integreatlyv1alpha1.RHMISpec{
 				Type:                 installType,
 				NamespacePrefix:      namespacePrefix,
+				RebalancePods:        rebalancePods,
 				SelfSignedCerts:      false,
 				SMTPSecret:           namespacePrefix + "smtp",
 				DeadMansSnitchSecret: namespacePrefix + "deadmanssnitch",
@@ -235,6 +238,13 @@ func createInstallationCR(ctx context.Context, serverClient k8sclient.Client) er
 	}
 
 	return nil
+}
+func getRebalancePods() bool {
+	rebalance, exists := os.LookupEnv("REBALANCE_PODS")
+	if !exists || rebalance == "true" {
+		return true
+	}
+	return false
 }
 
 func getCrName(installType string) string {
@@ -435,11 +445,29 @@ func (r *ReconcileInstallation) Reconcile(request reconcile.Request) (reconcile.
 		installation.Status.Stage = integreatlyv1alpha1.StageName("complete")
 		metrics.RHMIStatusAvailable.Set(1)
 		retryRequeue.RequeueAfter = 5 * time.Minute
+		if installation.Spec.RebalancePods {
+			r.reconcilePodDistribution(installation)
+		}
 	}
 	metrics.SetRHMIStatus(installation)
 
 	err = r.updateStatusAndObject(originalInstallation, installation)
 	return retryRequeue, err
+}
+
+func (r *ReconcileInstallation) reconcilePodDistribution(installation *integreatlyv1alpha1.RHMI) {
+
+	serverClient, err := k8sclient.New(r.restConfig, k8sclient.Options{})
+	if err != nil {
+		logrus.Errorf("Error getting server client for pod distribution %v", err.Error())
+		installation.Status.LastError = err.Error()
+		return
+	}
+	err = poddistribution.ReconcilePodDistribution(context.TODO(), serverClient, installation.Spec.NamespacePrefix, installation.Spec.Type)
+	if err != nil {
+		logrus.Errorf("Error reconciling pod distributions %v", err.Error())
+		installation.Status.LastError = err.Error()
+	}
 }
 
 func (r *ReconcileInstallation) updateStatusAndObject(original, installation *integreatlyv1alpha1.RHMI) error {
@@ -512,7 +540,7 @@ func (r *ReconcileInstallation) handleUninstall(installation *integreatlyv1alpha
 	metrics.SetRHMIStatus(installation)
 
 	// Clean up the products which have finalizers associated to them
-	merr := &multiErr{}
+	merr := &resources.MultiErr{}
 	finalizers := []string{}
 	for _, finalizer := range installation.Finalizers {
 		finalizers = append(finalizers, finalizer)
@@ -549,7 +577,7 @@ func (r *ReconcileInstallation) handleUninstall(installation *integreatlyv1alpha
 		//don't move to next stage until all products in this stage are removed
 		//update CR and return
 		if pendingUninstalls {
-			if len(merr.errors) > 0 {
+			if len(merr.Errors) > 0 {
 				installation.Status.LastError = merr.Error()
 				r.client.Status().Update(context.TODO(), installation)
 			}
@@ -790,9 +818,9 @@ func (r *ReconcileInstallation) processStage(installation *integreatlyv1alpha1.R
 
 		if err != nil {
 			if mErr == nil {
-				mErr = &multiErr{}
+				mErr = &resources.MultiErr{}
 			}
-			mErr.(*multiErr).Add(fmt.Errorf("failed installation of %s: %w", product.Name, err))
+			mErr.(*resources.MultiErr).Add(fmt.Errorf("failed installation of %s: %w", product.Name, err))
 		}
 
 		// Verify that watches for this product CRDs have been created
@@ -929,20 +957,4 @@ func requiredEnvVar(check func(string) error) func(string, bool) error {
 
 		return check(value)
 	}
-}
-
-type multiErr struct {
-	errors []string
-}
-
-func (mer *multiErr) Error() string {
-	return "product installation errors : " + strings.Join(mer.errors, ":")
-}
-
-//Add an error to the collection
-func (mer *multiErr) Add(err error) {
-	if mer.errors == nil {
-		mer.errors = []string{}
-	}
-	mer.errors = append(mer.errors, err.Error())
 }

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -463,10 +463,10 @@ func (r *ReconcileInstallation) reconcilePodDistribution(installation *integreat
 		installation.Status.LastError = err.Error()
 		return
 	}
-	err = poddistribution.ReconcilePodDistribution(context.TODO(), serverClient, installation.Spec.NamespacePrefix, installation.Spec.Type)
-	if err != nil {
-		logrus.Errorf("Error reconciling pod distributions %v", err.Error())
-		installation.Status.LastError = err.Error()
+	mErr := poddistribution.ReconcilePodDistribution(context.TODO(), serverClient, installation.Spec.NamespacePrefix, installation.Spec.Type)
+	if mErr != nil && len(mErr.Errors) > 0 {
+		logrus.Errorf("Error reconciling pod distributions %v", mErr)
+		installation.Status.LastError = mErr.Error()
 	}
 }
 

--- a/pkg/resources/multiErr.go
+++ b/pkg/resources/multiErr.go
@@ -1,0 +1,19 @@
+package resources
+
+import "strings"
+
+type MultiErr struct {
+	Errors []string
+}
+
+func (mer *MultiErr) Error() string {
+	return "product installation errors : " + strings.Join(mer.Errors, ":  ")
+}
+
+//Add an error to the collection
+func (mer *MultiErr) Add(err error) {
+	if mer.Errors == nil {
+		mer.Errors = []string{}
+	}
+	mer.Errors = append(mer.Errors, err.Error())
+}

--- a/pkg/resources/poddistribution/poddistribution.go
+++ b/pkg/resources/poddistribution/poddistribution.go
@@ -1,0 +1,318 @@
+package poddistribution
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	appsv1 "github.com/openshift/api/apps/v1"
+	"github.com/sirupsen/logrus"
+	k8appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sTypes "k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"time"
+)
+
+const (
+	// ZoneLabel is the label that specifies the zone where a node is
+	ZoneLabel = "topology.kubernetes.io/zone"
+	// Annotation counter on the pods controller, dc, rs, ss
+	PodRebalanceAttempts = "pod-rebalance-attempts"
+	maxBalanceAttempts   = 3
+)
+
+type KindNameSpaceName struct {
+	*k8sTypes.NamespacedName
+	Kind runtime.Object
+}
+
+func (knn KindNameSpaceName) String() string {
+	return fmt.Sprintf("%s/%s/%s", knn.Kind, knn.Namespace, knn.Name)
+}
+
+// Check the PodBalanceAttempts, ensure less than maxBalanceAttempts
+func verifyRebalanceCount(ctx context.Context, client k8sclient.Client, obj runtime.Object) (bool, error) {
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return false, nil
+	}
+	ant := metaObj.GetAnnotations()
+	// If there are no annotations then 0 balance attempts have been made
+	if ant == nil {
+		return true, nil
+	}
+	if val, ok := ant[PodRebalanceAttempts]; ok {
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return false, fmt.Errorf("Error converting string annotations %s", ant[PodRebalanceAttempts])
+		} else {
+			if i >= maxBalanceAttempts {
+				logrus.Warningf("Reached max balance attempts for %s on %s", metaObj.GetName(), metaObj.GetNamespace())
+				return false, nil
+			}
+		}
+	}
+
+	return true, nil
+}
+
+func getObject(ctx context.Context, client k8sclient.Client, knn *KindNameSpaceName) (runtime.Object, error) {
+	object := knn.Kind
+	err := client.Get(ctx, k8sTypes.NamespacedName{Name: knn.Name, Namespace: knn.Namespace}, object)
+	if err != nil {
+		return nil, fmt.Errorf("Error getting object %s, on ns %s: %w", knn.Name, knn.Namespace, err)
+	}
+	return object, nil
+
+}
+
+func getNamespaces(nsPrefix string, installType string) []string {
+	namespaces := []string{
+		nsPrefix + "3scale",
+		nsPrefix + "rhsso",
+		nsPrefix + "user-sso",
+	}
+
+	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		namespaces = append(namespaces, nsPrefix+"marin3r")
+	}
+	return namespaces
+}
+
+func ReconcilePodDistribution(ctx context.Context, client k8sclient.Client, nsPrefix string, installType string) *resources.MultiErr {
+	var mErr = &resources.MultiErr{}
+
+	isMultiAZCluster, err := resources.IsMultiAZCluster(ctx, client)
+	if err != nil {
+		mErr.Add(err)
+		return mErr
+	}
+	if !isMultiAZCluster {
+		return mErr
+	}
+
+	for _, ns := range getNamespaces(nsPrefix, installType) {
+		logrus.Infof("Reconciling Pod Balance in ns %s", ns)
+		unbalanced, err := findUnbalanced(ctx, ns, client)
+		if err != nil {
+			mErr.Add(fmt.Errorf("Error getting pods to balance on namespace %s. %w", ns, err))
+			continue
+		}
+		for knn, pods := range unbalanced {
+			obj, err := getObject(ctx, client, knn)
+			if err != nil {
+				mErr.Add(err)
+				continue
+			}
+			rebalance, err := verifyRebalanceCount(ctx, client, obj)
+			if err != nil {
+				mErr.Add(err)
+				continue
+			}
+			if rebalance {
+				err := forceRebalance(ctx, client, knn, pods)
+				if err != nil {
+					mErr.Add(err)
+				}
+			}
+		}
+	}
+	return mErr
+}
+
+func findUnbalanced(ctx context.Context, nameSpace string, client k8sclient.Client) (map[*KindNameSpaceName][]string, error) {
+	nodes := &corev1.NodeList{}
+	unBalanced := map[*KindNameSpaceName][]string{}
+	if err := client.List(ctx,
+		nodes, &k8sclient.ListOptions{}); err != nil {
+		return unBalanced, err
+	}
+	nodesToZone := map[string]string{}
+	for _, n := range nodes.Items {
+		for _, a := range n.Status.Addresses {
+			if a.Type == corev1.NodeInternalIP {
+				nodesToZone[a.Address] = n.Labels[ZoneLabel]
+				break
+			}
+		}
+	}
+	logrus.Debugf("nodes to zone %v", nodesToZone)
+	allKnn := []*KindNameSpaceName{}
+	balance := map[*KindNameSpaceName][]string{}
+	objPods := map[*KindNameSpaceName][]string{}
+	l := &corev1.PodList{}
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+	}
+	if err := client.List(ctx, l, listOpts...); err != nil {
+		return unBalanced, fmt.Errorf("Error getting pod lists %w", err)
+	}
+
+	// need to check if there is more than 1 pod of a kind
+	podCount := map[*KindNameSpaceName]int{}
+	logrus.Debugf("total pods in ns %s: %d", nameSpace, len(l.Items))
+	for _, p := range l.Items {
+		if p.Status.Phase != "Running" {
+			continue
+		}
+
+		for _, o := range p.OwnerReferences {
+			if o.Controller != nil && *o.Controller {
+				knn := &KindNameSpaceName{
+					NamespacedName: &k8sTypes.NamespacedName{
+						Namespace: nameSpace,
+					},
+				}
+
+				if o.Kind == "ReplicationController" {
+					knn.Name = p.Annotations["openshift.io/deployment-config.name"]
+					knn.Kind = &appsv1.DeploymentConfig{}
+				} else if o.Kind == "StatefulSet" {
+					knn.Name = o.Name
+					knn.Kind = &k8appsv1.StatefulSet{}
+				} else if o.Kind == "ReplicaSet" {
+					knn.Name = o.Name
+					knn.Kind = &k8appsv1.ReplicaSet{}
+				}
+
+				// If this knn already exists use it.
+				knn, allKnn = getExisting(knn, allKnn)
+
+				if _, ok := podCount[knn]; !ok {
+					podCount[knn] = 1
+				} else {
+					podCount[knn] = podCount[knn] + 1
+				}
+				if balance[knn] == nil {
+					balance[knn] = []string{}
+				}
+
+				if objPods[knn] == nil {
+					objPods[knn] = []string{}
+				}
+				objPods[knn] = append(objPods[knn], p.Name)
+
+				zone := nodesToZone[p.Status.HostIP]
+				if !zoneExists(balance[knn], zone) {
+					balance[knn] = append(balance[knn], nodesToZone[p.Status.HostIP])
+				}
+				break
+			}
+		}
+	}
+	for knn := range balance {
+		if len(balance[knn]) == 1 && podCount[knn] > 1 {
+			logrus.Warningf("Requires pod rebalance %s", knn)
+			unBalanced[knn] = objPods[knn]
+		}
+	}
+
+	return unBalanced, nil
+}
+
+func getExisting(knn *KindNameSpaceName, allKnn []*KindNameSpaceName) (*KindNameSpaceName, []*KindNameSpaceName) {
+	for _, val := range allKnn {
+		if knn.Namespace == val.Namespace &&
+			knn.Name == val.Name &&
+			knn.Kind.GetObjectKind().GroupVersionKind().Kind == val.Kind.GetObjectKind().GroupVersionKind().Kind {
+			return val, allKnn
+		}
+	}
+	return knn, append(allKnn, knn)
+}
+
+func zoneExists(zones []string, zone string) bool {
+	for _, z := range zones {
+		if z == zone {
+			return true
+		}
+	}
+	return false
+}
+
+// Delete a single pod to force redistribution
+func forceRebalance(ctx context.Context, client k8sclient.Client, knn *KindNameSpaceName, pods []string) error {
+
+	deletePod(ctx, client, pods[0], knn.Namespace)
+	// The wait prevents version clash errors when updating the controller
+	err := wait.Poll(time.Second*5, time.Second*5, func() (done bool, err error) {
+		err = updatePodBalanceAttemptsOnKNN(ctx, client, knn)
+		return true, err
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func deletePod(ctx context.Context, client k8sclient.Client, podName string, ns string) {
+	logrus.Infof("Attempting to delete pod %s, on ns %s", podName, ns)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      podName,
+			Namespace: ns,
+		},
+	}
+	err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      podName,
+		Namespace: ns,
+	}, pod)
+	if err != nil {
+		logrus.Errorf("Error getting pod %s on namespace %s. %v", podName, ns, err)
+		return
+	}
+	if err := client.Delete(ctx, pod); err != nil {
+		logrus.Errorf("Error deleting pod %s on namespace %s. %v", podName, ns, err)
+	}
+}
+
+func updatePodBalanceAttemptsOnKNN(ctx context.Context, client k8sclient.Client, knn *KindNameSpaceName) error {
+	obj := knn.Kind
+
+	err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      knn.Name,
+		Namespace: knn.Namespace,
+	}, obj)
+
+	if err != nil {
+		return fmt.Errorf("Error getting %s %s on namespace %s. %w", knn.Kind, knn.Name, knn.Namespace, err)
+	}
+	metaObj, err := meta.Accessor(obj)
+	if err != nil {
+		return err
+	}
+	ant, err := getAnnotations(metaObj.GetAnnotations(), knn.Name, knn.Namespace)
+	if err != nil {
+		return err
+	}
+	metaObj.SetAnnotations(ant)
+	if err := client.Update(ctx, obj); err != nil {
+		return fmt.Errorf("Error Updating %s %s on %s. %w", knn.Kind, knn.Name, knn.Namespace, err)
+	}
+	logrus.Infof("Successfully updated %s %s on %s", knn.Kind, knn.Name, knn.Namespace)
+	return nil
+}
+
+func getAnnotations(ant map[string]string, name string, ns string) (map[string]string, error) {
+	if ant == nil {
+		ant = map[string]string{}
+	}
+	if val, ok := ant[PodRebalanceAttempts]; ok {
+		i, err := strconv.Atoi(val)
+		if err != nil {
+			return nil, fmt.Errorf("Error converting annotation to int %s, %s, %s", PodRebalanceAttempts, name, ns)
+		}
+		i = i + 1
+		ant[PodRebalanceAttempts] = strconv.Itoa(i)
+	} else {
+		ant[PodRebalanceAttempts] = "1"
+	}
+
+	return ant, nil
+}

--- a/pkg/resources/poddistribution/poddistribution.go
+++ b/pkg/resources/poddistribution/poddistribution.go
@@ -33,7 +33,7 @@ type KindNameSpaceName struct {
 }
 
 func (knn KindNameSpaceName) String() string {
-	return fmt.Sprintf("%s/%s/%s", knn.Kind, knn.Namespace, knn.Name)
+	return fmt.Sprintf("%s/%s/%s", getKindString(knn.Kind), knn.Namespace, knn.Name)
 }
 
 // Check the PodBalanceAttempts, ensure less than maxBalanceAttempts
@@ -281,7 +281,7 @@ func updatePodBalanceAttemptsOnKNN(ctx context.Context, client k8sclient.Client,
 	}, obj)
 
 	if err != nil {
-		return fmt.Errorf("Error getting %s %s on namespace %s. %w", knn.Kind, knn.Name, knn.Namespace, err)
+		return fmt.Errorf("Error getting %s %s on namespace %s. %w", getKindString(knn.Kind), knn.Name, knn.Namespace, err)
 	}
 	metaObj, err := meta.Accessor(obj)
 	if err != nil {
@@ -293,10 +293,14 @@ func updatePodBalanceAttemptsOnKNN(ctx context.Context, client k8sclient.Client,
 	}
 	metaObj.SetAnnotations(ant)
 	if err := client.Update(ctx, obj); err != nil {
-		return fmt.Errorf("Error Updating %s %s on %s. %w", knn.Kind, knn.Name, knn.Namespace, err)
+		return fmt.Errorf("Error Updating %s %s on %s. %w", getKindString(knn.Kind), knn.Name, knn.Namespace, err)
 	}
-	logrus.Infof("Successfully updated %s %s on %s", knn.Kind, knn.Name, knn.Namespace)
+	logrus.Infof("Successfully updated %s %s on %s", getKindString(knn.Kind), knn.Name, knn.Namespace)
 	return nil
+}
+
+func getKindString(kind runtime.Object) string {
+	return kind.GetObjectKind().GroupVersionKind().Kind
 }
 
 func getAnnotations(ant map[string]string, name string, ns string) (map[string]string, error) {

--- a/pkg/resources/poddistribution/poddistribution_test.go
+++ b/pkg/resources/poddistribution/poddistribution_test.go
@@ -1,0 +1,321 @@
+package poddistribution
+
+import (
+	"context"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	apiappsv1 "github.com/openshift/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func getPod(name string, ownerName string, ip string, ownerKind string) corev1.Pod {
+	return corev1.Pod{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "redhat-rhoam-3scale",
+			OwnerReferences: []metav1.OwnerReference{
+				{
+					Kind:       ownerKind,
+					Name:       ownerName,
+					Controller: newTrue(),
+				},
+			},
+			Annotations: map[string]string{
+				"openshift.io/deployment-config.name": ownerName,
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase:  "Running",
+			HostIP: ip,
+		},
+	}
+}
+
+func getNode(name string, zone string, ip string) corev1.Node {
+	return corev1.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      name,
+			Namespace: "redhat-rhoam-3scale",
+			Labels: map[string]string{
+				"topology.kubernetes.io/zone": zone,
+			},
+		},
+		Status: corev1.NodeStatus{
+			Addresses: []corev1.NodeAddress{
+				{
+					Type:    "InternalIP",
+					Address: ip,
+				},
+			},
+		},
+	}
+}
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := corev1.SchemeBuilder.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = appsv1.SchemeBuilder.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = apiappsv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	return scheme, err
+}
+
+func newTrue() *bool {
+	b := true
+	return &b
+}
+
+func TestPodDistribution(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	dc1 := &apiappsv1.DeploymentConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "dc1",
+			Namespace: "redhat-rhoam-3scale",
+		},
+	}
+
+	rs1 := &appsv1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rs1",
+			Namespace: "redhat-rhoam-3scale",
+		},
+	}
+
+	ss1 := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ss1",
+			Namespace: "redhat-rhoam-3scale",
+		},
+	}
+
+	dc2 := &apiappsv1.DeploymentConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "dc2",
+			Namespace: "redhat-rhoam-3scale",
+			Annotations: map[string]string{
+				"pod-balance-attempts": "3",
+			},
+		},
+	}
+
+	rs2 := &appsv1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rs2",
+			Namespace: "redhat-rhoam-3scale",
+			Annotations: map[string]string{
+				"pod-balance-attempts": "3",
+			},
+		},
+	}
+
+	ss2 := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ss2",
+			Namespace: "redhat-rhoam-3scale",
+			Annotations: map[string]string{
+				"pod-balance-attempts": "3",
+			},
+		},
+	}
+
+	dc3 := &apiappsv1.DeploymentConfig{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "dc3",
+			Namespace: "invalid-namespace",
+			Annotations: map[string]string{
+				PodRebalanceAttempts: "3",
+			},
+		},
+	}
+
+	rs3 := &appsv1.ReplicaSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rs3",
+			Namespace: "redhat-rhoam-3scale",
+			Annotations: map[string]string{
+				PodRebalanceAttempts: "should-be-int",
+			},
+		},
+	}
+
+	ss3 := &appsv1.StatefulSet{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "ss3",
+			Namespace: "invalid-namespace",
+			Annotations: map[string]string{
+				PodRebalanceAttempts: "3",
+			},
+		},
+	}
+
+	podList3 := &corev1.PodList{
+		Items: []corev1.Pod{
+			getPod("deploypod1", "dc3", "1.1.1.1", "ReplicationController"),
+			getPod("deploypod2", "dc3", "1.1.1.1", "ReplicationController"),
+			getPod("sspod1", "ss3", "1.1.1.1", "StatefulSet"),
+			getPod("sspod2", "ss3", "1.1.1.1", "StatefulSet"),
+			getPod("rspod1", "rs3", "1.1.1.1", "ReplicaSet"),
+			getPod("rspod2", "rs3", "1.1.1.1", "ReplicaSet"),
+		},
+	}
+
+	podList1 := &corev1.PodList{
+		Items: []corev1.Pod{
+			getPod("deploypod1", "dc1", "1.1.1.1", "ReplicationController"),
+			getPod("deploypod2", "dc1", "1.1.1.1", "ReplicationController"),
+			getPod("sspod1", "ss1", "1.1.1.1", "StatefulSet"),
+			getPod("sspod2", "ss1", "1.1.1.1", "StatefulSet"),
+			getPod("rspod1", "rs1", "1.1.1.1", "ReplicaSet"),
+			getPod("rspod2", "rs1", "1.1.1.1", "ReplicaSet"),
+		},
+	}
+
+	nodeList1 := &corev1.NodeList{
+		Items: []corev1.Node{
+			getNode("node1", "zone1", "1.1.1.1"),
+			getNode("node2", "zone2", "2.2.2.2"),
+		},
+	}
+
+	podList2 := &corev1.PodList{
+		Items: []corev1.Pod{
+			getPod("deploypod1", "dc2", "1.1.1.1", "ReplicationController"),
+			getPod("deploypod2", "dc2", "2.2.2.2", "ReplicationController"),
+			getPod("sspod1", "ss2", "1.1.1.1", "StatefulSet"),
+			getPod("sspod2", "ss2", "2.2.2.2", "StatefulSet"),
+			getPod("rspod1", "rs2", "1.1.1.1", "ReplicaSet"),
+			getPod("rspod2", "rs2", "2.2.2.2", "ReplicaSet"),
+		},
+	}
+
+	deleteCount1 := 0
+	updateCount1 := 0
+	deleteCount2 := 0
+	updateCount2 := 0
+	deleteCount3 := 0
+	updateCount3 := 0
+
+	cases := []struct {
+		Name       string
+		FakeClient func() k8sclient.Client
+		Validate   func(*resources.MultiErr) error
+	}{
+		{
+			Name: "Test pods are forced to distribute",
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, nodeList1, podList1, dc1, rs1, ss1)
+				mockClient.DeleteFunc = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+					deleteCount1++
+					return nil
+				}
+				mockClient.UpdateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					updateCount1++
+					return nil
+				}
+				return mockClient
+			},
+			Validate: func(error *resources.MultiErr) error {
+				if deleteCount1 != 3 {
+					t.Fatalf("Expected deleteCount of 3, got %d", deleteCount1)
+				}
+				if updateCount1 != 3 {
+					t.Fatalf("Expected updateCount of 3, got %d", updateCount1)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Test no distribution as pods are correctly distributed",
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, nodeList1, podList2, dc2, rs2, ss2)
+				mockClient.DeleteFunc = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+					deleteCount2++
+					return nil
+				}
+				mockClient.UpdateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					updateCount2++
+					return nil
+				}
+				return mockClient
+			},
+			Validate: func(error *resources.MultiErr) error {
+				if deleteCount2 != 0 {
+					t.Fatalf("Expected deleteCount of 0, got %d", deleteCount2)
+				}
+				if updateCount2 != 0 {
+					t.Fatalf("Expected updateCount of 0, got %d", updateCount2)
+				}
+				return nil
+			},
+		},
+		{
+			// Even though the pods are not distributed correctly the limit of attempts is reached
+			Name: "Test no distribution as limits are reached",
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, nodeList1, podList2, dc2, rs2, ss2)
+				mockClient.DeleteFunc = func(ctx context.Context, obj runtime.Object, opts ...client.DeleteOption) error {
+					deleteCount3++
+					return nil
+				}
+				mockClient.UpdateFunc = func(ctx context.Context, obj runtime.Object, opts ...client.UpdateOption) error {
+					updateCount3++
+					return nil
+				}
+				return mockClient
+			},
+			Validate: func(error *resources.MultiErr) error {
+				if deleteCount3 != 0 {
+					t.Fatalf("Expected deleteCount of 0, got %d", deleteCount3)
+				}
+				if updateCount3 != 0 {
+					t.Fatalf("Expected updateCount of 0, got %d", updateCount3)
+				}
+				return nil
+			},
+		},
+		{
+			Name: "Test that errors are aggregated and returned",
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, nodeList1, podList3, dc3, rs3, ss3)
+				return mockClient
+			},
+			Validate: func(error *resources.MultiErr) error {
+				if len(error.Errors) != 3 {
+					t.Fatal("Expected 3 errors, got ", len(error.Errors))
+				}
+				return nil
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			error := ReconcilePodDistribution(context.TODO(), tc.FakeClient(), "redhat-rhoam-", "managed-api")
+			if err = tc.Validate(error); err != nil {
+				t.Fatal("test validation failed: ", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Description
Add pod distribution check and balance. On multiAZ clusters, the rhoam operator should reconcile pod distribution on deployments (and RS, SS) with > 1 replica count.  First check if the distribution meets the requirements i.e. Minimum pod distribution states that a replica count > 1 on clusters with > 1 zone should not all be on the same zone. If the minimum pod distribution is not satisfied for a given pod restart <=50% of the replica count. Limit this check and redistribution attempt to 3. If it fails after 3 attempts there may be another cause for the failing distribution, for example, resource usage.

More details on [JIRA](https://issues.redhat.com/browse/MGDAPI-680): 

## Verify

- Clone this repo
- Modify the [replica numbers](https://github.com/integr8ly/integreatly-operator/blob/95d6b50918c6937f5ae9a1eb3ae39550acc9d51a/pkg/config/threescale.go#L120) for 3Scale to 2. This simply increases the chances of pods not fully distributing i.e. facilitate with testing
- Install RHOAM with `USE_CLUSTER_STORAGE = 'true'`
- Stop the operator
- Run `./scripts/disableAZ.sh true us-east-1c` to disable the us-east-1c zone. Change details if needed depending on where the cluster is installed. Disable a second zone, i.e. two out of three. 
- Wait for all pods to be recreated in the remaining zone. This can take some time and the console may go offline for a period. Once pods are recreated, re-enable the zones you disabled `./scripts/disableAZ.sh false us-east-1c` 
- Check the  `MultiAZPodDistribution` alert in prometheus, it should now be triggered. 
- Run the `MultiAZPodDistribution` query in prometheus to identify the pods not distributed
- Restart the rhoam operator. Pods not balanced in the below namespace should be restarted by the operator to attempt to force a rebalance. 
- Check the logs for indications of this. See below. 
- Verify ReplicaSet, DeploymentConfig, StatefulSet associated with the pods have a new annotation  ``` pod-balance-attempts: '1' ``` indicating the number of times a pod on the controller was restarted. 
- Most pods restarted will schedule on a different zone to its peer pods, thus alter the alert. This is not guaranteed.
- Verify that some, if not all Pods, from `MultiAZPodDistribution` have resolved. 

## Verify disabling rebalancing 
Setting env var `export REBALANCE_PODS="false"` will disable any attempt to rebalance. 
Restart the operator, after a full install, and verify the rebalance logic has not executed. The attempt to rebalance will happen almost immediately after a restart and when all products are fully installed. Simply check for non existence of log entry `"Reconciling Pod Balance in ns"`

### Namespaces
- redhat-rhoam-3scale
- redhat-rhoam-rhsso
- redhat-rhoam-userrhsso
- redhat-rhoam-marin3r

### Logs to grep:
- "Reconciling Pod Balance in ns"
- "Requires pod rebalance"
- "Attempting to delete pod"
- "Updating pod balance annotation"
