### PR TITLE
add osde2e rhmi support

### DIFF
--- a/make/osde2e.mk
+++ b/make/osde2e.mk
@@ -15,4 +15,4 @@ image/osde2e/build/push: image/osde2e/build image/osde2e/push
 
 .PHONY: test/compile/osde2e
 test/compile/osde2e:
-	CGO_ENABLED=0 go test -v -c -o managed-api-test-harness.test ./test/osde2e
+	CGO_ENABLED=0 go test -v -c -o managed-api-test-harness.test ./test/osde2e -ginkgo.noColor

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -33,7 +33,7 @@ type alertManagerConfig struct {
 const (
 	threescaleOperatorDeploymentName          = "3scale-operator"
 	threescaleApicastProdDeploymentConfigName = "apicast-production"
-	monitoringTimeout                         = time.Minute * 40
+	monitoringTimeout                         = time.Minute * 25
 	monitoringRetryInterval                   = time.Minute
 	verifyOperatorDeploymentTimeout           = time.Minute * 5
 	verifyOperatorDeploymentRetryInterval     = time.Second * 15

--- a/test/osde2e/managed_api_test.go
+++ b/test/osde2e/managed_api_test.go
@@ -2,7 +2,6 @@ package osde2e
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/integr8ly/integreatly-operator/test/common"
 	. "github.com/onsi/ginkgo"
@@ -21,47 +20,15 @@ var _ = Describe("integreatly", func() {
 	})
 
 	RunTests := func() {
-
-		os.Setenv("WATCH_NAMESPACE", "redhat-rhoam-operator")
-		os.Setenv("SKIP_FLAKES", "true")
-		common.NamespacePrefix = "redhat-rhoam-"
-		common.RHMIOperatorNamespace = common.NamespacePrefix + "operator"
-		common.MonitoringOperatorNamespace = common.NamespacePrefix + "middleware-monitoring-operator"
-		common.MonitoringFederateNamespace = common.NamespacePrefix + "middleware-monitoring-federate"
-		common.AMQOnlineOperatorNamespace = common.NamespacePrefix + "amq-online"
-		common.ApicurioRegistryProductNamespace = common.NamespacePrefix + "apicurio-registry"
-		common.ApicurioRegistryOperatorNamespace = common.ApicurioRegistryProductNamespace + "-operator"
-		common.ApicuritoProductNamespace = common.NamespacePrefix + "apicurito"
-		common.ApicuritoOperatorNamespace = common.ApicuritoProductNamespace + "-operator"
-		common.CloudResourceOperatorNamespace = common.NamespacePrefix + "cloud-resources-operator"
-		common.CodeReadyProductNamespace = common.NamespacePrefix + "codeready-workspaces"
-		common.CodeReadyOperatorNamespace = common.CodeReadyProductNamespace + "-operator"
-		common.FuseProductNamespace = common.NamespacePrefix + "fuse"
-		common.FuseOperatorNamespace = common.FuseProductNamespace + "-operator"
-		common.RHSSOUserProductOperatorNamespace = common.NamespacePrefix + "user-sso"
-		common.RHSSOUserOperatorNamespace = common.RHSSOUserProductOperatorNamespace + "-operator"
-		common.RHSSOProductNamespace = common.NamespacePrefix + "rhsso"
-		common.RHSSOOperatorNamespace = common.RHSSOProductNamespace + "-operator"
-		common.SolutionExplorerProductNamespace = common.NamespacePrefix + "solution-explorer"
-		common.SolutionExplorerOperatorNamespace = common.SolutionExplorerProductNamespace + "-operator"
-		common.ThreeScaleProductNamespace = common.NamespacePrefix + "3scale"
-		common.ThreeScaleOperatorNamespace = common.ThreeScaleProductNamespace + "-operator"
-		common.UPSProductNamespace = common.NamespacePrefix + "ups"
-		common.UPSOperatorNamespace = common.UPSProductNamespace + "-operator"
-		common.MonitoringSpecNamespace = common.NamespacePrefix + "monitoring"
-		common.Marin3rOperatorNamespace = common.NamespacePrefix + "marin3r-operator"
-		common.Marin3rProductNamespace = common.NamespacePrefix + "marin3r"
-		common.CustomerGrafanaNamespace = common.NamespacePrefix + "customer-monitoring-operator"
-
 		// get all automated tests
 		tests := []common.Tests{
 			{
-				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
-				TestCases: common.GetHappyPathTestCases(installType),
+				Type:      "Integreatly Operator pre-test",
+				TestCases: OSD_E2E_PRE_TESTS,
 			},
 			{
-				Type:      fmt.Sprintf("%s pre-test", installType),
-				TestCases: OSD_E2E_PRE_TESTS,
+				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
+				TestCases: common.GetHappyPathTestCases(installType),
 			},
 		}
 
@@ -79,9 +46,7 @@ var _ = Describe("integreatly", func() {
 				}
 			})
 		}
-
 	}
 
 	RunTests()
-
 })

--- a/test/osde2e/suite_test.go
+++ b/test/osde2e/suite_test.go
@@ -2,17 +2,17 @@ package osde2e
 
 import (
 	"fmt"
-	"testing"
-
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"testing"
 
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/test/common"
@@ -52,12 +52,15 @@ func TestAPIs(t *testing.T) {
 	}
 	//TODO: Trigger operator install
 
-	//TODO: validate operator has completed install
-
 	// get install type
+	setVars("redhat-rhmi-operator", "redhat-rhmi-", t)
 	installType, err = common.GetInstallType(cfg)
 	if err != nil {
-		t.Fatalf("could not get install type %s", err)
+		setVars("redhat-rhoam-operator", "redhat-rhoam-", t)
+		installType, err = common.GetInstallType(cfg)
+		if err != nil {
+			t.Fatalf("could not get install type %s", err)
+		}
 	}
 
 	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s/%s", testResultsDirectory, jUnitOutputFilename))
@@ -86,3 +89,42 @@ var _ = AfterSuite(func() {
 	err := testEnv.Stop()
 	Expect(err).ToNot(HaveOccurred())
 })
+
+func setVars(possibleWN, possibleNS string, t *testing.T) {
+	err := os.Setenv("WATCH_NAMESPACE", possibleWN)
+	if err != nil {
+		t.Fatalf("Failed to set WATCH_NAMESPACE env var %s", err)
+	}
+	err = os.Setenv("SKIP_FLAKES", "true")
+	if err != nil {
+		t.Logf("Failed to set SKIP_FLAKES env var %s", err)
+	}
+	common.NamespacePrefix = possibleNS
+	common.RHMIOperatorNamespace = common.NamespacePrefix + "operator"
+	common.MonitoringOperatorNamespace = common.NamespacePrefix + "middleware-monitoring-operator"
+	common.MonitoringFederateNamespace = common.NamespacePrefix + "middleware-monitoring-federate"
+	common.AMQOnlineOperatorNamespace = common.NamespacePrefix + "amq-online"
+	common.ApicurioRegistryProductNamespace = common.NamespacePrefix + "apicurio-registry"
+	common.ApicurioRegistryOperatorNamespace = common.ApicurioRegistryProductNamespace + "-operator"
+	common.ApicuritoProductNamespace = common.NamespacePrefix + "apicurito"
+	common.ApicuritoOperatorNamespace = common.ApicuritoProductNamespace + "-operator"
+	common.CloudResourceOperatorNamespace = common.NamespacePrefix + "cloud-resources-operator"
+	common.CodeReadyProductNamespace = common.NamespacePrefix + "codeready-workspaces"
+	common.CodeReadyOperatorNamespace = common.CodeReadyProductNamespace + "-operator"
+	common.FuseProductNamespace = common.NamespacePrefix + "fuse"
+	common.FuseOperatorNamespace = common.FuseProductNamespace + "-operator"
+	common.RHSSOUserProductOperatorNamespace = common.NamespacePrefix + "user-sso"
+	common.RHSSOUserOperatorNamespace = common.RHSSOUserProductOperatorNamespace + "-operator"
+	common.RHSSOProductNamespace = common.NamespacePrefix + "rhsso"
+	common.RHSSOOperatorNamespace = common.RHSSOProductNamespace + "-operator"
+	common.SolutionExplorerProductNamespace = common.NamespacePrefix + "solution-explorer"
+	common.SolutionExplorerOperatorNamespace = common.SolutionExplorerProductNamespace + "-operator"
+	common.ThreeScaleProductNamespace = common.NamespacePrefix + "3scale"
+	common.ThreeScaleOperatorNamespace = common.ThreeScaleProductNamespace + "-operator"
+	common.UPSProductNamespace = common.NamespacePrefix + "ups"
+	common.UPSOperatorNamespace = common.UPSProductNamespace + "-operator"
+	common.MonitoringSpecNamespace = common.NamespacePrefix + "monitoring"
+	common.Marin3rOperatorNamespace = common.NamespacePrefix + "marin3r-operator"
+	common.Marin3rProductNamespace = common.NamespacePrefix + "marin3r"
+	common.CustomerGrafanaNamespace = common.NamespacePrefix + "customer-monitoring-operator"
+}


### PR DESCRIPTION
# Description
Addresses: https://issues.redhat.com/browse/INTLY-10444

Enabled rhmi osde2e and changed the timeout on the alerts_mechanism tests as the RHMI installation takes longer, and in case if that test is flaky, we can't be giving it 40minutes before it fails as instead of failing single test, we might end up having an entire suite of tests timinig out.