### PR TITLE
set keycloak Update Strategy to Rolling as default

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -251,6 +251,11 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("650m"), corev1.ResourceMemory: k8sresource.MustParse("2G")},
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("650m"), corev1.ResourceMemory: k8sresource.MustParse("2G")},
 		}
+
+		//Set keycloak Update Strategy to Rolling as default
+		//Keycloak operator should make decision based on the image, and can change update strategy
+		kc.Spec.Migration.MigrationStrategy = keycloak.StrategyRolling
+
 		//OSD has more resources than PROW, so adding an exception
 		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)
 

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -39,8 +39,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-
-	appsv1 "github.com/openshift/api/apps/v1"
 )
 
 var (
@@ -306,8 +304,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 
 		//Set keycloak Update Strategy to Rolling as default
 		//Keycloak operator should make decision based on the image, and can change update strategy
-		//kc.Spec.Migration.MigrationStrategy = "rolling"
-		kc.Spec.Migration.MigrationStrategy = keycloak.MigrationStrategy(strings.ToLower(string(appsv1.DeploymentStrategyTypeRolling)))
+		kc.Spec.Migration.MigrationStrategy = keycloak.StrategyRolling
 
 		//OSD has more resources than PROW, so adding an exception
 		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -39,6 +39,8 @@ import (
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	appsv1 "github.com/openshift/api/apps/v1"
 )
 
 var (
@@ -304,7 +306,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 
 		//Set keycloak Update Strategy to Rolling as default
 		//Keycloak operator should make decision based on the image, and can change update strategy
-		kc.Spec.Migration.MigrationStrategy = "rolling"
+		//kc.Spec.Migration.MigrationStrategy = "rolling"
+		kc.Spec.Migration.MigrationStrategy = keycloak.MigrationStrategy(strings.ToLower(string(appsv1.DeploymentStrategyTypeRolling)))
 
 		//OSD has more resources than PROW, so adding an exception
 		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -301,6 +301,11 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("750m"), corev1.ResourceMemory: k8sresource.MustParse("1500Mi")},
 			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("1500m"), corev1.ResourceMemory: k8sresource.MustParse("1500Mi")},
 		}
+
+		//Set keycloak Update Strategy to Rolling as default
+		//Keycloak operator should make decision based on the image, and can change update strategy
+		kc.Spec.Migration.MigrationStrategy = "rolling"
+
 		//OSD has more resources than PROW, so adding an exception
 		numberOfReplicas := r.Config.GetReplicasConfig(r.Installation)
 		if kc.Spec.Instances < numberOfReplicas {


### PR DESCRIPTION
# Description
- Fix of Keyckloak Update Strategy, to avoid downtime.  https://issues.redhat.com/browse/MGDAPI-1386

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

## Verification - Manual Test Procedure
[Test_MGDAPI-1386-Fix_UpdateStrategy_v2.zip](https://github.com/integr8ly/integreatly-operator/files/6272368/Test_MGDAPI-1386-Fix_UpdateStrategy_v2.zip)

## Issue and fix brief description
### Before fix 
  * Rolling upgrade is not working for keycloak in Openshift project redhat-rhoam-user-sso.  
  * It cause downtime of SSO / keycloak - around 2 mins.

### After fix 
  * Rolling upgrade is working correctly for keycloak in Openshift project redhat-rhoam-user-sso.  
  * No downtime. Keycloak Pods are replaced to new version according to Rolling Update Strategy.

## Testing Procedure

### Initial test and environment preparation

*  Create Openshift Dedicated Cluster
*  Configure Keycloak to have 3 replicas

### Run integreately operator:
```
$ pwd
.../integr8ly/integreatly-operator
```
```
$ INSTALLATION_TYPE=managed-api make cluster/prepare/local
$ INSTALLATION_TYPE=managed-api IN_PROW=true USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml
$ INSTALLATION_TYPE=managed-api make code/run
```
*  Check that all keycloak pods are running.
*  *Checking projects redhat-rhoam-user-sso and redhat-rhoam-rhsso. Details below are for redhat-rhoam-user-sso* 
```
$ oc get pod
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          96m
keycloak-1   1/1     Running   0          87m
keycloak-2   1/1     Running   0          85m
```

### Create new manifest
  We will create new manifest that using different keycloak-operator image version, as in sample below:

* Create new manifest dir by duplication of latest available manifest dir:   *integreatly-operator/manifests/integreatly-rhsso/12.0.3 and rename it to *12.0.4*.  
* Rename and update file ***integreatly-operator/manifests/integreatly-rhsso/12.0.4/keycloak-operator.v12.0.4.clusterserviceversion.yaml*** as in following example:  
  - Previous (12.0.3) installation used keycloak-operator image version 12.0.3.  
  - Will use keycloak-operator image version 12.0.1 for test new installation 12.0.4.  
*The change of the image should cause pods update.*

*integreatly-operator/manifests/integreatly-rhsso/12.0.4/keycloak-operator.v12.0.4.clusterserviceversion.yaml* fragments:
```
apiVersion: operators.coreos.com/v1alpha1
kind: ClusterServiceVersion
metadata:
  annotations:
    ....
    containerImage: 'quay.io/keycloak/keycloak-operator:12.0.1'
    description: 'An Operator for installing and managing Keycloak'
    repository: 'https://github.com/keycloak/keycloak-operator'
....
  name: keycloak-operator.v12.0.4
  namespace: placeholder
spec:
  apiservicedefinitions: {}
  customresourcedefinitions:
......
  displayName: Keycloak Operator
....
  install:
    spec:
      deployments:
        - name: keycloak-operator
          spec:
            ....
              spec:
                containers:
                  - command:
....
                    image: quay.io/keycloak/keycloak-operator:12.0.1
                    imagePullPolicy: Always
                    name: keycloak-operator
                    resources: {}
                serviceAccountName: keycloak-operator
      permissions:
.....
  version: 12.0.4
  replaces: keycloak-operator.v12.0.3
```

* Update file ***integr8ly/integreatly-operator/manifests/integreatly-rhsso/rhsso.package.yaml***
Set ***currentCSV***
```
packageName: rhmi-rhsso
channels:
  - name: rhmi
    currentCSV: keycloak-operator.v12.0.4
```

### Rerun Integreatly Operator  
*If operator running locally - cancel it , and rerun*

```
$^CtrlC
$ INSTALLATION_TYPE=managed-api make code/run
```

### Check Keycloak pods update behavior  

**Expecting results**:  Rolling update, without downtime.  
Rolling update should appear similar to following example:
```
$ oc project
Using project "redhat-rhoam-user-sso" on server ....
$ oc get pod
NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          96m
keycloak-1   1/1     Running   0          87m
keycloak-2   1/1     Running   0          85m

[vmogilev@vmogilev 12.0.6]$ oc get pod -w
\NAME         READY   STATUS    RESTARTS   AGE
keycloak-0   1/1     Running   0          97m
keycloak-1   1/1     Running   0          88m
keycloak-2   1/1     Running   0          86m
keycloak-2   1/1     Terminating   0          87m
keycloak-2   0/1     Terminating   0          87m
keycloak-2   0/1     Terminating   0          87m
keycloak-2   0/1     Terminating   0          87m
keycloak-2   0/1     Pending       0          0s
keycloak-2   0/1     Pending       0          0s
keycloak-2   0/1     Init:0/1      0          0s
keycloak-2   0/1     Init:0/1      0          2s
keycloak-2   0/1     PodInitializing   0          4s
keycloak-2   0/1     Running           0          5s
keycloak-2   1/1     Running           0          60s
keycloak-1   1/1     Terminating       0          89m
keycloak-1   0/1     Terminating       0          89m
keycloak-1   0/1     Terminating       0          89m
keycloak-1   0/1     Terminating       0          89m
keycloak-1   0/1     Pending           0          0s
keycloak-1   0/1     Pending           0          0s
....
....

$ oc get all
NAME             READY   STATUS    RESTARTS   AGE
pod/keycloak-0   1/1     Running   0          4s
pod/keycloak-1   1/1     Running   0          105s
pod/keycloak-2   1/1     Running   0          2m52s

$oc get csv
NAME                        DISPLAY            VERSION           REPLACES                      PHASE
keycloak-operator.v12.0.4   Keycloak Operator  12.0.4            keycloak-operator.v12.0.3     Succeeded
```

### Explore at StatefulSet ***statefulset.apps/keycloak*** .   
The configuration will contain Rolling update strategy, as in example below:
```
$ oc get statefulset.apps/keycloak -oyaml |less
kind: StatefulSet
apiVersion: apps/v1
metadata:
  selfLink: /apis/apps/v1/namespaces/redhat-rhoam-user-sso/statefulsets/keycloak
  name: keycloak
.....
  managedFields:
    - manager: keycloak-operator
      operation: Update
....
      fieldsV1:
        'f:metadata':
....                    
          'f:updateStrategy':
            'f:rollingUpdate':
.....      
  podManagementPolicy: OrderedReady
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      partition: 0
  revisionHistoryLimit: 10
status:
  observedGeneration: 3
  replicas: 3
  readyReplicas: 3
  currentReplicas: 3
  updatedReplicas: 3
  currentRevision: keycloak-95d45fd99
  updateRevision: keycloak-95d45fd99
  collisionCount: 0
```
***Similar test and verification was done for project redhat-rhoam-rhsso***

### Test Analyses
As we could see in described test procedure steps:
* Keycloack pods update was produced with Rolling Strategy
* No downtime.


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer