### PR TITLE
INTLY-10344 Update all "RegistryCsServiceEndpointDown" alerts to warning

### DIFF
--- a/pkg/products/amqonline/prometheusRules.go
+++ b/pkg/products/amqonline/prometheusRules.go
@@ -97,7 +97,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 					{
 						Alert: "RHMIAMQOnlineStandardAuthServiceEndpointDown",

--- a/pkg/products/apicurito/prometheusRules.go
+++ b/pkg/products/apicurito/prometheusRules.go
@@ -76,7 +76,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace=`%s`} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 				},
 			},

--- a/pkg/products/codeready/prometheusRules.go
+++ b/pkg/products/codeready/prometheusRules.go
@@ -65,7 +65,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 				},
 			},

--- a/pkg/products/fuse/prometheusRules.go
+++ b/pkg/products/fuse/prometheusRules.go
@@ -95,7 +95,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 					{
 						Alert: "RHMIFuseOnlineOperatorSyndesisOperatorMetricsServiceEndpointDown",

--- a/pkg/products/solutionexplorer/prometheusRules.go
+++ b/pkg/products/solutionexplorer/prometheusRules.go
@@ -45,7 +45,7 @@ func (r *Reconciler) newAlertReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 				},
 			},

--- a/pkg/products/ups/prometheusRules.go
+++ b/pkg/products/ups/prometheusRules.go
@@ -55,7 +55,7 @@ func (r *Reconciler) newAlertsReconciler() resources.AlertReconciler {
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
-						Labels: map[string]string{"severity": "critical"},
+						Labels: map[string]string{"severity": "warning"},
 					},
 					{
 						Alert: "RHMIUPSOperatorUnifiedPushOperatorMetricsServiceEndpointDown",


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
JIRA: https://issues.redhat.com/browse/INTLY-10344
As requested by CS-SRE, I downgraded severity of "*RegistryCsServiceEndpointDown" alerts down to "warning".
Note: in the diff you might notice that not all products have been updated, that's because some had this alert marked as a "warning" already.

Prometheus config before my changes (installed RHMI v2.7.1):
https://gist.github.com/matskiv/86114be66931bcb37fd13081a2341aae/raw/6743c18123850f32cee8fe259b3ca3275cad9875/config-before

Prometheus config with the change (I just run locally with the new code, operator updated the alerts automatically):
https://gist.github.com/matskiv/86114be66931bcb37fd13081a2341aae/raw/6743c18123850f32cee8fe259b3ca3275cad9875/config-after

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer