### PR TITLE
fix 3scale installation with user with uppercase letters

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1557,7 +1557,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	for _, kcUser := range added {
-		user, _ := r.tsClient.GetUser(kcUser.UserName, *accessToken)
+		user, _ := r.tsClient.GetUser(strings.ToLower(kcUser.UserName), *accessToken)
 		// recheck the user is new.
 		// 3scale user may being update during the update phase
 		if user == nil {
@@ -1587,7 +1587,7 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	// update KeycloakUser attribute after user is created in 3scale
 	userCreated3ScaleName := "3scale_user_created"
 	for _, user := range kcu {
-		tsUser, err := r.tsClient.GetUser(user.UserName, *accessToken)
+		tsUser, err := r.tsClient.GetUser(strings.ToLower(user.UserName), *accessToken)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress,
 				fmt.Errorf("failed to get 3scale user with keycloak username %s, err: %s", user.UserName, err)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

3scale username is lowercased when added, so we should lower case KC Username when trying to get 3scale user. Installation may be stuck otherwise by being unable to get 3scale user that should have been added

* https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/threescale/reconciler.go#L1569

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer