### PR TITLE
Fix rhmi version

### DIFF
--- a/packagemanifests/integreatly-operator/integreatly-operator.package.yaml
+++ b/packagemanifests/integreatly-operator/integreatly-operator.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: integreatly-operator.v2.7.0
+- currentCSV: integreatly-operator.v2.8.0
   name: rhmi
 defaultChannel: rhmi
 packageName: integreatly


### PR DESCRIPTION
# Description
Update version as 2.8.0 was released the day before this file was merged with the operator sdk bump 
