### PR TITLE
fix potential nil pointers when logging

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -260,8 +260,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.reconcileAlertManagerConfigSecret(ctx, serverClient)
 	r.Log.Infof("ReconcileAlertManagerConfigSecret", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		if err != nil {
+			r.Log.Warning("failed to reconcile alert manager config secret " + err.Error())
+		}
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alert manager config secret", err)
-		r.Log.Warning("failed to reconcile alert manager config secret " + err.Error())
 		return phase, err
 	}
 
@@ -275,7 +277,9 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.reconcileDashboards(ctx, serverClient)
 	r.Log.Infof("reconcileDashboards", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		r.Log.Warning("Failure reconciling dashboards " + err.Error())
+		if err != nil {
+			r.Log.Warning("Failure reconciling dashboards " + err.Error())
+		}
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile dashboards", err)
 		return phase, err
 	}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1479,7 +1479,9 @@ func (r *Reconciler) reconcileRHSSOIntegration(ctx context.Context, serverClient
 			"published":                         "true",
 		}, *accessToken)
 		if err != nil || res.StatusCode != http.StatusCreated {
-			r.log.Info("Failed to add authentication provider:" + err.Error())
+			if err != nil {
+				r.log.Info("Failed to add authentication provider:" + err.Error())
+			}
 			return integreatlyv1alpha1.PhaseInProgress, err
 		}
 	}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
There can be potential nil pointer when calling `err.Error()` for logging in certain conditional blocks that can cause a panic 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Validation
* `e2e` and `rhoam-e2e` prow tests should pass 

## Checklist
- [ ] Verified independently on a cluster by reviewer