### PR TITLE
OSDe2e add uninstall stage

### DIFF
--- a/test/osde2e/managed_api_test.go
+++ b/test/osde2e/managed_api_test.go
@@ -68,4 +68,8 @@ func TestManagedAPI(t *testing.T) {
 	t.Run("Managed-API-e2e-test", func(t *testing.T) {
 		common.RunTestCases(happyPathTestCases, t, config)
 	})
+
+	t.Run("Managed-API-uninstall", func(t *testing.T) {
+		common.RunTestCases(UNINSTALL, t, config)
+	})
 }

--- a/test/osde2e/uninstall.go
+++ b/test/osde2e/uninstall.go
@@ -1,0 +1,46 @@
+package osde2e
+
+import (
+	goctx "context"
+	"github.com/integr8ly/integreatly-operator/test/common"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"testing"
+	"time"
+)
+
+var (
+	UNINSTALL = []common.TestCase{
+		{Description: "Managed-API uninstall", Test: Uninstall},
+	}
+)
+
+//Uninstall stage is triggered at the end of e2e tests, whether the tests were successful or not
+func Uninstall(t *testing.T, ctx *common.TestingContext) {
+	err := wait.Poll(time.Second*15, time.Minute*40, func() (done bool, err error) {
+
+		// Get RHMI CR - if getRHMI fails, we assume that RHOAM has been deleted
+		rhmi, err := getRHMI(ctx.Client)
+		if err != nil {
+			t.Log("Uninstall Completed")
+			return true, nil
+		}
+
+		// Apply deletetion timestamp
+		if rhmi.DeletionTimestamp == nil {
+			err := ctx.Client.Delete(goctx.TODO(), rhmi)
+			if err != nil {
+				t.Logf("Could not delete RHOAM CR due to %v, retryting...", err)
+				return false, nil
+			}
+			t.Log("Successfully marked RHOAM CR for deletion")
+			return false, nil
+		}
+
+		t.Logf("Delete of RHOAM in progress - current stage is %v", rhmi.Status.Stage)
+		return false, nil
+	})
+
+	if err != nil {
+		t.Errorf("Could not delete RHOAM CR - Uninstall took longer than 40 minutes: %v", err)
+	}
+}


### PR DESCRIPTION
# Description
Add unistall stage to osde2e image.

To Verify:

- Provision a 6 node cluster ( NOTE: Please only do it in between osde2e runs. Ideally start provisioning after 12pm run has kicked in, it might happen that if you provision 6node cluster there will be no more quota for osde2e run)
- Wait for the cluster to fully install + certs must be present
- Checkout this branch and edit the line in: https://github.com/integr8ly/integreatly-operator/blob/master/make/osde2e.mk#L2
 Change the org to your own in quay.io
- run `make image/osde2e/build/push
- Go to your quay.io and make sure that the repository has been created, is public, and image with osde2e tag is present
- Git clone the following repo: https://github.com/openshift/osde2e
- In osde2e repo run the following commands: `go mod tidy` `go mod vendor` `make build`
- Create the following script: 
```
#!/usr/bin/env bash
make build

CLUSTER_ID="<YOUR_CLUSTER_ID>" \
OSD_ENV="stage" \
OCM_TOKEN="<YOUR OCM TOKEN HERE>" \
ADDON_IDS="managed-api-service" \
ADDON_TEST_HARNESSES="quay.io/<YOUR_QUAY_USER_HERE>/integreatly-operator-test-harness:osde2e" \
POLLING_TIMEOUT="7000" \
SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/integr8ly-ci-secrets" \
MUST_GATHER="false" \
SKIP_CLUSTER_HEALTH_CHECKS="true" \
./out/osde2e test --configs "addon-suite","aws","stage" --skip-health-check
```
- run the script `bash YOUR_SCRIPT`
- wait for the script to fully complete (can take about 1hr)
- after the script fully completed, confirm that RHOAM has been uninstalled.
NOTE: If not - please make sure to uninstall addon via ocm ui, otherwise, we might leaving orphaned aws resources.
