### PR TITLE
MGDAPI-1002 - improve logging in marin3r reconciler

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -492,7 +492,7 @@ func GetGrafanaConsoleURL(ctx context.Context, serverClient k8sclient.Client, in
 
 	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: defaultRoutename, Namespace: ns}, grafanaRoute)
 	if err != nil {
-		return "", fmt.Errorf("Failed to get route for Grafana: %w", err)
+		return "", err
 	}
 
 	return "https://" + grafanaRoute.Spec.Host, nil

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -19,6 +19,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	marin3r "github.com/3scale/marin3r/pkg/apis/operator/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
@@ -262,7 +263,21 @@ func (r *Reconciler) reconcileAlerts(ctx context.Context, client k8sclient.Clien
 
 	granafaConsoleURL, err := grafana.GetGrafanaConsoleURL(ctx, client, installation)
 	if err != nil {
+		if productsStage, ok := installation.Status.Stages[v1alpha1.ProductsStage]; ok {
+			if productsStage.Products != nil {
+				grafanaProduct, grafanaProductExists := productsStage.Products[v1alpha1.ProductGrafana]
+				// Ignore the Forbidden and NotFound errors if Grafana is not installed yet
+				if !grafanaProductExists ||
+					(grafanaProduct.Status != v1alpha1.PhaseCompleted &&
+						(k8serr.IsForbidden(err) || k8serr.IsNotFound(err))) {
+
+					logrus.Info("Failed to get Grafana console URL. Awaiting completion of Grafana installation")
+					return integreatlyv1alpha1.PhaseInProgress, nil
+				}
+			}
+		}
 		logrus.Errorf("failed to get Grafana console URL %v", err)
+		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	grafanaDashboardURL := fmt.Sprintf("%s/d/66ab72e0d012aacf34f907be9d81cd9e/rate-limiting", granafaConsoleURL)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
JIRA: https://issues.redhat.com/browse/MGDAPI-1002

Marin3r and customer monitoring [are in the same stage](https://github.com/integr8ly/integreatly-operator/blob/a78b3aaad51a74f32355b60b524bb7e12d4514aa/pkg/controller/installation/types.go#L48-L49),
and marin3r reconciler [tries to retrieve grafana URL](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/marin3r/reconciler.go#L225-L263) before "redhat-rhoam-customer-monitoring" ns is created.
This results into an error message in logs which can in fact be ignored under specific circumstances (during installation, before grafana is installed). Error message:

> time="2020-12-17T00:29:28Z" level=error msg="failed to get Grafana console URL Failed to get route for Grafana: routes.route.openshift.io \"grafana-route\" is forbidden: User \"system:serviceaccount:redhat-rhoam-operator:rhmi-operator\" cannot get resource \"routes\" in API group \"route.openshift.io\" in the namespace \"redhat-rhoam-customer-monitoring\""

This change should ensure that this error is not logged when Garafana isn't fully installed.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer