### PR TITLE
Remove keycloak route MGDAPI-1026

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -45,6 +45,7 @@ var (
 	numberOfReplicas          = 2
 	ssoType                   = "rhsso"
 	postgresResourceName      = "rhsso-postgres-rhmi"
+	routeName                 = "keycloak-edge"
 )
 
 const (
@@ -150,7 +151,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon)
+	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to handle in progress phase", err)
 		return phase, err

--- a/test-cases/tests/authorization/b01b-verify-that-the-users-can-login-in-all-products.md
+++ b/test-cases/tests/authorization/b01b-verify-that-the-users-can-login-in-all-products.md
@@ -19,7 +19,7 @@ Products:
 
 - OpenShift Console
 - 3Scale (redhat-rhoam-3scale), route name: zync-3scale-provider, URL starting with "https://3scale-admin"
-- User SSO (redhat-rhoam-user-sso), route name: keycloak-edge
+- User SSO (redhat-rhoam-user-sso), route name: keycloak
 
 ## Steps
 

--- a/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
+++ b/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
@@ -100,7 +100,7 @@ Measure the downtime of the RHOAM components during a AWS Availability Zone fail
    If you did it manually then you need to generate a token:
 
    ```bash
-   curl -X POST 'https://keycloak-edge-redhat-rhoam-user-sso.apps.<YOUR-CLUSTER>.s1.devshift.org:443/auth/realms/<YOUR-REALM>/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=password&client_id=<CLIENT-ID>&client_secret=<CLIENT-SECRET>&username=<USER>&password=<PASSWORD>" | jq -r '.access_token'
+   curl -X POST 'https://keycloak-redhat-rhoam-user-sso.apps.<YOUR-CLUSTER>.s1.devshift.org:443/auth/realms/<YOUR-REALM>/protocol/openid-connect/token' -H "Content-Type: application/x-www-form-urlencoded" --data "grant_type=password&client_id=<CLIENT-ID>&client_secret=<CLIENT-SECRET>&username=<USER>&password=<PASSWORD>" | jq -r '.access_token'
    ```
 
    All the required values for the command above are available in your user SSO instance.

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -133,6 +133,13 @@ var (
 		},
 	}
 
+	rhoamUserSsoRoutes = []ExpectedRoute{
+		ExpectedRoute{
+			Name:  "keycloak",
+			isTLS: true,
+		},
+	}
+
 	apicuritoRoutes = []ExpectedRoute{
 		ExpectedRoute{
 			Name:  "apicurito",
@@ -168,7 +175,7 @@ var managedApiExpectedRoutes = map[string][]ExpectedRoute{
 	"3scale":                         threeScaleRoutes,
 	"middleware-monitoring-operator": middlewareMonitoringRoutes,
 	"rhsso":                          rhssoRoutes,
-	"user-sso":                       userSsoRoutes,
+	"user-sso":                       rhoamUserSsoRoutes,
 	"customer-monitoring-operator":   customerGrafanaRoutes,
 }
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDAPI-1026

# Description
Currently, we have 2 routes for user-sso for RHOAM, one called `keycloak` is KCO generated route, and another one, `keycloak-edge`, is managed by RHOAM operator. Both routes use re-encrypt TLS termination policy and it makes no point in keeping two as only the edge route is being used.

# How
- KCO route has been disabled leaving only the `keycloak-edge` route available. 
- The name of the `keycloak-edge` route has been updated to `keycloak` since it is no longer using edge termination policy, and also since this work is preparing us for enabling user-sso rate-limiting in the future if it happens that we decide not to enable rate-limiting on user-sso, we can switch back to KCO managed routing without changing the host address.
- Unit test has been updated to test if the RHOAM full reconcile works as expected ( with the new route )
- E2E test has been updated to reflect changes
- Some test cases have been updated to match the new name for the route

# Verify
## RHOAM
- Install Managed-API from this branch
- Navigate to user sso ns and confirm that there's only 1 route present. 
- Check if user-sso can be accessed
- Confirm that RHOAM e2e test passed

## RHMI
- Install RHMI from this branch
- Navigate to user sso ns and confirm that there's 2 routes present (edge and keycloak route)
- Confirm that user-sso can be accessed via the edge route
- Confirm that RHMI e2e test passed on this PR