### PR TITLE
fix: create grafana sa role and binding in code to avoid conflicts wi…

### DIFF
--- a/deploy/olm-catalog/integreatly-operator/2.8.0/integreatly-operator.v2.8.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/integreatly-operator/2.8.0/integreatly-operator.v2.8.0.clusterserviceversion.yaml
@@ -331,6 +331,18 @@ spec:
           verbs:
           - get
           - list
+        - apiGroups:
+            - authentication.k8s.io
+          resources:
+            - tokenreviews
+          verbs:
+            - create
+        - apiGroups:
+            - authorization.k8s.io
+          resources:
+            - subjectaccessreviews
+          verbs:
+            - create
         serviceAccountName: rhmi-operator
       deployments:
       - name: rhmi-operator

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -479,3 +479,18 @@ rules:
       - get
       - list
   # END Permission to get cluster infrastructure details for alerting
+
+  # Permissions to grant those roles to child operators that use the OAuth proxy
+  - apiGroups:
+      - authentication.k8s.io
+    resources:
+      - tokenreviews
+    verbs:
+      - create
+  - apiGroups:
+      - authorization.k8s.io
+    resources:
+      - subjectaccessreviews
+    verbs:
+      - create
+  # END Permissions to grant those roles to child operators that use the OAuth proxy

--- a/manifests/integreatly-grafana/3.8.1/grafana-operator.v3.8.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-grafana/3.8.1/grafana-operator.v3.8.1.clusterserviceversion.yaml
@@ -94,21 +94,6 @@ spec:
       mediatype: image/svg+xml
   install:
     spec:
-      clusterPermissions:
-        - rules:
-            - apiGroups:
-                - authentication.k8s.io
-              resources:
-                - tokenreviews
-              verbs:
-                - create
-            - apiGroups:
-                - authorization.k8s.io
-              resources:
-                - subjectaccessreviews
-              verbs:
-                - create
-          serviceAccountName: grafana-serviceaccount
       deployments:
         - name: grafana-operator
           spec:

--- a/manifests/integreatly-monitoring/1.5.0/application-monitoring-operator.v1.5.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-monitoring/1.5.0/application-monitoring-operator.v1.5.0.clusterserviceversion.yaml
@@ -101,20 +101,6 @@ spec:
           - subjectaccessreviews
           verbs:
           - create
-        serviceAccountName: grafana-serviceaccount
-      - rules:
-        - apiGroups:
-          - authentication.k8s.io
-          resources:
-          - tokenreviews
-          verbs:
-          - create
-        - apiGroups:
-          - authorization.k8s.io
-          resources:
-          - subjectaccessreviews
-          verbs:
-          - create
         - apiGroups:
           - ""
           resources:


### PR DESCRIPTION
Resources that are updated by an operator should not be specified in the CSV. Otherwise this will lead to update conflicts and a noisy OLM log.

This was the case for the grafana-serviceaccount: the sa is created and updated by the grafana operator, but was also part of the AMO and User-facing Grafana CSVs.