### PR TITLE
MGDAPI-1451 - fix total alerts + budget query on critial slo dashboard

### DIFF
--- a/pkg/products/monitoring/dashboardsHelper.go
+++ b/pkg/products/monitoring/dashboardsHelper.go
@@ -5,9 +5,11 @@ import (
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	monitoring "github.com/integr8ly/integreatly-operator/pkg/products/monitoring/dashboards"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
 )
 
 func getSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI) (string, string, error) {
+	installationName := resources.InstallationNames[rhmi.Spec.Type]
 
 	switch dashboard {
 
@@ -29,10 +31,10 @@ func getSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI) (string, 
 	case "cluster-resources":
 		return monitoring.GetMonitoringGrafanaDBClusterResourcesJSON(rhmi.ObjectMeta.Name), "cluster-resources-new.json", nil
 	case "critical-slo-rhmi-alerts":
-		return monitoring.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(rhmi.Spec.NamespacePrefix, rhmi.Spec.Type), "critical-slo-alerts.json", nil
+		return monitoring.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(rhmi.Spec.NamespacePrefix, installationName), "critical-slo-alerts.json", nil
 
 	case "critical-slo-managed-api-alerts":
-		return monitoring.GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(rhmi.Spec.NamespacePrefix, rhmi.Spec.Type), "critical-slo-alerts.json", nil
+		return monitoring.GetMonitoringGrafanaDBCriticalSLOManagedAPIAlertsJSON(rhmi.Spec.NamespacePrefix, installationName), "critical-slo-alerts.json", nil
 
 	case "cro-resources":
 		return monitoring.MonitoringGrafanaDBCROResourcesJSON, "cro-resources.json", nil


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

E04B Test case fails due to Critical SLO total alerts and overal slo % dashboard not reflected due to using `spec.type` instead of product in dashboard query

Jira:
* https://issues.redhat.com/browse/MGDAPI-1451

## Verification
* Check out this branch 
* Run through test case E04B
  * https://issues.redhat.com/browse/MGDAPI-1420
  * Note: grep of number of replica for scaling down keycloak pods in test case may need to be changed to 1 if RHOAM is installed using the `IN_PROW` annotation
* Verify total slo dashboard is now reflected correctly
![Screenshot from 2021-03-23 17-34-30](https://user-images.githubusercontent.com/24636860/112284160-d4deb600-8c80-11eb-85ee-cd24388ea1c9.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer