### PR TITLE
add edge subscriptions checks to subscription controller

### DIFF
--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -37,16 +37,20 @@ var log = l.NewLoggerWithContext(l.Fields{l.ControllerLogContext: "subscription_
 
 const (
 	// IntegreatlyPackage - package name is used for Subsription name
-	IntegreatlyPackage          = "integreatly"
-	CSVNamePrefix               = "integreatly-operator"
-	RHMIAddonSubscription       = "addon-rhmi"
-	ManagedAPIAddonSubscription = "addon-managed-api-service"
+	IntegreatlyPackage              = "integreatly"
+	CSVNamePrefix                   = "integreatly-operator"
+	RHMIAddonSubscription           = "addon-rhmi"
+	RHMIAddonSubscriptionEdge       = "addon-rhmi-internal"
+	ManagedAPIAddonSubscription     = "addon-managed-api-service"
+	ManagedAPIAddonSubscriptionEdge = "addon-managed-api-service-internal"
 )
 
 var subscriptionsToReconcile []string = []string{
 	IntegreatlyPackage,
 	RHMIAddonSubscription,
 	ManagedAPIAddonSubscription,
+	RHMIAddonSubscriptionEdge,
+	ManagedAPIAddonSubscriptionEdge,
 }
 
 func New(mgr manager.Manager) (*SubscriptionReconciler, error) {


### PR DESCRIPTION
WHAT
Edge should behave the same as Production with regard to auto or manual upgrade of integreatly operator. Hive automatically sets auto upgrade on install plans to true. It's the responsibility of the operator to change this if required. Integreatly does this in the subscription controller. But not currently for edge. 

HOW
Update the subscription controller to check for edge Subscriptions. 