### PR TITLE
MDGAPI-1450 - Fix 3scale user updated back to original none lower cased username

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -2003,7 +2003,7 @@ func tsUserIDInKc(tsUser *User, kcUser *keycloak.KeycloakUser) bool {
 
 func kcContainsTs(kcUsers []keycloak.KeycloakAPIUser, tsUser *User) bool {
 	for _, kcu := range kcUsers {
-		if strings.EqualFold(kcu.UserName, tsUser.UserDetails.Username) {
+		if kcu.UserName == tsUser.UserDetails.Username {
 			return true
 		}
 	}
@@ -2013,7 +2013,7 @@ func kcContainsTs(kcUsers []keycloak.KeycloakAPIUser, tsUser *User) bool {
 
 func tsContainsKc(tsusers []*User, kcUser keycloak.KeycloakAPIUser) bool {
 	for _, tsu := range tsusers {
-		if strings.EqualFold(tsu.UserDetails.Username, kcUser.UserName) {
+		if tsu.UserDetails.Username == kcUser.UserName {
 			return true
 		}
 	}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1533,13 +1533,19 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	// can now be added.
 	for _, tsUser := range deleted {
 		if tsUser.UserDetails.Username != *systemAdminUsername {
+			statusCode := http.StatusServiceUnavailable
+
 			res, err := r.tsClient.DeleteUser(tsUser.UserDetails.Id, *accessToken)
-			metrics.SetThreeScaleUserAction(res.StatusCode, strconv.Itoa(tsUser.UserDetails.Id), http.MethodDelete)
 			if err != nil {
 				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale", tsUser.UserDetails.Id), err)
+			} else {
+				statusCode = res.StatusCode
 			}
-			if res.StatusCode != http.StatusOK {
-				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale with status code %d", tsUser.UserDetails.Id, res.StatusCode), errors.New("error on http request"))
+
+			metrics.SetThreeScaleUserAction(statusCode, strconv.Itoa(tsUser.UserDetails.Id), http.MethodDelete)
+
+			if statusCode != http.StatusOK {
+				r.log.Error(fmt.Sprintf("Failed to delete keycloak user %d from 3scale with status code %d", tsUser.UserDetails.Id, statusCode), errors.New("error on http request"))
 			}
 		}
 	}
@@ -1561,16 +1567,15 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	for _, kcUser := range added {
-		user, _ := r.tsClient.GetUser(strings.ToLower(kcUser.UserName), *accessToken)
+		user, _ := r.tsClient.GetUser(kcUser.UserName, *accessToken)
 		// recheck the user is new.
 		// 3scale user may being update during the update phase
 		if user == nil {
-			var statusCode int
-			res, err := r.tsClient.AddUser(strings.ToLower(kcUser.UserName), strings.ToLower(kcUser.Email), "", *accessToken)
+			statusCode := http.StatusServiceUnavailable
+			res, err := r.tsClient.AddUser(kcUser.UserName, strings.ToLower(kcUser.Email), "", *accessToken)
 
 			if err != nil {
 				r.log.Error(fmt.Sprintf("Failed to add keycloak user %s to 3scale", kcUser.UserName), err)
-				statusCode = http.StatusServiceUnavailable
 			} else {
 				statusCode = res.StatusCode
 			}
@@ -1589,9 +1594,43 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 	}
 
 	// update KeycloakUser attribute after user is created in 3scale
+	phase, err := r.updateKeycloakUsersAttributeWith3ScaleUserId(ctx, serverClient, kcu, accessToken)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		return phase, err
+	}
+
+	openshiftAdminGroup := &usersv1.Group{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: "dedicated-admins"}, openshiftAdminGroup)
+	if err != nil && !k8serr.IsNotFound(err) {
+		r.log.Info("Failed to retrieve dedicated admins: " + err.Error())
+		return integreatlyv1alpha1.PhaseInProgress, err
+	}
+	newTsUsers, err := r.tsClient.GetUsers(*accessToken)
+	if err != nil {
+		r.log.Info("Failed to get users: " + err.Error())
+		return integreatlyv1alpha1.PhaseInProgress, err
+	}
+
+	isWorkshop := installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeWorkshop)
+
+	err = syncOpenshiftAdminMembership(openshiftAdminGroup, newTsUsers, *systemAdminUsername, isWorkshop, r.tsClient, *accessToken)
+	if err != nil {
+		r.log.Info("Failed to sync openshift admin membership: " + err.Error())
+		return integreatlyv1alpha1.PhaseInProgress, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) updateKeycloakUsersAttributeWith3ScaleUserId(ctx context.Context, serverClient k8sclient.Client, kcu []keycloak.KeycloakAPIUser, accessToken *string) (integreatlyv1alpha1.StatusPhase, error) {
+	rhssoConfig, err := r.ConfigManager.ReadRHSSO()
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	userCreated3ScaleName := "3scale_user_created"
 	for _, user := range kcu {
-		tsUser, err := r.tsClient.GetUser(strings.ToLower(user.UserName), *accessToken)
+		tsUser, err := r.tsClient.GetUser(user.UserName, *accessToken)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseInProgress,
 				fmt.Errorf("failed to get 3scale user with keycloak username %s, err: %s", user.UserName, err)
@@ -1620,26 +1659,6 @@ func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *
 			return integreatlyv1alpha1.PhaseInProgress,
 				fmt.Errorf("failed to update KeycloakUser CR with %s attribute: %w", userCreated3ScaleName, err)
 		}
-	}
-
-	openshiftAdminGroup := &usersv1.Group{}
-	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: "dedicated-admins"}, openshiftAdminGroup)
-	if err != nil && !k8serr.IsNotFound(err) {
-		r.log.Info("Failed to retrieve dedicated admins: " + err.Error())
-		return integreatlyv1alpha1.PhaseInProgress, err
-	}
-	newTsUsers, err := r.tsClient.GetUsers(*accessToken)
-	if err != nil {
-		r.log.Info("Failed to get users: " + err.Error())
-		return integreatlyv1alpha1.PhaseInProgress, err
-	}
-
-	isWorkshop := installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeWorkshop)
-
-	err = syncOpenshiftAdminMembership(openshiftAdminGroup, newTsUsers, *systemAdminUsername, isWorkshop, r.tsClient, *accessToken)
-	if err != nil {
-		r.log.Info("Failed to sync openshift admin membership: " + err.Error())
-		return integreatlyv1alpha1.PhaseInProgress, err
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -1100,7 +1100,7 @@ func TestReconciler_getUserDiff(t *testing.T) {
 			want2: nil,
 		},
 		{
-			name: "Test - Keycloak User not in 3scale appended to added",
+			name: "Test - Keycloak User not in 3scale appended to added & comparison is case sensitive",
 			fields: fields{
 				ConfigManager: &config.ConfigReadWriterMock{ReadRHSSOFunc: func() (*config.RHSSO, error) {
 					return config.NewRHSSO(config.ProductConfig{
@@ -1119,7 +1119,7 @@ func TestReconciler_getUserDiff(t *testing.T) {
 				},
 				kcUsers: []keycloak.KeycloakAPIUser{
 					{
-						UserName: "NotIn3scale",
+						UserName: "3SCALE",
 					},
 					{
 						UserName: defaultInstallationNamespace,
@@ -1128,14 +1128,14 @@ func TestReconciler_getUserDiff(t *testing.T) {
 			},
 			want: []keycloak.KeycloakAPIUser{
 				{
-					UserName: "NotIn3scale",
+					UserName: "3SCALE",
 				},
 			},
 			want1: nil,
 			want2: nil,
 		},
 		{
-			name: "Test - 3scale User not in Keycloak appended to deleted",
+			name: "Test - 3scale User not in Keycloak appended to deleted & comparison is case sensitive",
 			fields: fields{
 				ConfigManager: &config.ConfigReadWriterMock{ReadRHSSOFunc: func() (*config.RHSSO, error) {
 					return config.NewRHSSO(config.ProductConfig{
@@ -1153,7 +1153,7 @@ func TestReconciler_getUserDiff(t *testing.T) {
 					},
 					{
 						UserDetails: UserDetails{
-							Username: "notInKeyCloak",
+							Username: "3SCALE",
 						},
 					},
 				},
@@ -1173,7 +1173,7 @@ func TestReconciler_getUserDiff(t *testing.T) {
 			want1: []*User{
 				{
 					UserDetails: UserDetails{
-						Username: "notInKeyCloak",
+						Username: "3SCALE",
 					},
 				},
 			},

--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/antchfx/xmlquery"
@@ -126,7 +127,7 @@ func (tsc *threeScaleClient) GetUser(username, accessToken string) (*User, error
 	}
 
 	for _, u := range users.Users {
-		if u.UserDetails.Username == username {
+		if u.UserDetails.Username == strings.ToLower(username) {
 			return u, nil
 		}
 	}
@@ -186,7 +187,7 @@ func (tsc *threeScaleClient) SetFromEmailAddress(emailAddress string, accessToke
 func (tsc *threeScaleClient) AddUser(username string, email string, password string, accessToken string) (*http.Response, error) {
 	data := make(map[string]string)
 	data["access_token"] = accessToken
-	data["username"] = username
+	data["username"] = strings.ToLower(username)
 	data["email"] = email
 	data["password"] = password
 	reqData, err := json.Marshal(data)
@@ -268,7 +269,7 @@ func (tsc *threeScaleClient) SetUserAsMember(userID int, accessToken string) (*h
 func (tsc *threeScaleClient) UpdateUser(userID int, username string, email string, accessToken string) (*http.Response, error) {
 	data, err := json.Marshal(map[string]string{
 		"access_token": accessToken,
-		"username":     username,
+		"username":     strings.ToLower(username),
 		"email":        email,
 	})
 	url := fmt.Sprintf("https://3scale-admin.%s/admin/api/users/%d.json", tsc.wildCardDomain, userID)


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Jira:
* https://issues.redhat.com/browse/MGDAPI-1450
## Type of change

<!-- Please delete options that are not relevant. -->
## Verification
**Note: Requires setting up GIthub IDP and signing in with Github User with uppercase letter in username. Reach out if you don't have one**
* Checkout this branch 
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api  
make cluster/prepare/local
SELF_SIGNED_CERTS=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml
make code/run
```
* Once installed, set up Github IDP on cluster via ocm
* Sign into 3scale as admin using `system-seed` secret credentials
* In incognito tab, sign in to 3scale as github user 
* Verify github username is lowercased
* Promote github user to admin
* As github user, update username to any value
* Verify username is updated back and is **lowercased** 
* Verify admin permissions are **not** reverted

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer