### PR TITLE
MGDAPI-1296: Ability to dynamically select GRPc or ConfigMap based installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ COPY templates /templates
 
 COPY manifests /manifests
 
+COPY products /products
+
 COPY build/bin /usr/local/bin
 RUN /usr/local/bin/user_setup
 

--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -13,6 +13,7 @@ COPY vendor ./vendor
 COPY test ./test
 COPY Makefile ./
 COPY manifests/ ./manifests
+COPY products ./products
 
 RUN make test/compile/functional
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,12 +4,15 @@ ENV OPERATOR=/usr/local/bin/rhmi-operator \
     USER_UID=1001 \
     USER_NAME=integreatly-operator \
     TEMPLATE_PATH=/usr/local/bin/templates/monitoring \
-    MANIFEST_DIR=/usr/local/bin/manifests
+    MANIFEST_DIR=/usr/local/bin/manifests \
+    PRODUCT_DECLARATION=/usr/local/bin/products/installation.yaml
 
 # install operator binary
 COPY build/_output/bin/integreatly-operator ${OPERATOR}
 # copy templates
 COPY templates /usr/local/bin/templates
+
+COPY products /usr/local/bin/products
 
 COPY manifests ${MANIFEST_DIR}
 

--- a/pkg/products/amqonline/reconciler_test.go
+++ b/pkg/products/amqonline/reconciler_test.go
@@ -68,6 +68,10 @@ const (
 	defaultNamespace = "amq-online"
 )
 
+var (
+	localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-amq-online")
+)
+
 func basicInstallation() *integreatlyv1alpha1.RHMI {
 	return &integreatlyv1alpha1.RHMI{
 		ObjectMeta: metav1.ObjectMeta{
@@ -248,7 +252,7 @@ func TestReconcile_reconcileAuthServices(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -303,7 +307,7 @@ func TestReconcile_reconcileInfraConfigs(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -351,7 +355,7 @@ func TestReconcile_reconcileAddressPlans(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -399,7 +403,7 @@ func TestReconcile_reconcileAddressSpacePlans(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -445,7 +449,7 @@ func TestReconcile_reconcileServiceAdmin(t *testing.T) {
 
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, s.Installation, s.FakeMPM, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("could not create reconciler %v", err)
 			}
@@ -588,7 +592,7 @@ func TestReconcile_reconcileConfig(t *testing.T) {
 	}
 	for _, s := range scenarios {
 		t.Run(s.Name, func(t *testing.T) {
-			r, err := NewReconciler(s.FakeConfig, nil, nil, s.Recorder, getLogger())
+			r, err := NewReconciler(s.FakeConfig, nil, nil, s.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatal("could not create reconciler", err)
 			}
@@ -745,6 +749,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/amqstreams/reconciler_test.go
+++ b/pkg/products/amqstreams/reconciler_test.go
@@ -33,6 +33,10 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var (
+	localProductDeclaration = *marketplace.LocalProductDeclaration("integreatly-amq-streams")
+)
+
 func basicConfigMock() *config.ConfigReadWriterMock {
 	return &config.ConfigReadWriterMock{
 		ReadAMQStreamsFunc: func() (ready *config.AMQStreams, e error) {
@@ -129,6 +133,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				&localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -218,6 +223,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				&localProductDeclaration,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -374,6 +380,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				&localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -514,6 +521,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				&localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/apicurioregistry/reconciler_test.go
+++ b/pkg/products/apicurioregistry/reconciler_test.go
@@ -29,6 +29,10 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var (
+	localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-apicurio-registry")
+)
+
 func basicConfigMock() *config.ConfigReadWriterMock {
 	return &config.ConfigReadWriterMock{
 		ReadAMQStreamsFunc: func() (ready *config.AMQStreams, e error) {
@@ -139,6 +143,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -226,6 +231,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -345,6 +351,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/apicurito/reconciler_test.go
+++ b/pkg/products/apicurito/reconciler_test.go
@@ -31,6 +31,7 @@ import (
 
 var (
 	defaultOperandNamespace = "apicurito"
+	localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-apicurito")
 )
 
 func TestReconciler_fullReconcile(t *testing.T) {
@@ -159,6 +160,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -234,6 +236,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -56,7 +56,11 @@ type Reconciler struct {
 	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for cloud resources")
+	}
+
 	config, err := configManager.ReadCloudResources()
 	if err != nil {
 		return nil, fmt.Errorf("could not read cloud resources config: %w", err)
@@ -78,7 +82,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		installation:  installation,
 		mpm:           mpm,
 		log:           logger,
-		Reconciler:    resources.NewReconciler(mpm),
+		Reconciler:    resources.NewReconciler(mpm).WithProductDeclaration(*productDeclaration),
 		recorder:      recorder,
 	}, nil
 }
@@ -356,16 +360,20 @@ func (r *Reconciler) reconcileBackupsStorage(ctx context.Context, installation *
 
 func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, inst *integreatlyv1alpha1.RHMI, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
 	target := marketplace.Target{
-		Pkg:       constants.CloudResourceSubscriptionName,
-		Namespace: operatorNamespace,
-		Channel:   marketplace.IntegreatlyChannel,
+		SubscriptionName: constants.CloudResourceSubscriptionName,
+		Namespace:        operatorNamespace,
 	}
-	catalogSourceReconciler := marketplace.NewConfigMapCatalogSourceReconciler(
-		manifestPackage,
+
+	catalogSourceReconciler, err := r.GetProductDeclaration().PrepareTarget(
+		r.log,
 		serverClient,
-		operatorNamespace,
 		marketplace.CatalogSourceName,
+		&target,
 	)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	return r.Reconciler.ReconcileSubscription(
 		ctx,
 		target,

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -56,7 +56,11 @@ type Reconciler struct {
 	log      l.Logger
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, log l.Logger) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, log l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for che")
+	}
+
 	config, err := configManager.ReadCodeReady()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve che config: %w", err)
@@ -78,7 +82,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		installation:  installation,
 		mpm:           mpm,
 		log:           log,
-		Reconciler:    resources.NewReconciler(mpm),
+		Reconciler:    resources.NewReconciler(mpm).WithProductDeclaration(*productDeclaration),
 		recorder:      recorder,
 	}, nil
 }
@@ -611,16 +615,20 @@ func getKeycloakClientSpec(cheURL string) keycloak.KeycloakClientSpec {
 
 func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, inst *integreatlyv1alpha1.RHMI, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
 	target := marketplace.Target{
-		Pkg:       constants.CodeReadySubscriptionName,
-		Namespace: operatorNamespace,
-		Channel:   marketplace.IntegreatlyChannel,
+		SubscriptionName: constants.CodeReadySubscriptionName,
+		Namespace:        operatorNamespace,
 	}
-	catalogSourceReconciler := marketplace.NewConfigMapCatalogSourceReconciler(
-		manifestPackage,
+
+	catalogSourceReconciler, err := r.GetProductDeclaration().PrepareTarget(
+		r.log,
 		serverClient,
-		operatorNamespace,
 		marketplace.CatalogSourceName,
+		&target,
 	)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	return r.Reconciler.ReconcileSubscription(
 		ctx,
 		target,

--- a/pkg/products/codeready/reconciler_test.go
+++ b/pkg/products/codeready/reconciler_test.go
@@ -67,6 +67,8 @@ var testCheCluster = chev1.CheCluster{
 	},
 }
 
+var localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-codeready-workspaces")
+
 func basicConfigMock() *config.ConfigReadWriterMock {
 	return &config.ConfigReadWriterMock{
 		GetOperatorNamespaceFunc: func() string {
@@ -187,6 +189,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				tc.Logger,
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -276,6 +279,7 @@ func TestCodeready_reconcileCluster(t *testing.T) {
 				scenario.FakeMPM,
 				scenario.Recorder,
 				scenario.Logger,
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedError)
@@ -393,6 +397,7 @@ func TestCodeready_reconcileClient(t *testing.T) {
 				scenario.FakeMPM,
 				scenario.Recorder,
 				scenario.Logger,
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != scenario.ExpectedCreateError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedCreateError)
@@ -502,6 +507,7 @@ func TestCodeready_reconcileProgress(t *testing.T) {
 				scenario.FakeMPM,
 				scenario.Recorder,
 				scenario.Logger,
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != scenario.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedError)
@@ -696,6 +702,7 @@ func TestCodeready_fullReconcile(t *testing.T) {
 				scenario.FakeMPM,
 				scenario.Recorder,
 				scenario.Logger,
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != scenario.ExpectedCreateError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, scenario.ExpectedCreateError)

--- a/pkg/products/fuse/reconciler_test.go
+++ b/pkg/products/fuse/reconciler_test.go
@@ -48,6 +48,8 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-fuse-online")
+
 func basicConfigMock() *config.ConfigReadWriterMock {
 	return &config.ConfigReadWriterMock{
 		ReadFuseFunc: func() (ready *config.Fuse, e error) {
@@ -195,6 +197,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -362,6 +365,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -553,6 +557,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.FakeMPM,
 				tc.Recorder,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -72,7 +72,11 @@ func (r *Reconciler) VerifyVersion(installation *integreatlyv1alpha1.RHMI) bool 
 	)
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for marin3r")
+	}
+
 	ns := installation.Spec.NamespacePrefix + defaultInstallationNamespace
 	config, err := configManager.ReadMarin3r()
 	if err != nil {
@@ -96,7 +100,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		installation:  installation,
 		mpm:           mpm,
 		log:           logger,
-		Reconciler:    resources.NewReconciler(mpm),
+		Reconciler:    resources.NewReconciler(mpm).WithProductDeclaration(*productDeclaration),
 		recorder:      recorder,
 	}, nil
 }
@@ -404,16 +408,20 @@ func (r *Reconciler) deleteDiscoveryService(ctx context.Context, client k8sclien
 
 func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
 	target := marketplace.Target{
-		Pkg:       constants.Marin3rSubscriptionName,
-		Namespace: operatorNamespace,
-		Channel:   marketplace.IntegreatlyChannel,
+		SubscriptionName: constants.Marin3rSubscriptionName,
+		Namespace:        operatorNamespace,
 	}
-	catalogSourceReconciler := marketplace.NewConfigMapCatalogSourceReconciler(
-		manifestPackage,
+
+	catalogSourceReconciler, err := r.GetProductDeclaration().PrepareTarget(
+		r.log,
 		serverClient,
-		operatorNamespace,
 		marketplace.CatalogSourceName,
+		&target,
 	)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	return r.Reconciler.ReconcileSubscription(
 		ctx,
 		target,

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -50,6 +50,8 @@ const (
 	mockAlertFromAddress             = "noreply-alert@devshift.org"
 )
 
+var localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-monitoring")
+
 func basicInstallation() *integreatlyv1alpha1.RHMI {
 	return &integreatlyv1alpha1.RHMI{
 		ObjectMeta: metav1.ObjectMeta{
@@ -190,7 +192,7 @@ func TestReconciler_config(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			_, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			_, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
@@ -250,7 +252,7 @@ func TestReconciler_reconcileCustomResource(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
 			}
@@ -456,7 +458,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}
@@ -605,7 +607,7 @@ func TestReconciler_testPhases(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("unexpected error : '%v'", err)
 			}

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+
 	"github.com/pkg/errors"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
@@ -60,9 +61,12 @@ type Reconciler struct {
 	*rhssocommon.Reconciler
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, APIURL string, keycloakClientFactory keycloakCommon.KeycloakClientFactory, logger l.Logger) (*Reconciler, error) {
-	config, err := configManager.ReadRHSSO()
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, APIURL string, keycloakClientFactory keycloakCommon.KeycloakClientFactory, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for RHSSO")
+	}
 
+	config, err := configManager.ReadRHSSO()
 	if err != nil {
 		return nil, err
 	}
@@ -72,7 +76,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	return &Reconciler{
 		Config:     config,
 		Log:        logger,
-		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, APIURL, keycloakClientFactory),
+		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, APIURL, keycloakClientFactory, *productDeclaration),
 	}, nil
 }
 

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -5,10 +5,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"testing"
+
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	configv1 "github.com/openshift/api/config/v1"
-	"testing"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -53,6 +54,7 @@ import (
 
 var (
 	defaultOperatorNamespace = "integreatly-operator"
+	localProductDeclaration  = marketplace.LocalProductDeclaration("integreatly-rhsso")
 )
 
 func basicConfigMock() *config.ConfigReadWriterMock {
@@ -220,6 +222,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.APIURL,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -386,6 +389,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -607,6 +611,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/rhssocommon/reconciler_test.go
+++ b/pkg/products/rhssocommon/reconciler_test.go
@@ -374,6 +374,7 @@ func TestReconciler_handleProgress(t *testing.T) {
 				tc.Recorder,
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
+				*marketplace.LocalProductDeclaration("integreatly-rhsso"),
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -96,7 +96,11 @@ type Reconciler struct {
 	*rhssocommon.Reconciler
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, apiUrl string, keycloakClientFactory keycloakCommon.KeycloakClientFactory, logger l.Logger) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, apiUrl string, keycloakClientFactory keycloakCommon.KeycloakClientFactory, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for user SSO")
+	}
+
 	config, err := configManager.ReadRHSSOUser()
 	if err != nil {
 		return nil, err
@@ -107,7 +111,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	return &Reconciler{
 		Config:     config,
 		Log:        logger,
-		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, apiUrl, keycloakClientFactory),
+		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, apiUrl, keycloakClientFactory, *productDeclaration),
 	}, nil
 }
 

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -52,6 +52,7 @@ import (
 
 var (
 	defaultOperatorNamespace = "integreatly-operator"
+	localProductDeclaration  = marketplace.LocalProductDeclaration("integreatly-rhsso")
 )
 
 func basicConfigMock() *config.ConfigReadWriterMock {
@@ -211,6 +212,7 @@ func TestReconciler_config(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -379,6 +381,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil {
 				t.Fatal("unexpected err ", err)
@@ -602,6 +605,7 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
@@ -828,6 +832,7 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 				tc.ApiUrl,
 				tc.KeycloakClientFactory,
 				getLogger(),
+				localProductDeclaration,
 			)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)

--- a/pkg/products/solutionexplorer/reconciler_test.go
+++ b/pkg/products/solutionexplorer/reconciler_test.go
@@ -26,6 +26,10 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
+var (
+	localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-solution-explorer")
+)
+
 type SolutionExplorerScenario struct {
 	Name            string
 	ExpectErr       bool
@@ -108,7 +112,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			mockResolver := tc.OauthResolver()
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeOauthClient, tc.FakeMPM, mockResolver, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeOauthClient, tc.FakeMPM, mockResolver, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatal("unexpected err setting up reconciler ", err)
 			}
@@ -177,7 +181,7 @@ func TestSolutionExplorer(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeOauthClient, tc.FakeMPM, tc.OauthResolver(), tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeOauthClient, tc.FakeMPM, tc.OauthResolver(), tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil && err.Error() != tc.ExpectedError {
 				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
 			}

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -3,11 +3,12 @@ package threescale
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"testing"
+
 	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	k8sTypes "k8s.io/apimachinery/pkg/types"
-	"net/http"
-	"testing"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	openshiftv1 "github.com/openshift/api/apps/v1"
@@ -48,6 +49,7 @@ import (
 
 var (
 	integreatlyOperatorNamespace = "integreatly-operator-ns"
+	localProductDeclaration      = marketplace.LocalProductDeclaration("integreatly-3scale")
 )
 
 func getBuildScheme() (*runtime.Scheme, error) {
@@ -176,7 +178,7 @@ func TestThreeScale(t *testing.T) {
 				t.Fatalf("Error creating config manager")
 			}
 
-			tsReconciler, err := NewReconciler(configManager, scenario.Installation, scenario.FakeAppsV1Client, scenario.FakeOauthClient, scenario.FakeThreeScaleClient, scenario.MPM, scenario.Recorder, getLogger())
+			tsReconciler, err := NewReconciler(configManager, scenario.Installation, scenario.FakeAppsV1Client, scenario.FakeOauthClient, scenario.FakeThreeScaleClient, scenario.MPM, scenario.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatalf("Error creating new reconciler %s: %v", constants.ThreeScaleSubscriptionName, err)
 			}

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -55,7 +55,11 @@ type Reconciler struct {
 	recorder record.EventRecorder
 }
 
-func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger) (*Reconciler, error) {
+func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
+	if productDeclaration == nil {
+		return nil, fmt.Errorf("no product declaration found for ups")
+	}
+
 	config, err := configManager.ReadUps()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve ups config: %w", err)
@@ -82,7 +86,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		installation:  installation,
 		mpm:           mpm,
 		log:           logger,
-		Reconciler:    resources.NewReconciler(mpm),
+		Reconciler:    resources.NewReconciler(mpm).WithProductDeclaration(*productDeclaration),
 		recorder:      recorder,
 	}, nil
 }
@@ -326,16 +330,20 @@ func preUpgradeBackupExecutor(installation *integreatlyv1alpha1.RHMI) backup.Bac
 
 func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, inst *integreatlyv1alpha1.RHMI, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
 	target := marketplace.Target{
-		Pkg:       constants.UPSSubscriptionName,
-		Namespace: operatorNamespace,
-		Channel:   marketplace.IntegreatlyChannel,
+		SubscriptionName: constants.UPSSubscriptionName,
+		Namespace:        operatorNamespace,
 	}
-	catalogSourceReconciler := marketplace.NewConfigMapCatalogSourceReconciler(
-		manifestPackage,
+
+	catalogSourceReconciler, err := r.GetProductDeclaration().PrepareTarget(
+		r.log,
 		serverClient,
-		operatorNamespace,
 		marketplace.CatalogSourceName,
+		&target,
 	)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	return r.Reconciler.ReconcileSubscription(
 		ctx,
 		target,

--- a/pkg/products/ups/reconciler_test.go
+++ b/pkg/products/ups/reconciler_test.go
@@ -3,8 +3,9 @@ package ups
 import (
 	"context"
 	"errors"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"testing"
+
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 
 	upsv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -29,6 +30,8 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+var localProductDeclaration = marketplace.LocalProductDeclaration("integreatly-unifiedpush")
 
 func getBuildScheme() (*runtime.Scheme, error) {
 	scheme := runtime.NewScheme()
@@ -203,7 +206,7 @@ func TestReconciler_ReconcileCustomResource(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatal("unexpected err settin up reconciler ", err)
 			}
@@ -270,7 +273,7 @@ func TestReconciler_ReconcileHost(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
-			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger())
+			reconciler, err := NewReconciler(tc.FakeConfig, tc.Installation, tc.FakeMPM, tc.Recorder, getLogger(), localProductDeclaration)
 			if err != nil {
 				t.Fatal("unexpected err settin up reconciler ", err)
 			}

--- a/pkg/resources/marketplace/products_installation.go
+++ b/pkg/resources/marketplace/products_installation.go
@@ -1,0 +1,102 @@
+package marketplace
+
+import (
+	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ProductsInstallation contains the declaration of all product operators and
+// how to install them
+type ProductsInstallation struct {
+	Products ProductsDeclaration `yaml:"products"`
+}
+
+type ProductsDeclaration map[string]ProductDeclaration
+
+// ProductDeclaration specifies how to install a product operator, either via
+// local manifests, or an index image
+type ProductDeclaration struct {
+	// Where to install the product from. Either "local", or "index"
+	InstallFrom ProductInstallationSource `yaml:"installFrom"`
+	// If InstallFrom is "local", the directory where the manifests for this
+	// product is stored
+	ManifestsDir *string `yaml:"manifestsDir,omitempty"`
+	// If InstallFrom is "index", the tag of the index image that serves
+	// the manifests
+	Index string `yaml:"index,omitempty"`
+	// Channel to install the product. Defaults to `rhmi`
+	Channel string `yaml:"channel"`
+	// Name of the package that provides the product
+	Package string `yaml:"package,omitempty"`
+}
+
+type ProductInstallationSource string
+
+var ProductInstallationSourceLocal ProductInstallationSource = "local"
+var ProductInstallationSourceIndex ProductInstallationSource = "index"
+
+func LocalProductDeclaration(manifestsPath string) *ProductDeclaration {
+	manifestsDir := fmt.Sprintf("manifests/%s", manifestsPath)
+
+	return &ProductDeclaration{
+		InstallFrom:  ProductInstallationSourceLocal,
+		ManifestsDir: &manifestsDir,
+	}
+}
+
+// ToCatalogSourceReconciler creates a `CatalogSourceReconciler` instance that
+// reconciles the correct CatalogSource using the specification from p
+func (p *ProductDeclaration) ToCatalogSourceReconciler(log logger.Logger, client k8sclient.Client, namespace, catalogSourceName string) (CatalogSourceReconciler, error) {
+	switch p.InstallFrom {
+	case ProductInstallationSourceIndex:
+		return NewGRPCImageCatalogSourceReconciler(p.Index, client, namespace, catalogSourceName, log), nil
+	case ProductInstallationSourceLocal:
+		if p.ManifestsDir == nil {
+			return nil, fmt.Errorf("installation source %s requires manifestsDir", p.InstallFrom)
+		}
+		return NewConfigMapCatalogSourceReconciler(*p.ManifestsDir, client, namespace, catalogSourceName), nil
+	}
+
+	return nil, fmt.Errorf("installation source %s not supported", p.InstallFrom)
+}
+
+// GetChannel returns the channel for the product declared in p. Default to
+// `rhmi` if the field is empty
+func (p *ProductDeclaration) GetChannel() string {
+	if p.Channel == "" {
+		return IntegreatlyChannel
+	}
+
+	return p.Channel
+}
+
+// GetPackage returns the package for the product declared in p, and whether
+// the package was specified or not
+func (p *ProductDeclaration) GetPackage() (string, bool) {
+	return p.Package, p.Package != ""
+}
+
+// PrepareTarget mutates a minimal target to fullfil the installation of the product
+// declared by p, and returns a `CatalogSourceReconciler` instance that reconciles
+// the CatalogSource that provides the product
+func (p *ProductDeclaration) PrepareTarget(log logger.Logger, client k8sclient.Client, catalogSourceName string, target *Target) (CatalogSourceReconciler, error) {
+	catalogSourceReconciler, err := p.ToCatalogSourceReconciler(
+		log, client, target.Namespace, catalogSourceName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	channel := p.GetChannel()
+	pkg, ok := p.GetPackage()
+	if !ok {
+		pkg = target.SubscriptionName
+	}
+
+	target.Channel = channel
+	target.Package = pkg
+
+	return catalogSourceReconciler, nil
+}

--- a/pkg/resources/marketplace/products_installation_loader.go
+++ b/pkg/resources/marketplace/products_installation_loader.go
@@ -1,0 +1,52 @@
+package marketplace
+
+import (
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+var (
+	DefaultProductsInstallationPath = "products/installation.yaml"
+)
+
+// ProductsInstallationLoader knows how to retrieve the ProductsInstallation
+// instance
+type ProductsInstallationLoader interface {
+	GetProductsInstallation() (*ProductsInstallation, error)
+}
+
+type FSProductsInstallationLoader struct {
+	path string
+}
+
+var _ ProductsInstallationLoader = &FSProductsInstallationLoader{}
+
+// NewFSProductInstallationLoader creates a ProductsInstallationLoader instance
+// that retrieves the ProductsInstallation from the file system as a YAML file
+func NewFSProductInstallationLoader(path string) ProductsInstallationLoader {
+	return &FSProductsInstallationLoader{
+		path: path,
+	}
+}
+
+func (l *FSProductsInstallationLoader) GetProductsInstallation() (*ProductsInstallation, error) {
+	file, err := ioutil.ReadFile(l.path)
+	if err != nil {
+		return nil, err
+	}
+
+	productsInstallation := &ProductsInstallation{}
+	err = yaml.Unmarshal(file, productsInstallation)
+
+	return productsInstallation, err
+}
+
+func GetProductsInstallationPath() string {
+	if path, ok := os.LookupEnv("PRODUCT_DECLARATION"); ok {
+		return path
+	}
+
+	return DefaultProductsInstallationPath
+}

--- a/pkg/resources/marketplace/products_installation_test.go
+++ b/pkg/resources/marketplace/products_installation_test.go
@@ -1,0 +1,199 @@
+package marketplace
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestPrepareTarget(t *testing.T) {
+	type assertionFunc func(Target, CatalogSourceReconciler, error) error
+
+	// Utility meta assertions
+	all := func(assertions ...assertionFunc) assertionFunc {
+		return func(t Target, csr CatalogSourceReconciler, e error) error {
+			for _, assertion := range assertions {
+				if err := assertion(t, csr, e); err != nil {
+					return err
+				}
+			}
+
+			return nil
+		}
+	}
+	noError := func(_ Target, _ CatalogSourceReconciler, err error) error {
+		if err != nil {
+			return fmt.Errorf("unexpected error: %v", err)
+		}
+		return nil
+	}
+	targetEquals := func(expected Target) assertionFunc {
+		return func(t Target, _ CatalogSourceReconciler, _ error) error {
+			if !reflect.DeepEqual(t, expected) {
+				return errors.New("mutated target doesn't match expected")
+			}
+
+			return nil
+		}
+	}
+	createsGRPCReconciler := func(image, namespace, csName string) assertionFunc {
+		return func(_ Target, csr CatalogSourceReconciler, _ error) error {
+			r, ok := csr.(*GRPCImageCatalogSourceReconciler)
+			if !ok {
+				return errors.New("unexpected type for CatalogSourceReconciler. Expected GRPCImageCatalogSourceReconciler")
+			}
+
+			if r.Image != image {
+				return fmt.Errorf("unexpected image. Expected %s, got %s", image, r.Image)
+			}
+			if r.Namespace != namespace {
+				return fmt.Errorf("unexpected namespace. Expected %s, got %s", namespace, r.Namespace)
+			}
+			if r.CSName != csName {
+				return fmt.Errorf("unexpected CatalogSource name. Expected %s, got %s", csName, r.CSName)
+			}
+
+			return nil
+		}
+	}
+	createsConfigMapReconciler := func(manifestsDir, namespace, csName string) assertionFunc {
+		return func(_ Target, csr CatalogSourceReconciler, _ error) error {
+			r, ok := csr.(*ConfigMapCatalogSourceReconciler)
+			if !ok {
+				return errors.New("unexpected type for CatalogSourceReconciler. Expected ConfigMapCatalogSourceReconciler")
+			}
+
+			if r.ManifestsProductDirectory != manifestsDir {
+				return fmt.Errorf("unexpected manifests dir. Expected %s, got %s", manifestsDir, r.ManifestsProductDirectory)
+			}
+			if r.Namespace != namespace {
+				return fmt.Errorf("unexpected namespace. Expected %s, got %s", namespace, r.Namespace)
+			}
+			if r.CSName != csName {
+				return fmt.Errorf("unexpected CatalogSource name. Expected %s, got %s", csName, r.CSName)
+			}
+
+			return nil
+		}
+	}
+
+	manifestsDir := func(s string) *string {
+		return &s
+	}
+
+	scenarios := []struct {
+		Name string
+
+		ProductDeclaration ProductDeclaration
+		Target             Target
+		CatalogSourceName  string
+
+		Assertion assertionFunc
+	}{
+		{
+			Name: "Local declaration",
+			ProductDeclaration: ProductDeclaration{
+				InstallFrom:  ProductInstallationSourceLocal,
+				ManifestsDir: manifestsDir("manifests/test"),
+				Channel:      "test-channel",
+				Package:      "test-package",
+			},
+			Target: Target{
+				Namespace:        "test-namespace",
+				SubscriptionName: "test-product",
+			},
+			CatalogSourceName: "test-cs",
+			Assertion: all(
+				noError,
+				targetEquals(Target{
+					Namespace:        "test-namespace",
+					SubscriptionName: "test-product",
+					Package:          "test-package",
+					Channel:          "test-channel",
+				}),
+				createsConfigMapReconciler(
+					"manifests/test",
+					"test-namespace",
+					"test-cs",
+				),
+			),
+		},
+
+		{
+			Name: "Index declaration",
+			ProductDeclaration: ProductDeclaration{
+				InstallFrom: ProductInstallationSourceIndex,
+				Index:       "quay.io/test/index",
+				Channel:     "test-channel",
+				Package:     "test-package",
+			},
+			Target: Target{
+				Namespace:        "test-namespace",
+				SubscriptionName: "test-product",
+			},
+			CatalogSourceName: "test-cs",
+			Assertion: all(
+				noError,
+				targetEquals(Target{
+					Namespace:        "test-namespace",
+					SubscriptionName: "test-product",
+					Package:          "test-package",
+					Channel:          "test-channel",
+				}),
+				createsGRPCReconciler(
+					"quay.io/test/index",
+					"test-namespace",
+					"test-cs",
+				),
+			),
+		},
+
+		{
+			Name: "Default channel and package",
+			ProductDeclaration: ProductDeclaration{
+				InstallFrom: ProductInstallationSourceIndex,
+				Index:       "quay.io/test/index",
+			},
+			Target: Target{
+				Namespace:        "test-namespace",
+				SubscriptionName: "test-product",
+			},
+			CatalogSourceName: "test-cs",
+			Assertion: all(
+				noError,
+				targetEquals(Target{
+					Namespace:        "test-namespace",
+					SubscriptionName: "test-product",
+					// Package is set from SubscriptionName
+					Package: "test-product",
+					// Channel defaults to `rhmi`
+					Channel: "rhmi",
+				}),
+			),
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			// Client should not be used. Empty client will suffice
+			client := fake.NewFakeClient()
+
+			target := &scenario.Target
+
+			csReconciler, err := scenario.ProductDeclaration.PrepareTarget(
+				logger.NewLogger(),
+				client,
+				scenario.CatalogSourceName,
+				target,
+			)
+
+			if assertionError := scenario.Assertion(*target, csReconciler, err); assertionError != nil {
+				t.Fatal(assertionError)
+			}
+		})
+	}
+}

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -317,7 +317,7 @@ func TestNewReconciler_ReconcileSubscription(t *testing.T) {
 			testNamespace := "test-ns"
 			manifestsDirectory := "fakemanifestsdirectory"
 			cfgMapCsReconciler := marketplace.NewConfigMapCatalogSourceReconciler(manifestsDirectory, tc.client, testNamespace, marketplace.CatalogSourceName)
-			status, err := reconciler.ReconcileSubscription(context.TODO(), marketplace.Target{Namespace: testNamespace, Channel: "integreatly", Pkg: tc.SubscriptionName}, []string{testNamespace}, backup.NewNoopBackupExecutor(), tc.client, cfgMapCsReconciler, getLogger())
+			status, err := reconciler.ReconcileSubscription(context.TODO(), marketplace.Target{Namespace: testNamespace, Channel: "integreatly", SubscriptionName: tc.SubscriptionName, Package: tc.SubscriptionName}, []string{testNamespace}, backup.NewNoopBackupExecutor(), tc.client, cfgMapCsReconciler, getLogger())
 			if tc.ExpectErr && err == nil {
 				t.Fatal("expected an error but got none")
 			}

--- a/products/installation.yaml
+++ b/products/installation.yaml
@@ -1,0 +1,104 @@
+# Product declaration file. This file declares the available product operators
+# and how to install them.
+# 
+# Currently supports "local" and "index" installations.
+#
+# ------------------------------------------------------------------------------
+#
+# Local:
+#
+# Install the operator by creating a CatalogSource pointing to manifests
+# from a ConfigMap reconciled from a local directory.
+#
+# Example:
+#
+# ```
+# product:
+#   installFrom: "local"
+#   manifestsDir: "integreatly-product"
+#   channel: "rhmi"
+# ```
+#
+# ------------------------------------------------------------------------------
+#
+# Index:
+#
+# Install the operator by creating a CatalogSource pointing to an index image
+#
+# * Example:
+#
+# ```
+# product:
+#   installFrom: "index"
+#   index: "quay.io/org/product-index:latest"
+#   channel: "alpha"
+# ```
+#
+# ------------------------------------------------------------------------------
+#
+# Common fields:
+# * `channel`: Name of the channel to point the Subscription to. Defaults to "rhmi"
+# * `package`: Name of the package. Defaults to the subscription name of each product
+#
+products:
+  3scale:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-3scale"
+  amqonline:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-amq-online"
+  amqstreams:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-amq-streams"
+  apicurio-registry:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-apicurio-registry"
+  apicurito:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-apicurito"
+  cloud-resources:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-cloud-resources"
+  codeready-workspaces:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-codeready-workspaces"
+  fuse:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-fuse-online"
+  grafana:
+    channel: "rhmi"
+    installFrom: "local"
+    manifestsDir: "integreatly-grafana"
+  marin3r:
+    installFrom: "local"
+    manifestsDir: "integreatly-marin3r"
+    channel: "rhmi"
+  middleware-monitoring:
+    channel: rhmi
+    installFrom: "local"
+    manifestsDir: "integreatly-monitoring"
+  rhsso:
+    installFrom: "local"
+    manifestsDir: "integreatly-rhsso"
+    channel: "rhmi"
+  rhssouser:
+    installFrom: "local"
+    manifestsDir: "integreatly-rhsso"
+    channel: "rhmi"
+  solution-explorer:
+    channel: rhmi
+    installFrom: "local"
+    manifestsDir: "integreatly-solution-explorer"
+  ups:  
+    channel: rhmi
+    installFrom: "local"
+    manifestsDir: "integreatly-unifiedpush"
+  


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-1296

Create `products/installation.yaml` file that declares the product operator installation strategy. Allows to point to either a manifests directory or an index image.

Modify marketplace package to use this file to instantiate the `CatalogSourceReconciler` implementations

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer