### PR TITLE
set cidrvalue to empty rather than returning

### DIFF
--- a/deploy/cro-aws-config.yml
+++ b/deploy/cro-aws-config.yml
@@ -3,7 +3,5 @@ apiVersion: v1
 metadata:
   name: cloud-resources-aws-strategies
 data:
-  _network: >-
-    { "production": { "createStrategy": {} } }
   blobstorage: >-
     { "production": { "createStrategy": {}, "deleteStrategy": {} } }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"strings"
+	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/backup"
@@ -406,8 +407,8 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 		return err
 	}
 
-	if !ok {
-		return nil
+	if !ok || cidrValue == "" && r.installation.ObjectMeta.CreationTimestamp.Time.Before(time.Now().Add(-(1*time.Minute))) {
+		cidrValue = ""
 	}
 
 	cfgMap := &corev1.ConfigMap{}


### PR DESCRIPTION
# Description

- Set the cidrvalue to nil if there is no addonParam after some time
- Remove the network block from the local dev setup to mimic addon installation

## Verification

Against a byoc cluster

INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make cluster/prepare/local
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make code/run/service_account

Verify cloud-resources-aws-strategies config map does not contain a default entry { "production": { "createStrategy": {} } }
Verify that the vpc in aws has been created with a sensible default.
Verify that the rds is created inside that vpc.