### PR TITLE
fix in the logic which was causing cr to not be udpated

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1108,16 +1108,10 @@ func (r *RHMIReconciler) processSKU(installation *rhmiv1alpha1.RHMI, namespace s
 
 	// if both are empty it's the first round of installation
 	// or if the secretname is not the same as what the SKU is marked there has been a change
-	// so set toSKU and update the status object
+	// so set toSKU and update the status object and set isSKUpdated to true
 	if (installation.Status.ToSKU == "" && installation.Status.SKU == "") ||
 		skuParam != installation.Status.SKU {
-		installation.Status.ToSKU = installationSKU.GetName()
-	}
-
-	// if the secret is different to what's currently set in SKU there has been an update
-	// OR there is a TOSKU value in the cr, which can happen if a second sku change is made before the operator reaches
-	// the end of the reconcile on a first sku change where it resets the SKU and to sku values
-	if skuParam != installation.Status.SKU || installation.Status.ToSKU != "" {
+		installation.Status.ToSKU = skuParam
 		isSKUUpdated = true
 	}
 


### PR DESCRIPTION
# Description


## Verification

Install the operator using the following steps:

`INSTALLATION_TYPE=managed-api make cluster/prepare `
`INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
`INSTALLATION_TYPE=managed-api make code/run `

Verify that the toSKU value is set on initial install.


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer