### PR TITLE
MGDAPI-1165 - Fix panic from namespace label controller 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ COMPILE_TARGET=./tmp/_output/bin/$(PROJECT)
 OPERATOR_SDK_VERSION=1.2.0
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "$(QUAY_PASSWORD)"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
-IN_PROW="false"
+IN_PROW ?= "false"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker

--- a/controllers/namespacelabel/namespacelabel_controller.go
+++ b/controllers/namespacelabel/namespacelabel_controller.go
@@ -141,6 +141,10 @@ func (r *NamespaceLabelReconciler) Reconcile(request ctrl.Request) (ctrl.Result,
 		}
 
 		rhmiCr, err := resources.GetRhmiCr(r.Client, ctx, request.NamespacedName.Namespace, log)
+		if err != nil || rhmiCr == nil {
+			return reconcile.Result{Requeue: true, RequeueAfter: 1 * time.Minute}, nil
+		}
+
 		if rhmiCr.Spec.Type == "managed" {
 			deletionConfigMap = "rhmi"
 		}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Observed a panic during an uninstall due to RHMI CR no longer being present due to not checking for err or reference before continuing the namesapce label reconcile
```
INFO[2021-01-26T15:11:00Z] Looking for RHMI CR                           controller=namespacelabel_controller ns=
E0126 15:11:00.609530   72817 runtime.go:78] Observed a panic: "invalid memory address or nil pointer dereference" (runtime error: invalid memory address or nil pointer dereference)
goroutine 1068 [running]:
k8s.io/apimachinery/pkg/util/runtime.logPanic(0x1f190a0, 0x3aa2090)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:74 +0xa3
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:48 +0x82
panic(0x1f190a0, 0x3aa2090)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/integr8ly/integreatly-operator/pkg/controller/namespacelabel.(*ReconcileNamespaceLabel).Reconcile(0xc00072a310, 0x0, 0x0, 0xc0014ab5e0, 0x15, 0xc000e16cd8, 0xc000eba240, 0xc001523148, 0x2732bc0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/pkg/controller/namespacelabel/namespacelabel_controller.go:189 +0x1db
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000c14cc0, 0x1fba300, 0xc003aad880, 0xc000bba500)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000c14cc0, 0x0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000c14cc0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0010b0720)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0010b0720, 0x3b9aca00, 0x0, 0x1, 0xc000060540)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0010b0720, 0x3b9aca00, 0xc000060540)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x328
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x118 pc=0x1ca013b]

goroutine 1068 [running]:
k8s.io/apimachinery/pkg/util/runtime.HandleCrash(0x0, 0x0, 0x0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/runtime/runtime.go:55 +0x105
panic(0x1f190a0, 0x3aa2090)
        /usr/local/go/src/runtime/panic.go:679 +0x1b2
github.com/integr8ly/integreatly-operator/pkg/controller/namespacelabel.(*ReconcileNamespaceLabel).Reconcile(0xc00072a310, 0x0, 0x0, 0xc0014ab5e0, 0x15, 0xc000e16cd8, 0xc000eba240, 0xc001523148, 0x2732bc0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/pkg/controller/namespacelabel/namespacelabel_controller.go:189 +0x1db
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000c14cc0, 0x1fba300, 0xc003aad880, 0xc000bba500)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:256 +0x162
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000c14cc0, 0x0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:232 +0xcb
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).worker(0xc000c14cc0)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:211 +0x2b
k8s.io/apimachinery/pkg/util/wait.JitterUntil.func1(0xc0010b0720)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:152 +0x5e
k8s.io/apimachinery/pkg/util/wait.JitterUntil(0xc0010b0720, 0x3b9aca00, 0x0, 0x1, 0xc000060540)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:153 +0xf8
k8s.io/apimachinery/pkg/util/wait.Until(0xc0010b0720, 0x3b9aca00, 0xc000060540)
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/k8s.io/apimachinery/pkg/util/wait/wait.go:88 +0x4d
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1
        /home/kevinfan/go/src/github.com/integr8ly/integreatly-operator/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:193 +0x328
FATA[4039] Failed to run operator locally: failed to run operator locally: failed to exec []string{"build/_output/bin/integreatly-operator-local"}: exit status 2 
```
Jira:
* https://issues.redhat.com/browse/MGDAPI-1165

## Verification
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api  
make cluster/prepare/local
SELF_SIGNED_CERTS=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml
make code/run
```
* Trigger uninstall by deleting RHMI CR
* Verify no panic occurs when uninstallation completes
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer