### PR TITLE
3scale user action failure metric and alert

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -66,6 +66,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
+	customMetrics.Registry.MustRegister(integreatlymetrics.ThreeScaleUserAction)
 	integreatlymetrics.OperatorVersion.Add(1)
 }
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -90,6 +90,17 @@ var (
 			"stage",
 		},
 	)
+
+	ThreeScaleUserAction = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "threescale_user_action",
+			Help: "Status of user CRUD action in 3scale",
+		},
+		[]string{
+			"username",
+			"action",
+		},
+	)
 )
 
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
@@ -125,4 +136,8 @@ func SetRhmiVersions(stage string, version string, toVersion string, firstInstal
 
 	RHOAMVersion.Reset()
 	RHOAMVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
+}
+
+func SetThreeScaleUserAction(httpStatus int, username, action string) {
+	ThreeScaleUserAction.WithLabelValues(username, action).Set(float64(httpStatus))
 }

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -128,6 +128,22 @@ var rhssoTest2 = &keycloak.KeycloakUser{
 	},
 }
 
+var rhssoTest3 = &keycloak.KeycloakUser{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      "alongusernamethatisabovefourtycharacterslong",
+		Namespace: testRhssoNamespace,
+		Labels: map[string]string{
+			rhsso.SSOLabelKey: rhsso.SSOLabelValue,
+		},
+	},
+	Spec: keycloak.KeycloakUserSpec{
+		User: keycloak.KeycloakAPIUser{
+			UserName: "alongusernamethatisabovefourtycharacterslong",
+			Email:    "test2@example.com",
+		},
+	},
+}
+
 var testDedicatedAdminsGroup = &usersv1.Group{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "dedicated-admins",
@@ -722,6 +738,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		backendRedisSec,
 		rhssoTest2,
 		rhssoTest1,
+		rhssoTest3,
 		ns,
 		operatorNS,
 		apicastProduction,

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1476,6 +1476,25 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	added, deleted := r.getUserDiff(kcu, tsUsers.Users)
+	// the deleted entries are addressed first
+	// a common use case is where one idp is added to give early access to the cluster
+	// later that idp is removed and a more permanent one is added
+	// if there are any duplicate emails across the set of users the user from the first idp
+	// should be removed first and that allows for the new one which had a potential conflict
+	// can now be added.
+	for _, tsUser := range deleted {
+		if tsUser.UserDetails.Username != *systemAdminUsername {
+			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
+			metrics.SetThreeScaleUserAction(res.StatusCode, string(tsUser.UserDetails.Id), http.MethodDelete)
+			if err != nil {
+				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale", tsUser.UserDetails.Id), err)
+			}
+			if res.StatusCode != http.StatusOK {
+				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale with status code %d", tsUser.UserDetails.Id, res.StatusCode), errors.New("error on http request"))
+			}
+		}
+	}
+
 	for _, kcUser := range added {
 		res, err := r.tsClient.AddUser(strings.ToLower(kcUser.UserName), strings.ToLower(kcUser.Email), "", *accessToken)
 
@@ -1490,18 +1509,6 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 		}
 		if res.StatusCode != http.StatusCreated {
 			r.log.Error(fmt.Sprintf("Failed to add keycloak user %s to 3scale with status code %d", kcUser.UserName, res.StatusCode), errors.New("error on http request"))
-		}
-	}
-	for _, tsUser := range deleted {
-		if tsUser.UserDetails.Username != *systemAdminUsername {
-			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
-			metrics.SetThreeScaleUserAction(res.StatusCode, string(tsUser.UserDetails.Id), http.MethodDelete)
-			if err != nil {
-				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale", tsUser.UserDetails.Id), err)
-			}
-			if res.StatusCode != http.StatusOK {
-				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale with status code %d", tsUser.UserDetails.Id, res.StatusCode), errors.New("error on http request"))
-			}
 		}
 	}
 

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -454,6 +454,13 @@ func commonExpectedRules() []alertsTestRule {
 			},
 		},
 		{
+			File: NamespacePrefix + "3scale-ksm-3scale-user-alerts.yaml",
+			Rules: []string{
+				"ThreeScaleUserCreationFailed",
+				"ThreeScaleUserDeletionFailed",
+			},
+		},
+		{
 			File: NamespacePrefix + "user-sso-ksm-endpoint-alerts.yaml",
 			Rules: []string{
 				"RHMIUserRhssoKeycloakServiceEndpointDown",


### PR DESCRIPTION
# Changes
expose new metric around user creation and deletion in 3scale
allow installation to complete when the user creation fails
add new alert that will fire when the user creation in 3scale fails
test updates

# Description
https://issues.redhat.com/browse/MGDAPI-1154
https://issues.redhat.com/browse/MGDAPI-1155
https://issues.redhat.com/browse/MGDAPI-1156


## Verification

### 1) Installation should not be blocked by user creation failure and alert should fire

#### 1.1) Prepare cluster 
`INSTALLATION_TYPE=managed-api IN_PROW=true make cluster/prepare/local`

Create a User with the following yaml and `oc apply -f` you cannot create through the UI without configuring a OAuthClient or 
```
apiVersion: user.openshift.io/v1
kind: User
metadata:
  name: alongusernamethatisabovefourtycharacterslong
```
and
```
apiVersion: user.openshift.io/v1
kind: User
metadata:
  name: auserlessthanfourtycharacters
```

#### 1.2) Install in cluster to verify monitoring

Run the operator in cluster - local run won't provide the metrics
Update operator.yaml quay images with `quay.io/laurafitzgerald/managed-api-service:v1.1.0-1154`
update env INSTALLATION_TYPE='managed-api'

`oc apply -f deploy/operator.yaml`

Add this annotation to the rhmi cr once it's created to allow it to install on ocm stage cluster
```
annotations:
    in_prow: 'true'
```

#### 1.3) Verify that the alert is firing

Example shown below

![Screenshot 2021-02-01 at 12 21 47](https://user-images.githubusercontent.com/6498727/106458306-1b394500-6488-11eb-897b-cdfef51c9ad2.png)


#### 1.4) Verify that the installation completes

After some time check that the rhmi cr goes to complete status and is not blocked by the failure to create the user in 3scale

You can also check that the user `auserlessthanfourtycharacters` is created in 3scale

Navigate to `https://3scale-admin.<your-cluster>/p/admin/account/users`
You should see `admin` an `auserlessthanfourtycharacters` but not `alongusernamethatisabovefourtycharacterslong` registered in 3scale.

#### 1.5) Verify deletion of users still reflects to 3scale as expected

Delete the user with `oc delete user auserlessthanfourtycharacters`

Check that the user is removed in the 3scale console link above.

### 2) Updating user email gets recreated in 3scale

The installation is complete from the previous step.

#### 2.1) Log in as admin user to 3scale
 
`https://3scale-admin.apps.<your-cluster>/p/admin/account/users`

#### 2.2) Edit any user and update the username

Wait for a while and the user will be set back.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [x] This change requires a SOP update - we likely need to add a SOP for this
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer