### PR TITLE
Remove unused podmonitors from keycloak namespaces

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -376,6 +376,7 @@ rules:
     resources:
       - prometheusrules
       - servicemonitors
+      - podmonitors
     verbs:
       - get
       - list

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -191,6 +191,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.RemovePodMonitors(ctx, serverClient, r.Config)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to remove pod monitor", err)
+		return phase, err
+	}
+
 	phase, err = resources.ReconcileSecretToRHMIOperatorNamespace(ctx, serverClient, r.ConfigManager, adminCredentialSecretName, productNamespace)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile admin credential secret to RHMI operator namespace", err)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -244,6 +244,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.RemovePodMonitors(ctx, serverClient, r.Config)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to remove pod monitor", err)
+		return phase, err
+	}
+
 	if err := r.reconcileConsoleLink(ctx, serverClient); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}


### PR DESCRIPTION
# Description
remove unused keycloack pod monitors since v12.0.1 no longer uses them. 

## Verify
1. Install 2.7.2 rhmi branch
2. verify keycloak-pod-monitor cr exists on cluster in both rhsso and user-sso namespaces
3. Verify alerts for keycloak-pod-monitor is firing in alertmanager
4. Install 2.8.0 from this branch 
5. Verify podmonitors are removed 
6. Verify alerts are no longer in alertmanager, this can take up to 3 minutes for alertmanager to rebuild its config. 