### PR TITLE
Prepare EC2 for Hyperfoil install

### DIFF
--- a/scripts/ec2_deploy_teardown/tearDown.sh
+++ b/scripts/ec2_deploy_teardown/tearDown.sh
@@ -20,32 +20,6 @@ for (( i=0; i<5; i++ )) do
     sleep 5
 done
 
-echo "Obtaining address allocation details"
-ELIP=`aws ec2 describe-addresses --filters Name=instance-id,Values=$EC2 --region ${CLUSTER_REGION} --query Addresses[0].AllocationId --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $ELIP =~ "eipalloc-" ]]; then
-      echo "Address "${ELIP}" identified"
-      break
-    fi
-    sleep 5
-done
-
-echo "Obtaining address association details"
-ASSOC=`aws ec2 describe-addresses --filters Name=instance-id,Values=$EC2 --region ${CLUSTER_REGION} --query Addresses[0].AssociationId --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $ASSOC =~ "eipassoc-" ]]; then
-      echo "Address "${ASSOC}" identified"
-      break
-    fi
-    sleep 5
-done
-
-echo "Disassociating address "$ASSOC
-aws ec2 disassociate-address --association-id $ASSOC --region $CLUSTER_REGION
-
-echo "Releasing address "$ELIP
-aws ec2 release-address --allocation-id $ELIP --region $CLUSTER_REGION
-
 echo "Terminating EC2 instance "$EC2
 aws ec2 terminate-instances --instance-ids $EC2 --region $CLUSTER_REGION
 for (( i=0; i<60; i++ )) do


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

- Improved waiting for EC2 to become ready.
- Adding IP address from where there will be allowed full access to EC2 instance
- Adding rule to allow full access from localhost. Useful for Hyperfoil since both agent and controller might be hosted on the same EC2 instance (for now) and they use some non-standard ports and protocols (jgroups)
- Not using Elastic IP for publiIP of EC2 instance. It's not required and since there is a limit of just 5 Elastic IPs on AWS level it better not to use it unless really needed

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification steps
I used this script to create EC2 instance using 601144055808 AWS account, log in and have a look (sorry, removed already) :
https://console.aws.amazon.com/ec2/v2/home?region=us-east-1#InstanceDetails:instanceId=i-0b8c1403c97faf483

See it's security group and its security group's ingress rules.

To see the output of the script, see the console log of
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Public/job/trepel-ec2-deploy/43


**Note** This PR is not for improving of error handling of the script, there is a separate ticket in the backlog for that.