### PR TITLE
SKU metric

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1113,16 +1113,10 @@ func (r *RHMIReconciler) processSKU(installation *rhmiv1alpha1.RHMI, namespace s
 
 	// if both are empty it's the first round of installation
 	// or if the secretname is not the same as what the SKU is marked there has been a change
-	// so set toSKU and update the status object
+	// so set toSKU and update the status object and set isSKUpdated to true
 	if (installation.Status.ToSKU == "" && installation.Status.SKU == "") ||
 		skuParam != installation.Status.SKU {
-		installation.Status.ToSKU = installationSKU.GetName()
-	}
-
-	// if the secret is different to what's currently set in SKU there has been an update
-	// OR there is a TOSKU value in the cr, which can happen if a second sku change is made before the operator reaches
-	// the end of the reconcile on a first sku change where it resets the SKU and to sku values
-	if skuParam != installation.Status.SKU || installation.Status.ToSKU != "" {
+		installation.Status.ToSKU = skuParam
 		isSKUUpdated = true
 	}
 

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -342,6 +342,8 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	// Check for stage complete to avoid setting the metric when installation is happening
 	if string(installation.Status.Stage) == "complete" {
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
+
+		metrics.SetActiveSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
 	}
 
 	alertsClient, err := k8sclient.New(r.mgr.GetConfig(), k8sclient.Options{
@@ -410,10 +412,12 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		if installation.Spec.RebalancePods {
 			r.reconcilePodDistribution(installation)
 		}
+
 		if installation.Spec.Type == string(rhmiv1alpha1.InstallationTypeManagedApi) {
 			if installationSKU.IsUpdated() {
 				installation.Status.SKU = installationSKU.GetName()
 				installation.Status.ToSKU = ""
+				metrics.SetActiveSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
 			}
 		}
 	}

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -316,6 +316,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		if err = r.Status().Update(context.TODO(), installation); err != nil {
 			return ctrl.Result{}, err
 		}
+		metrics.SetSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
 	}
 
 	// either not checked, or rechecking preflight checks

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -343,7 +343,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	if string(installation.Status.Stage) == "complete" {
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 
-		metrics.SetActiveSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
+		metrics.SetSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
 	}
 
 	alertsClient, err := k8sclient.New(r.mgr.GetConfig(), k8sclient.Options{
@@ -417,7 +417,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 			if installationSKU.IsUpdated() {
 				installation.Status.SKU = installationSKU.GetName()
 				installation.Status.ToSKU = ""
-				metrics.SetActiveSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
+				metrics.SetSKU(string(installation.Status.Stage), installation.Status.SKU, installation.Status.ToSKU)
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -58,7 +58,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.ThreeScaleUserAction)
-	customMetrics.Registry.MustRegister(integreatlymetrics.ActiveSKU)
+	customMetrics.Registry.MustRegister(integreatlymetrics.SKU)
 	integreatlymetrics.OperatorVersion.Add(1)
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/main.go
+++ b/main.go
@@ -58,6 +58,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.ThreeScaleUserAction)
+	customMetrics.Registry.MustRegister(integreatlymetrics.ActiveSKU)
 	integreatlymetrics.OperatorVersion.Add(1)
 
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -102,7 +102,7 @@ var (
 		},
 	)
 
-	ActiveSKU = prometheus.NewGaugeVec(
+	SKU = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "active_sku",
 			Help: "Status of the current sku config",
@@ -158,7 +158,7 @@ func ResetThreeScaleUserAction() {
 	ThreeScaleUserAction.Reset()
 }
 
-func SetActiveSKU(stage string, sku string, toSKU string) {
-	ActiveSKU.Reset()
-	ActiveSKU.WithLabelValues(stage, sku, toSKU).Set(float64(1))
+func SetSKU(stage string, sku string, toSKU string) {
+	SKU.Reset()
+	SKU.WithLabelValues(stage, sku, toSKU).Set(float64(1))
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -101,6 +101,18 @@ var (
 			"action",
 		},
 	)
+
+	ActiveSKU = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "active_sku",
+			Help: "Status of the current sku config",
+		},
+		[]string{
+			"stage",
+			"sku",
+			"toSKU",
+		},
+	)
 )
 
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
@@ -144,4 +156,9 @@ func SetThreeScaleUserAction(httpStatus int, username, action string) {
 
 func ResetThreeScaleUserAction() {
 	ThreeScaleUserAction.Reset()
+}
+
+func SetActiveSKU(stage string, sku string, toSKU string) {
+	ActiveSKU.Reset()
+	ActiveSKU.WithLabelValues(stage, sku, toSKU).Set(float64(1))
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -104,7 +104,7 @@ var (
 
 	SKU = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "active_sku",
+			Name: "rhoam_sku",
 			Help: "Status of the current sku config",
 		},
 		[]string{

--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string 
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}

--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string 
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string 
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			}, 
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			},
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			},
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string 
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string 
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			},
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string 
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			},
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -29,6 +29,22 @@ func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
+			},
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Active SKU",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,sku,toSKU",
+				"tags": "",
+				"titleFormat": "Active SKU",
+				"type": "tags",
+				"useValueForTime": false
 			}
 		]
 	},

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -33,7 +33,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,sku,toSKU)(active_sku{toSKU!=\"\"})",
+				"expr": "count by (stage,sku,toSKU)(rhoam_sku{toSKU!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -37,12 +37,12 @@ func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,
-				"name": "Active SKU",
+				"name": "SKU",
 				"showIn": 0,
 				"step": "",
 				"tagKeys": "stage,sku,toSKU",
 				"tags": "",
-				"titleFormat": "Active SKU",
+				"titleFormat": "SKU Change (million per day)",
 				"type": "tags",
 				"useValueForTime": false
 			}


### PR DESCRIPTION
# Description
Added a new metric for the currrent SKU configuration for RHOAM. The metric stores the current config, and if the config is changing what it is changing to. This metric also has an annotation in Grafana so when the SKU config is changed it can be seen in Grafana.

## Type of change
- [x] New feature (non-breaking change which adds functionality)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

## Verify
- Install RHOAM based on an image with new changes (ask me for image details)
   - Run make cluster/deploy with IMAGE_FORMAT set to the image details I will supply
   - Run make cluster/prepare/sku to create the sku secret in the operator namespace
- Change the SKU configuration
   - Select a value to change the sku value to. Any value that 'name' is set to in the sku-config config map in the operator namespace is a valid entry.
   - Run make cluster/prepare/sku again with a QUOTA set to the new sku value (5 should work fine).
- Verify that the annotation appears on Grafana by checking a dashboard

![image](https://user-images.githubusercontent.com/45426048/114553311-6aa4aa00-9c5d-11eb-9a27-cf9a7a11c7ad.png)



