### PR TITLE
Update Keycloak-metrics-spi

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -227,7 +227,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.1/keycloak-metrics-spi-2.0.1.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.2.0/keycloak-metrics-spi-2.2.0.jar",
 			"https://github.com/integr8ly/authentication-delay-plugin/releases/download/1.0.2/authdelay.jar",
 		}
 		kc.Labels = GetInstanceLabels()

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -274,7 +274,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		owner.AddIntegreatlyOwnerAnnotations(kc, installation)
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.1/keycloak-metrics-spi-2.0.1.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.2.0/keycloak-metrics-spi-2.2.0.jar",
 		}
 		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Labels = getMasterLabels()


### PR DESCRIPTION
# Description
Update Keycloak metrics SPI jar version 

## Verification
1. Install from this branch
2. Confirm RHSSO and UserSSO download this jar by checking the Keycloak pod  extension container logs
3. Run test H07 to verify Keycloak-metrics dashboard shows data 
