### PR TITLE
fix: getting cluster id in sso-idp script

### DIFF
--- a/scripts/setup-sso-idp.sh
+++ b/scripts/setup-sso-idp.sh
@@ -78,7 +78,7 @@ echo "Keycloak realm: $REALM"
 
 # If CLUSTER_ID is not passed, find out ID based on currently targeted server
 set +e # ignore errors in environments without ocm command
-CLUSTER_ID="${CLUSTER_ID:-$(ocm get /api/clusters_mgmt/v1/clusters/ --parameter "search=managed='true'" 2>/dev/null | jq -r ".items[] | select(.api.url == \"$(oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*')\") | .id ")}"
+CLUSTER_ID="${CLUSTER_ID:-$(ocm get clusters --parameter search="api.url like '$(oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*')'" 2>/dev/null | jq -r .items[0].id)}"
 set -e
 
 if [[ ${CLUSTER_ID} ]]; then


### PR DESCRIPTION
# Description
The issue with getting no result for a cluster ID was seen couple of times in nightly pipelines and is causing problems when running e2e test (IDP tests)

The command I'm introducing in this PR is a command that I was using lately in my local scripts and it was working for me every time.

I verified it's also working against the cluster where the issue with sso-idp script can be currently seen:
```
No CLUSTER_ID detected. IDP will be added directly into "cluster" OAuth resource.
```

In the new `ocm` command we're asking ocm directly to search for the specific cluster API URL instead of asking it to get the full list of managed clusters and then filter them. I thought that it doesn't really matter which approach we choose, but in this case it does. (But why - I have no idea.)