### PR TITLE
add back AMO 1.2.1

### DIFF
--- a/manifests/integreatly-monitoring/1.2.1/application-monitoring-operator.v1.2.1.clusterserviceversion.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/application-monitoring-operator.v1.2.1.clusterserviceversion.yaml
@@ -6,11 +6,11 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring stack
     certified: "false"
-    containerImage: quay.io/integreatly/application-monitoring-operator:v1.4.0
+    containerImage: quay.io/integreatly/application-monitoring-operator:v1.2.1
     createdAt: "2019-09-26 10:51:00"
     description: Operator managed and installs Prometheus, Alertmanager, Grafana
     support: Red Hat, Inc.
-  name: application-monitoring-operator.v1.4.0
+  name: application-monitoring-operator.v1.2.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -230,7 +230,7 @@ spec:
                       fieldPath: metadata.name
                 - name: OPERATOR_NAME
                   value: application-monitoring-operator
-                image: quay.io/integreatly/application-monitoring-operator:v1.4.0
+                image: quay.io/integreatly/application-monitoring-operator:v1.2.1
                 imagePullPolicy: Always
                 name: application-monitoring-operator
                 ports:
@@ -350,5 +350,4 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
-  replaces: application-monitoring-operator.v1.2.1
-  version: 1.4.0
+  version: 1.2.1

--- a/manifests/integreatly-monitoring/1.2.1/applicationmonitoring.integreatly.org_applicationmonitorings_crd.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/applicationmonitoring.integreatly.org_applicationmonitorings_crd.yaml
@@ -1,0 +1,42 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: applicationmonitorings.applicationmonitoring.integreatly.org
+spec:
+  group: applicationmonitoring.integreatly.org
+  names:
+    kind: ApplicationMonitoring
+    listKind: ApplicationMonitoringList
+    plural: applicationmonitorings
+    singular: applicationmonitoring
+  scope: Namespaced
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      required: ["spec"]
+      properties:
+        spec:
+          required: ["labelSelector"]
+          properties:
+            labelSelector:
+              type: string
+              minimum: 1
+              description: The selector used by the Prometheus and Grafana Operators to discover resources
+            additionalScrapeConfigSecretName:
+              type: string
+              description: The name of the secret from which additional scrape configs will be passed to the prometheus operator
+            additionalScrapeConfigSecretKey:
+              type: string
+              description: The key under which additional scrape configs are stored within the secret
+            prometheusRetention:
+              type: string
+              description: Retention time for prometheus data. See https://prometheus.io/docs/prometheus/latest/storage/
+            prometheusStorageRequest:
+              type: string
+              description: How much storage to assign to a volume claim for persisting Prometheus data. See https://github.com/coreos/prometheus-operator/blob/ca400fdc3edd0af0df896a338eca270e115b74d7/Documentation/api.md#storagespec
+            prometheusInstanceNamespaces:
+              type: string
+              description: The list of namespaces to watch for prometheus custom resources
+            alertmanagerInstanceNamespaces:
+              type: string
+              description: The list of namespaces to watch for alertmanager custom resources

--- a/manifests/integreatly-monitoring/1.2.1/applicationmonitoring.integreatly.org_blackboxtargets_crd.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/applicationmonitoring.integreatly.org_blackboxtargets_crd.yaml
@@ -1,0 +1,60 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: blackboxtargets.applicationmonitoring.integreatly.org
+spec:
+  group: applicationmonitoring.integreatly.org
+  names:
+    kind: BlackboxTarget
+    listKind: BlackboxTargetList
+    plural: blackboxtargets
+    singular: blackboxtarget
+  scope: Namespaced
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#types-kinds'
+          type: string
+        metadata:
+          type: object
+        spec:
+          properties:
+            blackboxTargets:
+              description: 'Defines an endpoint which can be probed using the Prometheus Blackbox exporter'
+              items:
+                properties:
+                  module:
+                    type: string
+                  service:
+                    type: string
+                  url:
+                    type: string
+                required:
+                - url
+                - service
+                - module
+                type: object
+              type: array
+          type: object
+        status:
+          properties:
+            phase:
+              description: 'The field phase is a status field indicating which phase the controller is with regards to reconciling blackbox target resources.'
+              format: int64
+              type: integer
+          required:
+          - phase
+          type: object
+  version: v1alpha1
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true

--- a/manifests/integreatly-monitoring/1.2.1/grafana_crd.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/grafana_crd.yaml
@@ -1,0 +1,128 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanas.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: Grafana
+    listKind: GrafanaList
+    plural: grafanas
+    singular: grafana
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      required: ["spec"]
+      properties:
+        spec:
+          properties:
+            containers:
+              type: array
+              items:
+                type: object
+                description: Additional container to add to the grafana pod
+            secrets:
+              type: array
+              items:
+                type: string
+                description: Secret to be mounted as volume into the grafana deployment
+            configMaps:
+              type: array
+              items:
+                type: string
+                description: Config map to be mounted as volume into the grafana deployment
+            logLevel:
+              type: string
+              description: Log level of the grafana instance, defaults to info
+            adminUser:
+              type: string
+              description: Default admin user name
+            adminPassword:
+              type: string
+              description: Default admin password
+            basicAuth:
+              type: boolean
+              description: Basic auth enabled
+            disableLoginForm:
+              type: boolean
+              description: Disable login form
+            disableSignoutMenu:
+              type: boolean
+              description: Disable signout menu
+            anonymous:
+              type: boolean
+              description: Anonymous auth enabled
+            config:
+              type: object
+              description: Grafana config
+            ingress:
+              type: object
+              properties:
+                enabled:
+                  type: boolean
+                  description: Create an ingress / route
+                path:
+                  type: string
+                  description: Ingress path
+                hostname:
+                  type: string
+                  description: The hostname of the ingress / route
+                annotations:
+                  type: object
+                  description: Additional annotations for the ingress / route
+                labels:
+                  type: object
+                  description: Additional labels for the ingress / route
+                targetPort:
+                  type: string
+                  description: Override port to target in the grafana service
+            service:
+              type: object
+              properties:
+                ports:
+                  type: array
+                  description: Override default ports
+                  items:
+                    type: object
+                    descripton: A port to add to the grafana service
+                annotations:
+                  type: object
+                  description: Additional annotations for the service
+                labels:
+                  type: object
+                  description: Additional labels for the service
+                type:
+                  type: string
+                  description: Service type (NodePort, ClusterIP or LoadBalancer)
+            deployment:
+              type: object
+              properties:
+                annotations:
+                  type: object
+                  description: Additional annotations for the service
+                labels:
+                  type: object
+                  description: Additional labels for the service
+            serviceAccount:
+              type: object
+              properties:
+                annotations:
+                  type: object
+                  description: Additional annotations for the serviceaccount
+                labels:
+                  type: object
+                  description: Additional labels for the serviceaccount
+            client:
+              type: object
+              description: Grafana client settings
+            compat:
+              type: object
+              description: Backwards compatibility switches
+            dashboardLabelSelectors:
+              type: array
+              items:
+                type: object
+                description: Label selector or match expressions

--- a/manifests/integreatly-monitoring/1.2.1/grafana_dashboard_crd.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/grafana_dashboard_crd.yaml
@@ -1,0 +1,29 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanadashboards.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: GrafanaDashboard
+    listKind: GrafanaDashboardList
+    plural: grafanadashboards
+    singular: grafanadashboard
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          properties:
+            name:
+              type: string
+            json:
+              type: string
+            plugins:
+              type: array
+              items:
+                description: Grafana Plugin Object
+                type: object

--- a/manifests/integreatly-monitoring/1.2.1/grafana_datasource_crd.yaml
+++ b/manifests/integreatly-monitoring/1.2.1/grafana_datasource_crd.yaml
@@ -1,0 +1,35 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: grafanadatasources.integreatly.org
+spec:
+  group: integreatly.org
+  names:
+    kind: GrafanaDataSource
+    listKind: GrafanaDataSourceList
+    plural: grafanadatasources
+    singular: grafanadatasource
+  scope: Namespaced
+  subresources:
+    status: {}
+  version: v1alpha1
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          type: string
+        kind:
+          type: string
+        metadata:
+          type: object
+        spec:
+          required: ["datasources", "name"]
+          properties:
+            name:
+              type: string
+              minimum: 1
+            datasources:
+              type: array
+              items:
+                description: Grafana Datasource Object
+                type: object


### PR DESCRIPTION
# Description
AMO 1.2.1 Manifest folder was remove when 1.4.0 was added. 1.2.1 is present in RHMI 2.7.2, hence the removal breaks the upgrade of RHMI to 2.8.0

# Verify
Install RHMI based on v2.7.2 tag. 
Verify 1.2.1 of AMO installed 
Checkout this branch
Install RHMI 
Verify 1.5.1 of AMO installed 
Log into Prometheus, Grafana and AlertManager and sanity check settings