### PR TITLE
Adding logging to help debug e2e tests

### DIFF
--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -43,13 +43,14 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
 		dumpAuthResources(ctx.Client, t)
-		// t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+		// t.Fatalf("[%s] error occurred: %v", getTimeStampPrefix(), err)
 		t.Skipf("flakey test [%s] error ocurred: %v jira https://issues.redhat.com/browse/MGDAPI-557 ", getTimeStampPrefix(), err)
 	}
 
 	// Make sure 3Scale is available
 	err = tsClient.Ping()
 	if err != nil {
+		t.Log("Error during making sure 3Scale is available")
 		t.Fatal(err)
 	}
 
@@ -59,12 +60,14 @@ func Test3ScaleCrudlPermissions(t *testing.T, ctx *TestingContext) {
 	// Create a product
 	productId, err := tsClient.CreateProduct(fmt.Sprintf("dummy-product-%v", r1.Intn(100000)))
 	if err != nil {
+		t.Log("Error during create the product")
 		t.Fatal(err)
 	}
 
 	// Delete the product
 	err = tsClient.DeleteProduct(productId)
 	if err != nil {
+		t.Log("Error during deleting the product")
 		t.Fatal(err)
 	}
 }

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -69,18 +69,21 @@ func TestIntegreatlyAlertsMechanism(t *testing.T, ctx *TestingContext) {
 	}
 
 	if threescaleAlertsFiring {
+		t.Log("3Scale alerts firing unexpectedly")
 		t.FailNow()
 	}
 
 	// scale down Threescale operator and product pods and verify that threescale alert is firing
 	err = performTest(t, ctx, originalOperatorReplicas)
 	if err != nil {
+		t.Log("Error During scale down 3Scale operator and product pods and verify that 3scale alert is firing")
 		t.Fatal(err)
 	}
 
 	// verify the operator has been scaled backup
 	err = checkThreescaleOperatorReplicasAreReady(ctx, t, originalOperatorReplicas)
 	if err != nil {
+		t.Log("Error During verify the operator has been scaled backup")
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Extra logging added to H03 & C03. These tests have been marked as flaky but is still showing failures in the nightly pipelines. These logs are to help identify the cause of the new failures.

