### PR TITLE
Node anti-affinity rules for RHOAM

### DIFF
--- a/pkg/resources/podAntiAffinity.go
+++ b/pkg/resources/podAntiAffinity.go
@@ -15,10 +15,12 @@ import (
 const (
 	// ZoneLabel is the label that specifies the zone where a node is
 	ZoneLabel = "topology.kubernetes.io/zone"
+	// NodeLabel is the label that specifies pods listed on a node
+	NodeLabel = "kubernetes.io/hostname"
 	// AntiAffinityRequiredEnvVar is an environment variable that, when set to
 	// true, makes the product pod replicas use "required" anti affinity rules
-	// by AZ
-	AntiAffinityRequiredEnvVar = "FORCE_ZONE_DISTRIBUTION"
+	// by AZ and Node
+	AntiAffinityRequiredEnvVar = "FORCED_DISTRIBUTION"
 )
 
 // MutateMultiAZAntiAffinity returns a PodTemplateMutation that sets the anti
@@ -61,6 +63,15 @@ func MultiAZAntiAffinityPreferred(matchLabels map[string]string) *corev1.Affinit
 					},
 					Weight: 100,
 				},
+				{
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &v1.LabelSelector{
+							MatchLabels: matchLabels,
+						},
+						TopologyKey: NodeLabel,
+					},
+					Weight: 100,
+				},
 			},
 		},
 	}
@@ -77,6 +88,12 @@ func MultiAZAntiAffinityRequired(matchLabels map[string]string) *corev1.Affinity
 						MatchLabels: matchLabels,
 					},
 					TopologyKey: ZoneLabel,
+				},
+				{
+					LabelSelector: &v1.LabelSelector{
+						MatchLabels: matchLabels,
+					},
+					TopologyKey: NodeLabel,
 				},
 			},
 		},


### PR DESCRIPTION
# Description
Jira: https://issues.redhat.com/browse/MGDAPI-720
Add anti-affinity rules to nodes

# Verification
- Install RHOAM from this branch on a ccs multi az cluster
- Keep an eye on RHMI CR and before envoy-side car containers are attached to apicast production pods run the following script:
```
#!/bin/sh
# Prereq:
# - oc
# - jq
# Usage:
# ./podsAz.sh [<namespace>]
# <namespace> parameter is optional, defaults to ALL namespaces when ommited
# Function:
# Lists the Pods for a namespace and their Availability Zones

NODES_ARR=()
ZONES_ARR=()

# get list of node names and their zones and push this information into two arrays
nodes=$(oc get nodes -o json | jq -r '.items[].metadata | .name + " " + .labels["topology.kubernetes.io/zone"]')
while read -a line; do
  NODES_ARR+=(${line[0]})
  ZONES_ARR+=(${line[1]})
done <<< "$nodes"

# returns associated zone for a node name passed as parameter
get_zone() {
  for i in ${!NODES_ARR[@]}; do
    if [[ ${NODES_ARR[$i]} == $1 ]]; then
      echo ${ZONES_ARR[$i]}
      break
    fi
  done
}

NAMESPACE="redhat-rhoam-3scale"
if [[ $NAMESPACE == "" ]]; then
  echo "Pods distribution for ALL namespaces"
  NAMESPACE_ARG="--all-namespaces"
else
  echo "Pods distribution for '$NAMESPACE'"
  NAMESPACE_ARG="-n $NAMESPACE"
fi

pods=$(oc get pods $NAMESPACE_ARG -o json | jq -r '.items[] | .metadata.namespace + " " + .metadata.name + " " + .spec.nodeName + .spec.nodeIP')
echo "| Pod namespace | Pod name | Availability Zone |"
echo "| ------------- | -------- | ----------------- |"
while read -a pod; do
  echo "| ${pod[0]} | ${pod[1]} | $(get_zone ${pod[2]}) | ${pod[2]}"
done <<< "$pods"
```
with a command: ./myscript.sh redhat-rhoam-3scale
Verify that all of the apicast production pods are evenly distributed across nodes and zones. Example:
```
| redhat-rhoam-3scale | apicast-production-1-h5rnb | eu-west-1a | ip-10-0-142-162.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-1-25cqc | eu-west-1a | ip-10-0-158-236.eu-west-1.compute.internal

| redhat-rhoam-3scale | apicast-production-1-k6kr2 | eu-west-1b | ip-10-0-185-34.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-1-f9bz8 | eu-west-1b | ip-10-0-187-91.eu-west-1.compute.internal

| redhat-rhoam-3scale | apicast-production-1-cj4lp | eu-west-1c | ip-10-0-213-64.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-1-vmnxg | eu-west-1c | ip-10-0-212-242.eu-west-1.compute.internal
```

- After installation reports completed, verify that the pods are still distributed across zones and nodes (but not evenly)
Example:
```
| redhat-rhoam-3scale | apicast-production-3-596ds | eu-west-1c | ip-10-0-192-250.eu-west-1.compute.internal

| redhat-rhoam-3scale | apicast-production-3-k8p7r | eu-west-1a | ip-10-0-142-162.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-3-rz5sq | eu-west-1a | ip-10-0-159-229.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-3-scgnx | eu-west-1a | ip-10-0-158-236.eu-west-1.compute.internal

| redhat-rhoam-3scale | apicast-production-3-b77n6 | eu-west-1b | ip-10-0-167-157.eu-west-1.compute.internal
| redhat-rhoam-3scale | apicast-production-3-vm97x | eu-west-1b | ip-10-0-185-34.eu-west-1.compute.internal
```