### PR TITLE
Add support for a from alert email address

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ export SELF_SIGNED_CERTS   ?= true
 # Setting the INSTALLATION_TYPE to managed-api will configure the values required for RHOAM installs
 export INSTALLATION_TYPE   ?= managed
 
+export ALERT_SMTP_FROM ?=no-reply-alert@devshift.org
 export USE_CLUSTER_STORAGE ?= true
 export OPERATORS_IN_PRODUCT_NAMESPACE ?= false # e2e tests and createInstallationCR() need to be updated when default is changed
 export DELOREAN_PULL_SECRET_NAME ?= integreatly-delorean-pull-secret

--- a/deploy/crds/integreatly.org_rhmis_crd.yaml
+++ b/deploy/crds/integreatly.org_rhmis_crd.yaml
@@ -17,20 +17,18 @@ spec:
       description: RHMI is the Schema for the RHMI API
       properties:
         apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+          description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
           type: string
         kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
           type: string
         metadata:
           type: object
         spec:
           description: RHMISpec defines the desired state of Installation
           properties:
+            alertFromAddress:
+              type: string
             alertingEmailAddress:
               type: string
             alertingEmailAddresses:
@@ -44,25 +42,17 @@ spec:
               - cssre
               type: object
             deadMansSnitchSecret:
-              description: "DeadMansSnitchSecret is the name of a secret in the installation
-                namespace containing connection details for Dead Mans Snitch. The
-                secret must contain the following fields: \n url"
+              description: "DeadMansSnitchSecret is the name of a secret in the installation namespace containing connection details for Dead Mans Snitch. The secret must contain the following fields: \n url"
               type: string
             masterURL:
               type: string
             namespacePrefix:
               type: string
             operatorsInProductNamespace:
-              description: OperatorsInProductNamespace is a flag that decides if the
-                product operators should be installed in the product namespace (when
-                set to true) or in standalone namespace (when set to false, default).
-                Standalone namespace will be used only for those operators that support
-                it.
+              description: OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.
               type: boolean
             pagerDutySecret:
-              description: "PagerDutySecret is the name of a secret in the installation
-                namespace containing PagerDuty account details. The secret must contain
-                the following fields: \n serviceKey"
+              description: "PagerDutySecret is the name of a secret in the installation namespace containing PagerDuty account details. The secret must contain the following fields: \n serviceKey"
               type: string
             priorityClassName:
               type: string
@@ -76,26 +66,22 @@ spec:
               - name
               - namespace
               type: object
+            rebalancePods:
+              type: boolean
             routingSubdomain:
               type: string
             selfSignedCerts:
               type: boolean
             smtpSecret:
-              description: "SMTPSecret is the name of a secret in the installation
-                namespace containing SMTP connection details. The secret must contain
-                the following fields: \n host port tls username password"
+              description: "SMTPSecret is the name of a secret in the installation namespace containing SMTP connection details. The secret must contain the following fields: \n host port tls username password"
               type: string
             type:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: string
             useClusterStorage:
               type: string
-            rebalancePods:
-              type: boolean
           required:
+          - alertFromAddress
           - namespacePrefix
           - type
           type: object
@@ -149,10 +135,7 @@ spec:
                 - name
                 - phase
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
+              description: 'INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html'
               type: object
             toVersion:
               type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -54,3 +54,6 @@ spec:
               value: "managed"
             - name: REBALANCE_PODS
               value: "true"
+            # this should be set for production and development via MT repo
+            - name: ALERT_SMTP_FROM
+              value: "default@test.com"

--- a/pkg/apis/integreatly/v1alpha1/rhmi_types.go
+++ b/pkg/apis/integreatly/v1alpha1/rhmi_types.go
@@ -119,6 +119,8 @@ var (
 
 	DefaultOriginPullSecretName      = "pull-secret"
 	DefaultOriginPullSecretNamespace = "openshift-config"
+
+	EnvKeyAlertSMTPFrom = "ALERT_SMTP_FROM"
 )
 
 // RHMISpec defines the desired state of Installation
@@ -138,6 +140,7 @@ type RHMISpec struct {
 	AlertingEmailAddress   string                 `json:"alertingEmailAddress,omitempty"`
 	PriorityClassName      string                 `json:"priorityClassName,omitempty"`
 	AlertingEmailAddresses AlertingEmailAddresses `json:"alertingEmailAddresses,omitempty"`
+	AlertFromAddress       string                 `json:"alertFromAddress,omitempty"`
 
 	// OperatorsInProductNamespace is a flag that decides if
 	// the product operators should be installed in the product

--- a/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
+++ b/pkg/apis/integreatly/v1alpha1/zz_generated.openapi.go
@@ -151,6 +151,12 @@ func schema_pkg_apis_integreatly_v1alpha1_RHMISpec(ref common.ReferenceCallback)
 							Ref: ref("github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1.AlertingEmailAddresses"),
 						},
 					},
+					"alertFromAddress": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"string"},
+							Format: "",
+						},
+					},
 					"operatorsInProductNamespace": {
 						SchemaProps: spec.SchemaProps{
 							Description: "OperatorsInProductNamespace is a flag that decides if the product operators should be installed in the product namespace (when set to true) or in standalone namespace (when set to false, default). Standalone namespace will be used only for those operators that support it.",

--- a/pkg/controller/installation/installation_controller.go
+++ b/pkg/controller/installation/installation_controller.go
@@ -664,6 +664,12 @@ func (r *ReconcileInstallation) preflightChecks(installation *integreatlyv1alpha
 			_, err := strconv.ParseBool(s)
 			return err
 		}),
+		integreatlyv1alpha1.EnvKeyAlertSMTPFrom: requiredEnvVar(func(s string) error {
+			if s == "" {
+				return fmt.Errorf(" env var %s is required ", integreatlyv1alpha1.EnvKeyAlertSMTPFrom)
+			}
+			return nil
+		}),
 	}); err != nil {
 		return result, err
 	}

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	prometheus "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -740,11 +741,16 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 		smtpToCustomerAddress = prepareEmailAddresses(smtpToCustomerAddressCRVal)
 	}
 
+	smtpAlertFromAddress := os.Getenv(integreatlyv1alpha1.EnvKeyAlertSMTPFrom)
+	if r.installation.Spec.AlertFromAddress != "" {
+		smtpAlertFromAddress = r.installation.Spec.AlertFromAddress
+	}
+
 	// parse the config template into a secret object
 	templateUtil := NewTemplateHelper(map[string]string{
 		"SMTPHost":              string(smtpSecret.Data["host"]),
 		"SMTPPort":              string(smtpSecret.Data["port"]),
-		"AlertManagerRoute":     alertmanagerRoute.Spec.Host,
+		"SMTPFrom":              smtpAlertFromAddress,
 		"SMTPUsername":          string(smtpSecret.Data["username"]),
 		"SMTPPassword":          string(smtpSecret.Data["password"]),
 		"SMTPToCustomerAddress": smtpToCustomerAddress,

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -47,6 +47,7 @@ const (
 	mockAlertingEmailAddress         = "noreply-test@rhmi-redhat.com"
 	mockBUAlertingEmailAddress       = "noreply-bu-test@rhmi-redhat.com"
 	mockIsMultiAZCluster             = true
+	mockAlertFromAddress             = "noreply-alert@devshift.org"
 )
 
 func basicInstallation() *integreatlyv1alpha1.RHMI {
@@ -71,6 +72,7 @@ func basicInstallation() *integreatlyv1alpha1.RHMI {
 
 func basicInstallationWithAlertEmailAddress() *integreatlyv1alpha1.RHMI {
 	installation := basicInstallation()
+	installation.Spec.AlertFromAddress = mockAlertFromAddress
 	installation.Spec.AlertingEmailAddress = mockCustomerAlertingEmailAddress
 	installation.Spec.AlertingEmailAddresses.CSSRE = mockAlertingEmailAddress
 	installation.Spec.AlertingEmailAddresses.BusinessUnit = mockBUAlertingEmailAddress
@@ -622,14 +624,16 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 		t.Fatal(err)
 	}
 	basicLogger := logrus.NewEntry(logrus.StandardLogger())
-	basicReconciler := &Reconciler{
-		installation: basicInstallation(),
-		Logger:       basicLogger,
-		Config: &config.Monitoring{
-			Config: map[string]string{
-				"OPERATOR_NAMESPACE": defaultInstallationNamespace,
+	basicReconciler := func() *Reconciler {
+		return &Reconciler{
+			installation: basicInstallation(),
+			Logger:       basicLogger,
+			Config: &config.Monitoring{
+				Config: map[string]string{
+					"OPERATOR_NAMESPACE": defaultInstallationNamespace,
+				},
 			},
-		},
+		}
 	}
 
 	installation := basicInstallation()
@@ -690,14 +694,14 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 	templateUtil := NewTemplateHelper(map[string]string{
 		"SMTPHost":              string(smtpSecret.Data["host"]),
 		"SMTPPort":              string(smtpSecret.Data["port"]),
-		"AlertManagerRoute":     alertmanagerRoute.Spec.Host,
+		"SMTPFrom":              mockAlertFromAddress,
 		"SMTPUsername":          string(smtpSecret.Data["username"]),
 		"SMTPPassword":          string(smtpSecret.Data["password"]),
 		"PagerDutyServiceKey":   string(pagerdutySecret.Data["serviceKey"]),
 		"DeadMansSnitchURL":     string(dmsSecret.Data["url"]),
-		"SMTPToCustomerAddress": fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
-		"SMTPToSREAddress":      fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
-		"SMTPToBUAddress":       fmt.Sprintf("noreply@%s", alertmanagerRoute.Spec.Host),
+		"SMTPToCustomerAddress": mockCustomerAlertingEmailAddress,
+		"SMTPToSREAddress":      mockAlertingEmailAddress,
+		"SMTPToBUAddress":       mockBUAlertingEmailAddress,
 	})
 
 	testSecretData, err := templateUtil.loadTemplate(alertManagerConfigTemplatePath)
@@ -717,7 +721,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			wantErr: "could not obtain pagerduty credentials secret: secrets \"test-pd\" not found",
 			want:    integreatlyv1alpha1.PhaseFailed,
@@ -730,7 +734,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, emptyPagerdutySecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			wantErr: "secret key is undefined in pager duty secret",
 			want:    integreatlyv1alpha1.PhaseFailed,
@@ -741,7 +745,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			wantErr: "could not obtain dead mans snitch credentials secret: secrets \"test-dms\" not found",
 			want:    integreatlyv1alpha1.PhaseFailed,
@@ -754,7 +758,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, emptyDMSSecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			wantErr: "url is undefined in dead mans snitch secret",
 			want:    integreatlyv1alpha1.PhaseFailed,
@@ -765,7 +769,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, dmsSecret)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			want: integreatlyv1alpha1.PhaseAwaitingComponents,
 		},
@@ -779,7 +783,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				}
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				return basicReconciler()
 			},
 			wantErr: "could not obtain alert manager route: test",
 			want:    integreatlyv1alpha1.PhaseFailed,
@@ -790,7 +794,9 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, dmsSecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				rec := basicReconciler()
+				rec.installation = basicInstallationWithAlertEmailAddress()
+				return rec
 			},
 			want: integreatlyv1alpha1.PhaseCompleted,
 			wantFn: func(c k8sclient.Client) error {
@@ -810,7 +816,9 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, dmsSecret, alertmanagerRoute, alertmanagerConfigSecret)
 			},
 			reconciler: func() *Reconciler {
-				return basicReconciler
+				rec := basicReconciler()
+				rec.installation = basicInstallationWithAlertEmailAddress()
+				return rec
 			},
 			want: integreatlyv1alpha1.PhaseCompleted,
 			wantFn: func(c k8sclient.Client) error {
@@ -830,7 +838,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, dmsSecret, alertmanagerRoute)
 			},
 			reconciler: func() *Reconciler {
-				reconciler := basicReconciler
+				reconciler := basicReconciler()
 				reconciler.installation = basicInstallationWithAlertEmailAddress()
 				return reconciler
 			},
@@ -843,7 +851,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 				templateUtil := NewTemplateHelper(map[string]string{
 					"SMTPHost":              string(smtpSecret.Data["host"]),
 					"SMTPPort":              string(smtpSecret.Data["port"]),
-					"AlertManagerRoute":     alertmanagerRoute.Spec.Host,
+					"SMTPFrom":              mockAlertFromAddress,
 					"SMTPUsername":          string(smtpSecret.Data["username"]),
 					"SMTPPassword":          string(smtpSecret.Data["password"]),
 					"PagerDutyServiceKey":   string(pagerdutySecret.Data["serviceKey"]),

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -1,7 +1,7 @@
 global:
   resolve_timeout: 5m
   smtp_smarthost: {{ index .Params "SMTPHost" }}:{{ index .Params "SMTPPort" }}
-  smtp_from: noreply@{{ index .Params "AlertManagerRoute" }}
+  smtp_from: {{ index .Params "SMTPFrom" }}
   smtp_auth_username: {{ index .Params "SMTPUsername" }}
   smtp_auth_password: {{ index .Params "SMTPPassword"}}
 route:


### PR DESCRIPTION
# Description
$subject

As part of this change we will need to add a new parameter to the managed tenants repo see PR 471

**Verification**

Spin up a cluster and run the operator locally overriding ALERT_SMTP_FROM and setting it to a value of your choice.

Once the install is complete, check the smtp config in alert manager

```
oc get secret alertmanager-application-monitoring -n redhat-rhoam-middleware-monitoring-operator -o=yaml
```

it should have the ```smtp_from``` set to your chosen email address.



## Type of change

<!-- Please delete options that are not relevant. -->


- [x] New feature (non-breaking change which adds functionality)


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer