### PR TITLE
Fix RHOAM replicas applied to RHMI

### DIFF
--- a/pkg/config/rhsso.go
+++ b/pkg/config/rhsso.go
@@ -2,6 +2,9 @@ package config
 
 import (
 	"errors"
+
+	testResources "github.com/integr8ly/integreatly-operator/test/resources"
+
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
@@ -30,4 +33,11 @@ func (r *RHSSO) Validate() error {
 		return errors.New("config product name is not defined")
 	}
 	return r.ValidateCommon()
+}
+
+func (r *RHSSO) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) int {
+	if testResources.RunningInProw(inst) {
+		return 1
+	}
+	return 2
 }

--- a/pkg/config/rhssoUser.go
+++ b/pkg/config/rhssoUser.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"errors"
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"strconv"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
+	testResources "github.com/integr8ly/integreatly-operator/test/resources"
 )
 
 type RHSSOUser struct {
@@ -46,4 +48,16 @@ func (r *RHSSOUser) Validate() error {
 		return errors.New("config product name is not defined")
 	}
 	return r.ValidateCommon()
+}
+
+func (r *RHSSOUser) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) int {
+	if testResources.RunningInProw(inst) {
+		return 1
+	}
+
+	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		return 3
+	}
+
+	return 2
 }

--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"errors"
+
 	"github.com/integr8ly/integreatly-operator/test/resources"
 
 	threescaleapps "github.com/3scale/3scale-operator/pkg/apis/apps"
@@ -104,20 +105,7 @@ func (t *ThreeScale) Validate() error {
 }
 
 func (t *ThreeScale) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) map[string]int64 {
-	if resources.RunningInProw(inst) {
-		return map[string]int64{
-			"systemApp":       1,
-			"systemSidekiq":   1,
-			"apicastProd":     1,
-			"apicastStage":    1,
-			"backendListener": 1,
-			"backendWorker":   1,
-			"backendCron":     1,
-			"zyncApp":         1,
-			"zyncQue":         1,
-		}
-	}
-	return map[string]int64{
+	threeScaleComponents := map[string]int64{
 		"systemApp":       3,
 		"systemSidekiq":   3,
 		"apicastProd":     6,
@@ -127,5 +115,19 @@ func (t *ThreeScale) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) map[strin
 		"backendCron":     1,
 		"zyncApp":         3,
 		"zyncQue":         3,
+	}
+
+	if resources.RunningInProw(inst) {
+		setDefaultNumberOfReplicas(1, threeScaleComponents)
+	} else if inst.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		setDefaultNumberOfReplicas(2, threeScaleComponents)
+	}
+
+	return threeScaleComponents
+}
+
+func setDefaultNumberOfReplicas(defaultNumberOfReplicas int64, threeScaleComponents map[string]int64) {
+	for i := range threeScaleComponents {
+		threeScaleComponents[i] = int64(defaultNumberOfReplicas)
 	}
 }

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -586,7 +586,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 			SelfSignedCerts:                  r.installation.Spec.SelfSignedCerts,
 		}
 
-		if isMultiAZCluster {
+		if isMultiAZCluster && r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 			m.Spec.Affinity = resources.SelectAntiAffinityForCluster(antiAffinityRequired, map[string]string{
 				"prometheus":   "application-monitoring",
 				"alertmanager": "application-monitoring",

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,8 +3,8 @@ package rhsso
 import (
 	"context"
 	"fmt"
+
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
-	testResources "github.com/integr8ly/integreatly-operator/test/resources"
 	"github.com/integr8ly/integreatly-operator/version"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -42,7 +42,6 @@ var (
 	githubIdpAlias            = "github"
 	authFlowAlias             = "authdelay"
 	adminCredentialSecretName = "credential-" + keycloakName
-	numberOfReplicas          = 2
 	ssoType                   = "rhsso"
 	postgresResourceName      = "rhsso-postgres-rhmi"
 )
@@ -235,9 +234,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("1"), corev1.ResourceMemory: k8sresource.MustParse("2G")},
 		}
 		//OSD has more resources than PROW, so adding an exception
-		if testResources.RunningInProw(r.Installation) {
-			numberOfReplicas = 1
-		}
+		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)
+
 		if kc.Spec.Instances < numberOfReplicas {
 			kc.Spec.Instances = numberOfReplicas
 		}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,7 +3,6 @@ package rhssouser
 import (
 	"context"
 	"fmt"
-	testResources "github.com/integr8ly/integreatly-operator/test/resources"
 	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
@@ -47,7 +46,6 @@ var (
 	idpAlias                  = "openshift-v4"
 	masterRealmName           = "master"
 	adminCredentialSecretName = "credential-" + keycloakName
-	numberOfReplicas          = 3
 	ssoType                   = "user sso"
 	postgresResourceName      = "rhssouser-postgres-rhmi"
 )
@@ -274,9 +272,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("1"), corev1.ResourceMemory: k8sresource.MustParse("2G")},
 		}
 		//OSD has more resources than PROW, so adding an exception
