### PR TITLE
MGDAPI-1292: Remove control-plane label from operator Deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -3,18 +3,14 @@ kind: Deployment
 metadata:
   name: rhmi-operator
   namespace: system
-  labels:
-    control-plane: controller-manager
 spec:
   selector:
     matchLabels:
-      control-plane: controller-manager
       name: rhmi-operator
   replicas: 1
   template:
     metadata:
       labels:
-        control-plane: controller-manager
         name: rhmi-operator
     spec:
       serviceAccountName: "rhmi-operator"

--- a/config/prometheus/monitor.yaml
+++ b/config/prometheus/monitor.yaml
@@ -4,7 +4,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    control-plane: controller-manager
+    name: rhmi-operator
   name: rhmi-operator-metrics
   namespace: system
 spec:
@@ -13,4 +13,4 @@ spec:
       port: http-metrics
   selector:
     matchLabels:
-      control-plane: controller-manager
+      name: rhmi-operator

--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    control-plane: controller-manager
-  name: operator-metrics
+    name: rhmi-operator
+  name: operator-metrics-service
   namespace: system
 spec:
   ports:
@@ -11,4 +11,4 @@ spec:
     port: 8383
     targetPort: 8383
   selector:
-    control-plane: controller-manager
+    name: rhmi-operator


### PR DESCRIPTION
# Description

Newly scaffolded operators include the following label on the manager Deployment as well as selectors:

```yaml
control-plane: controller-manager
```

When upgrading the operator from a pre-operator-sdk migration release that doesn't include this label, it fails due to the fact that the field is immutable.

Remove this label from the deployment as well as the selectors that
point to the operator (ServiceMonitor and metrics Service)

## Verification steps

1. Tag the RHOAM 1.2.0 image to your org and push it to quay
2. Update the CSV for RHOAM 1.2.0 in `packagemanifests/1.2.0` to point to your quay org
3. Generate a bundle for it
    ```sh
    ORG=<your org> OLM_TYPE=managed-api-service BUNDLE_VERSIONS=1.2.0 ./scripts/bundle-rhmi-operators.sh
    ```
4.  The script will create a CatalogSource pointing to 1.2.0. In your cluster, install the RHOAM operator from OperatorHub
5.  Generate the manifests for (a fictitious) 1.3.0
    ```sh
    SEMVER=1.3.0 OLM_TYPE=managed-api-service make release/prepare
    ```
    > It will create the manifests in the `packagemanifests/1.3.0` folder.
6. Build the 1.3.0 image and push it to quay
    ```sh
    TAG=1.3.0 ORG=sfrancog INSTALLATION_TYPE=managed-api make image/build/push
    ```
6. Update the CSV for RHOAM 1.3.0 in `packagemanifests/1.3.0` to point to your newly generated image
7. Generate the bundle and index for the 1.3.0 upgrade
    ```sh
    ORG=<your org> OLM_TYPE=managed-api-service BUNDLE_VERSIONS=1.3.0,1.2.0 ./scripts/bundle-rhmi-operators.sh
    ```
    > The script will update the CatalogSource to point to 1.3.0, so the upgrade will be available shortly
6. Approve the upgrade once it's made available in OLM
7. Verify that the upgrade finishes successfully



> #### Manifests cache
> If a change needs to be made in the manifests after they have been pulled by the CatalogSource, push the manifests again and delete the ConfigMap generated for them (usually a long hash name)  in the `openshift-marketplace` namespace, it will force OLM to pull them again

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer