### PR TITLE
Updated A25 e2e test to accommodate dynamic CIDR blocks

### DIFF
--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/service/ec2"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
 
@@ -300,4 +301,27 @@ func GetClustersAvailableZones(nodes *v1.NodeList) map[string]bool {
 		}
 	}
 	return zones
+}
+
+// getVpcCidrBlock returns the cidr block using a key/value tag pairing
+func getVpcCidrBlock(session *ec2.EC2, clusterTagName, clusterTagValue string) (string, error) {
+	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
+		Filters: []*ec2.Filter{
+			{
+				Name:   aws.String(fmt.Sprintf("%s", clusterTagName)),
+				Values: []*string{aws.String(clusterTagValue)},
+			},
+		},
+	})
+	if err != nil {
+		return "", fmt.Errorf("could not find vpc: %v", err)
+	}
+
+	// only one vpc is expected
+	vpcs := describeVpcs.Vpcs
+	if len(vpcs) != 1 {
+		return "", fmt.Errorf("expected 1 vpc but found %d", len(vpcs))
+	}
+
+	return aws.StringValue(vpcs[0].CidrBlock), nil
 }

--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -303,12 +303,12 @@ func GetClustersAvailableZones(nodes *v1.NodeList) map[string]bool {
 	return zones
 }
 
-// getVpcCidrBlock returns the cidr block using a key/value tag pairing
+// getVpcCidrBlock returns a cidr block using a key/value tag pairing
 func getVpcCidrBlock(session *ec2.EC2, clusterTagName, clusterTagValue string) (string, error) {
 	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String(fmt.Sprintf("%s", clusterTagName)),
+				Name:   aws.String(clusterTagName),
 				Values: []*string{aws.String(clusterTagValue)},
 			},
 		},

--- a/test/functional/aws_standalone_vpc.go
+++ b/test/functional/aws_standalone_vpc.go
@@ -30,10 +30,20 @@ import (
 )
 
 var (
-	resourceType    = "_network"
-	tier            = "production"
-	dummyIpAddress  = "172.11.0.0/24"
-	strategyMapName = "cloud-resources-aws-strategies"
+	resourceType      = "_network"
+	tier              = "production"
+	dummyIpAddress    = "172.11.0.0/24"
+	strategyMapName   = "cloud-resources-aws-strategies"
+	allowedCidrRanges = []string{
+		"10.255.255.255/8",
+		"172.31.255.255/12",
+	}
+)
+
+const (
+	vpcClusterTagKey         = "tag:integreatly.org/clusterID"
+	clusterOwnedTagKeyPrefix = "tag:kubernetes.io/cluster/"
+	clusterOwnedTagValue     = "owned"
 )
 
 type strategyMap struct {
@@ -160,16 +170,47 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 		t.Skip("_network key does not exist in aws strategy configmap, skipping standalone vpc network test")
 	}
 
-	// get the vpc cidr block
-	expectedCidr, err := getCidrBlock(strat)
-	if err != nil {
-		t.Fatal("could not get cidr block", err)
-	}
-
 	// get the cluster id used for tagging aws resources
 	clusterTag, err := getClusterID(ctx, testingCtx.Client)
 	if err != nil {
 		t.Fatal("could not get cluster id", err)
+	}
+
+	// get the vpc cidr block
+	expectedCidr, err := getCidrBlockFromStrategyMap(strat)
+	if err != nil {
+		t.Fatal("could not get cidr block from strategy map", err)
+	}
+
+	vpcCidrBlock := expectedCidr
+	// if the cidr strategy map is empty then attempt to retrieve the cidr block from the vpc
+	if expectedCidr == "" {
+		vpcCidrBlock, err = getVpcCidrBlock(ec2Sess, vpcClusterTagKey, clusterTag)
+		if err != nil {
+			t.Fatal("could not get cidr block from vpc", err)
+		}
+
+		// check the cidr block is in the allowed range
+		err = verifyCidrBlockIsInAllowedRange(vpcCidrBlock)
+		if err != nil {
+			t.Fatalf("cidr block %s is not within the allowed range %s", vpcCidrBlock, err)
+		}
+
+		// build tag key to retrieve cluster vpc
+		// denoted -> kubernetes.io/cluster/<cluster-id>=owned
+		clusterOwnedVpcKey := clusterOwnedTagKeyPrefix + clusterTag
+
+		// retrieve the cluster cidr
+		clusterCidr, err := getVpcCidrBlock(ec2Sess, clusterOwnedVpcKey, clusterOwnedTagValue)
+		if err != nil {
+			t.Fatal("could not get cidr block from vpc", err)
+		}
+
+		// check if the cidr blocks overlap
+		err = checkForOverlappingCidrBlocks(vpcCidrBlock, clusterCidr)
+		if err != nil {
+			t.Fatal(err)
+		}
 	}
 
 	clusterNodes := &v1.NodeList{}
@@ -180,7 +221,7 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 	availableZones := GetClustersAvailableZones(clusterNodes)
 
 	// verify vpc
-	vpc, err := verifyVpc(ec2Sess, clusterTag, expectedCidr)
+	vpc, err := verifyVpc(ec2Sess, clusterTag, vpcCidrBlock)
 	testErrors.vpcError = err.(*networkConfigTestError).vpcError
 
 	// fail immediately if the vpc is nil, since all of the
@@ -190,7 +231,7 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 	}
 
 	// verify subnets
-	subnets, err := verifySubnets(ec2Sess, clusterTag, expectedCidr)
+	subnets, err := verifySubnets(ec2Sess, clusterTag, vpcCidrBlock)
 	testErrors.subnetsError = err.(*networkConfigTestError).subnetsError
 
 	// verify security groups
@@ -198,7 +239,7 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 	testErrors.securityGroupError = err.(*networkConfigTestError).securityGroupError
 
 	// we have to manually construct the subnet group names for rds and elasticache,
-	// since tag filtering isnt currently available
+	// since tag filtering isn't currently available
 	subnetGroupName := resources.ShortenString(fmt.Sprintf("%s-%s", clusterTag, "subnet-group"), 40)
 
 	// build array list of all vpc private subnets
@@ -218,7 +259,7 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 	testErrors.cacheSubnetGroupsError = err.(*networkConfigTestError).cacheSubnetGroupsError
 
 	// verify peering connection
-	conn, err := verifyPeeringConnection(ec2Sess, clusterTag, expectedCidr, aws.StringValue(vpc.VpcId))
+	conn, err := verifyPeeringConnection(ec2Sess, clusterTag, vpcCidrBlock, aws.StringValue(vpc.VpcId))
 	testErrors.peeringConnError = err.(*networkConfigTestError).peeringConnError
 
 	// verify standalone vpc route table
@@ -226,12 +267,12 @@ func TestStandaloneVPCExists(t *testing.T, testingCtx *common.TestingContext) {
 	testErrors.standaloneRouteTableError = err.(*networkConfigTestError).standaloneRouteTableError
 
 	// verify cluster route table
-	err = verifyClusterRouteTables(ec2Sess, clusterTag, expectedCidr, conn, availableZones)
+	err = verifyClusterRouteTables(ec2Sess, clusterTag, vpcCidrBlock, conn, availableZones)
 	testErrors.clusterRouteTablesError = err.(*networkConfigTestError).clusterRouteTablesError
 
 	// update the _network create strategy in the aws strategy map and ensure
 	// this does not change the existing vpc
-	err = verifyCidrBlockUpdate(ctx, testingCtx, ec2Sess, strategyMap, clusterTag, expectedCidr)
+	err = verifyCidrBlockUpdate(ctx, testingCtx, ec2Sess, strategyMap, clusterTag, vpcCidrBlock)
 	testErrors.updateCidrBlockError = err.(*networkConfigTestError).updateCidrBlockError
 
 	// if any error was found, fail the test
@@ -250,7 +291,7 @@ func verifyVpc(session *ec2.EC2, clusterTag, expectedCidr string) (*ec2.Vpc, err
 	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Name:   aws.String(vpcClusterTagKey),
 				Values: []*string{aws.String(clusterTag)},
 			},
 		},
@@ -288,7 +329,7 @@ func verifySubnets(session *ec2.EC2, clusterTag, expectedCidr string) ([]*ec2.Su
 	describeSubnets, err := session.DescribeSubnets(&ec2.DescribeSubnetsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Name:   aws.String(vpcClusterTagKey),
 				Values: []*string{aws.String(clusterTag)},
 			},
 		},
@@ -338,7 +379,7 @@ func verifySecurityGroup(session *ec2.EC2, clusterTag string) error {
 	describeGroups, err := session.DescribeSecurityGroups(&ec2.DescribeSecurityGroupsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Name:   aws.String(vpcClusterTagKey),
 				Values: []*string{aws.String(clusterTag)},
 			},
 		},
@@ -448,7 +489,7 @@ func verifyPeeringConnection(session *ec2.EC2, clusterTag, expectedCidr, vpcID s
 	peeringConn, err := session.DescribeVpcPeeringConnections(&ec2.DescribeVpcPeeringConnectionsInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Name:   aws.String(vpcClusterTagKey),
 				Values: []*string{aws.String(clusterTag)},
 			},
 		},
@@ -493,7 +534,7 @@ func verifyStandaloneRouteTable(session *ec2.EC2, clusterTag string, conn *ec2.V
 	describeRouteTables, err := session.DescribeRouteTables(&ec2.DescribeRouteTablesInput{
 		Filters: []*ec2.Filter{
 			{
-				Name:   aws.String("tag:integreatly.org/clusterID"),
+				Name:   aws.String(vpcClusterTagKey),
 				Values: []*string{aws.String(clusterTag)},
 			},
 		},
@@ -633,7 +674,7 @@ func verifyCidrBlockUpdate(ctx context.Context, testingCtx *common.TestingContex
 		vpcOutput, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
 			Filters: []*ec2.Filter{
 				{
-					Name:   aws.String("tag:integreatly.org/clusterID"),
+					Name:   aws.String(vpcClusterTagKey),
 					Values: []*string{aws.String(clusterTag)},
 				},
 			},
@@ -702,13 +743,13 @@ func getClusterID(ctx context.Context, client client.Client) (string, error) {
 	return infra.Status.InfrastructureName, nil
 }
 
-func getCidrBlock(strat *strategyMap) (string, error) {
+func getCidrBlockFromStrategyMap(strat *strategyMap) (string, error) {
 	vpcCreateConfig := &ec2.CreateVpcInput{}
 	if err := json.Unmarshal(strat.CreateStrategy, vpcCreateConfig); err != nil {
 		return "", err
 	}
 	if vpcCreateConfig.CidrBlock == nil {
-		return "", fmt.Errorf("cidr block cannot be empty")
+		return "", fmt.Errorf("cidr block cannot be nil")
 	}
 	return aws.StringValue(vpcCreateConfig.CidrBlock), nil
 }
@@ -720,4 +761,40 @@ func contains(strs []*string, str *string) bool {
 		}
 	}
 	return false
+}
+
+func checkForOverlappingCidrBlocks(vpcCidrBlock, clusterCIDRBlock string) error {
+	_, vpcCidr, err := net.ParseCIDR(vpcCidrBlock)
+	if err != nil {
+		return fmt.Errorf("error parsing vpc cidr block: %s", vpcCidr)
+	}
+
+	_, clusterCidr, err := net.ParseCIDR(clusterCIDRBlock)
+	if err != nil {
+		return fmt.Errorf("error parsing cluster cidr block: %s", clusterCidr)
+	}
+
+	if vpcCidr.Contains(clusterCidr.IP) || clusterCidr.Contains(vpcCidr.IP) {
+		return fmt.Errorf("vpc cidr block (%s) overlaps with the cluster cidr block: (%s)", vpcCidr, clusterCidr)
+	}
+
+	return nil
+}
+
+func verifyCidrBlockIsInAllowedRange(cidrBlock string) error {
+	_, cidr, err := net.ParseCIDR(cidrBlock)
+	if err != nil {
+		return fmt.Errorf("error parsing cidr %s", cidrBlock)
+	}
+
+	for _, allowedCidrRanges := range allowedCidrRanges {
+		_, cidrRangeNet, err := net.ParseCIDR(allowedCidrRanges)
+		if err != nil {
+			return fmt.Errorf("error parsing cidr %s", cidrBlock)
+		}
+		if cidrRangeNet.Contains(cidr.IP) {
+			return nil
+		}
+	}
+	return fmt.Errorf("%s is not in the expected cidr range", cidrBlock)
 }


### PR DESCRIPTION
## Description
[MGDAPI-1077](https://issues.redhat.com/browse/MGDAPI-1077
)

The changes in [this](https://github.com/integr8ly/cloud-resource-operator/pull/201) PR caused the `A25` e2e test to fail. When installing RHOAM via the add-on the user must specify a CIDR block. If the user doesn't specify a CIDR block, CRO will dynamically allocate one. The test was updated to account for the dynamic CIDR block.

## Verification Steps
We want to make sure that the test works for both use cases:  
1. If the CIDR block is _**not**_ specified
2. If a CIDR block _**is**_ specified

### 1. CIDR block is _not_ specified
- Provision a BYOC cluster
- Install RHOAM via the addon and when prompted to enter a CIDR block leave the field to its default empty state (_**important**_)
- Once the install is complete, we want to make sure the CIDR block in the `cloud-resources-aws-strategies` configmap is _**empty**_ which will mean CRO would have allocated a CIDR block dynamically:
```
oc get configmaps cloud-resources-aws-strategies -n redhat-rhoam-operator -o json | jq '.data' | grep -i _network
```
- Verify that the test works if the CIDR block is empty, as the test will retrieve the CIDR block directly from the VPC itself by running the test in isolation using the below command. You can reduce the poll time [HERE](https://github.com/integr8ly/integreatly-operator/blob/87d66ce1d2111f628420bc5ad23305c1ad1ea4ab/test/functional/aws_standalone_vpc.go#L673) to reduce the time it takes for the test to run
```
go clean -testcache && go test -v ./test/functional -run="//^A25" -timeout=80m
```
- Verify that the test passes without error

### 2. CIDR block _is_ specified
- Create a BYOC cluster, install RHOAM via the addon and enter a valid CIDR block when prompted to enter (_**important**_)
- Ensure that the CIDR block in the `cloud-resources-aws-strategies` configmap matches what was specified via the addon UI prompt (`192.168.0.0/16`):
```
oc get configmaps cloud-resources-aws-strategies -n redhat-rhoam-operator -o json | jq '.data' | grep -i _network
```
- Set the test to use the RHOAM namespace: `export WATCH_NAMESPACE=redhat-rhoam-operator`
- As the CIDR block was specified by the user (and not dynamically generated via CRO), we want to ensure that the test _passes_ for this use-case:
```
go clean -testcache && go test -v ./test/functional -run="//^A25" -timeout=80m
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer