### PR TITLE
fix RHMI installation - fetching monitoring secret from hardcoded namespace

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -749,7 +749,7 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 
 	var existingSMTPFromAddress = ""
 	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) {
-		existingSMTPFromAddress, err = resources.GetExistingSMTPFromAddress(ctx, serverClient)
+		existingSMTPFromAddress, err = resources.GetExistingSMTPFromAddress(ctx, serverClient, r.Config.GetOperatorNamespace())
 		if err != nil {
 			if !apiErrors.IsNotFound(err) {
 				r.Log.Error("Error getting application monitoring secret", err)

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1383,7 +1383,12 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 }
 
 func (r *Reconciler) reconcileOutgoingEmailAddress(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-	existingSMTPFromAddress, err := resources.GetExistingSMTPFromAddress(ctx, serverClient)
+	monitoringConfig, err := r.ConfigManager.ReadMonitoring()
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	existingSMTPFromAddress, err := resources.GetExistingSMTPFromAddress(ctx, serverClient, monitoringConfig.GetOperatorNamespace())
 
 	if err != nil {
 		r.log.Error("Error getting smtp_from address from secret alertmanager-application-monitoring", err)

--- a/pkg/resources/smtp.go
+++ b/pkg/resources/smtp.go
@@ -13,14 +13,13 @@ import (
 const (
 	alertManagerConfigSecretFileName = "alertmanager.yaml"
 	alertManagerConfigSecretName     = "alertmanager-application-monitoring"
-	operatorNs                       = "redhat-rhoam-middleware-monitoring-operator"
 )
 
 type alertManagerConfig struct {
 	Global map[string]string `yaml:"global"`
 }
 
-func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client) (string, error) {
+func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client, operatorNs string) (string, error) {
 	amSecret := &corev1.Secret{}
 	err := client.Get(ctx, types.NamespacedName{Name: alertManagerConfigSecretName,
 		Namespace: operatorNs}, amSecret)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
RHMI fails to install due to fetching secret from hardcoded RHOAM namespace  `redhat-rhoam-middleware-monitoring-operator` which is not available in RHMI
```
ERRO[2021-03-11T14:50:53Z] Error getting application monitoring secret   error="secrets \"alertmanager-application-monitoring\" is forbidden: User \"system:serviceaccount:redhat-rhmi-operator:rhmi-operator\" cannot get resource \"secrets\" in API group \"\" in the namespace \"redhat-rhoam-middleware-monitoring-operator\"" product=middleware-monitoring
```
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer