### PR TITLE
Add make cmd for stopping operator running on cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,3 +516,12 @@ packagemanifests: manifests kustomize
 .PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
+
+.PHONY: block-operator-pod
+block-operator-pod:
+	oc patch cm $(shell grep -e "LeaderElectionID" main.go | cut -d '"' -f2) -n $(NAMESPACE) -p '{"metadata":{"annotations": {"control-plane.alpha.kubernetes.io/leader": ""}}}'
+	@echo -e "To restart the operator running on the cluster run:\n\tmake unblock-operator-pod INSTALLATION_TYPE=${INSTALLATION_TYPE}"
+
+.PHONY: unblock-operator-pod
+unblock-operator-pod:
+	oc delete cm $(shell grep -e "LeaderElectionID" main.go | cut -d '"' -f2) -n $(NAMESPACE)


### PR DESCRIPTION
# Description
Adding a new command for blocking the on-cluster operator from reconciling.
Leader election ConfigMap is used for this.
Setting the value to empty will result in parsing error, which will block the leader election logic.
Also, added a command for unblocking the operator (by deleting the ConfigMap).

Related to: https://issues.redhat.com/browse/MGDAPI-1398

**Verification steps:**
Install RHOAM 1.3.0+ on a cluster (with operator running in the cluster)
Run `make block-operator-pod INSTALLATION_TYPE=managed-api`
Verify that operator stopped reconciling (check logs after 1 minute, and after some additional time - e.g. 10mins)
Run `make unblock-operator-pod INSTALLATION_TYPE=managed-api`
Verify that operator is reconciling again


## Type of change
<!-- Please delete options that are not relevant. -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer