### PR TITLE
Revert "Add make cmd for stopping operator running on cluster"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -516,12 +516,3 @@ packagemanifests: manifests kustomize
 .PHONY: bundle-build
 bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
-
-.PHONY: block-operator-pod
-block-operator-pod:
-	oc patch cm $(shell grep -e "LeaderElectionID" main.go | cut -d '"' -f2) -n $(NAMESPACE) -p '{"metadata":{"annotations": {"control-plane.alpha.kubernetes.io/leader": ""}}}'
-	@echo -e "To restart the operator running on the cluster run:\n\tmake unblock-operator-pod INSTALLATION_TYPE=${INSTALLATION_TYPE}"
-
-.PHONY: unblock-operator-pod
-unblock-operator-pod:
-	oc delete cm $(shell grep -e "LeaderElectionID" main.go | cut -d '"' -f2) -n $(NAMESPACE)


### PR DESCRIPTION
# Description
This reverts commit a49d8f796e7760ff3bc15e952057fa250a28ca12.
Scaling down the operator deployment seems to work reliably, so there is no need in these make commands.
I don't think anyone started using these commands, so safe to remove.

Related to: https://issues.redhat.com/browse/MGDAPI-1398 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer