### PR TITLE
Removed references to non-existent redhat-rhoam-customer-monitoring namespace

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -71,7 +71,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		return nil, fmt.Errorf("no product declaration found for grafana")
 	}
 
-	ns := installation.Spec.NamespacePrefix + defaultInstallationNamespace
+	ns := installation.Spec.NamespacePrefix + defaultInstallationNamespace + "-operator"
 	config, err := configManager.ReadGrafana()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve grafana config: %w", err)
@@ -81,11 +81,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		configManager.WriteConfig(config)
 	}
 	if config.GetOperatorNamespace() == "" {
-		if installation.Spec.OperatorsInProductNamespace {
-			config.SetOperatorNamespace(config.GetNamespace())
-		} else {
-			config.SetOperatorNamespace(config.GetNamespace() + "-operator")
-		}
+		config.SetOperatorNamespace(config.GetNamespace())
 	}
 
 	return &Reconciler{


### PR DESCRIPTION
# Description
The PR removes references to a non-existent namespace from the grafana reconciler to fix an OLM Operator Pod Error.

**Related JIRA ticket:** https://issues.redhat.com/browse/INTLY-10561

## How to Verify

- Install RHOAM using this PR branch.
- Confirm that the OLM operator pod is no longer logging the error: "no target CSV for namespace redhat-rhoam-customer-monitoring".
- Confirm that the customer grafana is still working as expected.


## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)

