### PR TITLE
reset 3scale user metric on each reconcile

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -141,3 +141,7 @@ func SetRhmiVersions(stage string, version string, toVersion string, firstInstal
 func SetThreeScaleUserAction(httpStatus int, username, action string) {
 	ThreeScaleUserAction.WithLabelValues(username, action).Set(float64(httpStatus))
 }
+
+func ResetThreeScaleUserAction() {
+	ThreeScaleUserAction.Reset()
+}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1476,6 +1476,9 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	added, deleted := r.getUserDiff(kcu, tsUsers.Users)
+	// reset the user action metric before we re-reconcile
+	// in order to get up to date metrics on user creation
+	metrics.ResetThreeScaleUserAction()
 	// the deleted entries are addressed first
 	// a common use case is where one idp is added to give early access to the cluster
 	// later that idp is removed and a more permanent one is added


### PR DESCRIPTION

**What**
reset the threescale_user_action metric on each reconciliation
if the uses is resolved we want the metric to resolve so the alert will resolve

**JIRA**
Verification

It's installed to my cluster -> contact me for credentials

Create user in sso with too longer username (>40 characters)
Verify the alert fires
Delete the user as a resolution
Verify alert stops firing but history is still present in prometheus


![Screenshot 2021-02-03 at 13 17 32](https://user-images.githubusercontent.com/6498727/106753079-152b9b80-6623-11eb-8d14-b169c38e8628.png)


# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer