### PR TITLE
Added if statement to backup/restore script to handle script being run without aws cli

### DIFF
--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -20,5 +20,4 @@ then
    test_postgres_backup $POSTGRES_CR_NAME $DATABASE_SECRET $AWS_DB_ID $AWS_REGION $NS_PREFIX
 else
     echo "AWS CLI is not installed, test will not be run, please install AWS CLI"
-    exit
 fi

--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -15,7 +15,7 @@ DATABASE_SECRET="rhsso-postgres-$RHMI_CR_NAME"
 
 # Perform the test
 
-if command -v gti > /dev/null
+if command -v aws > /dev/null
 then 
    test_postgres_backup $POSTGRES_CR_NAME $DATABASE_SECRET $AWS_DB_ID $AWS_REGION $NS_PREFIX
 else

--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -14,4 +14,11 @@ POSTGRES_CR_NAME="rhsso-postgres-$RHMI_CR_NAME"
 DATABASE_SECRET="rhsso-postgres-$RHMI_CR_NAME"
 
 # Perform the test
-test_postgres_backup $POSTGRES_CR_NAME $DATABASE_SECRET $AWS_DB_ID $AWS_REGION $NS_PREFIX
+
+if command -v gti > /dev/null
+then 
+   test_postgres_backup $POSTGRES_CR_NAME $DATABASE_SECRET $AWS_DB_ID $AWS_REGION $NS_PREFIX
+else
+    echo "AWS CLI is not installed, test will not be run, please install AWS CLI"
+    exit
+fi


### PR DESCRIPTION
# Description
While testing the functionality of this script, I ran into an issue where after the script had run for some time, it eventually failed due to an AWS error, this is because I did not have the aws cli installed at the time. I have updated the script so that it will abort if it does not detect aws cli, to save time as well as avoid any data being left on the cluster.