### PR TITLE
fix(monitoring):INTLY-10367 change the default scraping interval and …

### DIFF
--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -8,6 +8,17 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 )
 
+const (
+	// Configuration key to set the scrape interval for the federate metrics
+	MonitoringParamFederateScrapeInterval = "FEDERATE_SCRAPE_INTERVAL"
+	// Configuration key to set the scrape timeout for the federate metrics
+	MonitoringParamFederateScrapeTimeout = "FEDERATE_SCRAPE_TIMEOUT"
+	// The default value for the scrape interval for the federate metrics. Default is 60s.
+	MonitoringDefaultFederateScrapeInterval = "60s"
+	// The default value for the scrape interval for the federate timeout. Default is 30s.
+	MonitoringDefaultFederateScrapeTimeout = "30s"
+)
+
 type Monitoring struct {
 	Config ProductConfig
 }
@@ -175,4 +186,12 @@ func (m *Monitoring) Validate() error {
 	}
 
 	return nil
+}
+
+// Try to get the value for the given key from the configuration if it exists. Otherwise return the default value instead.
+func (m *Monitoring) GetExtraParamWithDefault(key string, v string) string {
+	if val, ok := m.Config[key]; ok {
+		return val
+	}
+	return v
 }

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -401,8 +401,8 @@ func (r *Reconciler) reconcileFederation(ctx context.Context, serverClient k8scl
 					Params: map[string][]string{
 						"match[]": []string{"{__name__=\"ALERTS\",alertstate=\"firing\"}"},
 					},
-					Interval:      "30s",
-					ScrapeTimeout: "30s",
+					Interval:      r.Config.GetExtraParamWithDefault(config.MonitoringParamFederateScrapeInterval, config.MonitoringDefaultFederateScrapeInterval),
+					ScrapeTimeout: r.Config.GetExtraParamWithDefault(config.MonitoringParamFederateScrapeTimeout, config.MonitoringDefaultFederateScrapeTimeout),
 					HonorLabels:   true,
 				},
 			},
@@ -685,6 +685,8 @@ func (r *Reconciler) populateParams(ctx context.Context, serverClient k8sclient.
 	r.extraParams["openshift_monitoring_namespace"] = OpenshiftMonitoringNamespace
 	r.extraParams["openshift_monitoring_prometheus_username"] = datasources.DataSources[0].BasicAuthUser
 	r.extraParams["openshift_monitoring_prometheus_password"] = datasources.DataSources[0].BasicAuthPassword
+	r.extraParams["openshift_monitoring_federate_scrape_interval"] = r.Config.GetExtraParamWithDefault(config.MonitoringParamFederateScrapeInterval, config.MonitoringDefaultFederateScrapeInterval)
+	r.extraParams["openshift_monitoring_federate_scrape_timeout"] = r.Config.GetExtraParamWithDefault(config.MonitoringParamFederateScrapeTimeout, config.MonitoringDefaultFederateScrapeTimeout)
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/templates/monitoring/jobs/openshift_monitoring_federation.yaml
+++ b/templates/monitoring/jobs/openshift_monitoring_federation.yaml
@@ -5,7 +5,8 @@
     namespaces:
       names:
       - {{ index .Params "openshift_monitoring_namespace" }}
-  scrape_interval: 30s
+  scrape_interval: {{ index .Params "openshift_monitoring_federate_scrape_interval" }}
+  scrape_timeout: {{ index .Params "openshift_monitoring_federate_scrape_timeout" }}
   metrics_path: /federate
   params:
     match[]:


### PR DESCRIPTION
…timeout for federate metrics and make them configurable

# Description
https://issues.redhat.com/browse/INTLY-10367

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification Steps

1. Checkout the branc. Make sure you have an openshift cluster and then run `make code/run` to run it locally.
2. Once the monitoring stack is installed, go and check the `rhmi-additional-scrape-configs` secret in the `redhat-rhmi-middleware-monitoring-operator` namespace and see the scrape config for openshift metric federation. Default should be interval: 60s and timeout: 30s.
3. Go to the `redhat-rhmi-operator` namespace and update the configmap called `
redhat-rhmi-installation-config`. Set `FEDERATE_SCRAPE_INTERVAL` and `FEDERATE_SCRAPE_TIMEOUT` in the `middleware-monitoring` to something like `90s` and `60s` respectively.
4. Repeat step 2 and check the values are updated to match the configuration.
5. Check `rhmi-alerts-federate` servicemonitor in the `redhat-rhmi-middleware-monitoring-federate` namespace to have the same configuration as well. 

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer