### PR TITLE
MGDAPI-1040 - ignore non-Running pods when capturing resource requests

### DIFF
--- a/scripts/capture_resource_metrics.sh
+++ b/scripts/capture_resource_metrics.sh
@@ -39,10 +39,12 @@ testDuration=$(($endTimestamp-$startTimestamp))
 INSTANT_QUERIES=(\
   "sum(cluster:capacity_cpu_cores:sum)"\
   "sum(cluster:capacity_cpu_cores:sum{label_node_role_kubernetes_io!~'master|infra'})"\
+  "sum(kube_node_status_allocatable_cpu_cores * on (node) (kube_node_role{role='worker'} == on (node) group_left () (count by (node) (kube_node_role{}))))"\
   "sum(cluster:capacity_memory_bytes:sum)/1024/1024/1024"\
   "sum(cluster:capacity_memory_bytes:sum{label_node_role_kubernetes_io!~'master|infra'})/1024/1024/1024"\
-  "sum(kube_pod_container_resource_requests_cpu_cores{namespace=~'redhat-rhoam-.*',container!='lifecycle'})"\
-  "sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'redhat-rhoam-.*', container!='lifecycle'}) / 1000/1000"\
+  "kube_node_status_allocatable_memory_bytes * on (node) (kube_node_role{role='worker'} == on (node) group_left () (count by (node) (kube_node_role{}))) / 1024 / 1024 / 1024"\
+  "sum(kube_pod_container_resource_requests_cpu_cores{namespace=~'redhat-rhoam-.*',container!='lifecycle'} * on(namespace, pod) group_left() max by (namespace, pod) ( kube_pod_status_phase{phase='Running'} == 1 ))"\
+  "sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'redhat-rhoam-.*', container!='lifecycle'} * on(namespace, pod) group_left() max by (namespace, pod) ( kube_pod_status_phase{phase='Running'} == 1 )) / 1024 /1024"\
 )
 
 # Order of the queries must strictly match the rows from the spreadsheet that is used to collect these data


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/MGDAPI-1040
In this PR I:
a) added queries for capturing allocatable CPU and RAM on worker nodes (new rows in perf spreadsheet also added)
b) resource requests now only capture requests of Running pods

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Data from testing
Original query includes requests of a failed pod for some period of time:
![Screenshot 2021-01-14 at 12 20 36](https://user-images.githubusercontent.com/1605799/104586763-95875e00-566e-11eb-825d-ecdb5179c362.png)
Fixed query doesn't include failed pod:
![Screenshot 2021-01-14 at 12 20 44](https://user-images.githubusercontent.com/1605799/104586771-97512180-566e-11eb-9489-aed9252930f2.png)
Details about pod status:
![Screenshot 2021-01-14 at 12 23 59](https://user-images.githubusercontent.com/1605799/104586776-98824e80-566e-11eb-9d93-2dd05281fe78.png)
Details about pod requests:
![Screenshot 2021-01-14 at 12 24 30](https://user-images.githubusercontent.com/1605799/104586778-991ae500-566e-11eb-9bab-3993408f87c8.png)
