### PR TITLE
Fix make release/prepare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -419,7 +419,7 @@ prepare-patch-release:
 
 .PHONY: release/prepare
 release/prepare: kustomize
-	@./scripts/prepare-release.sh
+	@KUSTOMIZE_PATH=$(KUSTOMIZE) ./scripts/prepare-release.sh
 
 .PHONY: push/csv
 push/csv:

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -28,19 +28,26 @@ else
   ORG="$ORG"
 fi
 
+# Optional environment variable to set a different Kustomize path. If this
+# variable is not set, it will use the one from the $PATH
+if [[ -z $KUSTOMIZE_PATH ]]; then
+  KUSTOMIZE=$(which kustomize)
+else
+  KUSTOMIZE=$KUSTOMIZE_PATH
+fi
+
 create_new_csv() {
 
   if [[ -z "$PREVIOUS_VERSION" ]]
     then
-      kustomize build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi 
+      "${KUSTOMIZE[@]}" build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi 
     else
-      kustomize build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi --from-version $PREVIOUS_VERSION
+      "${KUSTOMIZE[@]}" build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi --from-version $PREVIOUS_VERSION
   fi
 }
 
 update_csv() {
-  kustomize build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi 
-  # operator-sdk generate csv --csv-version "$VERSION" --default-channel --operator-name "$OLM_TYPE" --csv-channel=rhmi --update-crds
+  "${KUSTOMIZE[@]}" build config/manifests-$OPERATOR_TYPE | operator-sdk generate packagemanifests --kustomize-dir=config/manifests-$OPERATOR_TYPE --output-dir packagemanifests/$OLM_TYPE --version $VERSION --default-channel --channel rhmi 
 }
 
 # The base CSV is used to generate the final CSV by combining it with the other operator


### PR DESCRIPTION
# Description

Fix `make release/prepare` to work with Kustomize when it's not installed. The Makefile will automatically install (in a temporal
directory) Kustomize if it's not found on the $PATH. However, when running `release/prepare`, it will invoke the `prepare-release.sh` script, which assumes Kustomize is in the $PATH.

Modify the script to use an optional environment variable with the path to Kustomize, and the Makefile to pass the temporal path when running the script.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer