### PR TITLE
MGDAPI-815 - Fix flaky E02 & E03 

### DIFF
--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -100,16 +100,21 @@ func TestIntegreatlyCustomerDashboardsExist(t *testing.T, ctx *TestingContext) {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
 
-	monitoringGrafanaPods := getGrafanaPods(t, ctx, MonitoringOperatorNamespace)
+	// Pod and container to perform curls from
+	prometheusPodName, err := getMonitoringAppPodName("prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to get prometheus pod name", err)
+	}
+	curlContainerName := "prometheus"
+
 	customerMonitoringGrafanaPods := getGrafanaPods(t, ctx, CustomerGrafanaNamespace)
 
 	output, err := execToPod(fmt.Sprintf("curl %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
-		monitoringGrafanaPods.Items[0].ObjectMeta.Name,
+		prometheusPodName,
 		MonitoringOperatorNamespace,
-		"grafana", ctx)
+		curlContainerName, ctx)
 	if err != nil {
-		t.Skip("failed to exec to pod:", err)
-		//t.Fatal("failed to exec to pod:", err, "pod name:", customerMonitoringGrafanaPods.Items[0].Name)
+		t.Fatal("failed to exec to pod:", err, "pod name:", prometheusPodName, "container name:", containerName, "namespace:", MonitoringOperatorNamespace)
 	}
 
 	var grafanaApiCallOutput []dashboardsTestRule
@@ -133,15 +138,21 @@ func TestIntegreatlyMiddelewareDashboardsExist(t *testing.T, ctx *TestingContext
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
 
+	// Pod and container to perform curls from
+	prometheusPodName, err := getMonitoringAppPodName("prometheus", ctx)
+	if err != nil {
+		t.Fatal("failed to get prometheus pod name", err)
+	}
+	curlContainerName := "prometheus"
+
 	monitoringGrafanaPods := getGrafanaPods(t, ctx, MonitoringOperatorNamespace)
 
-	output, err := execToPod("curl localhost:3000/api/search",
-		monitoringGrafanaPods.Items[0].ObjectMeta.Name,
+	output, err := execToPod(fmt.Sprintf("curl %v:3000/api/search", monitoringGrafanaPods.Items[0].Status.PodIP),
+		prometheusPodName,
 		MonitoringOperatorNamespace,
-		"grafana", ctx)
+		curlContainerName, ctx)
 	if err != nil {
-		//Flaky test: https://issues.redhat.com/browse/MGDAPI-815
-		t.Skip("failed to exec to pod:", err)
+		t.Fatal("failed to exec to pod:", err, "pod name:", prometheusPodName, "container name:", containerName, "namespace:", MonitoringOperatorNamespace)
 	}
 
 	var grafanaApiCallOutput []dashboardsTestRule


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Grafana pod in monitoring no longer has `curl` command causing tests to fail.
Change test to allow performing curl to grafana pod ip from another pod and container

Jira:
* https://issues.redhat.com/browse/MGDAPI-815

## Verification
* Install RHOAM
* Run E02 & E03 functional test a few times
```
go clean -testcache && MULTIAZ=true WATCH_NAMESPACE=redhat-rhoam-operator go test -v ./test/functional -run="//(^(E02)|(E03))" -timeout=80m
```
* Verify tests passes


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer