### PR TITLE
test: fix A16: readded sysadmin ImpersonationCfg

### DIFF
--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -50,6 +50,10 @@ func TestAPIs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get start test environment %s", err)
 	}
+	cfg.Impersonate = rest.ImpersonationConfig{
+		UserName: "system:admin",
+		Groups:   []string{"system:authenticated"},
+	}
 
 	// get install type
 	installType, err = common.GetInstallType(cfg)


### PR DESCRIPTION
# Description
https://issues.redhat.com/browse/MGDAPI-525

A16 test was failing when the test container was running on OpenShift due to missing [sysadmin impersonationConfig](https://github.com/integr8ly/integreatly-operator/blob/d600ea4d1b964fa0d351b058dbd86a1bae8d3f9e/test/functional/integreatly_test.go#L15-L18), that was removed during operator-sdk migration

After the config was added back, [the test is passing again](https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Playground/job/psturc-rhoam-master/37/artifact/results/integreatly-operator-test/logs/container.log/*view*/)