### PR TITLE
don't reconcile users from deleted IDPs

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -474,6 +474,8 @@ rules:
       - config.openshift.io
     resources:
       - infrastructures
+      - oauths
     verbs:
       - get
+      - list
   # END Permission to get cluster infrastructure details for alerting

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+	"github.com/pkg/errors"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -431,10 +432,9 @@ func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []user
 }
 
 func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string) ([]keycloak.KeycloakAPIUser, error) {
-	openshiftUsers := &usersv1.UserList{}
-	err := serverClient.List(ctx, openshiftUsers)
+	openshiftUsers, err := userHelper.GetUsersInActiveIDPs(ctx, serverClient)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "could not get users in active IDPs")
 	}
 
 	groups := &usersv1.GroupList{}

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	configv1 "github.com/openshift/api/config/v1"
 	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -150,7 +151,10 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	if err != nil {
 		return nil, err
 	}
-
+	err = configv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
 	return scheme, err
 }
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1078,7 +1078,7 @@ func (r *Reconciler) routesExist(ctx context.Context, serverClient k8sclient.Cli
 	}
 
 	if len(routes.Items) >= expectedRoutes {
-		r.log.Warningf("Required number of routes do not exist", l.Fields{"required": expectedRoutes})
+		r.log.Warningf("Required number of routes do not exist", l.Fields{"found": len(routes.Items), "required": expectedRoutes})
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
# Description
Treat users attached to deleted IDP as if they were deleted.

## Verification
- Provision OCM cluster
- Add github IDP through OCM
- Login to cluster using the IDP and see that a matching openshift user is created in the cluster
- Provision RHOAM
- See keycloakuser CR for your github user is created in redhat-rhoam-rhsso namespace
- Login to 3scale as admin, and see your user is created
- Delete your IDP from OCM
- Wait for operator to reconcile
- See keycloakuser CR is deleted
- See user is deleted from 3scale

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer