### PR TITLE
Avoid workload-webapp double deployment

### DIFF
--- a/test-cases/tests/alerts/c05a-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
+++ b/test-cases/tests/alerts/c05a-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
@@ -19,6 +19,9 @@ tags:
 
 ## Description
 
+> Note: double-check that the workload webapp is not already deployed before attempting to deploy it.
+> Note: some alerts might fire due to automated tests, these can be safely ignored.
+
 Verify that the RHMI alerts are exposed via Telementry to cloud.redhat.com and that no critical RHMI alerts have fired during lifespan of cluster.
 
 This should be one of the last testcases performed on a cluster to allow for maximum burn-in time on cluster.
@@ -49,8 +52,20 @@ oc get rhmi rhmi -n redhat-rhmi-operator -o json | jq -r .spec.alertingEmailAddr
    > Note: there may be other alerts from the Openshift firing, however for the purposses of this test, it only fails if RHMI alerts are firing here.
 
 5. Check no unexpected alert email notifications were received. Check this when cluster is more than a few hours old, at least 1 day old, and before cluster is deprovisioned.
+
    > If any critical alerts fired during any of these periods:
    >
    > 1. Take screenshots showing the time the alerts fired and when they were resolved
    > 2. Create a followup bug JIRA and inform release coordinators. Example JIRA: https://issues.redhat.com/browse/INTLY-9443
    > 3. Request that cluster lifespan be extended to allow time for cluster to be investigated (ask release coordinator).
+
+6. Open the RHMI Grafana Console in the `redhat-rhmi-middleware-monitoring-operator` namespace
+
+```bash
+echo "https://$(oc get route grafana-route -n redhat-rhmi-middleware-monitoring-operator -o=jsonpath='{.spec.host}')"
+```
+
+7. Select the **Workload App** dashboard
+
+> Verify that **AMQ**, **3scale** and **SSO** are working by checking the **Status** graph.
+> Make sure the proper time interval is selected (you can ignore downtimes during automated tests and destructive test-cases).

--- a/test-cases/tests/alerts/c05b-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
+++ b/test-cases/tests/alerts/c05b-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
@@ -20,6 +20,9 @@ tags:
 
 ## Description
 
+> Note: double-check that the workload webapp is not already deployed before attempting to deploy it.
+> Note: some alerts might fire due to automated tests and destructive test-cases, these can be safely ignored.
+
 Verify that the RHOAM alerts are exposed via Telementry to cloud.redhat.com and that no critical RHOAM alerts have fired during lifespan of cluster.
 
 This should be one of the last testcases performed on a cluster to allow for maximum burn-in time on cluster.
@@ -48,8 +51,20 @@ Testcase should not be performed on a cluster that has been used for destructive
    > Note: there may be other alerts from the Openshift firing, however for the purposses of this test, it only fails if RHOAM alerts are firing here.
 
 5. Check no unexpected alert email notifications were received. Check this when cluster is more than a few hours old, at least 1 day old, and before cluster is deprovisioned.
+
    > If any critical alerts fired during any of these periods:
    >
    > 1. Take screenshots showing the time the alerts fired and when they were resolved
    > 2. Create a followup bug JIRA and inform release coordinators. Example JIRA: https://issues.redhat.com/browse/INTLY-9443
    > 3. Request that cluster lifespan be extended to allow time for cluster to be investigated (ask release coordinator).
+
+6. Open the RHOAM Grafana Console in the `redhat-rhoam-middleware-monitoring-operator` namespace
+
+```bash
+echo "https://$(oc get route grafana-route -n redhat-rhoam-middleware-monitoring-operator -o=jsonpath='{.spec.host}')"
+```
+
+7. Select the **Workload App** dashboard
+
+> Verify that **3scale** and **SSO** are working by checking the **Status** graph.
+> Make sure the proper time interval is selected (you can ignore downtimes during automated tests and destructive test-cases).

--- a/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
+++ b/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
@@ -46,6 +46,8 @@ Measure the downtime of the RHOAM components during a AWS Availability Zone fail
    make local/deploy
    ```
 
+   > Note: do not re-deploy if the workload-web-app is already present in the cluster.
+
 4. Record the pod distribution from 3scale, user-sso, rhsso, marin3r, and middleware-monitoring-operator namespaces using [podsAZ](https://github.com/integr8ly/integreatly-operator/blob/master/scripts/podsAz.sh) script
 
    ```bash

--- a/test-cases/tests/products/h25-verify-rate-limiting-can-be-disabled-and-reenabled-by-follow.md
+++ b/test-cases/tests/products/h25-verify-rate-limiting-can-be-disabled-and-reenabled-by-follow.md
@@ -15,6 +15,8 @@ tags:
 
 ## Description
 
+> Note: double-check that workload webapp is not already deployed before attempting to deploy it.
+
 This test case should prove that it is possible for SRE to disable/enable rate limiting service without affecting the RHOAM services availability
 
 ## Prerequisites

--- a/test-cases/tests/upgrade/n01a-measure-downtime-during-openshift-upgrade.md
+++ b/test-cases/tests/upgrade/n01a-measure-downtime-during-openshift-upgrade.md
@@ -42,6 +42,8 @@ Mesure the downtime of the RHMI components during the OpenShift upgrade (not to 
    make local/deploy
    ```
 
+   > Note: do not re-deploy if the workload-web-app is already present in the cluster.
+
    See step 9 and 10, you might want to do these pre-upgrade as well.
 
 4. In terminal window #2, run the following command to trigger the OpenShift upgrade

--- a/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
+++ b/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
@@ -44,6 +44,8 @@ Mesure the downtime of the RHOAM components during the OpenShift upgrade (not to
    make local/deploy
    ```
 
+   > Note: do not re-deploy if the workload-web-app is already present in the cluster.
+
    See step 9 and 10, you might want to do these pre-upgrade as well.
 
 4. In terminal window #2, run the following command to trigger the OpenShift upgrade

--- a/test-cases/tests/upgrade/n02a-upgrade-rhmi.md
+++ b/test-cases/tests/upgrade/n02a-upgrade-rhmi.md
@@ -42,6 +42,8 @@ Note: If [N09 test case](https://github.com/integr8ly/integreatly-operator/blob/
    make local/deploy
    ```
 
+   > Note: do not re-deploy if the workload-web-app is already present in the cluster
+
    There should be no errors in the command output and product (AMQ, 3scale, SSO) URLS should not be blank. Alternatively, you can check the `Environment` tab in workload-webapp namespace in OpenShift console. See step 8 and 9, you might want to do these pre-upgrade as well.
 
 3. Edit RHMIConfig in the `redhat-rhmi-operator` config to start the upgrade

--- a/test-cases/tests/upgrade/n02b-upgrade-rhoam.md
+++ b/test-cases/tests/upgrade/n02b-upgrade-rhoam.md
@@ -42,6 +42,8 @@ Note: If [N09 test case](https://github.com/integr8ly/integreatly-operator/blob/
    make local/deploy
    ```
 
+   > Note: do not re-deploy if the workload-web-app is already present in the cluster.
+
    There should be no errors in the command output and product (3scale, SSO) URLS should not be blank. Alternatively, you can check the `Environment` tab in workload-webapp namespace in OpenShift console. See step 8 and 9, you might want to do these pre-upgrade as well.
 
 3. Edit RHOAMConfig in the `redhat-rhoam-operator` config to start the upgrade


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

Added note to avoid double deployment of workload-web-app. Also added steps to alerts/c05 testcases to actually use workload-web-app and that alerts firing and downtimes due to automated tests and destructive test cases can be ignored.
