### PR TITLE
MDGAPI-1098 - Retry to install product operators if failed install plan

### DIFF
--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	productsConfig "github.com/integr8ly/integreatly-operator/pkg/config"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/pkg/apis/integreatly/v1alpha1"
@@ -200,7 +199,7 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, target marketpla
 	if err != nil && !k8serr.IsAlreadyExists(err) {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create subscription in namespace: %s: %w", target.Namespace, err)
 	}
-	ips, _, err := r.mpm.GetSubscriptionInstallPlans(ctx, client, target.Pkg, target.Namespace)
+	ips, sub, err := r.mpm.GetSubscriptionInstallPlans(ctx, client, target.Pkg, target.Namespace)
 	if err != nil {
 		// this could be the install plan or subscription so need to check if sub nil or not TODO refactor
 		if k8serr.IsNotFound(err) || k8serr.IsNotFound(errors.Unwrap(err)) {
@@ -217,6 +216,24 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, target marketpla
 		err = upgradeApproval(ctx, preUpgradeBackupExecutor, client, &ip, log)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error approving installplan for %v: %w", target.Pkg, err)
+		}
+
+		// Workaround to re-install product operator if install plan fails due to https://bugzilla.redhat.com/show_bug.cgi?id=1923111
+		if ip.Status.Phase == operatorsv1alpha1.InstallPlanPhaseFailed {
+			if sub.Status.InstalledCSV != "" {
+				log.Warningf("Deleting csv for re-install due to failed install plan", l.Fields{"ns": target.Namespace, "install plan": target.Pkg, "csv": sub.Status.InstalledCSV})
+				csv := &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{Namespace: target.Namespace, Name: sub.Status.InstalledCSV},
+				}
+				if err := client.Delete(ctx, csv); err != nil && k8serr.IsNotFound(err) {
+					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete csv for re-intstall: %s", err)
+				}
+			}
+			log.Warningf("Deleting subscription and csv for re-install due to failed install plan", l.Fields{"ns": target.Namespace, "install plan": target.Pkg})
+			if err := client.Delete(ctx, sub); err != nil && k8serr.IsNotFound(err) {
+				return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete subscription for re-intstall: %s", err)
+			}
+			return integreatlyv1alpha1.PhaseAwaitingOperator, nil
 		}
 
 		//if it's approved but not complete, then it's in progress

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -225,12 +225,12 @@ func (r *Reconciler) ReconcileSubscription(ctx context.Context, target marketpla
 				csv := &operatorsv1alpha1.ClusterServiceVersion{
 					ObjectMeta: metav1.ObjectMeta{Namespace: target.Namespace, Name: sub.Status.InstalledCSV},
 				}
-				if err := client.Delete(ctx, csv); err != nil && k8serr.IsNotFound(err) {
+				if err := client.Delete(ctx, csv); err != nil && !k8serr.IsNotFound(err) {
 					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete csv for re-intstall: %s", err)
 				}
 			}
-			log.Warningf("Deleting subscription and csv for re-install due to failed install plan", l.Fields{"ns": target.Namespace, "install plan": target.Pkg})
-			if err := client.Delete(ctx, sub); err != nil && k8serr.IsNotFound(err) {
+			log.Warningf("Deleting subscription for re-install due to failed install plan", l.Fields{"ns": target.Namespace, "install plan": target.Pkg})
+			if err := client.Delete(ctx, sub); err != nil && !k8serr.IsNotFound(err) {
 				return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete subscription for re-intstall: %s", err)
 			}
 			return integreatlyv1alpha1.PhaseAwaitingOperator, nil

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	"testing"
 	"time"
 
@@ -195,8 +196,10 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 			Installation:     &integreatlyv1alpha1.RHMI{},
 		},
 		{
-			Name:   "test reconcile subscription returns phase failed if unable to delete subscription due for re-install ",
-			client: fakeclient.NewFakeClientWithScheme(scheme),
+			Name: "test reconcile subscription returns phase failed if unable to delete subscription due for re-install ",
+			client: &moqclient.SigsClientInterfaceMock{DeleteFunc: func(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteOption) error {
+				return fmt.Errorf("some error")
+			}},
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
@@ -213,8 +216,10 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 			ExpectErr:        true,
 		},
 		{
-			Name:   "test reconcile subscription returns phase failed if unable to delete csv due for re-install ",
-			client: fakeclient.NewFakeClientWithScheme(scheme),
+			Name: "test reconcile subscription returns phase failed if unable to delete csv for re-install ",
+			client: &moqclient.SigsClientInterfaceMock{DeleteFunc: func(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteOption) error {
+				return fmt.Errorf("some error")
+			}},
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Install plans can fail for operators that are installed in multiples namespaces such as keycloak. This looks to be due to transient errors / race condition by OLM. As this issue looks to be external to RHOAM and a flaky issue, we should have a way to try re-install the stuck products 

Logged OLM bugzilla ticket that will be investigated in their future sprint
* https://bugzilla.redhat.com/show_bug.cgi?id=1923111

Jira:
* https://issues.redhat.com/browse/MGDAPI-1098

## Verification
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api  
make cluster/prepare/local
make code/run
```
* Once RHSSO is installed, run script to update keycloak CRD to try reproduce install plan failure for User SSO
```
 while true; do                                                                                  
        oc patch crd keycloakusers.keycloak.org  --type=json -p='[{"op" : "add", "path" : "/metadata/labels/test", "value": "test"}]'
        oc patch crd keycloakusers.keycloak.org  --type=json -p='[{"op" : "remove", "path" : "/metadata/labels/test"}]'
done
```
* Check for failed install plan for user sso
  * If no failed install plan, uninstall the keycloak operator in user sso to re-trigger installation and repeat till failure
![image](https://user-images.githubusercontent.com/24636860/106512139-1fd21d80-64c9-11eb-8a63-d643269ada8e.png)
* Stop the script that updates keycloak CRD
* Verify RHOAM will delete the subscription to retry the install (following log lines should appear in log)
```
WARN[2021-02-01T20:07:58Z] Deleting csv for re-install due to failed install plan  csv=keycloak-operator.v11.0.3 install plan=rhmi-rhsso ns=redhat-rhoam-user-sso-operator product=rhssouser
WARN[2021-02-01T20:07:58Z] Deleting subscription for re-install due to failed install plan  install plan=rhmi-rhsso ns=redhat-rhoam-user-sso-operator product=rhssouser
```
* Verifiy install completes successfully
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer