### PR TITLE
MGDAPI-1180: Update CRD and webhook API versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,7 +102,7 @@ endif
 BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)
-CRD_OPTIONS ?= "crd:trivialVersions=true"
+CRD_OPTIONS ?= "crd:crdVersions=v1,trivialVersions=false"
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/config/crd/bases/integreatly.org_rhmiconfigs.yaml
+++ b/config/crd/bases/integreatly.org_rhmiconfigs.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,106 +15,106 @@ spec:
     plural: rhmiconfigs
     singular: rhmiconfig
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: RHMIConfig is the Schema for the rhmiconfigs API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RHMIConfigSpec defines the desired state of RHMIConfig
-          properties:
-            backup:
-              properties:
-                applyOn:
-                  description: 'apply-on: string, day time. Format: "DDD hh:mm" >
-                    "wed 20:00". UTC time'
-                  type: string
-              type: object
-            maintenance:
-              properties:
-                applyFrom:
-                  description: 'apply-from: string, day time. Currently this is a
-                    6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
-                  type: string
-              type: object
-            upgrade:
-              properties:
-                contacts:
-                  description: 'contacts: list of contacts which are comma separated
-                    "user1@example.com,user2@example.com"'
-                  type: string
-                notBeforeDays:
-                  description: Minimum of days since an upgrade is made available
-                    until it's approved
-                  nullable: true
-                  type: integer
-                schedule:
-                  type: boolean
-                waitForMaintenance:
-                  description: If this value is true, upgrades will be approved in
-                    the next maintenance window n days after the upgrade is made available.
-                    Being n the value of `notBeforeDays`.
-                  nullable: true
-                  type: boolean
-              type: object
-          type: object
-        status:
-          description: RHMIConfigStatus defines the observed state of RHMIConfig
-          properties:
-            maintenance:
-              description: "status block reflects the current configuration of the
-                cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00
-                \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980 -
-                17 Jan 1980\""
-              properties:
-                applyFrom:
-                  type: string
-                duration:
-                  type: string
-              type: object
-            upgrade:
-              properties:
-                scheduled:
-                  description: Scheduled contains the information on the next upgrade
-                    schedule
-                  properties:
-                    for:
-                      description: For is the calculated time when the upgrade is
-                        scheduled for, in format "2 Jan 2006 15:04"
-                      type: string
-                  type: object
-              type: object
-            upgradeAvailable:
-              properties:
-                availableAt:
-                  description: 'Time of new update becoming available Format: "DDD
-                    hh:mm" > "sun 23:00". UTC time'
-                  format: date-time
-                  type: string
-                targetVersion:
-                  description: 'target-version: string, version of incoming RHMI Operator'
-                  type: string
-              type: object
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RHMIConfig is the Schema for the rhmiconfigs API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RHMIConfigSpec defines the desired state of RHMIConfig
+            properties:
+              backup:
+                properties:
+                  applyOn:
+                    description: 'apply-on: string, day time. Format: "DDD hh:mm"
+                      > "wed 20:00". UTC time'
+                    type: string
+                type: object
+              maintenance:
+                properties:
+                  applyFrom:
+                    description: 'apply-from: string, day time. Currently this is
+                      a 6 hour window. Format: "DDD hh:mm" > "sun 23:00". UTC time'
+                    type: string
+                type: object
+              upgrade:
+                properties:
+                  contacts:
+                    description: 'contacts: list of contacts which are comma separated
+                      "user1@example.com,user2@example.com"'
+                    type: string
+                  notBeforeDays:
+                    description: Minimum of days since an upgrade is made available
+                      until it's approved
+                    nullable: true
+                    type: integer
+                  schedule:
+                    type: boolean
+                  waitForMaintenance:
+                    description: If this value is true, upgrades will be approved
+                      in the next maintenance window n days after the upgrade is made
+                      available. Being n the value of `notBeforeDays`.
+                    nullable: true
+                    type: boolean
+                type: object
+            type: object
+          status:
+            description: RHMIConfigStatus defines the observed state of RHMIConfig
+            properties:
+              maintenance:
+                description: "status block reflects the current configuration of the
+                  cr \n \tstatus: \t\tmaintenance: \t\t\tapply-from: 16-05-2020 23:00
+                  \t\t\tduration: \"6hrs\" \t\tupgrade: \t\t\twindow: \"3 Jan 1980
+                  - 17 Jan 1980\""
+                properties:
+                  applyFrom:
+                    type: string
+                  duration:
+                    type: string
+                type: object
+              upgrade:
+                properties:
+                  scheduled:
+                    description: Scheduled contains the information on the next upgrade
+                      schedule
+                    properties:
+                      for:
+                        description: For is the calculated time when the upgrade is
+                          scheduled for, in format "2 Jan 2006 15:04"
+                        type: string
+                    type: object
+                type: object
+              upgradeAvailable:
+                properties:
+                  availableAt:
+                    description: 'Time of new update becoming available Format: "DDD
+                      hh:mm" > "sun 23:00". UTC time'
+                    format: date-time
+                    type: string
+                  targetVersion:
+                    description: 'target-version: string, version of incoming RHMI
+                      Operator'
+                    type: string
+                type: object
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/bases/integreatly.org_rhmis.yaml
+++ b/config/crd/bases/integreatly.org_rhmis.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
@@ -15,162 +15,161 @@ spec:
     plural: rhmis
     singular: rhmi
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: RHMI is the Schema for the rhmis API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: RHMISpec defines the desired state of RHMI
-          properties:
-            alertFromAddress:
-              type: string
-            alertingEmailAddress:
-              type: string
-            alertingEmailAddresses:
-              properties:
-                businessUnit:
-                  type: string
-                cssre:
-                  type: string
-              required:
-              - businessUnit
-              - cssre
-              type: object
-            deadMansSnitchSecret:
-              description: "DeadMansSnitchSecret is the name of a secret in the installation
-                namespace containing connection details for Dead Mans Snitch. The
-                secret must contain the following fields: \n url"
-              type: string
-            masterURL:
-              type: string
-            namespacePrefix:
-              type: string
-            operatorsInProductNamespace:
-              description: OperatorsInProductNamespace is a flag that decides if the
-                product operators should be installed in the product namespace (when
-                set to true) or in standalone namespace (when set to false, default).
-                Standalone namespace will be used only for those operators that support
-                it.
-              type: boolean
-            pagerDutySecret:
-              description: "PagerDutySecret is the name of a secret in the installation
-                namespace containing PagerDuty account details. The secret must contain
-                the following fields: \n serviceKey"
-              type: string
-            priorityClassName:
-              type: string
-            pullSecret:
-              properties:
-                name:
-                  type: string
-                namespace:
-                  type: string
-              required:
-              - name
-              - namespace
-              type: object
-            rebalancePods:
-              type: boolean
-            routingSubdomain:
-              type: string
-            selfSignedCerts:
-              type: boolean
-            smtpSecret:
-              description: "SMTPSecret is the name of a secret in the installation
-                namespace containing SMTP connection details. The secret must contain
-                the following fields: \n host port tls username password"
-              type: string
-            type:
-              type: string
-            useClusterStorage:
-              type: string
-          required:
-          - namespacePrefix
-          - type
-          type: object
-        status:
-          description: RHMIStatus defines the observed state of RHMI
-          properties:
-            gitHubOAuthEnabled:
-              type: boolean
-            lastError:
-              type: string
-            preflightMessage:
-              type: string
-            preflightStatus:
-              type: string
-            smtpEnabled:
-              type: boolean
-            stage:
-              type: string
-            stages:
-              additionalProperties:
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RHMI is the Schema for the rhmis API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RHMISpec defines the desired state of RHMI
+            properties:
+              alertFromAddress:
+                type: string
+              alertingEmailAddress:
+                type: string
+              alertingEmailAddresses:
+                properties:
+                  businessUnit:
+                    type: string
+                  cssre:
+                    type: string
+                required:
+                - businessUnit
+                - cssre
+                type: object
+              deadMansSnitchSecret:
+                description: "DeadMansSnitchSecret is the name of a secret in the
+                  installation namespace containing connection details for Dead Mans
+                  Snitch. The secret must contain the following fields: \n url"
+                type: string
+              masterURL:
+                type: string
+              namespacePrefix:
+                type: string
+              operatorsInProductNamespace:
+                description: OperatorsInProductNamespace is a flag that decides if
+                  the product operators should be installed in the product namespace
+                  (when set to true) or in standalone namespace (when set to false,
+                  default). Standalone namespace will be used only for those operators
+                  that support it.
+                type: boolean
+              pagerDutySecret:
+                description: "PagerDutySecret is the name of a secret in the installation
+                  namespace containing PagerDuty account details. The secret must
+                  contain the following fields: \n serviceKey"
+                type: string
+              priorityClassName:
+                type: string
+              pullSecret:
                 properties:
                   name:
                     type: string
-                  phase:
+                  namespace:
                     type: string
-                  products:
-                    additionalProperties:
-                      properties:
-                        host:
-                          type: string
-                        mobile:
-                          type: boolean
-                        name:
-                          type: string
-                        operator:
-                          type: string
-                        status:
-                          type: string
-                        type:
-                          type: string
-                        version:
-                          type: string
-                      required:
-                      - host
-                      - name
-                      - status
-                      - version
-                      type: object
-                    type: object
                 required:
                 - name
-                - phase
+                - namespace
                 type: object
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "make" to regenerate code after modifying
-                this file'
-              type: object
-            toVersion:
-              type: string
-            version:
-              type: string
-          required:
-          - lastError
-          - stage
-          - stages
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+              rebalancePods:
+                type: boolean
+              routingSubdomain:
+                type: string
+              selfSignedCerts:
+                type: boolean
+              smtpSecret:
+                description: "SMTPSecret is the name of a secret in the installation
+                  namespace containing SMTP connection details. The secret must contain
+                  the following fields: \n host port tls username password"
+                type: string
+              type:
+                type: string
+              useClusterStorage:
+                type: string
+            required:
+            - namespacePrefix
+            - type
+            type: object
+          status:
+            description: RHMIStatus defines the observed state of RHMI
+            properties:
+              gitHubOAuthEnabled:
+                type: boolean
+              lastError:
+                type: string
+              preflightMessage:
+                type: string
+              preflightStatus:
+                type: string
+              smtpEnabled:
+                type: boolean
+              stage:
+                type: string
+              stages:
+                additionalProperties:
+                  properties:
+                    name:
+                      type: string
+                    phase:
+                      type: string
+                    products:
+                      additionalProperties:
+                        properties:
+                          host:
+                            type: string
+                          mobile:
+                            type: boolean
+                          name:
+                            type: string
+                          operator:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                          version:
+                            type: string
+                        required:
+                        - host
+                        - name
+                        - status
+                        - version
+                        type: object
+                      type: object
+                  required:
+                  - name
+                  - phase
+                  type: object
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "make" to regenerate code after modifying
+                  this file'
+                type: object
+              toVersion:
+                type: string
+              version:
+                type: string
+            required:
+            - lastError
+            - stage
+            - stages
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/webhooks/operator_webhooks_test.go
+++ b/pkg/webhooks/operator_webhooks_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -27,7 +27,7 @@ func TestReconcile(t *testing.T) {
 	// Set up testing scheme
 	scheme := runtime.NewScheme()
 	corev1.AddToScheme(scheme)
-	v1beta1.AddToScheme(scheme)
+	admissionv1.AddToScheme(scheme)
 	schemeBuilder.AddToScheme(scheme)
 	v1alpha1.SchemeBuilder.AddToScheme(scheme)
 	scheme.AddKnownTypes(schemeBuilder.GroupVersion, &mockValidator{})
@@ -298,8 +298,8 @@ func mockCAController(ctx context.Context, client k8sclient.Client, stop <-chan 
 	}
 }
 
-func findValidatingWebhookConfig(client k8sclient.Client) (*v1beta1.ValidatingWebhookConfiguration, error) {
-	vwc := &v1beta1.ValidatingWebhookConfiguration{}
+func findValidatingWebhookConfig(client k8sclient.Client) (*admissionv1.ValidatingWebhookConfiguration, error) {
+	vwc := &admissionv1.ValidatingWebhookConfiguration{}
 	err := client.Get(
 		context.TODO(),
 		k8sclient.ObjectKey{Name: "test.integreatly.org"},
@@ -312,8 +312,8 @@ func findValidatingWebhookConfig(client k8sclient.Client) (*v1beta1.ValidatingWe
 	return vwc, nil
 }
 
-func findMutatingWebhookConfig(client k8sclient.Client, name string) (*v1beta1.MutatingWebhookConfiguration, error) {
-	mwc := &v1beta1.MutatingWebhookConfiguration{}
+func findMutatingWebhookConfig(client k8sclient.Client, name string) (*admissionv1.MutatingWebhookConfiguration, error) {
+	mwc := &admissionv1.MutatingWebhookConfiguration{}
 	err := client.Get(
 		context.TODO(),
 		k8sclient.ObjectKey{Name: fmt.Sprintf("%s.integreatly.org", name)},

--- a/pkg/webhooks/reconciler.go
+++ b/pkg/webhooks/reconciler.go
@@ -8,7 +8,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	pkgerr "github.com/pkg/errors"
 
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -61,10 +61,10 @@ type MutatingWebhookReconciler struct {
 
 func (reconciler *MutatingWebhookReconciler) Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error {
 	var (
-		sideEffects    = v1beta1.SideEffectClassNone
+		sideEffects    = admissionv1.SideEffectClassNone
 		port           = int32(servicePort)
-		matchPolicy    = v1beta1.Exact
-		failurePolicy  = v1beta1.Fail
+		matchPolicy    = admissionv1.Exact
+		failurePolicy  = admissionv1.Fail
 		timeoutSeconds = int32(30)
 	)
 	watchNS, err := resources.GetWatchNamespace()
@@ -73,30 +73,30 @@ func (reconciler *MutatingWebhookReconciler) Reconcile(ctx context.Context, clie
 	}
 	namespaceSegments := strings.Split(watchNS, "-")
 	namespacePrefix := strings.Join(namespaceSegments[0:2], "-") + "-"
-	cr := &v1beta1.MutatingWebhookConfiguration{
+	cr := &admissionv1.MutatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: fmt.Sprintf("%s.integreatly.org", reconciler.name),
 		},
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, client, cr, func() error {
-		cr.Webhooks = []v1beta1.MutatingWebhook{
+		cr.Webhooks = []admissionv1.MutatingWebhook{
 			{
 				Name:        fmt.Sprintf("%s-mutating-config.integreatly.org", reconciler.name),
 				SideEffects: &sideEffects,
-				ClientConfig: v1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundle,
-					Service: &v1beta1.ServiceReference{
+					Service: &admissionv1.ServiceReference{
 						Namespace: namespacePrefix + "operator",
 						Name:      operatorPodServiceName,
 						Path:      &reconciler.Path,
 						Port:      &port,
 					},
 				},
-				Rules: []v1beta1.RuleWithOperations{
+				Rules: []admissionv1.RuleWithOperations{
 					{
 						Operations: reconciler.rule.Operations,
-						Rule: v1beta1.Rule{
+						Rule: admissionv1.Rule{
 							APIGroups:   reconciler.rule.APIGroups,
 							APIVersions: reconciler.rule.APIVersions,
 							Resources:   reconciler.rule.Resources,
@@ -117,10 +117,10 @@ func (reconciler *MutatingWebhookReconciler) Reconcile(ctx context.Context, clie
 
 func (reconciler *ValidatingWebhookReconciler) Reconcile(ctx context.Context, client k8sclient.Client, caBundle []byte) error {
 	var (
-		sideEffects    = v1beta1.SideEffectClassNone
+		sideEffects    = admissionv1.SideEffectClassNone
 		port           = int32(servicePort)
-		matchPolicy    = v1beta1.Exact
-		failurePolicy  = v1beta1.Fail
+		matchPolicy    = admissionv1.Exact
+		failurePolicy  = admissionv1.Fail
 		timeoutSeconds = int32(30)
 	)
 	watchNS, err := resources.GetWatchNamespace()
@@ -129,30 +129,30 @@ func (reconciler *ValidatingWebhookReconciler) Reconcile(ctx context.Context, cl
 	}
 	namespaceSegments := strings.Split(watchNS, "-")
 	namespacePrefix := strings.Join(namespaceSegments[0:2], "-") + "-"
-	cr := &v1beta1.ValidatingWebhookConfiguration{
+	cr := &admissionv1.ValidatingWebhookConfiguration{
 		ObjectMeta: v1.ObjectMeta{
 			Name: fmt.Sprintf("%s.integreatly.org", reconciler.name),
 		},
 	}
 
 	_, err = controllerutil.CreateOrUpdate(ctx, client, cr, func() error {
-		cr.Webhooks = []v1beta1.ValidatingWebhook{
+		cr.Webhooks = []admissionv1.ValidatingWebhook{
 			{
 				Name:        fmt.Sprintf("%s-validating-config.integreatly.org", reconciler.name),
 				SideEffects: &sideEffects,
-				ClientConfig: v1beta1.WebhookClientConfig{
+				ClientConfig: admissionv1.WebhookClientConfig{
 					CABundle: caBundle,
-					Service: &v1beta1.ServiceReference{
+					Service: &admissionv1.ServiceReference{
 						Namespace: namespacePrefix + "operator",
 						Name:      operatorPodServiceName,
 						Path:      &reconciler.Path,
 						Port:      &port,
 					},
 				},
-				Rules: []v1beta1.RuleWithOperations{
+				Rules: []admissionv1.RuleWithOperations{
 					{
 						Operations: reconciler.rule.Operations,
-						Rule: v1beta1.Rule{
+						Rule: admissionv1.Rule{
 							APIGroups:   reconciler.rule.APIGroups,
 							APIVersions: reconciler.rule.APIVersions,
 							Resources:   reconciler.rule.Resources,

--- a/pkg/webhooks/rules.go
+++ b/pkg/webhooks/rules.go
@@ -1,13 +1,13 @@
 package webhooks
 
-import "k8s.io/api/admissionregistration/v1beta1"
+import v1 "k8s.io/api/admissionregistration/v1"
 
 // The `RuleWithOperations` and `Rule` types redefine the original ones from
-// k8s.io/api/admissionregistration/v1beta1 in order to allow to define methods
+// k8s.io/api/admissionregistration/v1 in order to allow to define methods
 // to build the rule as a fluent interface.
 
 type RuleWithOperations struct {
-	Operations []v1beta1.OperationType
+	Operations []v1.OperationType
 	Rule
 }
 
@@ -15,7 +15,7 @@ type Rule struct {
 	APIGroups   []string
 	APIVersions []string
 	Resources   []string
-	Scope       v1beta1.ScopeType
+	Scope       v1.ScopeType
 }
 
 func NewRule() RuleWithOperations {
@@ -31,27 +31,27 @@ func (rule RuleWithOperations) OneResource(apiGroup, apiVersion, resource string
 }
 
 func (rule RuleWithOperations) NamespacedScope() RuleWithOperations {
-	rule.Scope = v1beta1.NamespacedScope
+	rule.Scope = v1.NamespacedScope
 
 	return rule
 }
 
 func (rule RuleWithOperations) ForCreate() RuleWithOperations {
-	rule.Operations = append(rule.Operations, v1beta1.Create)
+	rule.Operations = append(rule.Operations, v1.Create)
 	return rule
 }
 
 func (rule RuleWithOperations) ForUpdate() RuleWithOperations {
-	rule.Operations = append(rule.Operations, v1beta1.Update)
+	rule.Operations = append(rule.Operations, v1.Update)
 	return rule
 }
 
 func (rule RuleWithOperations) ForDelete() RuleWithOperations {
-	rule.Operations = append(rule.Operations, v1beta1.Delete)
+	rule.Operations = append(rule.Operations, v1.Delete)
 	return rule
 }
 
 func (rule RuleWithOperations) ForAll() RuleWithOperations {
-	rule.Operations = append(rule.Operations, v1beta1.OperationAll)
+	rule.Operations = append(rule.Operations, v1.OperationAll)
 	return rule
 }

--- a/test/common/rhmi_config.go
+++ b/test/common/rhmi_config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	userv1 "github.com/openshift/api/user/v1"
-	"k8s.io/api/admissionregistration/v1beta1"
+	admissionv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -321,7 +321,7 @@ func RHMIConfigTemplate() *v1alpha1.RHMIConfig {
 
 func waitForValidatingWebhook(client dynclient.Client) error {
 	return wait.PollImmediate(time.Second, time.Second*30, func() (bool, error) {
-		vwc := &v1beta1.ValidatingWebhookConfiguration{}
+		vwc := &admissionv1.ValidatingWebhookConfiguration{}
 		err := client.Get(goctx.TODO(),
 			dynclient.ObjectKey{Name: "rhmiconfig.integreatly.org"},
 			vwc,


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-1180

v1beta1 API version of CRDs and Admission resources (webhooks) will be deprecated soon. Update the project to use v1 instead.

* Update CRD generation options to enable v1 API version of CRD
* Update imports of ValidatingWebhookConfiguration and MutatingWebhookConfiguration to reference v1 API version instead of
v1beta1.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer