### PR TITLE
WIP Hyperfoil stats script refactor

### DIFF
--- a/scripts/hyperfoil-request-stats.sh
+++ b/scripts/hyperfoil-request-stats.sh
@@ -11,8 +11,11 @@
 
 RUN=$1
 hundred=100
+H1='Accept: application/json'
 
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/all/json | jq . > "Backup.json"
+echo 'Downloading data, this may take awhile...'
+curl -s -H "$H1" ${HYPERFOIL_URL}/run/${RUN}/stats/all | jq . > Backup.json 
+
 
 cat Backup.json | jq '.stats[].total.summary.invalid' > failed.txt
 cat Backup.json | jq '.stats[].total.summary.requestCount' > total.txt

--- a/scripts/hyperfoil-request-stats.sh
+++ b/scripts/hyperfoil-request-stats.sh
@@ -12,15 +12,15 @@
 RUN=$1
 hundred=100
 
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total | jq '.statistics[].summary.invalid' > failed.txt
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total | jq '.statistics[].summary.requestCount' > total.txt
+curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/all/json | jq . > "Backup.json"
 
+cat Backup.json | jq '.stats[].total.summary.invalid' > failed.txt
+cat Backup.json | jq '.stats[].total.summary.requestCount' > total.txt
 
 failed=$(awk '{s+=$1} END {print s}' failed.txt)
 echo 'failed = ' $failed
 total=$(awk '{s+=$1} END {print s}' total.txt)
 echo 'total = ' $total
-
 
 one_percent=$(expr $total / $hundred)
 echo 'one percent = '$one_percent
@@ -35,9 +35,9 @@ echo " "
 echo '==============================================================================================='
 echo '90% Percentile'
 echo " "
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total| jq '.statistics[] | select(.phase | test("steady.")) | select(.metric | test("post.")) | .summary.percentileResponseTime."90.0"' > post-percentile
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total| jq '.statistics[] | select(.phase | test("steady.")) | select(.metric | test("get.")) | .summary.percentileResponseTime."90.0"' > get-percentile
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total| jq '.statistics[] | select(.phase | test("steady.")) | select(.metric | test("create.")) | .summary.percentileResponseTime."90.0"' > login-percentile
+cat Backup.json | jq '.stats[] | select(.phase | test("steady")) | select(.metric| test("post.")) | .total.summary.percentileResponseTime."90.0"' > post-percentile
+cat Backup.json | jq '.stats[] | select(.phase | test("steady")) | select(.metric| test("get.")) | .total.summary.percentileResponseTime."90.0"' > get-percentile
+cat Backup.json | jq '.stats[] | select(.phase | test("steady")) | select(.metric| test("create.")) | .total.summary.percentileResponseTime."90.0"' > login-percentile
 for percentile in post-percentile get-percentile login-percentile
 do
     NoOfEndpoints=$(wc -l ${percentile} | awk '{print $1}')
@@ -46,4 +46,4 @@ do
     max=$(grep -Eo '[0-9]+' ${percentile} | sort -rn | head -n 1)
     echo ${percentile}" Mean = "$mean"ns Max = "$max"ns"
 done
-curl -s ${HYPERFOIL_URL}/run/${RUN}/stats/total | jq '.' > Backup.json
+


### PR DESCRIPTION
# Description
Currently the hyperfoil-requests-stats.sh script uses /run/:runId/stats/total, after a controller restart the cli does not return data for runs before the restart. The endpoint /run/:runId/stats/all will persist data after controller restart.
## Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer