### PR TITLE
Fixing 3scale routes warning

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1084,9 +1084,9 @@ func (r *Reconciler) routesExist(ctx context.Context, serverClient k8sclient.Cli
 	}
 
 	if len(routes.Items) >= expectedRoutes {
-		r.log.Warningf("Required number of routes do not exist", l.Fields{"found": len(routes.Items), "required": expectedRoutes})
 		return true, nil
 	}
+	r.log.Warningf("Required number of routes do not exist", l.Fields{"found": len(routes.Items), "required": expectedRoutes})
 	return false, nil
 }
 


### PR DESCRIPTION
# Description
Small change in 3scale reconciler to stop "required number of routes do not exist" warning from triggering as part of MGDAPI-1308 https://issues.redhat.com/browse/MGDAPI-1308

## Type of change
- [:heavy_check_mark: ] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ :heavy_check_mark:] Verified independently on a cluster by reviewer