### PR TITLE
MGDAPI-700 Add Request and Limit resources to the statsd-exporter pod.

### DIFF
--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -4,9 +4,7 @@ import (
 	"context"
 	"fmt"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
-
 	"github.com/pkg/errors"
-
 	"strconv"
 
 	prometheus "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -34,6 +32,7 @@ import (
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -480,11 +479,18 @@ func (r *Reconciler) reconcilePromStatsdExporter(ctx context.Context, client k8s
 								ContainerPort: metricsPort,
 							},
 						},
+						Resources: corev1.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    k8sresource.MustParse("3m"),
+								corev1.ResourceMemory: k8sresource.MustParse("40Mi")},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    k8sresource.MustParse("3m"),
+								corev1.ResourceMemory: k8sresource.MustParse("40Mi")},
+						},
 					},
 				},
 			},
 		}
-
 		return nil
 	})
 


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Add Request and Limit resources to the statsd-exporter pod
Resources are higher than required to allow for initial spike in resources usages during start up.
*JIRA* https://issues.redhat.com/browse/MGDAPI-700

*Verify*
This is hard to Verify.
- On install the `prom-statsd-exporter` pod in the `redhat-rhoam-main3r` namespace should start correctly.
- Destroying and recreating the pod should not go into any crash off loops
- Metrics should show in grafana after about 3 minutes from pod creation
- Cluster metrics from a load test run shows the pod is does not increase under system load. https://snapshot.raintank.io/dashboard/snapshot/zPx50Zdzpn3tl0TrF1bGWHl27abgdChB?orgId=2 You are wanting to look at the charts for the `prom-statsd-exporter-6bf4478bdf-c58lq` pod. Note these charts do not have the initial spike in resource usage.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer