### PR TITLE
MGDAPI-1248: Unify memory unit used in Grafana

### DIFF
--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -2762,7 +2762,7 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 				"values": []
 			},
 			"yaxes": [{
-					"format": "decbytes",
+					"format": "bytes",
 					"label": null,
 					"logBase": 1,
 					"max": null,
@@ -2859,7 +2859,7 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 					"pattern": "Value #A",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests",
@@ -2873,7 +2873,7 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 					"pattern": "Value #B",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests %",
@@ -2901,7 +2901,7 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 					"pattern": "Value #D",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Limits %",

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -547,7 +547,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 					"pattern": "Value #A",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests",
@@ -561,7 +561,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 					"pattern": "Value #B",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests %",
@@ -589,7 +589,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 					"pattern": "Value #D",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Limits %",

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -579,7 +579,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 					"pattern": "Value #A",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests",
@@ -593,7 +593,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 					"pattern": "Value #B",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Requests %",
@@ -621,7 +621,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 					"pattern": "Value #D",
 					"thresholds": [],
 					"type": "number",
-					"unit": "decbytes"
+					"unit": "bytes"
 				},
 				{
 					"alias": "Memory Limits %",

--- a/templates/monitoring/fuseonline/addon-ops-home-dashboard.yml
+++ b/templates/monitoring/fuseonline/addon-ops-home-dashboard.yml
@@ -1238,7 +1238,7 @@ spec:
             "rgba(237, 129, 40, 0.89)",
             "#d44a3a"
           ],
-          "format": "decbytes",
+          "format": "bytes",
           "gauge": {
             "maxValue": 100,
             "minValue": 0,


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/MGDAPI-1248

There has been some confusion caused by the use of MB in some places, and MiB in other.
This PR would unify the unit used to represent memory.
MiB should be used from now on.

## Type of change

<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer