### PR TITLE
Fix time for instant queries in capture_resource_metrics.sh

### DIFF
--- a/scripts/capture_resource_metrics.sh
+++ b/scripts/capture_resource_metrics.sh
@@ -42,7 +42,7 @@ INSTANT_QUERIES=(\
   "sum(kube_node_status_allocatable_cpu_cores * on (node) (kube_node_role{role='worker'} == on (node) group_left () (count by (node) (kube_node_role{}))))"\
   "sum(cluster:capacity_memory_bytes:sum)/1024/1024/1024"\
   "sum(cluster:capacity_memory_bytes:sum{label_node_role_kubernetes_io!~'master|infra'})/1024/1024/1024"\
-  "kube_node_status_allocatable_memory_bytes * on (node) (kube_node_role{role='worker'} == on (node) group_left () (count by (node) (kube_node_role{}))) / 1024 / 1024 / 1024"\
+  "sum(kube_node_status_allocatable_memory_bytes * on (node) (kube_node_role{role='worker'} == on (node) group_left () (count by (node) (kube_node_role{}))) / 1024 / 1024 / 1024)"\
   "sum(kube_pod_container_resource_requests_cpu_cores{namespace=~'redhat-rhoam-.*',container!='lifecycle'} * on(namespace, pod) group_left() max by (namespace, pod) ( kube_pod_status_phase{phase='Running'} == 1 ))"\
   "sum(kube_pod_container_resource_requests_memory_bytes{namespace=~'redhat-rhoam-.*', container!='lifecycle'} * on(namespace, pod) group_left() max by (namespace, pod) ( kube_pod_status_phase{phase='Running'} == 1 )) / 1024 /1024"\
 )

--- a/scripts/capture_resource_metrics.sh
+++ b/scripts/capture_resource_metrics.sh
@@ -84,7 +84,7 @@ LOAD_QUERIES=(\
 #
 for query in "${INSTANT_QUERIES[@]}";
 do
-  curl -s -G -H "Authorization: Bearer $TOKEN" --data-urlencode "query=$query" -H 'Accept: application/json' $PROM_QUERY_ROUTE | jq -r ".data.result[0].value[1]"
+  curl -s -G -H "Authorization: Bearer $TOKEN" --data-urlencode "query=$query" --data-urlencode "time=$endTime" -H 'Accept: application/json' $PROM_QUERY_ROUTE | jq -r ".data.result[0].value[1]"
 done
 
 for query in "${IDLE_QUERIES[@]}";


### PR DESCRIPTION
# Description
Fixes a bug in the ./scripts/capture_resource_metrics.sh
Now it will run "instant queries" at a time when a run ended,
instead of running them at a time when script runs.
This is useful if you run the script much later after the run finish time.

Edit: I also fix one query (Allocatable RAM on workers)

## Type of change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer