### PR TITLE
set 3scale outgoing email address to smtp_secret

### DIFF
--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -717,7 +717,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 		"Subject":               fmt.Sprintf(`[%s] {{template "email.default.subject" . }}`, clusterInfra.Status.InfrastructureName),
 	})
 
-	testSecretData, err := templateUtil.loadTemplate(alertManagerConfigTemplatePath)
+	testSecretData, err := templateUtil.LoadTemplate(alertManagerConfigTemplatePath)
 
 	tests := []struct {
 		name         string
@@ -885,7 +885,7 @@ func TestReconciler_reconcileAlertManagerConfigSecret(t *testing.T) {
 					"Subject":               fmt.Sprintf(`[%s] {{template "email.default.subject" . }}`, clusterInfra.Status.InfrastructureName),
 				})
 
-				testSecretData, err := templateUtil.loadTemplate(alertManagerConfigTemplatePath)
+				testSecretData, err := templateUtil.LoadTemplate(alertManagerConfigTemplatePath)
 				if err != nil {
 					return err
 				}

--- a/pkg/products/monitoring/templateHelper.go
+++ b/pkg/products/monitoring/templateHelper.go
@@ -62,7 +62,7 @@ func joinQuote(values []monitoring.BlackboxtargetData) string {
 
 // load a templates from a given resource name. The templates must be located
 // under ./templates and the filename must be <resource-name>.yaml
-func (h *TemplateHelper) loadTemplate(name string) ([]byte, error) {
+func (h *TemplateHelper) LoadTemplate(name string) ([]byte, error) {
 	path := fmt.Sprintf("%s/%s", h.TemplatePath, name)
 	tpl, err := ioutil.ReadFile(path)
 	if err != nil {
@@ -89,7 +89,7 @@ func (h *TemplateHelper) loadTemplate(name string) ([]byte, error) {
 }
 
 func (h *TemplateHelper) CreateResource(template string) (runtime.Object, error) {
-	tpl, err := h.loadTemplate(template)
+	tpl, err := h.LoadTemplate(template)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/products/threescale/three_scale_moq.go
+++ b/pkg/products/threescale/three_scale_moq.go
@@ -39,6 +39,9 @@ var _ ThreeScaleInterface = &ThreeScaleInterfaceMock{}
 // 			GetUsersFunc: func(accessToken string) (*Users, error) {
 // 				panic("mock out the GetUsers method")
 // 			},
+// 			SetFromEmailAddressFunc: func(emailAddress string, accessToken string) (*http.Response, error) {
+// 				panic("mock out the SetFromEmailAddress method")
+// 			},
 // 			SetNamespaceFunc: func(ns string)  {
 // 				panic("mock out the SetNamespace method")
 // 			},
@@ -78,6 +81,9 @@ type ThreeScaleInterfaceMock struct {
 
 	// GetUsersFunc mocks the GetUsers method.
 	GetUsersFunc func(accessToken string) (*Users, error)
+
+	// SetFromEmailAddressFunc mocks the SetFromEmailAddress method.
+	SetFromEmailAddressFunc func(emailAddress string, accessToken string) (*http.Response, error)
 
 	// SetNamespaceFunc mocks the SetNamespace method.
 	SetNamespaceFunc func(ns string)
@@ -142,6 +148,13 @@ type ThreeScaleInterfaceMock struct {
 			// AccessToken is the accessToken argument value.
 			AccessToken string
 		}
+		// SetFromEmailAddress holds details about calls to the SetFromEmailAddress method.
+		SetFromEmailAddress []struct {
+			// EmailAddress is the emailAddress argument value.
+			EmailAddress string
+			// AccessToken is the accessToken argument value.
+			AccessToken string
+		}
 		// SetNamespace holds details about calls to the SetNamespace method.
 		SetNamespace []struct {
 			// Ns is the ns argument value.
@@ -180,6 +193,7 @@ type ThreeScaleInterfaceMock struct {
 	lockGetAuthenticationProviders      sync.RWMutex
 	lockGetUser                         sync.RWMutex
 	lockGetUsers                        sync.RWMutex
+	lockSetFromEmailAddress             sync.RWMutex
 	lockSetNamespace                    sync.RWMutex
 	lockSetUserAsAdmin                  sync.RWMutex
 	lockSetUserAsMember                 sync.RWMutex
@@ -428,6 +442,41 @@ func (mock *ThreeScaleInterfaceMock) GetUsersCalls() []struct {
 	mock.lockGetUsers.RLock()
 	calls = mock.calls.GetUsers
 	mock.lockGetUsers.RUnlock()
+	return calls
+}
+
+// SetFromEmailAddress calls SetFromEmailAddressFunc.
+func (mock *ThreeScaleInterfaceMock) SetFromEmailAddress(emailAddress string, accessToken string) (*http.Response, error) {
+	if mock.SetFromEmailAddressFunc == nil {
+		panic("ThreeScaleInterfaceMock.SetFromEmailAddressFunc: method is nil but ThreeScaleInterface.SetFromEmailAddress was just called")
+	}
+	callInfo := struct {
+		EmailAddress string
+		AccessToken  string
+	}{
+		EmailAddress: emailAddress,
+		AccessToken:  accessToken,
+	}
+	mock.lockSetFromEmailAddress.Lock()
+	mock.calls.SetFromEmailAddress = append(mock.calls.SetFromEmailAddress, callInfo)
+	mock.lockSetFromEmailAddress.Unlock()
+	return mock.SetFromEmailAddressFunc(emailAddress, accessToken)
+}
+
+// SetFromEmailAddressCalls gets all the calls that were made to SetFromEmailAddress.
+// Check the length with:
+//     len(mockedThreeScaleInterface.SetFromEmailAddressCalls())
+func (mock *ThreeScaleInterfaceMock) SetFromEmailAddressCalls() []struct {
+	EmailAddress string
+	AccessToken  string
+} {
+	var calls []struct {
+		EmailAddress string
+		AccessToken  string
+	}
+	mock.lockSetFromEmailAddress.RLock()
+	calls = mock.calls.SetFromEmailAddress
+	mock.lockSetFromEmailAddress.RUnlock()
 	return calls
 }
 

--- a/pkg/resources/smtp.go
+++ b/pkg/resources/smtp.go
@@ -1,0 +1,41 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	alertManagerConfigSecretFileName = "alertmanager.yaml"
+	alertManagerConfigSecretName     = "alertmanager-application-monitoring"
+	operatorNs                       = "redhat-rhoam-middleware-monitoring-operator"
+)
+
+type alertManagerConfig struct {
+	Global map[string]string `yaml:"global"`
+}
+
+func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client) (string, error) {
+	amSecret := &corev1.Secret{}
+	err := client.Get(ctx, types.NamespacedName{Name: alertManagerConfigSecretName,
+		Namespace: operatorNs}, amSecret)
+
+	if err != nil {
+		return "", err
+	}
+
+	monitoring := amSecret.Data[alertManagerConfigSecretFileName]
+
+	var config alertManagerConfig
+	err = yaml.Unmarshal(monitoring, &config)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse alert monitoring yaml: %w", err)
+	}
+
+	return config.Global["smtp_from"], nil
+}


### PR DESCRIPTION
# Description
set 3scale outgoing email address to smtp_from field in the secret: alertmanager-application-monitoring
Currently the domain for the from email address defaults to the 3scale route. This is no longer compatible with send grid validation rules.

# Verify
Install RHOAM based on this branch
After 3scale reconciles verify that the outgoing email on 3scale is the same as the smtp_from field in the secret: alertmanager-application-monitoring in ns redhat-rhoam-middleware-monitoring-operator
To find the outgoing email address in 3scale
- Log in as admin (system-seed secret)
- Browse to Audience => Settings => Domains & Access => Outgoing Email 



