### PR TITLE
Remove patch to CatalogSource in RBAC resource

### DIFF
--- a/config/rbac-rhoam/kustomization.yaml
+++ b/config/rbac-rhoam/kustomization.yaml
@@ -8,11 +8,3 @@ patchesStrategicMerge:
   - patches/leader_election_role_binding.yaml
   # - patches/auth_proxy_role_binding.yaml
   - patches/role_binding.yaml
-
-patchesJSON6902:
-- target:
-    name: manager-role
-    group: rbac.authorization.k8s.io
-    version: v1
-    kind: ClusterRole
-  path: patches/catalogsources.yaml

--- a/config/rbac-rhoam/patches/catalogsources.yaml
+++ b/config/rbac-rhoam/patches/catalogsources.yaml
@@ -1,4 +1,0 @@
-# Set the resourceName to `rhoam-registry-cs` in the catalogsources rule
-- op: replace
-  path: /rules/22/resourceNames/0
-  value: rhoam-registry-cs


### PR DESCRIPTION
# Description

Remove unnecessary patch that renamed the resource `rhmi-registry-cs` to
`rhoam-registry-cs` in RHOAM installations. This is not needed because
the operator always uses `rhmi-registry-cs` regardless of installation
type.

## Verification steps

1. Run `cluster/prepare/local`
    ```sh
    INSTALLATION_TYPE=managed-api make cluster/prepare/local
    ```
2. Check that the role applied to the operator SA references `rhmi-registry-cs`

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer