### PR TITLE
update Grafana annotations

### DIFF
--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBClusterResourcesJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -3066,3 +3069,4 @@ const MonitoringGrafanaDBClusterResourcesJSON = `{
 	"title": "Resource Usage for Cluster",
 	"version": 9
 }`
+}

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBEndpointsDetailedJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBEndpointsDetailedJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -1239,3 +1242,4 @@ const MonitoringGrafanaDBEndpointsDetailedJSON = `{
 	"uid": "xtkCtBkiz2",
 	"version": 14
 }`
+}

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBEndpointsReportJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBEndpointsReportJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -1576,3 +1579,4 @@ const MonitoringGrafanaDBEndpointsReportJSON = `{
 	"title": "Endpoints Report",
 	"version": 19
 }`
+}

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBEndpointsSummaryJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBEndpointsSummaryJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -388,3 +391,4 @@ const MonitoringGrafanaDBEndpointsSummaryJSON = `{
 	"uid": "hZJ_054Zk",
 	"version": 5
 }`
+}

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBResourceByNSJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -775,3 +778,4 @@ const MonitoringGrafanaDBResourceByNSJSON = `{
 	"title": "Resource Usage By Namespace",
 	"version": 2
 }`
+}

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -1,6 +1,9 @@
 package monitoring
 
-const MonitoringGrafanaDBResourceByPodJSON = `{
+// This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
+// The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
+func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
+	return `{
 	"annotations": {
 		"list": [{
 				"builtIn": 1,
@@ -14,7 +17,7 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,version,to_version)(rhmi_version{to_version!=\"\"})",
+				"expr": "count by (stage,version,to_version)(` + installationName + `_version{to_version!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
@@ -829,3 +832,4 @@ const MonitoringGrafanaDBResourceByPodJSON = `{
 	"uid": "c84ae905b9f54268be6be82c9a5b7dd6",
 	"version": 2
 }`
+}

--- a/pkg/products/monitoring/dashboardsHelper.go
+++ b/pkg/products/monitoring/dashboardsHelper.go
@@ -2,40 +2,37 @@ package monitoring
 
 import (
 	"fmt"
-
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	monitoring "github.com/integr8ly/integreatly-operator/pkg/products/monitoring/dashboards"
-	"github.com/integr8ly/integreatly-operator/pkg/resources"
 )
 
-func getSpecDetailsForDashboard(dashboard, nsPrefix string, installType string) (string, string, error) {
-	product := resources.InstallationNames[installType]
+func getSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI) (string, string, error) {
 
 	switch dashboard {
 
 	case "endpointsdetailed":
-		return monitoring.MonitoringGrafanaDBEndpointsDetailedJSON, "endpointsdetailed.json", nil
+		return monitoring.GetMonitoringGrafanaDBEndpointsDetailedJSON(rhmi.ObjectMeta.Name), "endpointsdetailed.json", nil
 
 	case "endpointsreport":
-		return monitoring.MonitoringGrafanaDBEndpointsReportJSON, "endpointsreport.json", nil
+		return monitoring.GetMonitoringGrafanaDBEndpointsReportJSON(rhmi.ObjectMeta.Name), "endpointsreport.json", nil
 
 	case "endpointssummary":
-		return monitoring.MonitoringGrafanaDBEndpointsSummaryJSON, "endpointssummary.json", nil
+		return monitoring.GetMonitoringGrafanaDBEndpointsSummaryJSON(rhmi.ObjectMeta.Name), "endpointssummary.json", nil
 
 	case "resources-by-namespace":
-		return monitoring.MonitoringGrafanaDBResourceByNSJSON, "resources-by-namespace.json", nil
+		return monitoring.GetMonitoringGrafanaDBResourceByNSJSON(rhmi.ObjectMeta.Name), "resources-by-namespace.json", nil
 
 	case "resources-by-pod":
-		return monitoring.MonitoringGrafanaDBResourceByPodJSON, "resources-by-pod.json", nil
+		return monitoring.GetMonitoringGrafanaDBResourceByPodJSON(rhmi.ObjectMeta.Name), "resources-by-pod.json", nil
 
 	case "cluster-resources":
-		return monitoring.MonitoringGrafanaDBClusterResourcesJSON, "cluster-resources-new.json", nil
-
+		return monitoring.GetMonitoringGrafanaDBClusterResourcesJSON(rhmi.ObjectMeta.Name), "cluster-resources-new.json", nil
 	case "critical-slo-rhmi-alerts":
-		return monitoring.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(nsPrefix, product), "critical-slo-alerts.json", nil
+		return monitoring.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(rhmi.Spec.NamespacePrefix, rhmi.Spec.Type), "critical-slo-alerts.json", nil
 
 	case "critical-slo-managed-api-alerts":
-		return monitoring.GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(nsPrefix, product), "critical-slo-alerts.json", nil
+		return monitoring.GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(rhmi.Spec.NamespacePrefix, rhmi.Spec.Type), "critical-slo-alerts.json", nil
 
 	case "cro-resources":
 		return monitoring.MonitoringGrafanaDBCROResourcesJSON, "cro-resources.json", nil

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -541,8 +541,7 @@ func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClien
 			Namespace: r.Config.GetOperatorNamespace(),
 		},
 	}
-
-	specJSON, name, err := getSpecDetailsForDashboard(dashboard, r.installation.Spec.NamespacePrefix, r.installation.Spec.Type)
+	specJSON, name, err := getSpecDetailsForDashboard(dashboard, r.installation)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## What
updated Grafana annotations to match the installation type (rhoam or rhmi)

## Why
https://issues.redhat.com/browse/MGDAPI-1310 

## Verification steps 
- get the image and deploy the cluster by running:

`IMAGE_FORMAT=quay.io/hudeb/managed-api-service:v1.2.0 INSTALLATION_TYPE=<managed-api/managed>  make cluster/deploy`

- log in to the console as admin
- navigate Home -> Search and search for the redhat-rhoam-middleware-monitoring-operator. 
- Open redhat-rhoam-middleware-monitoring-operator and navigate Routes -> grafana-route. Follow the link  
- In Grafana for all boards (except Critical SLO summary): Share board -> Export -> View JSON
- Verify that following line `"expr": "count by (stage,version,to_version)(rhoam_version{to_version!=\"\"})",` has a valid installation type (`rhoam_version` or `rhmi_version` depending on your installation type) 