-		if testResources.RunningInProw(r.Installation) {
-			numberOfReplicas = 1
-		}
+		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)
 		if kc.Spec.Instances < numberOfReplicas {
 			kc.Spec.Instances = numberOfReplicas
 		}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -79,12 +79,10 @@ const (
 	externalRedisSecretName        = "system-redis"
 	externalBackendRedisSecretName = "backend-redis"
 	externalPostgresSecretName     = "system-database"
-
-	numberOfReplicas              int64 = 2
-	apicastStagingName                  = "apicast-staging"
-	apicastProductionName               = "apicast-production"
-	systemSeedSecretName                = "system-seed"
-	systemMasterApiCastSecretName       = "system-master-apicast"
+	apicastStagingName             = "apicast-staging"
+	apicastProductionName          = "apicast-production"
+	systemSeedSecretName           = "system-seed"
+	systemMasterApiCastSecretName  = "system-master-apicast"
 
 	apicastRatelimiting = "apicast-ratelimit"
 	registrySecretName  = "threescale-registry-auth"

--- a/test/common/scale_up_replicas_rhsso.go
+++ b/test/common/scale_up_replicas_rhsso.go
@@ -3,9 +3,10 @@ package common
 import (
 	goctx "context"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/test/resources"
 	"testing"
 	"time"
+
+	"github.com/integr8ly/integreatly-operator/pkg/config"
 
 	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -15,12 +16,10 @@ import (
 )
 
 var (
-	numberOfRhssoReplicas     = 2
-	numberOfUserRhssoReplicas = 3
-	rhssoName                 = "rhsso"
-	userSSOName               = "rhssouser"
-	requestURLSSO             = "/apis/keycloak.org/v1alpha1"
-	kindSSO                   = "Keycloaks"
+	rhssoName     = "rhsso"
+	userSSOName   = "rhssouser"
+	requestURLSSO = "/apis/keycloak.org/v1alpha1"
+	kindSSO       = "Keycloaks"
 )
 
 func TestReplicasInRHSSO(t *testing.T, ctx *TestingContext) {
@@ -28,11 +27,11 @@ func TestReplicasInRHSSO(t *testing.T, ctx *TestingContext) {
 	if err != nil {
 		t.Fatalf("failed to get RHMI instance %v", err)
 	}
-	if resources.RunningInProw(inst) {
-		checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), 1)
-	} else {
-		checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), numberOfRhssoReplicas)
-	}
+
+	rhssoConfig := config.NewRHSSO(map[string]string{})
+	numberOfRhssoReplicas := rhssoConfig.GetReplicasConfig(inst)
+	checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), numberOfRhssoReplicas)
+
 }
 
 func TestReplicasInUserSSO(t *testing.T, ctx *TestingContext) {
@@ -40,11 +39,10 @@ func TestReplicasInUserSSO(t *testing.T, ctx *TestingContext) {
 	if err != nil {
 		t.Fatalf("failed to get RHMI instance %v", err)
 	}
-	if resources.RunningInProw(inst) {
-		checkScalingOfKeycloakReplicas(t, ctx, userSSOName, GetPrefixedNamespace("user-sso"), 1)
-	} else {
-		checkScalingOfKeycloakReplicas(t, ctx, userSSOName, GetPrefixedNamespace("user-sso"), numberOfUserRhssoReplicas)
-	}
+
+	userRhssoConfig := config.NewRHSSO(map[string]string{})
+	numberOfUserRhssoReplicas := userRhssoConfig.GetReplicasConfig(inst)
+	checkScalingOfKeycloakReplicas(t, ctx, rhssoName, GetPrefixedNamespace("rhsso"), numberOfUserRhssoReplicas)
 }
 
 func checkScalingOfKeycloakReplicas(t *testing.T, ctx *TestingContext, keycloakCRName string, keycloakCRNamespace string, expectedReplicas int) {


### PR DESCRIPTION
# Description

RHOAM increased the number of replicas in RHSSO, User SSO and Three Scale, this requires more resources than RHMI needs, so this PR reverts back the number of replicas required by rhmi.

https://issues.redhat.com/browse/MGDAPI-732

## Verification steps

1) Install RHMI from this branch `INSTALLATION_TYPE=managed make cluster/prepare/local && INSTALLATION_TYPE=managed make code/run`

2) Verify if the following number of replicas are applied:

**Three scale**
```
"systemApp":       2,
"systemSidekiq":   2,
"apicastProd":     2,
"apicastStage":    2,
"backendListener": 2,
"backendWorker":   2,
"backendCron":     2,
"zyncApp":         2,
"zyncQue":         2
```

**RHSSO and SSO**
```
"keycloak":       2
```


UPDATE
**Application monitoring operator (AMO)**

```
"alertmanager":     1,
"prometheus":   1,
```

