### PR TITLE
Grafana Image Update (7.2.0)

### DIFF
--- a/pkg/resources/constants/grafanaConstants.go
+++ b/pkg/resources/constants/grafanaConstants.go
@@ -1,6 +1,6 @@
 package constants
 
 const (
-	GrafanaImage   = "quay.io/integreatly/grafana"
-	GrafanaVersion = "7.1.1"
+	GrafanaImage   = "quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256"
+	GrafanaVersion = "33d6a055a791b68d4073a00b34ace94f578c3bd15d7525406182a2d95a5da38a"
 )


### PR DESCRIPTION
## Description

[MGDAPI-1005](https://issues.redhat.com/browse/MGDAPI-1005)

Update Grafana version to mirror what's used in the `openshift-monitoring` Grafana (7.2.0).

## Verification Steps
- Install RHOAM from this branch
- Check the correct Grafana version is being used in both the `middleware-monitoring` and `customer-grafana` namespaces (`7.2.0`).
- Check that the same image is being used (check the pod/deployment YAML definition image field) in both namespaces, and that it matches the image used in the `openshift-monitoring` ns
- Login to both of the above-mentioned namespaces and ensure that dashboards load correctly
- Check the Grafana pod logs in both the `middleware-monitoring` and `customer-grafana` namespaces and ensure there are no errors

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer