### PR TITLE
allow uninstall during installation

### DIFF
--- a/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
+++ b/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	upsv1alpha1 "github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1"
 	monitoring "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	envoyconfigv1 "github.com/3scale/marin3r/apis/marin3r/v1alpha1"
 	discoveryservicev1 "github.com/3scale/marin3r/apis/operator/v1alpha1"
@@ -90,5 +91,6 @@ func init() {
 		envoyconfigv1.SchemeBuilder.AddToScheme,
 		discoveryservicev1.SchemeBuilder.AddToScheme,
 		apiextensionv1beta1.SchemeBuilder.AddToScheme,
+		apiextensionv1.SchemeBuilder.AddToScheme,
 	)
 }


### PR DESCRIPTION
# Description
JIRA: https://issues.redhat.com/browse/MGDAPI-1253
There is a bug that blocks uninstallation if it was triggered during the installation process. It must be a precise time and only on a fresh cluster. 
The reason for this: https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/rhssocommon/reconciler.go#L104-L108
Those lines of code are producing an error `no matches for kind \"KeycloakUser\" in version \"keycloak.org/v1alpha1\`  if there is no Keycloak CRD in a cluster and uninstallation loops. The way to fix it right now is to remove `finalizer.rhsso.integreatly.org` finalized from RHOAM CR 

## Verification steps
For complete verification, there will be two deletions: "traditional" with CRDs created and the "edge case". To make verification easier I propose to modify the code in `pkg/resources/marketplace/manager.go` at the line 86 to be as following: 
```
log.Infof("Creating subscription in ns if it doesn't already exist", l.Fields{"ns": t.Namespace})
if !(t.Namespace == "redhat-rhoam-rhsso-operator") {
	err = serverClient.Create(ctx, sub)
}
```
This change will not proceed the installation with "Edge Case" further than needed. Otherwise, there will be a tight window to trigger an uninstall. 
Additionally, If the "Edge Case" being tested not on the fresh cluster, please, consider running the following command: 
```
 oc delete -f manifests/integreatly-rhsso/12.0.3/ 
```
Otherwise, the uninstallation will never reach the "Edge Case" covered in this PR. 

The "Edge Case" verification: 
1. Install RHOAM: 
```
export INSTALLATION_TYPE=managed-api  
make cluster/prepare/local
SELF_SIGNED_CERTS=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml
make code/run
```
2. Trigger an uninstall when you see the following output: 
```
INFO[2021-03-22T14:45:37Z] Creating subscription in ns if it doesn't already exist  component=marketplace ns=redhat-rhoam-rhsso-operator
```
If you have not modified `manager.go` and the message appeared more then once you would need to run  ` oc delete -f manifests/integreatly-rhsso/12.0.3/ ` and make another attempt to test this change
3. Verify uninstallation succeeds

Traditional Uninstallation 
1. same as before
2. Trigger uninstallation when the `Keycloak` resource appears in the UI search tab (After the second time `Creating subscription in ns if it doesn't already exist` appears during the installation) 
3. Verify installation succeeds 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer