### PR TITLE
Updating Grafana version to 7.2.0

### DIFF
--- a/pkg/resources/constants/grafanaConstants.go
+++ b/pkg/resources/constants/grafanaConstants.go
@@ -2,5 +2,5 @@ package constants
 
 const (
 	GrafanaImage   = "quay.io/integreatly/grafana"
-	GrafanaVersion = "7.1.1"
+	GrafanaVersion = "7.2.0"
 )


### PR DESCRIPTION
##Description

[MGDAPI-1005](https://issues.redhat.com/browse/MGDAPI-1005)

Update Grafana version to mirror what's used in the `openshift-monitoring` Grafana (7.2.0).

## Verification Steps
- Install RHOAM
- Check the correct Grafana version is being used in both the middleware-monitoring and customer-grafana namespaces (`7.2.0`)
- Login to both of the above-mentioned namespaces and ensure that dashboards are present and that it loads without error

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer