### PR TITLE
MGDAPI-1170: Improve product operator installation

### DIFF
--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	prometheusmonitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -713,17 +714,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "amqonline-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "amqonline-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/amqstreams/reconciler_test.go
+++ b/pkg/products/amqstreams/reconciler_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
@@ -482,17 +483,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "amq-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "amq-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/apicurioregistry/reconciler_test.go
+++ b/pkg/products/apicurioregistry/reconciler_test.go
@@ -3,8 +3,9 @@ package apicurioregistry
 import (
 	"context"
 	"errors"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	apicurioregistry "github.com/Apicurio/apicurio-registry-operator/pkg/apis/apicur/v1alpha1"
 	kafkav1alpha1 "github.com/integr8ly/integreatly-operator/apis-products/kafka.strimzi.io/v1alpha1"
@@ -313,17 +314,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "apicurio-registry-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "apicurio-registry-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/apicurito/reconciler_test.go
+++ b/pkg/products/apicurito/reconciler_test.go
@@ -2,8 +2,9 @@ package apicurito
 
 import (
 	"context"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	apicuritov1alpha1 "github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -86,17 +87,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "apicurito-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "apicurito-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{
@@ -147,7 +144,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
 					return nil, nil, k8serr.NewNotFound(schema.GroupResource{}, "subs")
 				},
 			},

--- a/pkg/products/codeready/reconciler_test.go
+++ b/pkg/products/codeready/reconciler_test.go
@@ -340,8 +340,8 @@ func TestCodeready_reconcileClient(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return nil, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
 			Recorder: setupRecorder(),
@@ -376,8 +376,8 @@ func TestCodeready_reconcileClient(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return nil, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
 			Recorder: setupRecorder(),
@@ -656,8 +656,8 @@ func TestCodeready_fullReconcile(t *testing.T) {
 				if len(mockMPM.InstallOperatorCalls()) != 1 {
 					t.Fatalf("expected CreateSubscriptionCalls to be 1 bug got %d", len(mockMPM.InstallOperatorCalls()))
 				}
-				if len(mockMPM.GetSubscriptionInstallPlansCalls()) != 1 {
-					t.Fatalf("expected GetSubscriptionInstallPlansCalls to be 1 bug got %d", len(mockMPM.GetSubscriptionInstallPlansCalls()))
+				if len(mockMPM.GetSubscriptionInstallPlanCalls()) != 1 {
+					t.Fatalf("expected GetSubscriptionInstallPlanCalls to be 1 bug got %d", len(mockMPM.GetSubscriptionInstallPlanCalls()))
 				}
 			},
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -665,17 +665,13 @@ func TestCodeready_fullReconcile(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "codeready-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "codeready-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
@@ -521,17 +522,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "fuse-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "fuse-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	configv1 "github.com/openshift/api/config/v1"
-	"testing"
 
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
@@ -421,23 +422,23 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
 							TypeMeta: metav1.TypeMeta{
 								Kind:       "ApplicationMonitoring",
 								APIVersion: monitoringv1.SchemeGroupVersion.String(),
 							},
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "monitoring-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+							// Items: []operatorsv1alpha1.InstallPlan{
+							// 	{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "monitoring-install-plan",
 							},
-							ListMeta: metav1.ListMeta{},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
+							},
+							// },
+							// },
+							// ListMeta: metav1.ListMeta{},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{
 								Install: &operatorsv1alpha1.InstallPlanReference{
@@ -553,8 +554,8 @@ func TestReconciler_testPhases(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return nil, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
 			Product:  &integreatlyv1alpha1.RHMIProductStatus{},
@@ -570,8 +571,8 @@ func TestReconciler_testPhases(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*operatorsv1alpha1.InstallPlanList, *operatorsv1alpha1.Subscription, error) {
-					return &operatorsv1alpha1.InstallPlanList{}, &operatorsv1alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*operatorsv1alpha1.InstallPlan, *operatorsv1alpha1.Subscription, error) {
+					return nil, &operatorsv1alpha1.Subscription{}, nil
 				},
 			},
 			Product:  &integreatlyv1alpha1.RHMIProductStatus{},
@@ -587,20 +588,14 @@ func TestReconciler_testPhases(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, sub string, ns string) (*operatorsv1alpha1.InstallPlanList, *operatorsv1alpha1.Subscription, error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							TypeMeta: metav1.TypeMeta{
-								Kind:       "ApplicationMonitoring",
-								APIVersion: monitoringv1.SchemeGroupVersion.String(),
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, sub string, ns string) (*operatorsv1alpha1.InstallPlan, *operatorsv1alpha1.Subscription, error) {
+					return nil, &operatorsv1alpha1.Subscription{
+						Status: operatorsv1alpha1.SubscriptionStatus{
+							Install: &operatorsv1alpha1.InstallPlanReference{
+								Name: "monitoring-install-plan",
 							},
-							ListMeta: metav1.ListMeta{},
-						}, &operatorsv1alpha1.Subscription{
-							Status: operatorsv1alpha1.SubscriptionStatus{
-								Install: &operatorsv1alpha1.InstallPlanReference{
-									Name: "monitoring-install-plan",
-								},
-							},
-						}, nil
+						},
+					}, nil
 				},
 			},
 			Product:  &integreatlyv1alpha1.RHMIProductStatus{},

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -3,8 +3,9 @@ package monitoringspec
 import (
 	"context"
 	"errors"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -291,19 +292,14 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "monitoring-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "monitoring-install-plan",
 							},
-							ListMeta: metav1.ListMeta{},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
+							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{
 								Install: &operatorsv1alpha1.InstallPlanReference{
@@ -443,19 +439,14 @@ func TestReconciler_fullReconcileWithCleanUp(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "monitoring-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "monitoring-install-plan",
 							},
-							ListMeta: metav1.ListMeta{},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
+							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{
 								Install: &operatorsv1alpha1.InstallPlanReference{

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -5,9 +5,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	configv1 "github.com/openshift/api/config/v1"
-	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -566,17 +567,13 @@ func TestReconciler_fullReconcile(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "codeready-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "codeready-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -5,8 +5,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -560,17 +561,13 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "codeready-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "codeready-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{
@@ -790,17 +787,13 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "codeready-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "codeready-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/solutionexplorer/reconciler_test.go
+++ b/pkg/products/solutionexplorer/reconciler_test.go
@@ -150,17 +150,13 @@ func TestSolutionExplorer(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlanList, subscription *operatorsv1alpha1.Subscription, e error) {
-					return &operatorsv1alpha1.InstallPlanList{
-							Items: []operatorsv1alpha1.InstallPlan{
-								{
-									ObjectMeta: metav1.ObjectMeta{
-										Name: "solutionexplorer-install-plan",
-									},
-									Status: operatorsv1alpha1.InstallPlanStatus{
-										Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
-									},
-								},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *operatorsv1alpha1.InstallPlan, subscription *operatorsv1alpha1.Subscription, e error) {
+					return &operatorsv1alpha1.InstallPlan{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "solutionexplorer-install-plan",
+							},
+							Status: operatorsv1alpha1.InstallPlanStatus{
+								Phase: operatorsv1alpha1.InstallPlanPhaseComplete,
 							},
 						}, &operatorsv1alpha1.Subscription{
 							Status: operatorsv1alpha1.SubscriptionStatus{

--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -43,6 +43,10 @@ func getSigClient(preReqObjects []runtime.Object, scheme *runtime.Scheme) *clien
 				Install: &coreosv1alpha1.InstallPlanReference{
 					Name: installPlanFor3ScaleSubscription.Name,
 				},
+				InstallPlanRef: &corev1.ObjectReference{
+					Name:      installPlanFor3ScaleSubscription.Name,
+					Namespace: obj.Namespace,
+				},
 			}
 			err := sigsFakeClient.GetSigsClient().Create(ctx, obj)
 			if err != nil {

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1492,7 +1493,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	for _, tsUser := range deleted {
 		if tsUser.UserDetails.Username != *systemAdminUsername {
 			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
-			metrics.SetThreeScaleUserAction(res.StatusCode, string(tsUser.UserDetails.Id), http.MethodDelete)
+			metrics.SetThreeScaleUserAction(res.StatusCode, strconv.Itoa(tsUser.UserDetails.Id), http.MethodDelete)
 			if err != nil {
 				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale", tsUser.UserDetails.Id), err)
 			}

--- a/pkg/resources/marketplace/MarketplaceManager_moq.go
+++ b/pkg/resources/marketplace/MarketplaceManager_moq.go
@@ -20,8 +20,8 @@ var _ MarketplaceInterface = &MarketplaceInterfaceMock{}
 //
 // 		// make and configure a mocked MarketplaceInterface
 // 		mockedMarketplaceInterface := &MarketplaceInterfaceMock{
-// 			GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlanList, *coreosv1alpha1.Subscription, error) {
-// 				panic("mock out the GetSubscriptionInstallPlans method")
+// 			GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlan, *coreosv1alpha1.Subscription, error) {
+// 				panic("mock out the GetSubscriptionInstallPlan method")
 // 			},
 // 			InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t Target, operatorGroupNamespaces []string, approvalStrategy coreosv1alpha1.Approval, catalogSourceReconciler CatalogSourceReconciler) error {
 // 				panic("mock out the InstallOperator method")
@@ -33,16 +33,16 @@ var _ MarketplaceInterface = &MarketplaceInterfaceMock{}
 //
 // 	}
 type MarketplaceInterfaceMock struct {
-	// GetSubscriptionInstallPlansFunc mocks the GetSubscriptionInstallPlans method.
-	GetSubscriptionInstallPlansFunc func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlanList, *coreosv1alpha1.Subscription, error)
+	// GetSubscriptionInstallPlanFunc mocks the GetSubscriptionInstallPlan method.
+	GetSubscriptionInstallPlanFunc func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlan, *coreosv1alpha1.Subscription, error)
 
 	// InstallOperatorFunc mocks the InstallOperator method.
 	InstallOperatorFunc func(ctx context.Context, serverClient k8sclient.Client, t Target, operatorGroupNamespaces []string, approvalStrategy coreosv1alpha1.Approval, catalogSourceReconciler CatalogSourceReconciler) error
 
 	// calls tracks calls to the methods.
 	calls struct {
-		// GetSubscriptionInstallPlans holds details about calls to the GetSubscriptionInstallPlans method.
-		GetSubscriptionInstallPlans []struct {
+		// GetSubscriptionInstallPlan holds details about calls to the GetSubscriptionInstallPlan method.
+		GetSubscriptionInstallPlan []struct {
 			// Ctx is the ctx argument value.
 			Ctx context.Context
 			// ServerClient is the serverClient argument value.
@@ -68,14 +68,14 @@ type MarketplaceInterfaceMock struct {
 			CatalogSourceReconciler CatalogSourceReconciler
 		}
 	}
-	lockGetSubscriptionInstallPlans sync.RWMutex
-	lockInstallOperator             sync.RWMutex
+	lockGetSubscriptionInstallPlan sync.RWMutex
+	lockInstallOperator            sync.RWMutex
 }
 
-// GetSubscriptionInstallPlans calls GetSubscriptionInstallPlansFunc.
-func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlans(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlanList, *coreosv1alpha1.Subscription, error) {
-	if mock.GetSubscriptionInstallPlansFunc == nil {
-		panic("MarketplaceInterfaceMock.GetSubscriptionInstallPlansFunc: method is nil but MarketplaceInterface.GetSubscriptionInstallPlans was just called")
+// GetSubscriptionInstallPlan calls GetSubscriptionInstallPlanFunc.
+func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlan(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (*coreosv1alpha1.InstallPlan, *coreosv1alpha1.Subscription, error) {
+	if mock.GetSubscriptionInstallPlanFunc == nil {
+		panic("MarketplaceInterfaceMock.GetSubscriptionInstallPlanFunc: method is nil but MarketplaceInterface.GetSubscriptionInstallPlan was just called")
 	}
 	callInfo := struct {
 		Ctx          context.Context
@@ -88,16 +88,16 @@ func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlans(ctx context.Co
 		SubName:      subName,
 		Ns:           ns,
 	}
-	mock.lockGetSubscriptionInstallPlans.Lock()
-	mock.calls.GetSubscriptionInstallPlans = append(mock.calls.GetSubscriptionInstallPlans, callInfo)
-	mock.lockGetSubscriptionInstallPlans.Unlock()
-	return mock.GetSubscriptionInstallPlansFunc(ctx, serverClient, subName, ns)
+	mock.lockGetSubscriptionInstallPlan.Lock()
+	mock.calls.GetSubscriptionInstallPlan = append(mock.calls.GetSubscriptionInstallPlan, callInfo)
+	mock.lockGetSubscriptionInstallPlan.Unlock()
+	return mock.GetSubscriptionInstallPlanFunc(ctx, serverClient, subName, ns)
 }
 
-// GetSubscriptionInstallPlansCalls gets all the calls that were made to GetSubscriptionInstallPlans.
+// GetSubscriptionInstallPlanCalls gets all the calls that were made to GetSubscriptionInstallPlan.
 // Check the length with:
-//     len(mockedMarketplaceInterface.GetSubscriptionInstallPlansCalls())
-func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlansCalls() []struct {
+//     len(mockedMarketplaceInterface.GetSubscriptionInstallPlanCalls())
+func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlanCalls() []struct {
 	Ctx          context.Context
 	ServerClient k8sclient.Client
 	SubName      string
@@ -109,9 +109,9 @@ func (mock *MarketplaceInterfaceMock) GetSubscriptionInstallPlansCalls() []struc
 		SubName      string
 		Ns           string
 	}
-	mock.lockGetSubscriptionInstallPlans.RLock()
-	calls = mock.calls.GetSubscriptionInstallPlans
-	mock.lockGetSubscriptionInstallPlans.RUnlock()
+	mock.lockGetSubscriptionInstallPlan.RLock()
+	calls = mock.calls.GetSubscriptionInstallPlan
+	mock.lockGetSubscriptionInstallPlan.RUnlock()
 	return calls
 }
 

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -83,8 +83,8 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{alpha1.InstallPlan{Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseComplete}}}}, &alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plan *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return &alpha1.InstallPlan{Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseComplete}}, &alpha1.Subscription{}, nil
 				},
 			},
 			SubscriptionName: "something",
@@ -94,8 +94,8 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				if len(mock.InstallOperatorCalls()) != 1 {
 					t.Fatalf("expected create subscription to be called once but was called %v", len(mock.InstallOperatorCalls()))
 				}
-				if len(mock.GetSubscriptionInstallPlansCalls()) != 1 {
-					t.Fatalf("expected GetSubscriptionInstallPlansCalls to be called once but was called %v", len(mock.GetSubscriptionInstallPlansCalls()))
+				if len(mock.GetSubscriptionInstallPlanCalls()) != 1 {
+					t.Fatalf("expected GetSubscriptionInstallPlanCalls to be called once but was called %v", len(mock.GetSubscriptionInstallPlanCalls()))
 				}
 			},
 		},
@@ -107,7 +107,7 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
 					return nil, &alpha1.Subscription{ObjectMeta: metav1.ObjectMeta{
 						// simulate the time has passed
 						CreationTimestamp: metav1.Time{Time: time.Now().AddDate(0, 0, -1)},
@@ -141,15 +141,13 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{
-						{
-							Spec: alpha1.InstallPlanSpec{Approved: true},
-							Status: alpha1.InstallPlanStatus{
-								Phase: alpha1.InstallPlanPhaseInstalling,
-							},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return &alpha1.InstallPlan{
+						Spec: alpha1.InstallPlanSpec{Approved: true},
+						Status: alpha1.InstallPlanStatus{
+							Phase: alpha1.InstallPlanPhaseInstalling,
 						},
-					}}, &alpha1.Subscription{}, nil
+					}, &alpha1.Subscription{}, nil
 				},
 			},
 			SubscriptionName: "something",
@@ -162,7 +160,7 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
 					return nil, nil, fmt.Errorf("simulate error gettiing install plans")
 				},
 			},
@@ -177,8 +175,8 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{}}, &alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return nil, &alpha1.Subscription{}, nil
 				},
 			},
 			SubscriptionName: "something",
@@ -194,10 +192,10 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{
-						{Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed}},
-					}}, &alpha1.Subscription{}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return &alpha1.InstallPlan{
+						Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed},
+					}, &alpha1.Subscription{}, nil
 				},
 			},
 			SubscriptionName: "something",
@@ -214,10 +212,10 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{
-						{Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed}},
-					}}, &alpha1.Subscription{Status: alpha1.SubscriptionStatus{InstalledCSV: "test-csv"}}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return &alpha1.InstallPlan{
+						Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed},
+					}, &alpha1.Subscription{Status: alpha1.SubscriptionStatus{InstalledCSV: "test-csv"}}, nil
 				},
 			},
 			SubscriptionName: "something",
@@ -232,10 +230,10 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalgSourceReconciler marketplace.CatalogSourceReconciler) error {
 					return nil
 				},
-				GetSubscriptionInstallPlansFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlanList, subscription *alpha1.Subscription, e error) {
-					return &alpha1.InstallPlanList{Items: []alpha1.InstallPlan{
-						{Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed}},
-					}}, &alpha1.Subscription{Status: alpha1.SubscriptionStatus{InstalledCSV: "test-csv"}}, nil
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName string, ns string) (plans *alpha1.InstallPlan, subscription *alpha1.Subscription, e error) {
+					return &alpha1.InstallPlan{
+						Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseFailed},
+					}, &alpha1.Subscription{Status: alpha1.SubscriptionStatus{InstalledCSV: "test-csv"}}, nil
 				},
 			},
 			SubscriptionName: "something",

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -75,6 +76,7 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 		Installation     *integreatlyv1alpha1.RHMI
 		Target           marketplace.Target
 		Validate         func(t *testing.T, mock *marketplace.MarketplaceInterfaceMock)
+		Assertion        func(k8sclient.Client) error
 	}{
 		{
 			Name: "test reconcile subscription creates a new subscription  completes successfully ",
@@ -240,6 +242,70 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 			ExpectedStatus:   integreatlyv1alpha1.PhaseAwaitingOperator,
 			Installation:     &integreatlyv1alpha1.RHMI{},
 		},
+		{
+			Name: "test reconcile subscription deletes CSV and subscription if the CSV doesn't have a deployment",
+			client: fakeclient.NewFakeClientWithScheme(scheme,
+				&alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-ns",
+					},
+					Spec: alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: alpha1.NamedInstallStrategy{
+							StrategyName: alpha1.InstallStrategyNameDeployment,
+							StrategySpec: alpha1.StrategyDetailsDeployment{
+								DeploymentSpecs: []alpha1.StrategyDeploymentSpec{},
+							},
+						},
+					},
+				},
+				&alpha1.Subscription{
+					Status: alpha1.SubscriptionStatus{
+						InstalledCSV: "test-csv",
+					},
+				},
+			),
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{
+				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
+					return nil
+				},
+				GetSubscriptionInstallPlanFunc: func(ctx context.Context, serverClient k8sclient.Client, subName, ns string) (*alpha1.InstallPlan, *alpha1.Subscription, error) {
+					return &alpha1.InstallPlan{
+						Spec: alpha1.InstallPlanSpec{
+							Approved: true,
+							ClusterServiceVersionNames: []string{
+								"test-csv",
+							},
+						},
+						Status: alpha1.InstallPlanStatus{Phase: alpha1.InstallPlanPhaseComplete},
+					}, &alpha1.Subscription{Status: alpha1.SubscriptionStatus{InstalledCSV: "test-csv"}}, nil
+				},
+			},
+			SubscriptionName: "something",
+			ExpectedStatus:   integreatlyv1alpha1.PhaseAwaitingOperator,
+			Installation:     &integreatlyv1alpha1.RHMI{},
+			Assertion: func(client k8sclient.Client) error {
+				csv := &alpha1.ClusterServiceVersion{}
+				err := client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "test-csv",
+					Namespace: "test-ns",
+				}, csv)
+				if err == nil || !k8serr.IsNotFound(err) {
+					return errors.New("CSV was not deleted")
+				}
+
+				sub := &alpha1.Subscription{}
+				err = client.Get(context.TODO(), k8sclient.ObjectKey{
+					Name:      "something",
+					Namespace: "test-ns",
+				}, sub)
+				if err == nil || !k8serr.IsNotFound(err) {
+					return errors.New("Susbcription was not deleted")
+				}
+
+				return nil
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -264,7 +330,11 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 			if tc.Validate != nil {
 				tc.Validate(t, tc.FakeMPM.(*marketplace.MarketplaceInterfaceMock))
 			}
-
+			if tc.Assertion != nil {
+				if err := tc.Assertion(tc.client); err != nil {
+					t.Errorf("failed assertion: %v", err)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
# Description

### Duplicated install plans

Currently, as part of the product operators installation, the retrieval of the InstallPlans associated with the product is done by
listing all InstallPlans in the Subscription namespace. OLM however might create multiple InstallPlans where only one is valid and is referenced in the Subscription status as an `InstallPlanRef` field. The current approach will loop through all the InstallPlans in the namespace, approve them an wait for the status to be `Complete`, but if an invalid InstallPlan comes first in the list, it will remain stuck in progress, never reaching the valid one.

Change the `MarketPlaceInterface` and its `Manager` implementation to retrieve only the InstallPlan that is referenced by the Subscription, and update the unit tests that depend on this method.

### Missing deployment in CSVs

It's been noted that CSVs have been created with missing deployments, signaling the product operator as installed but the operator doesn't start running. Add logic to validate the CSVs and retry the installation if the CSV is found to be invalid

## Verification

1. Install a cluster with Openshift ~4.6.8~
2. Install RHOAM from this PR
    > While RHOAM progresses the products installation, check the InstallPlans in the product operator namespaces, check if there are more than one InstallPlan for namespace, this might happen arbitrarily
3. Verify that the installation completes successfilly

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer