### PR TITLE
adding sku package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ OPERATOR_SDK_VERSION=1.2.0
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "$(QUAY_PASSWORD)"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 IN_PROW ?= "false"
+SKU="DEV_SKU"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker
@@ -84,7 +85,7 @@ ifeq ($(INSTALLATION_TYPE), managed-api)
 	INSTALLATION_SHORTHAND ?= rhoam
 endif
 
-NAMESPACE=$(NAMESPACE_PREFIX)operator
+NAMESPACE ?= $(NAMESPACE_PREFIX)operator
 
 define wait_command
 	@echo Waiting for $(2) for $(3)...
@@ -323,7 +324,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/ratelimits cluster/prepare/delorean cluster/prepare/croaws
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/ratelimits cluster/prepare/sku cluster/prepare/delorean cluster/prepare/croaws
 	@ - oc create -f config/rbac/service_account.yaml -n $(NAMESPACE)
 	@ - $(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc create -f -
 
@@ -358,6 +359,11 @@ cluster/prepare/dms:
 .PHONY: cluster/prepare/ratelimits
 cluster/prepare/ratelimits:
 	@-oc create -n $(NAMESPACE) -f config/configmap/sku-limits-configmap.yaml
+
+.PHONY: cluster/prepare/sku
+cluster/prepare/sku:
+	@-oc create -n $(NAMESPACE) -f config/configmap/sku-config.yaml
+	@-oc process -n $(NAMESPACE) SKU=$(SKU) -f config/secrets/sku-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/delorean
 cluster/prepare/delorean: cluster/prepare/delorean/pullsecret

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ ifeq ($(INSTALLATION_TYPE), managed-api)
 	INSTALLATION_SHORTHAND ?= rhoam
 endif
 
-NAMESPACE ?= $(NAMESPACE_PREFIX)operator
+NAMESPACE=$(NAMESPACE_PREFIX)operator
 
 define wait_command
 	@echo Waiting for $(2) for $(3)...

--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -214,6 +214,8 @@ type RHMIStatus struct {
 	SMTPEnabled        bool                          `json:"smtpEnabled,omitempty"`
 	Version            string                        `json:"version,omitempty"`
 	ToVersion          string                        `json:"toVersion,omitempty"`
+	SKU                string                        `json:"skuUpdated,omitempty"`
+	ToSKU              string                        `json:"toSKU,omitempty"`
 }
 
 type RHMIStageStatus struct {

--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -214,7 +214,7 @@ type RHMIStatus struct {
 	SMTPEnabled        bool                          `json:"smtpEnabled,omitempty"`
 	Version            string                        `json:"version,omitempty"`
 	ToVersion          string                        `json:"toVersion,omitempty"`
-	SKU                string                        `json:"skuUpdated,omitempty"`
+	SKU                string                        `json:"sku,omitempty"`
 	ToSKU              string                        `json:"toSKU,omitempty"`
 }
 

--- a/config/configmap/sku-config.yaml
+++ b/config/configmap/sku-config.yaml
@@ -1,0 +1,193 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sku-config
+data:
+  sku-configs: |-
+    [
+    {
+              "name": "TWENTY_MILLION_SKU",
+              "rate-limiting": {
+                  "unit": "minute",
+                  "requests_per_unit": 1389,
+                  "alert_limits": []
+              },
+              "resources": {
+                  "backend_listener": {
+                      "replicas": 3,
+                      "resources": {
+                          "requests": {
+                              "cpu": 0.25,
+                              "memory": 450
+                          },
+                          "limits": {
+                              "cpu": 0.3,
+                              "memory": 500
+                          }
+                      }
+                  },
+                  "backend_worker": {
+                      "replicas": 3,
+                      "resources": {
+                          "requests": {
+                              "cpu": 0.15,
+                              "memory": 100
+                          },
+                          "limits": {
+                              "cpu": 0.2,
+                              "memory": 100
+                          }
+                      }
+                  },
+                  "apicast_production": {
+                      "replicas": 3,
+                      "resources": {
+                          "requests": {
+                              "cpu": 0.3,
+                              "memory": 250
+                          },
+                          "limits": {
+                              "cpu": 0.3,
+                              "memory": 300
+                          }
+                      }
+                  },
+                  "keycloak": {
+                      "replicas": 3,
+                      "resources": {
+                          "requests": {
+                              "cpu": 0.75,
+                              "memory": 1500
+                          },
+                          "limits": {
+                              "cpu": 0.75,
+                              "memory": 1500
+                          }
+                      }
+                  }
+              }
+          },
+       {
+          "name": "FIVE_MILLION_SKU",
+          "rate-limiting": {
+              "unit": "minute",
+              "requests_per_unit": 347,
+              "alert_limits": []
+          },
+          "resources": {
+              "backend_listener": {
+                  "replicas": 3,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.1,
+                          "memory": 450
+                      },
+                      "limits": {
+                          "cpu": 0.11,
+                          "memory": 500
+                      }
+                  }
+              },
+              "backend_worker": {
+                  "replicas": 3,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.03,
+                          "memory": 55
+                      },
+                      "limits": {
+                          "cpu": 0.04,
+                          "memory": 60
+                      }
+                  }
+              },
+              "apicast_production": {
+                  "replicas": 3,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.09,
+                          "memory": 250
+                      },
+                      "limits": {
+                          "cpu": 0.1,
+                          "memory": 270
+                      }
+                  }
+              },
+              "keycloak": {
+                  "replicas": 3,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.75,
+                          "memory": 1500
+                      },
+                      "limits": {
+                          "cpu": 0.75,
+                          "memory": 1500
+                      }
+                  }
+              }
+          }
+      },
+      {
+          "name": "DEV_SKU",
+          "rate-limiting": {
+              "unit": "minute",
+              "requests_per_unit": 20,
+              "alert_limits": []
+          },
+          "resources": {
+              "backend_listener": {
+                  "replicas": 1,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.1,
+                          "memory": 450
+                      },
+                      "limits": {
+                          "cpu": 0.11,
+                          "memory": 500
+                      }
+                  }
+              },
+              "backend_worker": {
+                  "replicas": 1,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.03,
+                          "memory": 55
+                      },
+                      "limits": {
+                          "cpu": 0.04,
+                          "memory": 60
+                      }
+                  }
+              },
+              "apicast_production": {
+                  "replicas": 1,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.09,
+                          "memory": 250
+                      },
+                      "limits": {
+                          "cpu": 0.1,
+                          "memory": 270
+                      }
+                  }
+              },
+              "keycloak": {
+                  "replicas": 1,
+                  "resources": {
+                      "requests": {
+                          "cpu": 0.75,
+                          "memory": 1500
+                      },
+                      "limits": {
+                          "cpu": 0.75,
+                          "memory": 1500
+                      }
+                  }
+              }
+          }
+      }]

--- a/config/crd/bases/integreatly.org_rhmis.yaml
+++ b/config/crd/bases/integreatly.org_rhmis.yaml
@@ -16,164 +16,164 @@ spec:
     singular: rhmi
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: RHMI is the Schema for the rhmis API
-          properties:
-            apiVersion:
-              description: 'APIVersion defines the versioned schema of this representation
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RHMI is the Schema for the rhmis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-              type: string
-            kind:
-              description: 'Kind is a string value representing the REST resource this
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RHMISpec defines the desired state of RHMI
-              properties:
-                alertFromAddress:
-                  type: string
-                alertingEmailAddress:
-                  type: string
-                alertingEmailAddresses:
-                  properties:
-                    businessUnit:
-                      type: string
-                    cssre:
-                      type: string
-                  required:
-                    - businessUnit
-                    - cssre
-                  type: object
-                deadMansSnitchSecret:
-                  description: "DeadMansSnitchSecret is the name of a secret in the
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RHMISpec defines the desired state of RHMI
+            properties:
+              alertFromAddress:
+                type: string
+              alertingEmailAddress:
+                type: string
+              alertingEmailAddresses:
+                properties:
+                  businessUnit:
+                    type: string
+                  cssre:
+                    type: string
+                required:
+                - businessUnit
+                - cssre
+                type: object
+              deadMansSnitchSecret:
+                description: "DeadMansSnitchSecret is the name of a secret in the
                   installation namespace containing connection details for Dead Mans
                   Snitch. The secret must contain the following fields: \n url"
-                  type: string
-                masterURL:
-                  type: string
-                namespacePrefix:
-                  type: string
-                operatorsInProductNamespace:
-                  description: OperatorsInProductNamespace is a flag that decides if
-                    the product operators should be installed in the product namespace
-                    (when set to true) or in standalone namespace (when set to false,
-                    default). Standalone namespace will be used only for those operators
-                    that support it.
-                  type: boolean
-                pagerDutySecret:
-                  description: "PagerDutySecret is the name of a secret in the installation
+                type: string
+              masterURL:
+                type: string
+              namespacePrefix:
+                type: string
+              operatorsInProductNamespace:
+                description: OperatorsInProductNamespace is a flag that decides if
+                  the product operators should be installed in the product namespace
+                  (when set to true) or in standalone namespace (when set to false,
+                  default). Standalone namespace will be used only for those operators
+                  that support it.
+                type: boolean
+              pagerDutySecret:
+                description: "PagerDutySecret is the name of a secret in the installation
                   namespace containing PagerDuty account details. The secret must
                   contain the following fields: \n serviceKey"
-                  type: string
-                priorityClassName:
-                  type: string
-                pullSecret:
+                type: string
+              priorityClassName:
+                type: string
+              pullSecret:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              rebalancePods:
+                type: boolean
+              routingSubdomain:
+                type: string
+              selfSignedCerts:
+                type: boolean
+              smtpSecret:
+                description: "SMTPSecret is the name of a secret in the installation
+                  namespace containing SMTP connection details. The secret must contain
+                  the following fields: \n host port tls username password"
+                type: string
+              type:
+                type: string
+              useClusterStorage:
+                type: string
+            required:
+            - namespacePrefix
+            - type
+            type: object
+          status:
+            description: RHMIStatus defines the observed state of RHMI
+            properties:
+              gitHubOAuthEnabled:
+                type: boolean
+              lastError:
+                type: string
+              preflightMessage:
+                type: string
+              preflightStatus:
+                type: string
+              sku:
+                type: string
+              smtpEnabled:
+                type: boolean
+              stage:
+                type: string
+              stages:
+                additionalProperties:
                   properties:
                     name:
                       type: string
-                    namespace:
+                    phase:
                       type: string
-                  required:
-                    - name
-                    - namespace
-                  type: object
-                rebalancePods:
-                  type: boolean
-                routingSubdomain:
-                  type: string
-                selfSignedCerts:
-                  type: boolean
-                smtpSecret:
-                  description: "SMTPSecret is the name of a secret in the installation
-                  namespace containing SMTP connection details. The secret must contain
-                  the following fields: \n host port tls username password"
-                  type: string
-                type:
-                  type: string
-                useClusterStorage:
-                  type: string
-              required:
-                - namespacePrefix
-                - type
-              type: object
-            status:
-              description: RHMIStatus defines the observed state of RHMI
-              properties:
-                gitHubOAuthEnabled:
-                  type: boolean
-                lastError:
-                  type: string
-                preflightMessage:
-                  type: string
-                preflightStatus:
-                  type: string
-                skuUpdated:
-                  type: string
-                smtpEnabled:
-                  type: boolean
-                stage:
-                  type: string
-                stages:
-                  additionalProperties:
-                    properties:
-                      name:
-                        type: string
-                      phase:
-                        type: string
-                      products:
-                        additionalProperties:
-                          properties:
-                            host:
-                              type: string
-                            mobile:
-                              type: boolean
-                            name:
-                              type: string
-                            operator:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                            version:
-                              type: string
-                          required:
-                            - host
-                            - name
-                            - status
-                            - version
-                          type: object
+                    products:
+                      additionalProperties:
+                        properties:
+                          host:
+                            type: string
+                          mobile:
+                            type: boolean
+                          name:
+                            type: string
+                          operator:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - host
+                        - name
+                        - status
+                        - version
                         type: object
-                    required:
-                      - name
-                      - phase
-                    type: object
-                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                      type: object
+                  required:
+                  - name
+                  - phase
+                  type: object
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                  type: object
-                toSKU:
-                  type: string
-                toVersion:
-                  type: string
-                version:
-                  type: string
-              required:
-                - lastError
-                - stage
-                - stages
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
+                type: object
+              toSKU:
+                type: string
+              toVersion:
+                type: string
+              version:
+                type: string
+            required:
+            - lastError
+            - stage
+            - stages
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/integreatly.org_rhmis.yaml
+++ b/config/crd/bases/integreatly.org_rhmis.yaml
@@ -16,160 +16,164 @@ spec:
     singular: rhmi
   scope: Namespaced
   versions:
-  - name: v1alpha1
-    schema:
-      openAPIV3Schema:
-        description: RHMI is the Schema for the rhmis API
-        properties:
-          apiVersion:
-            description: 'APIVersion defines the versioned schema of this representation
+    - name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: RHMI is the Schema for the rhmis API
+          properties:
+            apiVersion:
+              description: 'APIVersion defines the versioned schema of this representation
               of an object. Servers should convert recognized schemas to the latest
               internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-            type: string
-          kind:
-            description: 'Kind is a string value representing the REST resource this
+              type: string
+            kind:
+              description: 'Kind is a string value representing the REST resource this
               object represents. Servers may infer this from the endpoint the client
               submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-            type: string
-          metadata:
-            type: object
-          spec:
-            description: RHMISpec defines the desired state of RHMI
-            properties:
-              alertFromAddress:
-                type: string
-              alertingEmailAddress:
-                type: string
-              alertingEmailAddresses:
-                properties:
-                  businessUnit:
-                    type: string
-                  cssre:
-                    type: string
-                required:
-                - businessUnit
-                - cssre
-                type: object
-              deadMansSnitchSecret:
-                description: "DeadMansSnitchSecret is the name of a secret in the
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: RHMISpec defines the desired state of RHMI
+              properties:
+                alertFromAddress:
+                  type: string
+                alertingEmailAddress:
+                  type: string
+                alertingEmailAddresses:
+                  properties:
+                    businessUnit:
+                      type: string
+                    cssre:
+                      type: string
+                  required:
+                    - businessUnit
+                    - cssre
+                  type: object
+                deadMansSnitchSecret:
+                  description: "DeadMansSnitchSecret is the name of a secret in the
                   installation namespace containing connection details for Dead Mans
                   Snitch. The secret must contain the following fields: \n url"
-                type: string
-              masterURL:
-                type: string
-              namespacePrefix:
-                type: string
-              operatorsInProductNamespace:
-                description: OperatorsInProductNamespace is a flag that decides if
-                  the product operators should be installed in the product namespace
-                  (when set to true) or in standalone namespace (when set to false,
-                  default). Standalone namespace will be used only for those operators
-                  that support it.
-                type: boolean
-              pagerDutySecret:
-                description: "PagerDutySecret is the name of a secret in the installation
+                  type: string
+                masterURL:
+                  type: string
+                namespacePrefix:
+                  type: string
+                operatorsInProductNamespace:
+                  description: OperatorsInProductNamespace is a flag that decides if
+                    the product operators should be installed in the product namespace
+                    (when set to true) or in standalone namespace (when set to false,
+                    default). Standalone namespace will be used only for those operators
+                    that support it.
+                  type: boolean
+                pagerDutySecret:
+                  description: "PagerDutySecret is the name of a secret in the installation
                   namespace containing PagerDuty account details. The secret must
                   contain the following fields: \n serviceKey"
-                type: string
-              priorityClassName:
-                type: string
-              pullSecret:
-                properties:
-                  name:
-                    type: string
-                  namespace:
-                    type: string
-                required:
-                - name
-                - namespace
-                type: object
-              rebalancePods:
-                type: boolean
-              routingSubdomain:
-                type: string
-              selfSignedCerts:
-                type: boolean
-              smtpSecret:
-                description: "SMTPSecret is the name of a secret in the installation
-                  namespace containing SMTP connection details. The secret must contain
-                  the following fields: \n host port tls username password"
-                type: string
-              type:
-                type: string
-              useClusterStorage:
-                type: string
-            required:
-            - namespacePrefix
-            - type
-            type: object
-          status:
-            description: RHMIStatus defines the observed state of RHMI
-            properties:
-              gitHubOAuthEnabled:
-                type: boolean
-              lastError:
-                type: string
-              preflightMessage:
-                type: string
-              preflightStatus:
-                type: string
-              smtpEnabled:
-                type: boolean
-              stage:
-                type: string
-              stages:
-                additionalProperties:
+                  type: string
+                priorityClassName:
+                  type: string
+                pullSecret:
                   properties:
                     name:
                       type: string
-                    phase:
+                    namespace:
                       type: string
-                    products:
-                      additionalProperties:
-                        properties:
-                          host:
-                            type: string
-                          mobile:
-                            type: boolean
-                          name:
-                            type: string
-                          operator:
-                            type: string
-                          status:
-                            type: string
-                          type:
-                            type: string
-                          version:
-                            type: string
-                        required:
-                        - host
-                        - name
-                        - status
-                        - version
-                        type: object
-                      type: object
                   required:
-                  - name
-                  - phase
+                    - name
+                    - namespace
                   type: object
-                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                rebalancePods:
+                  type: boolean
+                routingSubdomain:
+                  type: string
+                selfSignedCerts:
+                  type: boolean
+                smtpSecret:
+                  description: "SMTPSecret is the name of a secret in the installation
+                  namespace containing SMTP connection details. The secret must contain
+                  the following fields: \n host port tls username password"
+                  type: string
+                type:
+                  type: string
+                useClusterStorage:
+                  type: string
+              required:
+                - namespacePrefix
+                - type
+              type: object
+            status:
+              description: RHMIStatus defines the observed state of RHMI
+              properties:
+                gitHubOAuthEnabled:
+                  type: boolean
+                lastError:
+                  type: string
+                preflightMessage:
+                  type: string
+                preflightStatus:
+                  type: string
+                skuUpdated:
+                  type: string
+                smtpEnabled:
+                  type: boolean
+                stage:
+                  type: string
+                stages:
+                  additionalProperties:
+                    properties:
+                      name:
+                        type: string
+                      phase:
+                        type: string
+                      products:
+                        additionalProperties:
+                          properties:
+                            host:
+                              type: string
+                            mobile:
+                              type: boolean
+                            name:
+                              type: string
+                            operator:
+                              type: string
+                            status:
+                              type: string
+                            type:
+                              type: string
+                            version:
+                              type: string
+                          required:
+                            - host
+                            - name
+                            - status
+                            - version
+                          type: object
+                        type: object
+                    required:
+                      - name
+                      - phase
+                    type: object
+                  description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
                   of cluster Important: Run "make" to regenerate code after modifying
                   this file'
-                type: object
-              toVersion:
-                type: string
-              version:
-                type: string
-            required:
-            - lastError
-            - stage
-            - stages
-            type: object
-        type: object
-    served: true
-    storage: true
-    subresources:
-      status: {}
+                  type: object
+                toSKU:
+                  type: string
+                toVersion:
+                  type: string
+                version:
+                  type: string
+              required:
+                - lastError
+                - stage
+                - stages
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/secrets/sku-secret.yaml
+++ b/config/secrets/sku-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: rhmi-s3-bucket
+  name: sku-secret
 objects:
   - apiVersion: v1
     kind: Secret

--- a/config/secrets/sku-secret.yaml
+++ b/config/secrets/sku-secret.yaml
@@ -1,0 +1,14 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: rhmi-s3-bucket
+objects:
+  - apiVersion: v1
+    kind: Secret
+    metadata:
+      name: addon-managed-api-service-parameters
+    stringData:
+      sku: ${SKU}
+parameters:
+  - name: SKU
+    value: ""

--- a/pkg/products/Reconciler_moq.go
+++ b/pkg/products/Reconciler_moq.go
@@ -6,6 +6,7 @@ package products
 import (
 	"context"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sync"
@@ -24,7 +25,7 @@ var _ Interface = &InterfaceMock{}
 // 			GetPreflightObjectFunc: func(ns string) runtime.Object {
 // 				panic("mock out the GetPreflightObject method")
 // 			},
-// 			ReconcileFunc: func(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+// 			ReconcileFunc: func(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, productConfig sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 // 				panic("mock out the Reconcile method")
 // 			},
 // 			VerifyVersionFunc: func(installation *integreatlyv1alpha1.RHMI) bool {
@@ -41,7 +42,7 @@ type InterfaceMock struct {
 	GetPreflightObjectFunc func(ns string) runtime.Object
 
 	// ReconcileFunc mocks the Reconcile method.
-	ReconcileFunc func(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error)
+	ReconcileFunc func(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, productConfig sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error)
 
 	// VerifyVersionFunc mocks the VerifyVersion method.
 	VerifyVersionFunc func(installation *integreatlyv1alpha1.RHMI) bool
@@ -63,6 +64,8 @@ type InterfaceMock struct {
 			Product *integreatlyv1alpha1.RHMIProductStatus
 			// ServerClient is the serverClient argument value.
 			ServerClient k8sclient.Client
+			// ProductConfig is the productConfig argument value.
+			ProductConfig sku.ProductConfig
 		}
 		// VerifyVersion holds details about calls to the VerifyVersion method.
 		VerifyVersion []struct {
@@ -107,41 +110,45 @@ func (mock *InterfaceMock) GetPreflightObjectCalls() []struct {
 }
 
 // Reconcile calls ReconcileFunc.
-func (mock *InterfaceMock) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (mock *InterfaceMock) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, productConfig sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	if mock.ReconcileFunc == nil {
 		panic("InterfaceMock.ReconcileFunc: method is nil but Interface.Reconcile was just called")
 	}
 	callInfo := struct {
-		Ctx          context.Context
-		Installation *integreatlyv1alpha1.RHMI
-		Product      *integreatlyv1alpha1.RHMIProductStatus
-		ServerClient k8sclient.Client
+		Ctx           context.Context
+		Installation  *integreatlyv1alpha1.RHMI
+		Product       *integreatlyv1alpha1.RHMIProductStatus
+		ServerClient  k8sclient.Client
+		ProductConfig sku.ProductConfig
 	}{
-		Ctx:          ctx,
-		Installation: installation,
-		Product:      product,
-		ServerClient: serverClient,
+		Ctx:           ctx,
+		Installation:  installation,
+		Product:       product,
+		ServerClient:  serverClient,
+		ProductConfig: productConfig,
 	}
 	mock.lockReconcile.Lock()
 	mock.calls.Reconcile = append(mock.calls.Reconcile, callInfo)
 	mock.lockReconcile.Unlock()
-	return mock.ReconcileFunc(ctx, installation, product, serverClient)
+	return mock.ReconcileFunc(ctx, installation, product, serverClient, productConfig)
 }
 
 // ReconcileCalls gets all the calls that were made to Reconcile.
 // Check the length with:
 //     len(mockedInterface.ReconcileCalls())
 func (mock *InterfaceMock) ReconcileCalls() []struct {
-	Ctx          context.Context
-	Installation *integreatlyv1alpha1.RHMI
-	Product      *integreatlyv1alpha1.RHMIProductStatus
-	ServerClient k8sclient.Client
+	Ctx           context.Context
+	Installation  *integreatlyv1alpha1.RHMI
+	Product       *integreatlyv1alpha1.RHMIProductStatus
+	ServerClient  k8sclient.Client
+	ProductConfig sku.ProductConfig
 } {
 	var calls []struct {
-		Ctx          context.Context
-		Installation *integreatlyv1alpha1.RHMI
-		Product      *integreatlyv1alpha1.RHMIProductStatus
-		ServerClient k8sclient.Client
+		Ctx           context.Context
+		Installation  *integreatlyv1alpha1.RHMI
+		Product       *integreatlyv1alpha1.RHMIProductStatus
+		ServerClient  k8sclient.Client
+		ProductConfig sku.ProductConfig
 	}
 	mock.lockReconcile.RLock()
 	calls = mock.calls.Reconcile

--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -3,6 +3,8 @@ package amqonline
 import (
 	"context"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"strconv"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -107,7 +109,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 // Reconcile reads that state of the cluster for amq online and makes changes based on the state read
 // and what is required
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -755,7 +757,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("unexpected error: %v", err)

--- a/pkg/products/amqstreams/reconciler.go
+++ b/pkg/products/amqstreams/reconciler.go
@@ -3,6 +3,7 @@ package amqstreams
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
@@ -94,7 +95,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 // Reconcile reads that state of the cluster for amq streams and makes changes based on the state read
 // and what is required
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/amqstreams/reconciler_test.go
+++ b/pkg/products/amqstreams/reconciler_test.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
+
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -148,7 +151,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}
@@ -527,7 +530,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)

--- a/pkg/products/apicurioregistry/reconciler.go
+++ b/pkg/products/apicurioregistry/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	apicurioregistry "github.com/Apicurio/apicurio-registry-operator/pkg/apis/apicur/v1alpha1"
 	kafkav1alpha1 "github.com/integr8ly/integreatly-operator/apis-products/kafka.strimzi.io/v1alpha1"
@@ -99,7 +100,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 }
 
 // Reconcile changes the current state to match the desired state.
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, client, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/apicurioregistry/reconciler_test.go
+++ b/pkg/products/apicurioregistry/reconciler_test.go
@@ -3,6 +3,8 @@ package apicurioregistry
 import (
 	"context"
 	"errors"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -158,7 +160,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}
@@ -357,7 +359,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)

--- a/pkg/products/apicurito/reconciler.go
+++ b/pkg/products/apicurito/reconciler.go
@@ -3,6 +3,9 @@ package apicurito
 import (
 	"context"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
+
 	"strings"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -101,7 +104,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/apicurito/reconciler_test.go
+++ b/pkg/products/apicurito/reconciler_test.go
@@ -2,6 +2,8 @@ package apicurito
 
 import (
 	"context"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -166,7 +168,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no errors, but got one: %v", err)

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -100,7 +101,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 
 	phase, err := r.ReconcileFinalizer(ctx, client, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 
@@ -104,7 +105,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()

--- a/pkg/products/codeready/reconciler_test.go
+++ b/pkg/products/codeready/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -204,7 +205,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}
@@ -717,7 +718,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), scenario.Installation, scenario.Product, scenario.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), scenario.Installation, scenario.Product, scenario.FakeClient, sku.ProductConfig{})
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error: %v, expected: %v", err, scenario.ExpectedError)
 			}

--- a/pkg/products/datasync/reconciler.go
+++ b/pkg/products/datasync/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -91,7 +92,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	}, nil
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	phase, err := r.reconcileTemplates(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile configmap", err)

--- a/pkg/products/datasync/reconciler_test.go
+++ b/pkg/products/datasync/reconciler_test.go
@@ -3,6 +3,7 @@ package datasync
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -130,7 +131,7 @@ func TestDataSync(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -3,8 +3,8 @@ package fuse
 import (
 	"context"
 	"fmt"
-
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	croResources "github.com/integr8ly/cloud-resource-operator/pkg/client"
@@ -121,7 +121,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 // Reconcile reads that state of the cluster for fuse and makes changes based on the state read
 // and what is required
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -212,7 +214,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}
@@ -563,7 +565,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)

--- a/pkg/products/fuseonopenshift/reconciler.go
+++ b/pkg/products/fuseonopenshift/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -153,7 +154,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	phase, err := r.reconcileConfigMap(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile configmap", err)

--- a/pkg/products/fuseonopenshift/reconciler_test.go
+++ b/pkg/products/fuseonopenshift/reconciler_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -292,7 +293,7 @@ func TestFuseOnOpenShift(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"sort"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -99,7 +100,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	}, nil
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Start Grafana reconcile")
 
 	operatorNamespace := r.Config.GetOperatorNamespace()

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -3,6 +3,7 @@ package marin3r
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"strconv"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -105,7 +106,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	}, nil
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, client k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Start marin3r reconcile")
 
 	operatorNamespace := r.Config.GetOperatorNamespace()

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"os"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -134,7 +135,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {
 		r.Log.Info("Phase: Monitoring ReconcileFinalizer")

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	configv1 "github.com/openshift/api/config/v1"
 
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
@@ -463,7 +464,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no error but got one: %v", err)
 			}
@@ -612,7 +613,7 @@ func TestReconciler_testPhases(t *testing.T) {
 				t.Fatalf("unexpected error : '%v'", err)
 			}
 
-			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil {
 				t.Fatalf("expected no error but got one: %v", err)
 			}

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
@@ -88,7 +89,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 
 // Reconcile method for monitorspec
 func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI,
-	product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()),
 		func() (integreatlyv1alpha1.StatusPhase, error) {
 			r.Log.Info("Phase: Monitoringspec ReconcileFinalizer")

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -3,6 +3,7 @@ package monitoringspec
 import (
 	"context"
 	"errors"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -324,7 +325,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 
 			ctx := context.TODO()
 			//Verify that reconcilation was completed successfuly
-			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient)
+			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no error but got one: %v", err)
 			}
@@ -493,7 +494,7 @@ func TestReconciler_fullReconcileWithCleanUp(t *testing.T) {
 			}
 
 			//Verify that reconcilation was completed successfuly
-			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient)
+			status, err := reconciler.Reconcile(ctx, tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no error but got one: %v", err)
 			}

--- a/pkg/products/reconciler.go
+++ b/pkg/products/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/marin3r"
@@ -82,7 +83,7 @@ type Interface interface {
 	//This is how we can communicate to the user via the status block of the RHMI CR what is causing a product to
 	//enter a failed state, and is written into the `status.lastError` of the CR along with any other errors from
 	//other reconcilers.
-	Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (newPhase integreatlyv1alpha1.StatusPhase, err error)
+	Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, productConfig sku.ProductConfig) (newPhase integreatlyv1alpha1.StatusPhase, err error)
 
 	//GetPreflightObjects informs the operator of what object it should look for, to check if the product is already installed. The
 	//namespace argument is the namespace currently being scanned for existing installations.
@@ -218,7 +219,7 @@ func NewReconciler(product integreatlyv1alpha1.ProductName, rc *rest.Config, con
 type NoOp struct {
 }
 
-func (n *NoOp) Reconcile(_ context.Context, _ *integreatlyv1alpha1.RHMI, _ *integreatlyv1alpha1.RHMIProductStatus, _ k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (n *NoOp) Reconcile(_ context.Context, _ *integreatlyv1alpha1.RHMI, _ *integreatlyv1alpha1.RHMIProductStatus, _ k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	return integreatlyv1alpha1.PhaseNone, nil
 }
 

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"github.com/pkg/errors"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
@@ -90,7 +91,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 // Reconcile reads that state of the cluster for rhsso and makes changes based on the state read
 // and what is required
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	configv1 "github.com/openshift/api/config/v1"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -237,7 +238,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no errors, but got one: %v", err)
 			}
@@ -617,7 +618,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no errors, but got one: %v", err)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
@@ -125,7 +126,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 
 // Reconcile reads that state of the cluster for rhsso and makes changes based on the state read
 // and what is required
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	operatorNamespace := r.Config.GetOperatorNamespace()
 	productNamespace := r.Config.GetNamespace()
 	phase, err := r.ReconcileFinalizer(ctx, serverClient, installation, string(r.Config.GetProductName()), func() (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -227,7 +229,7 @@ func TestReconciler_config(t *testing.T) {
 				return
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected error but got one: %v", err)
 			}
@@ -611,7 +613,7 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no errors, but got one: %v", err)
@@ -838,7 +840,7 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
 
-			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient)
+			status, err := testReconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.FakeClient, sku.ProductConfig{})
 
 			if err != nil && !tc.ExpectError {
 				t.Fatalf("expected no errors, but got one: %v", err)

--- a/pkg/products/solutionexplorer/reconciler.go
+++ b/pkg/products/solutionexplorer/reconciler.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
+	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
@@ -139,7 +140,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Reconciling solution explorer")
 
 	operatorNamespace := r.Config.GetOperatorNamespace()

--- a/pkg/products/solutionexplorer/reconciler_test.go
+++ b/pkg/products/solutionexplorer/reconciler_test.go
@@ -2,6 +2,7 @@ package solutionexplorer
 
 import (
 	"context"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -195,7 +196,7 @@ func TestSolutionExplorer(t *testing.T) {
 				return
 			}
 
-			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.client)
+			status, err := reconciler.Reconcile(context.TODO(), tc.Installation, tc.Product, tc.client, sku.ProductConfig{})
 			if err != nil && !tc.ExpectErr {
 				t.Fatalf("expected error but got one: %v", err)
 			}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -5,6 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
+
 	"net/http"
 	"strconv"
 	"strings"
@@ -182,7 +185,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Start Reconciling")
 
 	operatorNamespace := r.Config.GetOperatorNamespace()

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -3,6 +3,7 @@ package threescale
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 	"net/http"
 	"testing"
 
@@ -182,7 +183,7 @@ func TestThreeScale(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error creating new reconciler %s: %v", constants.ThreeScaleSubscriptionName, err)
 			}
-			status, err := tsReconciler.Reconcile(ctx, scenario.Installation, scenario.Product, scenario.FakeSigsClient)
+			status, err := tsReconciler.Reconcile(ctx, scenario.Installation, scenario.Product, scenario.FakeSigsClient, sku.ProductConfig{})
 			if err != nil {
 				t.Fatalf("Error reconciling %s: %v", constants.ThreeScaleSubscriptionName, err)
 			}

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 
@@ -108,7 +109,7 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1alpha1.RHMI, product *integreatlyv1alpha1.RHMIProductStatus, serverClient k8sclient.Client, _ sku.ProductConfig) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Start Reconcile")
 
 	operatorNamespace := r.Config.GetOperatorNamespace()

--- a/pkg/resources/sku/sku.go
+++ b/pkg/resources/sku/sku.go
@@ -41,14 +41,14 @@ type skuConfigReceiver struct {
 	Resources map[string]ResourceConfig `json:"resources,omitempty"`
 }
 
-func GetSKU(SKUId string, SKUConfig *corev1.ConfigMap, retSku *SKU) error {
-	received := &[]skuConfigReceiver{}
-	err := json.Unmarshal([]byte(SKUConfig.Data["sku-configs"]), received)
+func GetSKU(SKUId string, SKUConfig *corev1.ConfigMap, retSku *SKU, isUpdated bool) error {
+	allSKUs := &[]skuConfigReceiver{}
+	err := json.Unmarshal([]byte(SKUConfig.Data["sku-configs"]), allSKUs)
 	if err != nil {
 		return err
 	}
 	skuReceiver := skuConfigReceiver{}
-	for _, sku := range *received {
+	for _, sku := range *allSKUs {
 		if sku.Name == SKUId {
 			skuReceiver = sku
 			break
@@ -74,6 +74,7 @@ func GetSKU(SKUId string, SKUConfig *corev1.ConfigMap, retSku *SKU) error {
 	}
 	retSku.name = SKUId
 	retSku.productConfigs = map[v1alpha1.ProductName]ProductConfig{}
+	retSku.isUpdated = isUpdated
 
 	// loop through array of ddcss (deployment deploymentConfig StatefulSets)
 	for product, ddcssNames := range products {
@@ -97,10 +98,6 @@ func (s *SKU) GetProduct(productName v1alpha1.ProductName) ProductConfig {
 
 func (s *SKU) IsUpdated() bool {
 	return s.isUpdated
-}
-
-func (s *SKU) SetUpdated(isUpdated bool) {
-	s.isUpdated = isUpdated
 }
 
 func (p *ProductConfig) GetResourceConfig(ddcssName string) corev1.ResourceRequirements {

--- a/pkg/resources/sku/sku.go
+++ b/pkg/resources/sku/sku.go
@@ -1,0 +1,157 @@
+package sku
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	appsv1 "github.com/openshift/api/apps/v1"
+	appsv12 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v13 "k8s.io/api/core/v1"
+	"reflect"
+)
+
+type SKU struct {
+	name           string
+	productConfigs map[v1alpha1.ProductName]ProductConfig
+	isUpdated      bool
+}
+
+type ProductConfig struct {
+	productName     v1alpha1.ProductName
+	resourceConfigs map[string]ResourceConfig
+	sku             *SKU
+}
+
+type ResourceConfig struct {
+	Replicas  int32                       `json:"replicas,omitempty"`
+	Resources corev1.ResourceRequirements `json:"resources,omitempty"`
+}
+
+type RateLimit struct {
+	Unit            string  `json:"unit,omitempty"`
+	RequestsPerUnit int64   `json:"requests_per_unit,omitempty"`
+	AlertLimits     []int64 `json:"alert_limits,omitempty"`
+}
+
+type skuConfigReceiver struct {
+	Name      string                    `json:"name,omitempty"`
+	RateLimit RateLimit                 `json:"rate-limiting,omitempty"`
+	Resources map[string]ResourceConfig `json:"resources,omitempty"`
+}
+
+func GetSKU(SKUId string, SKUConfig *corev1.ConfigMap, retSku *SKU) error {
+	received := &[]skuConfigReceiver{}
+	err := json.Unmarshal([]byte(SKUConfig.Data["sku-configs"]), received)
+	if err != nil {
+		return err
+	}
+	skuReceiver := skuConfigReceiver{}
+	for _, sku := range *received {
+		if sku.Name == SKUId {
+			skuReceiver = sku
+			break
+		}
+	}
+	if skuReceiver.Name == "" {
+		return errors.New(fmt.Sprintf("could not find sku config with name '%s'", SKUId))
+	}
+
+	// map of products iterate over that to build the return map
+	products := map[v1alpha1.ProductName][]string{
+		v1alpha1.Product3Scale: {
+			"backend_listener",
+			"backend_worker",
+			"apicast_production",
+		},
+		v1alpha1.ProductRHSSOUser: {
+			"keycloak",
+		},
+		v1alpha1.ProductMarin3r: {
+			"marin3r",
+		},
+	}
+	retSku.name = SKUId
+	retSku.productConfigs = map[v1alpha1.ProductName]ProductConfig{}
+
+	// loop through array of ddcss (deployment deploymentConfig StatefulSets)
+	for product, ddcssNames := range products {
+		pc := ProductConfig{
+			sku:             retSku,
+			productName:     product,
+			resourceConfigs: map[string]ResourceConfig{},
+		}
+		// if any are missing set sane defaults
+		for _, ddcssName := range ddcssNames {
+			pc.resourceConfigs[ddcssName] = skuReceiver.Resources[ddcssName]
+		}
+		retSku.productConfigs[product] = pc
+	}
+	return nil
+}
+
+func (s *SKU) GetProduct(productName v1alpha1.ProductName) ProductConfig {
+	return s.productConfigs[productName]
+}
+
+func (s *SKU) IsUpdated() bool {
+	return s.isUpdated
+}
+
+func (s *SKU) SetUpdated(isUpdated bool) {
+	s.isUpdated = isUpdated
+}
+
+func (p *ProductConfig) GetResourceConfig(ddcssName string) corev1.ResourceRequirements {
+	return p.resourceConfigs[ddcssName].Resources
+}
+
+func (p ProductConfig) GetReplicas(ddcssName string) int32 {
+	return p.resourceConfigs[ddcssName].Replicas
+}
+
+func (p *ProductConfig) Configure(obj interface{}) error {
+	switch t := obj.(type) {
+	case *appsv1.DeploymentConfig:
+		if p.sku.isUpdated && t.Spec.Replicas < p.resourceConfigs[t.ObjectMeta.Name].Replicas {
+			t.Spec.Replicas = p.resourceConfigs[t.ObjectMeta.Name].Replicas
+		}
+		p.mutate(t.Spec.Template, t.ObjectMeta.Name)
+		break
+	case *appsv12.Deployment:
+		configReplicas := p.resourceConfigs[t.ObjectMeta.Name].Replicas
+		if p.sku.isUpdated && *t.Spec.Replicas < p.resourceConfigs[t.ObjectMeta.Name].Replicas {
+			t.Spec.Replicas = &configReplicas
+		}
+		p.mutate(&t.Spec.Template, t.ObjectMeta.Name)
+		break
+	case *appsv12.StatefulSet:
+		configReplicas := p.resourceConfigs[t.ObjectMeta.Name].Replicas
+		if p.sku.isUpdated && *t.Spec.Replicas < p.resourceConfigs[t.ObjectMeta.Name].Replicas {
+			t.Spec.Replicas = &configReplicas
+		}
+		p.mutate(&t.Spec.Template, t.ObjectMeta.Name)
+		break
+	default:
+		return errors.New(fmt.Sprintf("sku configuration can only be applied to Deployments, StatefulSets or Deployment Configs, found %s", reflect.TypeOf(obj)))
+	}
+	return nil
+}
+
+func (p *ProductConfig) mutate(temp *v13.PodTemplateSpec, name string) {
+	resources := p.resourceConfigs[name].Resources
+	templateResources := &temp.Spec.Containers[0].Resources
+
+	p.mutateResources(templateResources.Limits, resources.Limits)
+	p.mutateResources(templateResources.Requests, resources.Requests)
+}
+
+func (p *ProductConfig) mutateResources(pod, cfg v13.ResourceList) {
+	if p.sku.isUpdated && pod.Cpu().MilliValue() < cfg.Cpu().MilliValue() {
+		pod[v13.ResourceCPU] = cfg[v13.ResourceCPU]
+	}
+	if p.sku.isUpdated && pod.Memory().MilliValue() < cfg.Memory().MilliValue() {
+		pod[v13.ResourceMemory] = cfg[v13.ResourceMemory]
+	}
+}

--- a/pkg/resources/sku/sku_test.go
+++ b/pkg/resources/sku/sku_test.go
@@ -1,0 +1,633 @@
+package sku
+
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	v1 "github.com/openshift/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	v13 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"testing"
+)
+
+const (
+	TWENTYMILLIONSKU = "TWENTY_MILLION_SKU"
+	DEVSKU           = "DEV_SKU"
+)
+
+func TestGetSKU(t *testing.T) {
+
+	pointerToSKU := &SKU{}
+
+	type args struct {
+		SKUId     string
+		SKUConfig *corev1.ConfigMap
+		SKU       *SKU
+	}
+	tests := []struct {
+		name     string
+		args     args
+		want     *SKU
+		wantErr  bool
+		validate func(*SKU, *testing.T)
+	}{
+		{
+			name: "ensure error on no skuid found in config",
+			args: args{
+				SKUId:     "SKU_NOT_PRESENT_SKU",
+				SKUConfig: getSKUConfig(nil),
+				SKU:       pointerToSKU,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "test successful parsing of config map to sku object for DEV SKU",
+			args: args{
+				SKUId:     DEVSKU,
+				SKUConfig: getSKUConfig(nil),
+				SKU:       pointerToSKU,
+			},
+			want: &SKU{
+				name: DEVSKU,
+				productConfigs: map[v1alpha1.ProductName]ProductConfig{
+					v1alpha1.Product3Scale: {
+						productName: v1alpha1.Product3Scale,
+						resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+							rcs["apicast_production"] = ResourceConfig{
+								Replicas: int32(1),
+								Resources: v13.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("0.09"),
+										corev1.ResourceMemory: resource.MustParse("250"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("0.1"),
+										corev1.ResourceMemory: resource.MustParse("270"),
+									},
+								},
+							}
+						}),
+						sku: pointerToSKU,
+					},
+					v1alpha1.ProductMarin3r: {
+						productName: v1alpha1.ProductMarin3r,
+						resourceConfigs: map[string]ResourceConfig{
+							"marin3r": {0, v13.ResourceRequirements{}},
+						},
+						sku: pointerToSKU,
+					},
+					v1alpha1.ProductRHSSOUser: {
+						productName: v1alpha1.ProductRHSSOUser,
+						resourceConfigs: map[string]ResourceConfig{
+							"keycloak": {0, v13.ResourceRequirements{}},
+						},
+						sku: pointerToSKU,
+					},
+				},
+				isUpdated: false,
+			},
+			wantErr: false,
+			validate: func(sku *SKU, t *testing.T) {
+				gotReplicas := sku.GetProduct(v1alpha1.Product3Scale).GetReplicas("apicast_production")
+				wantReplicas := int32(1)
+				if gotReplicas != wantReplicas {
+					t.Errorf("Expected apicast_production replicas to be '%v' but got '%v'", wantReplicas, gotReplicas)
+				}
+				// to do more interrogations
+			},
+		},
+		{
+			name: "test successful parsing of config map to sku object for TWENTY million SKU",
+			args: args{
+				SKUId:     TWENTYMILLIONSKU,
+				SKUConfig: getSKUConfig(nil),
+				SKU:       pointerToSKU,
+			},
+			want: &SKU{
+				name: TWENTYMILLIONSKU,
+				productConfigs: map[v1alpha1.ProductName]ProductConfig{
+					v1alpha1.Product3Scale: {
+						productName: v1alpha1.Product3Scale,
+						resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+							rcs["backend_listener"] = ResourceConfig{
+								Replicas: int32(3),
+								Resources: v13.ResourceRequirements{
+									Requests: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("0.25"),
+										corev1.ResourceMemory: resource.MustParse("450"),
+									},
+									Limits: corev1.ResourceList{
+										corev1.ResourceCPU:    resource.MustParse("0.3"),
+										corev1.ResourceMemory: resource.MustParse("500"),
+									},
+								},
+							}
+						}),
+						sku: pointerToSKU,
+					},
+					v1alpha1.ProductMarin3r: {
+						productName: v1alpha1.ProductMarin3r,
+						resourceConfigs: map[string]ResourceConfig{
+							"marin3r": {0, v13.ResourceRequirements{}},
+						},
+						sku: pointerToSKU,
+					},
+					v1alpha1.ProductRHSSOUser: {
+						productName: v1alpha1.ProductRHSSOUser,
+						resourceConfigs: map[string]ResourceConfig{
+							"keycloak": {0, v13.ResourceRequirements{}},
+						},
+						sku: pointerToSKU,
+					},
+				},
+				isUpdated: false,
+			},
+			wantErr: false,
+			validate: func(sku *SKU, t *testing.T) {
+				gotReplicas := sku.GetProduct(v1alpha1.Product3Scale).GetReplicas("backend_listener")
+				wantReplicas := int32(3)
+				if gotReplicas != wantReplicas {
+					t.Errorf("Expected apicast_production replicas to be '%v' but got '%v'", wantReplicas, gotReplicas)
+				}
+				// to do more interrogations
+				// check the rate limit amounts
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := GetSKU(tt.args.SKUId, tt.args.SKUConfig, tt.args.SKU)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetSKU() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.want != nil && !reflect.DeepEqual(tt.want, tt.args.SKU) {
+				t.Errorf("they don't match, \n got = %v, \n want= %v ", tt.args.SKU, tt.want)
+			}
+
+			if tt.validate != nil {
+				tt.validate(tt.args.SKU, t)
+			}
+		})
+	}
+}
+
+func TestProductConfig_Configure(t *testing.T) {
+	type fields struct {
+		productName     v1alpha1.ProductName
+		resourceConfigs map[string]ResourceConfig
+		sku             *SKU
+	}
+	type args struct {
+		obj interface{}
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		validate func(obj interface{}, r map[string]ResourceConfig, t *testing.T)
+		wantErr  bool
+	}{
+		{
+			name: "validate that deploymentConfig backend-listener Resource Requests and Limits get updated",
+			fields: fields{
+				productName: v1alpha1.Product3Scale,
+				resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+					rcs["backend_listener"] = ResourceConfig{
+						Replicas: int32(3),
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.25"),
+								corev1.ResourceMemory: resource.MustParse("450"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.3"),
+								corev1.ResourceMemory: resource.MustParse("500"),
+							},
+						},
+					}
+				}),
+				sku: &SKU{
+					isUpdated: true,
+				},
+			},
+			args: args{obj: getDeploymentConfig("backend_listener", func(dc *v1.DeploymentConfig) {
+				dc.Spec.Replicas = int32(2)
+				dc.Spec.Template.Spec.Containers = []v13.Container{
+					{
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.111"),
+								corev1.ResourceMemory: resource.MustParse("100"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.111"),
+								corev1.ResourceMemory: resource.MustParse("100"),
+							},
+						},
+					},
+				}
+			},
+			),
+			},
+			validate: func(obj interface{}, r map[string]ResourceConfig, t *testing.T) {
+				dcSpec := obj.(*v1.DeploymentConfig).Spec
+				dcLimits := dcSpec.Template.Spec.Containers[0].Resources.Limits
+				configLimits := r["backend_listener"].Resources.Limits
+				if dcLimits.Cpu().MilliValue() != configLimits.Cpu().MilliValue() {
+					t.Errorf("deploymentConfig cpu limits not as expected, \n got = %v, \n want= %v ", dcLimits.Cpu().MilliValue(), configLimits.Cpu().MilliValue())
+				}
+				if dcLimits.Memory().MilliValue() != configLimits.Memory().MilliValue() {
+					t.Errorf("deploymentConfig memory limits not as expected, \n got = %v, \n want= %v ", dcLimits.Memory().MilliValue(), configLimits.Memory().MilliValue())
+				}
+				dcRequests := dcSpec.Template.Spec.Containers[0].Resources.Requests
+				configRequests := r["backend_listener"].Resources.Requests
+				if dcRequests.Cpu().MilliValue() != configRequests.Cpu().MilliValue() {
+					t.Errorf("deploymentConfig cpu requests not as expected, \n got = %v, \n want= %v ", dcRequests.Cpu().MilliValue(), configRequests.Cpu().MilliValue())
+				}
+				if dcRequests.Memory().MilliValue() != configRequests.Memory().MilliValue() {
+					t.Errorf("deploymentConfig memory requests not as expected, \n got = %v, \n want= %v ", dcRequests.Memory().MilliValue(), configRequests.Memory().MilliValue())
+				}
+				dcReplicas := dcSpec.Replicas
+				configReplicas := r["backend_listener"].Replicas
+				if dcReplicas != configReplicas {
+					t.Errorf("deploymentConfig replicas not as expected, \n got = %v, \n want= %v ", dcReplicas, configReplicas)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "validate that deploymentConfig backend-listener Resource Requests and Limits does not get updated on isUpdated false",
+			fields: fields{
+				productName: v1alpha1.Product3Scale,
+				resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+					rcs["backend_listener"] = ResourceConfig{
+						Replicas: int32(3),
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.25"),
+								corev1.ResourceMemory: resource.MustParse("450"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.3"),
+								corev1.ResourceMemory: resource.MustParse("500"),
+							},
+						},
+					}
+				}),
+				sku: &SKU{
+					isUpdated: false,
+				},
+			},
+			args: args{obj: getDeploymentConfig("backend_listener", func(dc *v1.DeploymentConfig) {
+				dc.Spec.Replicas = int32(2)
+				dc.Spec.Template.Spec.Containers = []v13.Container{
+					{
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.111"),
+								corev1.ResourceMemory: resource.MustParse("100"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.111"),
+								corev1.ResourceMemory: resource.MustParse("100"),
+							},
+						},
+					},
+				}
+			}),
+			},
+			validate: func(obj interface{}, r map[string]ResourceConfig, t *testing.T) {
+				dcSpec := obj.(*v1.DeploymentConfig).Spec
+				dcLimits := dcSpec.Template.Spec.Containers[0].Resources.Limits
+				configLimits := r["backend_listener"].Resources.Limits
+				if dcLimits.Cpu().MilliValue() == configLimits.Cpu().MilliValue() {
+					t.Errorf("deployment config cpu limits not as expected, isupdated is false so should not update, \n got = %v, \n want= %v ", dcLimits.Cpu().MilliValue(), configLimits.Cpu().MilliValue())
+				}
+				if dcLimits.Memory().MilliValue() == configLimits.Memory().MilliValue() {
+					t.Errorf("deployment config memory limits not as expected, isupdated is false so should not update, \n got = %v, \n want= %v ", dcLimits.Memory().MilliValue(), configLimits.Memory().MilliValue())
+				}
+				dcRequests := dcSpec.Template.Spec.Containers[0].Resources.Requests
+				configRequests := r["backend_listener"].Resources.Requests
+				if dcRequests.Cpu().MilliValue() == configRequests.Cpu().MilliValue() {
+					t.Errorf("deployment config cpu requests not as expected, isupdated is false so should not update, \n got = %v, \n want= %v ", dcRequests.Cpu().MilliValue(), configRequests.Cpu().MilliValue())
+				}
+				if dcRequests.Memory().MilliValue() == configRequests.Memory().MilliValue() {
+					t.Errorf("deployment config memory requests not as expected, isupdated is false so should not update, \n got = %v, \n want= %v ", dcRequests.Memory().MilliValue(), configRequests.Memory().MilliValue())
+				}
+				dcReplicas := dcSpec.Replicas
+				configReplicas := r["backend_listener"].Replicas
+				if dcReplicas == configReplicas {
+					t.Errorf("deploymentConfig replicas not as expected, isupdated is false so should not update \n got = %v, \n want= %v ", dcReplicas, configReplicas)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "validate that deploymentConfig backend-listener Resource Requests and Limits don't get updated if they are higher and isupdated is true",
+			fields: fields{
+				productName: v1alpha1.Product3Scale,
+				resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+					rcs["backend_listener"] = ResourceConfig{
+						Replicas: int32(3),
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("449"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("499"),
+							},
+						},
+					}
+				}),
+				sku: &SKU{
+					isUpdated: true,
+				},
+			},
+			args: args{obj: getDeploymentConfig("backend_listener", func(dc *v1.DeploymentConfig) {
+				dc.Spec.Replicas = int32(2)
+				dc.Spec.Template.Spec.Containers = []v13.Container{
+					{
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.25"),
+								corev1.ResourceMemory: resource.MustParse("450"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.3"),
+								corev1.ResourceMemory: resource.MustParse("500"),
+							},
+						},
+					},
+				}
+			}),
+			},
+			validate: func(obj interface{}, r map[string]ResourceConfig, t *testing.T) {
+				dcSpec := obj.(*v1.DeploymentConfig).Spec
+				dcLimits := dcSpec.Template.Spec.Containers[0].Resources.Limits
+				configLimits := r["backend_listener"].Resources.Limits
+				if dcLimits.Cpu().MilliValue() == configLimits.Cpu().MilliValue() {
+					t.Errorf("deployment config cpu limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", dcLimits.Cpu().MilliValue(), configLimits.Cpu().MilliValue())
+				}
+				if dcLimits.Memory().MilliValue() == configLimits.Memory().MilliValue() {
+					t.Errorf("deployment config memory limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", dcLimits.Memory().MilliValue(), configLimits.Memory().MilliValue())
+				}
+				dcRequests := dcSpec.Template.Spec.Containers[0].Resources.Requests
+				configRequests := r["backend_listener"].Resources.Requests
+				if dcRequests.Cpu().MilliValue() == configRequests.Cpu().MilliValue() {
+					t.Errorf("deployment config cpu requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", dcRequests.Cpu().MilliValue(), configRequests.Cpu().MilliValue())
+				}
+				if dcRequests.Memory().MilliValue() == configRequests.Memory().MilliValue() {
+					t.Errorf("deployment config memory requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", dcRequests.Memory().MilliValue(), configRequests.Memory().MilliValue())
+				}
+				dcReplicas := dcSpec.Replicas
+				configReplicas := r["backend_listener"].Replicas
+				if dcReplicas != configReplicas {
+					t.Errorf("deploymentConfig replicas not as expected, \n got = %v, \n want= %v ", dcReplicas, configReplicas)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "validate that statefulset backend-listener Resource Requests and Limits don't get updated if they are higher and isupdated is true",
+			fields: fields{
+				productName: v1alpha1.Product3Scale,
+				resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+					rcs["backend_listener"] = ResourceConfig{
+						Replicas: int32(3),
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("449"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("499"),
+							},
+						},
+					}
+				}),
+				sku: &SKU{
+					isUpdated: true,
+				},
+			},
+			args: args{obj: getStatefulSet("backend_listener", func(ss *appsv1.StatefulSet) {
+				replica := int32(2)
+				ss.Spec.Replicas = &replica
+				ss.Spec.Template.Spec.Containers = []v13.Container{
+					{
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.25"),
+								corev1.ResourceMemory: resource.MustParse("450"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.3"),
+								corev1.ResourceMemory: resource.MustParse("500"),
+							},
+						},
+					},
+				}
+			}),
+			},
+			validate: func(obj interface{}, r map[string]ResourceConfig, t *testing.T) {
+				ssSpec := obj.(*appsv1.StatefulSet).Spec
+				ssLimits := ssSpec.Template.Spec.Containers[0].Resources.Limits
+				configLimits := r["backend_listener"].Resources.Limits
+				if ssLimits.Cpu().MilliValue() == configLimits.Cpu().MilliValue() {
+					t.Errorf("statefulset cpu limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", ssLimits.Cpu().MilliValue(), configLimits.Cpu().MilliValue())
+				}
+				if ssLimits.Memory().MilliValue() == configLimits.Memory().MilliValue() {
+					t.Errorf("statefulset memory limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", ssLimits.Memory().MilliValue(), configLimits.Memory().MilliValue())
+				}
+				ssRequests := ssSpec.Template.Spec.Containers[0].Resources.Requests
+				configRequests := r["backend_listener"].Resources.Requests
+				if ssRequests.Cpu().MilliValue() == configRequests.Cpu().MilliValue() {
+					t.Errorf("statefulset cpu requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", ssRequests.Cpu().MilliValue(), configRequests.Cpu().MilliValue())
+				}
+				if ssRequests.Memory().MilliValue() == configRequests.Memory().MilliValue() {
+					t.Errorf("statefulset memory requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", ssRequests.Memory().MilliValue(), configRequests.Memory().MilliValue())
+				}
+				ssReplicas := ssSpec.Replicas
+				configReplicas := r["backend_listener"].Replicas
+				if *ssReplicas != configReplicas {
+					t.Errorf("statefulset replicas not as expected, \n got = %v, \n want= %v ", *ssReplicas, configReplicas)
+				}
+			},
+			wantErr: false,
+		},
+		{
+			name: "validate that deployment backend-listener Resource Requests and Limits don't get updated if they are higher and isupdated is true",
+			fields: fields{
+				productName: v1alpha1.Product3Scale,
+				resourceConfigs: getResourceConfig(func(rcs map[string]ResourceConfig) {
+					rcs["backend_listener"] = ResourceConfig{
+						Replicas: int32(3),
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("449"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.24"),
+								corev1.ResourceMemory: resource.MustParse("499"),
+							},
+						},
+					}
+				}),
+				sku: &SKU{
+					isUpdated: true,
+				},
+			},
+			args: args{obj: getDeployment("backend_listener", func(d *appsv1.Deployment) {
+				replica := int32(2)
+				d.Spec.Replicas = &replica
+				d.Spec.Template.Spec.Containers = []v13.Container{
+					{
+						Resources: v13.ResourceRequirements{
+							Requests: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.25"),
+								corev1.ResourceMemory: resource.MustParse("450"),
+							},
+							Limits: corev1.ResourceList{
+								corev1.ResourceCPU:    resource.MustParse("0.3"),
+								corev1.ResourceMemory: resource.MustParse("500"),
+							},
+						},
+					},
+				}
+			}),
+			},
+			validate: func(obj interface{}, r map[string]ResourceConfig, t *testing.T) {
+				dSpec := obj.(*appsv1.Deployment).Spec
+				dLimits := dSpec.Template.Spec.Containers[0].Resources.Limits
+				configLimits := r["backend_listener"].Resources.Limits
+				if dLimits.Cpu().MilliValue() == configLimits.Cpu().MilliValue() {
+					t.Errorf("deployment cpu limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", dLimits.Cpu().MilliValue(), configLimits.Cpu().MilliValue())
+				}
+				if dLimits.Memory().MilliValue() == configLimits.Memory().MilliValue() {
+					t.Errorf("deployment memory limits not as expected, it should not update when lower, \n got = %v, \n want= %v ", dLimits.Memory().MilliValue(), configLimits.Memory().MilliValue())
+				}
+				dRequests := dSpec.Template.Spec.Containers[0].Resources.Requests
+				configRequests := r["backend_listener"].Resources.Requests
+				if dRequests.Cpu().MilliValue() == configRequests.Cpu().MilliValue() {
+					t.Errorf("deployment cpu requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", dRequests.Cpu().MilliValue(), configRequests.Cpu().MilliValue())
+				}
+				if dRequests.Memory().MilliValue() == configRequests.Memory().MilliValue() {
+					t.Errorf("deployment memory requests not as expected, it should not update when lower, \n got = %v, \n want= %v ", dRequests.Memory().MilliValue(), configRequests.Memory().MilliValue())
+				}
+				dReplicas := dSpec.Replicas
+				configReplicas := r["backend_listener"].Replicas
+				if *dReplicas != configReplicas {
+					t.Errorf("deployment replicas not as expected, \n got = %v, \n want= %v ", *dReplicas, configReplicas)
+				}
+			},
+		},
+		{
+			name:    "validate error returned on non deployment deploymentConfig or StatefulSet Object passed",
+			args:    args{obj: v13.ConfigMap{}},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &ProductConfig{
+				productName:     tt.fields.productName,
+				resourceConfigs: tt.fields.resourceConfigs,
+				sku:             tt.fields.sku,
+			}
+			err := p.Configure(tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Configure() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if tt.validate != nil {
+				tt.validate(tt.args.obj, tt.fields.resourceConfigs, t)
+			}
+		})
+	}
+}
+
+func getResourceConfig(modifyFn func(rcs map[string]ResourceConfig)) map[string]ResourceConfig {
+	mock := map[string]ResourceConfig{
+		"apicast_production": {0, v13.ResourceRequirements{}},
+		"backend_listener":   {0, v13.ResourceRequirements{}},
+		"backend_worker":     {0, v13.ResourceRequirements{}},
+	}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}
+
+func getDeploymentConfig(name string, modifyFn func(dc *v1.DeploymentConfig)) *v1.DeploymentConfig {
+	mock := &v1.DeploymentConfig{
+		ObjectMeta: v12.ObjectMeta{
+			Name: name,
+		},
+		Spec: v1.DeploymentConfigSpec{
+			Template: &v13.PodTemplateSpec{
+				Spec: v13.PodSpec{
+					Containers: []v13.Container{},
+				},
+			},
+		}}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}
+
+func getStatefulSet(name string, modifyFn func(ss *appsv1.StatefulSet)) *appsv1.StatefulSet {
+	mock := &appsv1.StatefulSet{
+		ObjectMeta: v12.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: v13.PodTemplateSpec{
+				Spec: v13.PodSpec{
+					Containers: []v13.Container{},
+				},
+			},
+		}}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}
+
+func getDeployment(name string, modifyFn func(d *appsv1.Deployment)) *appsv1.Deployment {
+	mock := &appsv1.Deployment{
+		ObjectMeta: v12.ObjectMeta{
+			Name: name,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: v13.PodTemplateSpec{
+				Spec: v13.PodSpec{
+					Containers: []v13.Container{},
+				},
+			},
+		}}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}
+
+func getSKUConfig(modifyFn func(*v13.ConfigMap)) *v13.ConfigMap {
+	mock := &v13.ConfigMap{}
+	mock.Data = map[string]string{
+		"sku-configs": "[{\"name\": \"" + DEVSKU + "\",\"rate-limiting\": {\"unit\": \"minute\",\"requests_per_unit\": 1389,\"alert_limits\": []},\"resources\": {\"apicast_production\": {\"replicas\": 1,\"resources\": {\"requests\": {\"cpu\": 0.09,\"memory\": 250},\"limits\": {\"cpu\": 0.1,\"memory\": 270}}}}}, {\"name\": \"" + TWENTYMILLIONSKU + "\",\"rate-limiting\": {  \"unit\": \"minute\",  \"requests_per_unit\": 1389,  \"alert_limits\": []},\"resources\": {\"backend_listener\": {\"replicas\": 3,\"resources\": {  \"requests\": {\"cpu\": 0.25,\"memory\": 450  },  \"limits\": {\"cpu\": 0.3,\"memory\": 500}}}}}]",
+	}
+	if modifyFn != nil {
+		modifyFn(mock)
+	}
+	return mock
+}

--- a/pkg/resources/sku/sku_test.go
+++ b/pkg/resources/sku/sku_test.go
@@ -25,6 +25,7 @@ func TestGetSKU(t *testing.T) {
 		SKUId     string
 		SKUConfig *corev1.ConfigMap
 		SKU       *SKU
+		isUpdated bool
 	}
 	tests := []struct {
 		name     string
@@ -49,6 +50,7 @@ func TestGetSKU(t *testing.T) {
 				SKUId:     DEVSKU,
 				SKUConfig: getSKUConfig(nil),
 				SKU:       pointerToSKU,
+				isUpdated: false,
 			},
 			want: &SKU{
 				name: DEVSKU,
@@ -105,6 +107,7 @@ func TestGetSKU(t *testing.T) {
 				SKUId:     TWENTYMILLIONSKU,
 				SKUConfig: getSKUConfig(nil),
 				SKU:       pointerToSKU,
+				isUpdated: false,
 			},
 			want: &SKU{
 				name: TWENTYMILLIONSKU,
@@ -159,7 +162,7 @@ func TestGetSKU(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := GetSKU(tt.args.SKUId, tt.args.SKUConfig, tt.args.SKU)
+			err := GetSKU(tt.args.SKUId, tt.args.SKUConfig, tt.args.SKU, tt.args.isUpdated)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetSKU() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/test/common/sku.go
+++ b/test/common/sku.go
@@ -1,0 +1,59 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sku"
+	v1 "k8s.io/api/core/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestSKUValues(t TestingTB, ctx *TestingContext) {
+
+	//verify the config map is in place
+	_, err := getSKUConfigMap(ctx.Client)
+	if err != nil {
+		t.Fatal("failed to get sku config map", err)
+		// for now if the skuconfig map is not found we can return as we don't want to exercise the full test
+		return
+	}
+
+	// if no skuparam is found then set isdefault to true.
+	defaultSKU := false
+	skuName, found, err := addon.GetStringParameterByInstallType(context.TODO(), ctx.Client, rhmiv1alpha1.InstallationTypeManagedApi, RHMIOperatorNamespace, "sku")
+	if !found {
+		defaultSKU = true
+	}
+
+	installation, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatal("couldn't get RHMI cr for sku test")
+	}
+
+	//verify that the TOSKU value is set and that SKU is not set
+	//assuming this is run after installation
+	if installation.Status.SKU == "" {
+		t.Fatal("SKU status not set after installation")
+	}
+	if installation.Status.ToSKU != "" {
+		t.Fatal("toSKU status set after installation")
+	}
+
+	//verify the sku value is as expected depending on whether there is a default used or not.
+	if !defaultSKU {
+		if installation.Status.SKU != skuName {
+			t.Fatal(fmt.Sprintf("sku value set as '%s' but doesn't match the expected value: '%s'", installation.Status.SKU, skuName))
+		}
+	}
+
+}
+
+func getSKUConfigMap(c k8sclient.Client) (*v1.ConfigMap, error) {
+	skuConfigMap := &v1.ConfigMap{}
+	if err := c.Get(context.TODO(), k8sclient.ObjectKey{Name: sku.ConfigMapName, Namespace: RHMIOperatorNamespace}, skuConfigMap); err != nil {
+		return nil, fmt.Errorf("failed to get SKU config map: '%w'", err)
+	}
+	return skuConfigMap, nil
+}

--- a/test/common/sku.go
+++ b/test/common/sku.go
@@ -15,7 +15,7 @@ func TestSKUValues(t TestingTB, ctx *TestingContext) {
 	//verify the config map is in place
 	_, err := getSKUConfigMap(ctx.Client)
 	if err != nil {
-		t.Fatal("failed to get sku config map", err)
+		t.Log("failed to get sku config map, skipping test for now until fully implemented", err)
 		// for now if the skuconfig map is not found we can return as we don't want to exercise the full test
 		return
 	}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -26,6 +26,7 @@ var (
 			[]TestCase{
 				{"E09 - Verify customer dashboards exist", TestIntegreatlyCustomerDashboardsExist},
 				/*FLAKY on RHOAM*/ {"E10 - Verify Customer Grafana Route is accessible", TestCustomerGrafanaExternalRouteAccessible},
+				{"A23 - Verify sku values", TestSKUValues},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
 		},


### PR DESCRIPTION
# Description
Closes  https://issues.redhat.com/browse/MGDAPI-1219, https://issues.redhat.com/browse/MGDAPI-1220

## Verification

### Verify SKU and ToSKU are set as expected

Run `INSTALLATION_TYPE=managed-api make cluster/prepare/local`

Verify that a dummy secret and config map is in place.
Run `oc get secret addon-managed-api-service-parameters -n redhat-rhoam-operator -o json | jq -r '.data.sku' | base64 --decode` should output DEV_SKU. 
Run  `oc get configmap sku-config -n redhat-rhoam-operator -o json | jq .data` should return an object with key `skuconfigs` and a json object with skus.

Run `INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
Run `INSTALLATION_TYPE=managed-api make code/run`
The installation should start successfully.

Once the installation starts check that `toSKU` is set to `DEV_SKU`

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` should output `DEV_SKU`
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.SKU' should output null

Wait for the installation to go to complete status and then 

Check that toSKU is unset and SKU is set to `DEV_SKU`

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` -> null
`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.sku'` -> `DEV_SKU`

### Verify Default SKU and isUpdated

Wait for the installation to go to complete status and then 

`oc delete  secret addon-managed-api-service-parameters -n redhat-rhoam-operator` -> Note: this is just to simulate a SKU change and to check if the defaults are selected and wouldn't be done in production scenario.

Will delete the secret. On the next reconcile (so you may need to wait) this will be recognised as a change to the SKU. As there is no secret it will also use the default. 

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.sku'` -> `DEV_SKU`
`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` -> `default`

Wait for the reconcile to go back to a complete state: after that the values should be 

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.sku'` -> `default`
`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` -> `null`

You can also check that changing the value works as expected again (i.e. it will pick up a new specified value in parameter):

`make cluster/prepare/sku`

This would recreate the secret with a different param. This can be done even before the toSKU has changed to SKU. i.e. before a sku change is fully completed another can be done. At this stage the expected outcomes are:

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` -> `DEV_SKU`
`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.sku'` -> `default`

Again 
Wait for the reconcile to go back to a complete state: after that the values should be 

`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.sku'` -> `DEV_SKU`
`oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toSKU'` -> `null`

## Verify things aren't broken when either config map or sku param is not present.

Uninstall by `oc delete rhmi rhoam -n redhat-rhoam-operator`
`oc delete  secret addon-managed-api-service-parameters -n redhat-rhoam-operator`
`oc delete configmap sku-config -n redhat-rhoam-operator`

Don't run cluster/prepare!

Run `INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
Run `INSTALLATION_TYPE=managed-api make code/run`

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer