### PR TITLE
MGDAPI-557 - Try fix H03 test on nightly pipeline 

### DIFF
--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -37,10 +37,15 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	keycloakHost := rhmi.Status.Stages[v1alpha1.AuthenticationStage].Products[v1alpha1.ProductRHSSO].Host
 	redirectUrl := fmt.Sprintf("%v/p/admin/dashboard", host)
 
-	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, ctx.HttpClient, ctx.Client, t)
+	httpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, httpClient, ctx.Client, t)
 
 	// Login to 3Scale
-	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
+	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", httpClient)
 	if err != nil {
 		dumpAuthResources(ctx.Client, t)
 		// t.Fatalf("[%s] error occurred: %v", getTimeStampPrefix(), err)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

H03 e2e looks to fail consistently on nightly pipelines, but passes consistently when running locally. Going to try using new httpclient in threescale client and logging into 3scale to see does it help

Jira:
* https://issues.redhat.com/browse/MGDAPI-557

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer