### PR TITLE
[MGDAPI-1349] adding prow check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -450,6 +450,10 @@ vendor/fix:
 manifest/prodsec:
 	@./scripts/prodsec-manifest-generator.sh ${TYPE_OF_MANIFEST}
 
+.PHONY: kubebuilder/check
+kubebuilder/check: code/gen
+	git diff --exit-code config/crd/bases
+	git diff --exit-code config/rbac/role.yaml
 
 # # Run tests
 # ENVTEST_ASSETS_DIR = $(shell pwd)/testbin


### PR DESCRIPTION
## What 
added prow check for files generated by the kubebuiler 

## Why 
to check that files were not edited manually 
https://issues.redhat.com/browse/MGDAPI-1349 

## Validation steps 
- modify files in the `config/crd/bases` or `config/rbac/role.yaml` 
- commit your changes
- run `kubebuilder/check`
- ensure check fails (or `echo $?` to get exit code of check) 