### PR TITLE
test: flags for real time logging, readme update

### DIFF
--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -20,4 +20,4 @@ FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
 
-ENTRYPOINT [ "/integreatly-operator-test-harness.test", "-test.v", "-ginkgo.noColor" ]
+ENTRYPOINT [ "/integreatly-operator-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.noColor" ]

--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -18,4 +18,4 @@ FROM registry.access.redhat.com/ubi7/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/managed-api-test-harness.test managed-api-test-harness.test
 
-ENTRYPOINT [ "/managed-api-test-harness.test", "-test.v" ]
+ENTRYPOINT [ "/managed-api-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.noColor" ]

--- a/Makefile
+++ b/Makefile
@@ -224,7 +224,7 @@ test/e2e: cluster/deploy
 .PHONY: test/e2e/single
 test/e2e/single: export WATCH_NAMESPACE := $(NAMESPACE)
 test/e2e/single: 
-	go clean -testcache && go test -v ./test/functional -run="//^$(TEST)" -timeout=80m
+	go clean -testcache && go test ./test/functional -ginkgo.focus="$(TEST).*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
 
 .PHONY: test/functional
 test/functional: export WATCH_NAMESPACE := $(NAMESPACE)

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ make test/functional
 
 To run a single E2E test against a running cluster run the command below where E03 is the start of the test description:
 ```
-go clean -testcache && go test -v ./test/functional -run="//^E03" -timeout=80m
+INSTALLATION_TYPE=<managed/managed-api> TEST=E03 make test/e2e/single
 ```
 ### Product tests
 


### PR DESCRIPTION
# Description
* replaced `-test.run` with [`-ginkgo.focus`](https://onsi.github.io/ginkgo/#focused-specs) flag
* added `-ginkgo.v` and `ginkgo.progress` flags to "functional" and "osde2e" dockerfiles' entrypoints (for detailed log output and real time logging when ran locally)
* updated readme