### PR TITLE
EC2 name and type parametrized

### DIFF
--- a/scripts/ec2_deploy_teardown/tearDown.sh
+++ b/scripts/ec2_deploy_teardown/tearDown.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Obtaining security group"
-SECGRP=`aws ec2 describe-security-groups --region ${CLUSTER_REGION} --filters Name=group-name,Values=pipeline-sg --query SecurityGroups[0].GroupId --output text`
+SECGRP=`aws ec2 describe-security-groups --region ${CLUSTER_REGION} --filters Name=group-name,Values=${EC2_NAME}-sg --query SecurityGroups[0].GroupId --output text`
 for (( i=0; i<5; i++ )) do
     if [[ $SECGRP =~ "sg-" ]]; then
       echo "SECGRP "${SECGRP}" identified"
@@ -10,8 +10,8 @@ for (( i=0; i<5; i++ )) do
     sleep 5
 done
 
-echo "Obtaining EC2 micro-t2 instance"
-EC2=`aws ec2 describe-instances  --region ${CLUSTER_REGION} --filters Name=key-name,Values=pipelineKey Name=instance-state-name,Values=running --query Reservations[0].Instances[0].InstanceId --output text`
+echo "Obtaining EC2 instance"
+EC2=`aws ec2 describe-instances  --region ${CLUSTER_REGION} --filters Name=key-name,Values=${EC2_NAME}Key Name=instance-state-name,Values=running --query Reservations[0].Instances[0].InstanceId --output text`
 for (( i=0; i<5; i++ )) do
     if [[ $EC2 =~ "i-" ]]; then
       echo "EC2 "${EC2}" identified"
@@ -46,7 +46,7 @@ aws ec2 disassociate-address --association-id $ASSOC --region $CLUSTER_REGION
 echo "Releasing address "$ELIP
 aws ec2 release-address --allocation-id $ELIP --region $CLUSTER_REGION
 
-echo "Terminatinng EC2 instance "$EC2
+echo "Terminating EC2 instance "$EC2
 aws ec2 terminate-instances --instance-ids $EC2 --region $CLUSTER_REGION
 for (( i=0; i<60; i++ )) do
     commandResult=$(aws ec2 describe-instances  --region ${CLUSTER_REGION} --instance-ids $EC2 --query Reservations[0].Instances[0].State.Name --output text)
@@ -63,7 +63,7 @@ sleep 30
 echo "Deleting security group "$SECGRP
 aws ec2 delete-security-group --group-id $SECGRP --region $CLUSTER_REGION
 
-echo "Deleting key-pair pipelineKey from aws"
-aws ec2 delete-key-pair --key-name pipelineKey --region $CLUSTER_REGION
+echo "Deleting key-pair ${EC2_NAME}Key from aws"
+aws ec2 delete-key-pair --key-name ${EC2_NAME}Key --region $CLUSTER_REGION
 
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
https://issues.redhat.com/browse/MGDAPI-986
Improvements of the script. The EC2 instance type is now parametrized thus EC2 instances of different types (not just t2.micro) can be created and removed using the scripts.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x ] New feature (non-breaking change which adds functionality)

## Verification Steps
The PR has been verified via Jenkins where I used the scripts in the pipelines (this is what the scripts are primarily for):
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Playground/job/trepel-ec2/
see builds 2, 3 and 5.

I think it is sufficient to eye review the code changes and the build logs for verification.
