### PR TITLE
MGDAPI-1361: Include scheme in deletion webhook client

### DIFF
--- a/main.go
+++ b/main.go
@@ -187,7 +187,7 @@ func setupWebhooks(mgr ctrl.Manager) error {
 			Type: webhooks.ValidatingType,
 			Path: "/delete-rhmi",
 			Hook: &admission.Webhook{
-				Handler: addon.NewDeleteRHMIHandler(mgr.GetConfig()),
+				Handler: addon.NewDeleteRHMIHandler(mgr.GetConfig(), mgr.GetScheme()),
 			},
 		},
 	})


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-1361

Add the scheme when creating the k8s client that's used to handle requests in the deletion webhook. This is needed to be passed explicitly since the upgrade to operator-sdk v1.x

## Verification steps

1. Prepare the cluster
    ```sh
    INSTALLATION_TYPE=managed-api make cluster/prepare/local
    ```
2. Reproduce the conditions for the webhook to use the client by creating a RHMI CR that won't pass the pre-flight checks.
    ```sh
    INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml
    ```
   * Remove the `useClusterStorage` field from the spec of the created CR
3. Build an image of the operator (the operator needs to run in cluster in order to use the webhooks)
    ```sh
    TAG=1.4.0 ORG=<your quay username> INSTALLATION_TYPE=managed-api make image/build
    ```
4. Push the image
    ```sh
    docker push <tag of your operator image>
    ```
4. Deploy the operator using your image
    ```sh
    cd config/manager && kustomize edit set image controller=<tag of your operator image>
    kustomize build config/redhat-rhoam | oc create -f -
    ```
5. The operator will start running and reconcile the RHMI CR, it will fail the pre-flight checks
6. Delete the RHMI CR and verify that no error occurs.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer