### PR TITLE
MGDAPI-1289: Modify watches in namespace controller to enqueue correct requests

### DIFF
--- a/controllers/namespacelabel/enqueue.go
+++ b/controllers/namespacelabel/enqueue.go
@@ -1,0 +1,63 @@
+package controllers
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/workqueue"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+)
+
+// EnqueueNamespaceFromObject is an EventHandler that enqueues requests with
+// the name taken from the source namespace. Example:
+// An event cause by an object called Foo in the namespace Bar will enqueue
+// the following request:
+// { Name: "Bar", Namespace: "" }
+type EnqueueNamespaceFromObject struct{}
+
+var _ handler.EventHandler = &EnqueueNamespaceFromObject{}
+
+// Create implements EventHandler
+func (e *EnqueueNamespaceFromObject) Create(evt event.CreateEvent, q workqueue.RateLimitingInterface) {
+	if evt.Meta == nil {
+		return
+	}
+
+	addNamespaceRequest(evt.Meta, q)
+}
+
+// Update implements EventHandler
+func (e *EnqueueNamespaceFromObject) Update(evt event.UpdateEvent, q workqueue.RateLimitingInterface) {
+	if evt.MetaOld != nil {
+		addNamespaceRequest(evt.MetaOld, q)
+	}
+
+	if evt.MetaNew != nil {
+		addNamespaceRequest(evt.MetaNew, q)
+	}
+}
+
+// Delete implements EventHandler
+func (e *EnqueueNamespaceFromObject) Delete(evt event.DeleteEvent, q workqueue.RateLimitingInterface) {
+	if evt.Meta == nil {
+		return
+	}
+
+	addNamespaceRequest(evt.Meta, q)
+}
+
+// Generic implements EventHandler
+func (e *EnqueueNamespaceFromObject) Generic(evt event.GenericEvent, q workqueue.RateLimitingInterface) {
+	if evt.Meta == nil {
+		return
+	}
+
+	addNamespaceRequest(evt.Meta, q)
+}
+
+func addNamespaceRequest(meta metav1.Object, q workqueue.RateLimitingInterface) {
+	q.Add(ctrl.Request{NamespacedName: types.NamespacedName{
+		Name: meta.GetNamespace(),
+	}})
+}


### PR DESCRIPTION
# Description

The namespace controller watches Namespaces and ConfigMaps, which will enqueue different requests since the namespaces have their name in theresource name, while the ConfigMap is namespaced. In order to ensure uniform requests, add an EventHandler for the ConfigMap watch that enqueues only its namespace, and add predicates for both types of resources to watch exclusivelly what we're interested in: the operator namespace and the add-on ConfigMaps.

## Verification steps

1. Install RHOAM/RHMI from this PR
2. Create a ConfigMap called
    * RHOAM: `managed-api-service`
    * RHMI: `rhmi`
3. In the operator logs, verify that the following entry is immediately added (proof that the watch works for the ConfigMap):
    ```
    Reconciling namespace labels
    ```
4. Add the following label to the ConfigMap
    ```yaml
    # RHOAM
    "api.openshift.com/addon-managed-api-service-delete": "true"
    # RHMI
    "api.openshift.com/addon-rhmi-operator-delete": "true"
    ```
5. Verify that the uninstall starts immediately


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer