### PR TITLE
MGDAPI-693 - Fix RedisMemoryUsageMaxIn4Days alert firing during install

### DIFF
--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -358,7 +358,7 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	//    * [1h] - one hour data points
 	//    * , 5 * 3600 - multiplying data points by 5 hour, to allow 1 hour of pending before firing the alert
 	alertExp := intstr.FromString(
-		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[1h], 5 * 3600) <= 0 and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
+		fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_postgres_free_storage_average{job='%s'})[1h:1m], 5 * 3600) <= 0 and on (instanceID) (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25)))", job))
 
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopURL, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -377,7 +377,7 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	//    * [2h] - 2 hour data points
 	//    * , 4 * 24 * 3600 - multiplying data points by 4 days
 	alertExp = intstr.FromString(
-		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[6h], 4 * 24 * 3600) <= 0 and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
+		fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_postgres_free_storage_average{job='%s'})[6h:1m], 4 * 24 * 3600) <= 0) and on (instanceID) (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))", job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresWillFill, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -516,7 +516,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
 	//    * [1h] - one hour data points
 	//    * , 4 * 3600 - multiplying data points by 4 hours
-	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[1h], 5 * 3600) >= 100 and cro_redis_memory_usage_percentage_average > 75) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
+	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[1h:1m], 5 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > 75)", job, job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -533,7 +533,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
 	//    * [6h] - six hour data points
 	//    * , 4 * 24 * 3600 - multiplying data points by 4 days
-	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[6h], 4 * 24 * 3600) >= 100 and cro_redis_memory_usage_percentage_average > 75) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
+	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[6h:1m], 4 * 24 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > 75)", job, job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor60Mins, alertExp, labels)
 	if err != nil {

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -357,10 +357,8 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	// building a predict_linear query using 2 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
 	//    * [1h] - one hour data points
 	//    * , 5 * 3600 - multiplying data points by 5 hour, to allow 1 hour of pending before firing the alert
-	// and matching by label `job` if the current time is greater than 1 hour of the process start time for the cloud resource operator metrics.
-	//    * on(job) - matching queries by label job across both metrics
 	alertExp := intstr.FromString(
-		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[1h], 5 * 3600) <= 0 and on(job) (time() - process_start_time_seconds{job='%s'}) / 3600 > 2) and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))", job, job))
+		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[1h], 5 * 3600) <= 0 and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
 
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopURL, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -378,10 +376,8 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	// building a predict_linear query using 2 hour of data points to predict a 4 day projection, and checking if it is less than or equal 0
 	//    * [2h] - 2 hour data points
 	//    * , 4 * 24 * 3600 - multiplying data points by 4 days
-	// and matching by label `job` if the current time is greater than 6 hour of the process start time for the cloud resource operator metrics.
-	//    * on(job) - matching queries by label job across both metrics
 	alertExp = intstr.FromString(
-		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[6h], 4 * 24 * 3600) <= 0 and on(job) (time() - process_start_time_seconds{job='%s'}) / 3600 > 2 ) and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))", job, job))
+		fmt.Sprintf("(predict_linear(cro_postgres_free_storage_average{job='%s'}[6h], 4 * 24 * 3600) <= 0 and (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25))) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlPostgresWillFill, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -520,9 +516,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
 	//    * [1h] - one hour data points
 	//    * , 4 * 3600 - multiplying data points by 4 hours
-	// and matching by label `job` if the current time is greater than 1 hour of the process start time for the cloud resource operator metrics.
-	//    * on(job) - matching queries by label job across both metrics
-	alertExp = intstr.FromString(fmt.Sprintf("predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[1h], 5 * 3600) >= 100 and on(job) (time() - process_start_time_seconds{job='%s'}) / 3600 > 1", job, job))
+	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[1h], 5 * 3600) >= 100 and cro_redis_memory_usage_percentage_average > 75) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor60Mins, alertExp, labels)
 	if err != nil {
@@ -539,9 +533,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
 	//    * [6h] - six hour data points
 	//    * , 4 * 24 * 3600 - multiplying data points by 4 days
-	// and matching by label `job` if the current time is greater than 6 hour of the process start time for the cloud resource operator metrics.
-	//    * on(job) - matching queries by label job across both metrics
-	alertExp = intstr.FromString(fmt.Sprintf("predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[6h], 4 * 24 * 3600) >= 100 and on(job) (time() - process_start_time_seconds{job='%s'}) / 3600 > 1", job, job))
+	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(cro_redis_memory_usage_percentage_average{job='%s'}[6h], 4 * 24 * 3600) >= 100 and cro_redis_memory_usage_percentage_average > 75) * on(pod) group_left(label_name) kube_pod_labels{label_name='cloud-resource-operator'}", job))
 
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, cr.Namespace, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor60Mins, alertExp, labels)
 	if err != nil {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
* Update `RedisMemoryUsageMaxIn4Days` & `RedisMemoryUsageMaxIn4Hours` to include and statement to only fire if `cro_redis_memory_usage_percentage_average` > 75 
* Sum metrics based on `instanceID` and use time series from this data for prediction as restarting CRO will create new metrics under different pod name 

Jira:
* https://issues.redhat.com/browse/MGDAPI-693

## Verifcation
* Checkout this branch
* Install RHOAM on a **BYOC** cluster
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local 
SELF_SIGNED_CERTS=false USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
make code/run
```
* Verify `RedisMemoryUsageMaxIn4Days` is not firing during and after install
* Fill redis memory by following: https://github.com/integr8ly/cloud-resource-operator/tree/master/hack/redis
* Verify redis alerts are firing

![Screenshot from 2020-12-10 12-57-23](https://user-images.githubusercontent.com/24636860/101892679-945ca000-3b9b-11eb-975d-8b174f4f9257.png)

<!--  * Fill postgres memory by following: https://github.com/integr8ly/cloud-resource-operator/tree/master/hack/postgres
* Verify postgres alerts are firing  -->
* Restart cloud resource operator 
* Verify alerts are still firing even after restart

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer