### PR TITLE
Increase root volume size for the provisioned EC2

### DIFF
--- a/scripts/ec2_deploy_teardown/deployEC2.sh
+++ b/scripts/ec2_deploy_teardown/deployEC2.sh
@@ -60,7 +60,7 @@ for (( i=0; i<5; i++ )) do
 done
 
 echo "Starting EC2 instance"
-EC2=`aws ec2 run-instances --image-id $AMI --count 1 --instance-type ${EC2_TYPE} --key-name ${EC2_NAME}Key --security-group-ids $SECGRP --subnet-id $SUBNET --region ${CLUSTER_REGION} --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 50 } } ]" --query 'Instances[0].InstanceId' --output text`
+EC2=`aws ec2 run-instances --image-id $AMI --count 1 --instance-type ${EC2_TYPE} --key-name ${EC2_NAME}Key --security-group-ids $SECGRP --subnet-id $SUBNET --region ${CLUSTER_REGION} --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 50 } } ]" --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${EC2_NAME}}]" --query 'Instances[0].InstanceId' --output text`
 
 aws ec2 wait instance-status-ok --instance-ids ${EC2} --region ${CLUSTER_REGION}
 

--- a/scripts/ec2_deploy_teardown/deployEC2.sh
+++ b/scripts/ec2_deploy_teardown/deployEC2.sh
@@ -60,7 +60,7 @@ for (( i=0; i<5; i++ )) do
 done
 
 echo "Starting EC2 instance"
-EC2=`aws ec2 run-instances --image-id $AMI --count 1 --instance-type ${EC2_TYPE} --key-name ${EC2_NAME}Key --security-group-ids $SECGRP --subnet-id $SUBNET --region ${CLUSTER_REGION} --associate-public-ip-address --query 'Instances[0].InstanceId' --output text`
+EC2=`aws ec2 run-instances --image-id $AMI --count 1 --instance-type ${EC2_TYPE} --key-name ${EC2_NAME}Key --security-group-ids $SECGRP --subnet-id $SUBNET --region ${CLUSTER_REGION} --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 50 } } ]" --query 'Instances[0].InstanceId' --output text`
 
 aws ec2 wait instance-status-ok --instance-ids ${EC2} --region ${CLUSTER_REGION}
 


### PR DESCRIPTION
# Description
Increasing the size of root volume to allow for taking of full heap snapshots (up to 32GB).
Adding "Name" tag, so the instance name is displayed in AWS console.

Test run:
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Public/job/trepel-ec2-deploy/56/console
![Screenshot 2021-01-26 at 12 56 30](https://user-images.githubusercontent.com/1605799/105842132-619d2880-5fde-11eb-8d79-9ecf7e0f4149.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer