### PR TITLE
Improved ec2 deploy script error handling

### DIFF
--- a/scripts/ec2_deploy_teardown/deployEC2.sh
+++ b/scripts/ec2_deploy_teardown/deployEC2.sh
@@ -1,63 +1,60 @@
 #!/bin/bash
 
-echo "Creating key-pair"
-aws ec2 create-key-pair --key-name ${EC2_NAME}Key --query 'KeyMaterial' --output text --region ${CLUSTER_REGION} > ${EC2_NAME}Key.pem && Keyfile=true
+set -ex
 
 echo "Getting VPC Details"
-VPC=`aws ec2 describe-vpcs --region ${CLUSTER_REGION} --filters "Name=tag:Name,Values=${clusterID}*" --query "Vpcs[0].VpcId" --output text` 
-for (( i=0; i<5; i++ )) do
-    if [[ $VPC =~ "vpc-" ]]; then
-      echo "VPC "${VPC}" is available"
-      break
-    fi
-    sleep 5
-done
+VPC=`aws ec2 describe-vpcs --region ${CLUSTER_REGION} --filters "Name=tag:Name,Values=${clusterName}*" --query "Vpcs[0].VpcId" --output text`
+if [[ $VPC =~ "vpc-" ]]; then
+  echo "VPC "${VPC}" is available"
+else
+  echo "VPC not found for ${clusterName}"
+  exit 1  
+fi
 
 echo "Getting subnet details"
 SUBNET=`aws ec2 describe-subnets --region ${CLUSTER_REGION} --filters "Name=vpc-id,Values=$VPC" "Name=tag:Name,Values=*public*" --query Subnets[0].SubnetId --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $SUBNET =~ "subnet-" ]]; then
-      echo "SUBNET "${SUBNET}" is available"
-      break
-      else 
-      echo $SUBNET
-    fi
-    sleep 5
-done
+if [[ $SUBNET =~ "subnet-" ]]; then
+  echo "SUBNET "${SUBNET}" is available"
+else 
+  echo "Public subnet not found for VPC: ${VPC}, clusterName: ${clusterName}"
+  exit 1 
+fi
+
+echo "Getting image"
+AMI=`aws ec2 describe-images --filters "Name=is-public,Values=true" "Name=description,Values=Provided by Red Hat*" "Name=name,Values=${IMAGE}" --region ${CLUSTER_REGION} --output text --query 'Images[0].ImageId'`
+if [[ $AMI =~ "ami-" ]]; then
+  echo "AMI "${AMI}" is available"
+else
+  echo "AMI not found for ${IMAGE}"
+  exit 1 
+fi
+
+echo "Creating key-pair"
+aws ec2 create-key-pair --key-name ${EC2_NAME}Key --query 'KeyMaterial' --output text --region ${CLUSTER_REGION} > ${EC2_NAME}Key.pem
 
 echo "Creating security group"
 SECGRP=`aws ec2 create-security-group --group-name ${EC2_NAME}-sg --description "${EC2_NAME} security group" --vpc-id $VPC --region ${CLUSTER_REGION} --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $SECGRP =~ "sg-" ]]; then
-      echo "SECGRP "${SECGRP}" is created"
-      break
-    fi
-    sleep 5
-done
-
-# For Hyperfoil
-if [[ "${INSTALL_HYPERFOIL}x" == "truex" ]]; then
-    echo "Setting up ingress rules required for Hyperfoil"
-    if [[ "${FULL_ACCESS_IP}x" != "x" ]]; then
-        aws ec2 authorize-security-group-ingress --group-id ${SECGRP} --protocol all --cidr ${FULL_ACCESS_IP}/32 --region ${CLUSTER_REGION}
-    fi
-
-    aws ec2 authorize-security-group-ingress --group-id ${SECGRP} --protocol all --cidr 127.0.0.1/32 --region ${CLUSTER_REGION}
+if [[ $SECGRP =~ "sg-" ]]; then
+  echo "SECGRP "${SECGRP}" is created"
 fi
 
 echo "Authorising security group"
 aws ec2 authorize-security-group-ingress --group-id $SECGRP --protocol tcp --port 22 --cidr 0.0.0.0/0 --region ${CLUSTER_REGION}
 sleep 5
 
-echo "Getting image"
-AMI=`aws ec2 describe-images --filters "Name=is-public,Values=true" "Name=description,Values=Provided by Red Hat*" "Name=name,Values=${IMAGE}" --region ${CLUSTER_REGION} --output text --query 'Images[0].ImageId'`
-for (( i=0; i<5; i++ )) do
-    if [[ $AMI =~ "ami-" ]]; then
-      echo "AMI "${AMI}" is available"
-      break
-    fi
+if [[ "${FULL_ACCESS_IP}x" != "x" ]]; then
+    echo "Setting up ingress rule for ${FULL_ACCESS_IP}"
+    aws ec2 authorize-security-group-ingress --group-id ${SECGRP} --protocol all --cidr ${FULL_ACCESS_IP}/32 --region ${CLUSTER_REGION}
     sleep 5
-done
+fi
+
+# For Hyperfoil
+if [[ "${INSTALL_HYPERFOIL}x" == "truex" ]]; then
+    echo "Setting up ingress rule required for Hyperfoil"
+
+    aws ec2 authorize-security-group-ingress --group-id ${SECGRP} --protocol all --cidr 127.0.0.1/32 --region ${CLUSTER_REGION}
+    sleep 5
+fi
 
 echo "Starting EC2 instance"
 EC2=`aws ec2 run-instances --image-id $AMI --count 1 --instance-type ${EC2_TYPE} --key-name ${EC2_NAME}Key --security-group-ids $SECGRP --subnet-id $SUBNET --region ${CLUSTER_REGION} --associate-public-ip-address --block-device-mapping "[ { \"DeviceName\": \"/dev/sda1\", \"Ebs\": { \"VolumeSize\": 50 } } ]" --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=${EC2_NAME}}]" --query 'Instances[0].InstanceId' --output text`
@@ -66,13 +63,13 @@ aws ec2 wait instance-status-ok --instance-ids ${EC2} --region ${CLUSTER_REGION}
 
 echo "Getting public ip"
 PUBIP=`aws ec2 describe-instances --filters "Name=instance-id,Values=$EC2" --query 'Reservations[].Instances[].PublicDnsName' --region ${CLUSTER_REGION} --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $PUBIP =~ "compute-1.amazonaws.com" ]]; then
-      echo "Public IP "${PUBIP}" is available"
-      break
-    fi
-    sleep 5
-done
+if [[ $PUBIP =~ "compute-1.amazonaws.com" ]]; then
+  echo "Public IP "${PUBIP}" is available"
+else
+  echo "EC2 ${EC2} has been created but it does not seem to have public IP!"
+  echo "The key-pair ${EC2_NAME}Key and security group ${SECGRP} have been created so you might want to clean them up!"
+  exit 1
+fi
 
 INSTANCE=`aws ec2 describe-instances --instance-ids $EC2 --region ${CLUSTER_REGION} --output json`
 echo ${INSTANCE}

--- a/scripts/ec2_deploy_teardown/tearDown.sh
+++ b/scripts/ec2_deploy_teardown/tearDown.sh
@@ -1,24 +1,24 @@
 #!/bin/bash
 
+set -ex
+
 echo "Obtaining security group"
 SECGRP=`aws ec2 describe-security-groups --region ${CLUSTER_REGION} --filters Name=group-name,Values=${EC2_NAME}-sg --query SecurityGroups[0].GroupId --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $SECGRP =~ "sg-" ]]; then
-      echo "SECGRP "${SECGRP}" identified"
-      break
-    fi
-    sleep 5
-done
+if [[ $SECGRP =~ "sg-" ]]; then
+  echo "SECGRP "${SECGRP}" identified"
+else
+  echo "Security group not found!"
+  exit 1
+fi
 
 echo "Obtaining EC2 instance"
 EC2=`aws ec2 describe-instances  --region ${CLUSTER_REGION} --filters Name=key-name,Values=${EC2_NAME}Key Name=instance-state-name,Values=running --query Reservations[0].Instances[0].InstanceId --output text`
-for (( i=0; i<5; i++ )) do
-    if [[ $EC2 =~ "i-" ]]; then
-      echo "EC2 "${EC2}" identified"
-      break
-    fi
-    sleep 5
-done
+if [[ $EC2 =~ "i-" ]]; then
+  echo "EC2 "${EC2}" identified"
+else
+  echo "EC2 instance not found!"
+  exit 1
+fi
 
 echo "Terminating EC2 instance "$EC2
 aws ec2 terminate-instances --instance-ids $EC2 --region $CLUSTER_REGION


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Updated error handling of EC2 deploy (and remove) script. It fails with non-zero return code early now.

It also prints info about entities that have been already created for manual clean up (not ideal, but better than nothing).

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Verification steps

Verified in Jenkins already:
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Public/job/trepel-ec2-deploy/57/ (success)
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Public/job/trepel-ec2-deploy/58/ (early failure, duplicate key)

corresponding removal:
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/ManagedAPI/job/ec2-remove/98

