### PR TITLE
Prevent overriding RHMI production SMTP fromAddress value  in alert manager

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -828,7 +828,7 @@ func (r *Reconciler) getExistingSMTPFromAddress(ctx context.Context, client k8sc
 		return "", err
 	}
 
-	monitoring := amSecret.Data["alertmanager.yaml"]
+	monitoring := amSecret.Data[alertManagerConfigSecretFileName]
 
 	var config alertManagerConfig
 	err = yaml.Unmarshal(monitoring, &config)


### PR DESCRIPTION
# Description
A change to how the SMTP FromAddress is set in RHOAM has an impact on RHMI. Production RHMI instances have fromAddress domains set to the route domain of alert manager. This works with the SMTP Server / Service configured. This change prevents updates on clusters with an existing fromAddress configured in alert manager i.e. production RHMI clusters

# Verify
export ALERT_SMTP_FROM=test@test.com
Install RHMI as far as the monitoring stage
Verify that the alert manager config has `smtp_from: test@test.com`
Stop the operator

export ALERT_SMTP_FROM=test2@test.com
Rerun the operator.
After the monitoring stage has reconciled 
Verify that the alert manager **still has** config has `smtp_from: test@test.com` i.e. smtp_from was not overwrote


Delete the RHMI CR and repeat the test for RHOAM but verify that the email address does get over wrote

