### PR TITLE
Add alertmanager config changes

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -97,6 +97,7 @@ rules:
 - apiGroups:
   - config.openshift.io
   resources:
+  - clusterversions
   - infrastructures
   - oauths
   verbs:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -180,7 +180,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=list
 
 // Permission to get cluster infrastructure details for alerting
-// +kubebuilder:rbac:groups=config.openshift.io,resources=infrastructures;oauths,verbs=get;list
+// +kubebuilder:rbac:groups=config.openshift.io,resources=clusterversions;infrastructures;oauths,verbs=get;list
 
 // Permission to remove crd for the marin3r operator upgrade from 0.5.1 to 0.7.0
 // +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=delete;get;list

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -784,7 +784,7 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to fetch cluster infra details for alertmanager config: %w", err)
 	}
 
-	ClusterVersion := &configv1.ClusterVersion{}
+	clusterVersion := &configv1.ClusterVersion{}
 	if err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: clusterIDValue}, ClusterVersion); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to fetch cluster ID details for alertmanager config: %w", err)
 	}

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -785,7 +785,7 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 	}
 
 	clusterVersion := &configv1.ClusterVersion{}
-	if err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: clusterIDValue}, ClusterVersion); err != nil {
+	if err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: clusterIDValue}, clusterVersion); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to fetch cluster ID details for alertmanager config: %w", err)
 	}
 

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -807,7 +807,7 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 		"PagerDutyServiceKey":   pagerDutySecret,
 		"DeadMansSnitchURL":     dmsSecret,
 		"Subject":               fmt.Sprintf(`[%s] {{template "email.default.subject" . }}`, clusterInfra.Status.InfrastructureName),
-		"clusterID":             string(ClusterVersion.Spec.ClusterID),
+		"clusterID":             string(clusterVersion.Spec.ClusterID),
 		"clusterName":           clusterInfra.Status.InfrastructureName,
 		"clusterConsole":        clusterRoute.Spec.Host,
 	})

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -45,6 +45,10 @@ receivers:
   - name: critical
     pagerduty_configs:
       - service_key: {{ index .Params "PagerDutyServiceKey" }}
+        details:
+          cluster_name: {{ index .Params "clusterName" }}
+          cluster_ID: {{ index .Params "clusterID" }}
+          console: {{ index .Params "clusterConsole" }}      
     email_configs:
       - send_resolved: true
         to: {{ index .Params "SMTPToSREAddress" }}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
The PR make changes to add custom details under PagerDuty config in alertmanager template.

**Related JIRA ticket:** https://issues.redhat.com/browse/MGDAPI-1186
**Files updated:** 
- `controllers/rhmi/rhmi_controller.go` ~ add rbac marker to include _clusterversions_ object verbs/permissions.
- `pkg/products/monitoring/reconciler.go` ~ add cluster information parameters (**cluster_name**, **cluster_ID**, **console**) in the `templateUtil` helper function.
- `pkg/products/monitoring/reconciler_test.go` ~ add tests around changes made in the above file.
-  `templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml` ~ add custom details under PagerDuty config to include cluster information passed as params in the _reconciler.go_ file.

## How to Verify

- Install `RHOAM` using this PR branch.
- Confirm that the alertmanager config has this following section:


![am_PD](https://user-images.githubusercontent.com/30499743/112140990-be8e1700-8bfa-11eb-8c14-b29d59136eab.png)

- As a result of the above config changes, any incident triggered in PagerDuty will contain the three new fields as well, in the `custom details` section.
 
![pagerduty_custom_details](https://user-images.githubusercontent.com/30499743/112140532-2132e300-8bfa-11eb-84b0-6be019648c61.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer