### PR TITLE
MGDAPI-1028 - Add cluster infra id as part of alert email subject

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -468,3 +468,12 @@ rules:
     verbs:
       - list
   # END Permission to list nodes in order to determine if a cluster is multi-az
+
+  # Permission to get cluster infrastructure details for alerting
+  - apiGroups:
+      - config.openshift.io
+    resources:
+      - infrastructures
+    verbs:
+      - get
+  # END Permission to get cluster infrastructure details for alerting

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -40,12 +40,16 @@ receivers:
     email_configs:
       - send_resolved: true
         to: {{ index .Params "SMTPToSREAddress" }}
+        headers:
+          Subject: '{{ index .Params "Subject" }}'
   - name: critical
     pagerduty_configs:
       - service_key: {{ index .Params "PagerDutyServiceKey" }}
     email_configs:
       - send_resolved: true
         to: {{ index .Params "SMTPToSREAddress" }}
+        headers:
+          Subject: '{{ index .Params "Subject" }}'
   - name: deadmansswitch
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
@@ -53,14 +57,20 @@ receivers:
     email_configs:
       - send_resolved: True
         to: '{{ index .Params "SMTPToBUAddress" }}'
+        headers:
+          Subject: '{{ index .Params "Subject" }}'
   - name: BUandCustomer
     email_configs:
       - send_resolved: True
         to: '{{ index .Params "SMTPToBUAddress" }}, {{ index .Params "SMTPToCustomerAddress" }}'
+        headers:
+          Subject: '{{ index .Params "Subject" }}'
   - name: SRECustomerBU
     email_configs:
       - send_resolved: True
         to: '{{ index .Params "SMTPToSREAddress" }}, {{ index .Params "SMTPToBUAddress" }}, {{ index .Params "SMTPToCustomerAddress" }}'
+        headers:
+          Subject: '{{ index .Params "Subject" }}'
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
For CSSRE, it would nice to have the cluster id as part of the subject field in the emails sent by alertmanager to help them filter the alerts per cluster

Jira:
* https://issues.redhat.com/browse/MGDAPI-822
## Type of change

<!-- Please delete options that are not relevant. -->

## Short Verification
* Checkout this branch and install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Check alertmanager config in `alertmanager-application-monitoring` secret in `redhat-rhoam-middleware-monitoring-operator` namespace and verify that the your cluster infra id is used as part of the reciever email_configs

![Screenshot from 2021-01-07 14-42-40](https://user-images.githubusercontent.com/24636860/103909640-dbd33f00-50fb-11eb-92bb-c636188f48f2.png)
* Check config is loaded properly and reflected in alertmanager status page

![Screenshot from 2021-01-07 14-42-10](https://user-images.githubusercontent.com/24636860/103912393-2609ef80-50ff-11eb-9f73-12d1bb4eddb2.png)

## Longer Verification
* Install as per above
* Update the RHOAM CR alerting emails addresses to your own email address
* Update `redhat-rhoam-smtp` with valid credentials (reach out if verifying to get credentials)
* Once smtp credential have been reconciled to alertmanager. Trigger alerts to fire
  * Scale down RHSSO operator and RHSSO stateful set
  ```
  oc scale deployment keycloak-operator --replicas=0 -n redhat-rhoam-rhsso-operator
  oc scale statefulset keycloak --replicas=0 -n redhat-rhoam-rhsso
  ```
* Verify alert email contains the cluster infra id as part of email subject once received

![image](https://user-images.githubusercontent.com/24636860/103912264-f4912400-50fe-11eb-8907-87731fcc103e.png)

- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] Verified independently on a cluster by reviewer