### PR TITLE
MGDAPI-1429 - H03 & H07 test - wait for dedicated admin user to become 3scale admin

### DIFF
--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -14,6 +14,7 @@ COPY test ./test
 COPY Makefile ./
 COPY manifests/ ./manifests
 COPY products ./products
+COPY version ./version
 
 RUN make test/compile/functional
 

--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -11,6 +11,8 @@ COPY controllers/ controllers/
 COPY pkg ./pkg
 COPY vendor ./vendor
 COPY test ./test
+COPY manifests ./manifests
+COPY version ./version
 COPY Makefile ./
 RUN make test/compile/osde2e
 

--- a/test/common/3Scale_user_promotion.go
+++ b/test/common/3Scale_user_promotion.go
@@ -49,8 +49,10 @@ func Test3ScaleUserPromotion(t TestingTB, ctx *TestingContext) {
 
 	err = loginToThreeScale(t, host, dedicatedAdminUser, DefaultPassword, TestingIDPRealm, httpClient)
 	if err != nil {
-		t.Skip("Skipping due to known flaky behavior error, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/MGDAPI-936", err)
+		t.Fatalf("Failed to log into 3Scale: %v", err)
 	}
+
+	waitForUserToBecome3ScaleAdmin(t, ctx, host, threescaleLoginUser)
 
 	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectUrl, httpClient, ctx.Client, t)
 
@@ -99,7 +101,6 @@ func loginTo3ScaleAsDeveloper(t TestingTB, user string, host string, ctx *Testin
 
 	err = loginToThreeScale(t, host, user, DefaultPassword, TestingIDPRealm, httpClient)
 	if err != nil {
-		// t.Fatalf("Failed to log into 3Scale: %v", err)
-		t.Skip("Skipping due to known flaky behavior error, to be fixed ASAP.\nJIRA: https://issues.redhat.com/browse/MGDAPI-936", err)
+		t.Fatalf("Failed to log into 3Scale: %v", err)
 	}
 }

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -234,8 +234,7 @@ func sendTestEmail(ctx *TestingContext, t TestingTB) {
 	// Login to 3Scale
 	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
-		t.Skip("Skipping due to known flaky behavior, to be fixed ASAP.\nJIRA:  https://issues.redhat.com/browse/MGDAPI-558")
-		// t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
+		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
 	}
 
 	// Make sure 3Scale is available

--- a/test/common/authdelay_first_broker_login.go
+++ b/test/common/authdelay_first_broker_login.go
@@ -66,8 +66,7 @@ func TestAuthDelayFirstBrokerLogin(t TestingTB, ctx *TestingContext) {
 
 	err = loginToThreeScale(t, tsHost, testUser.UserName, DefaultPassword, TestingIDPRealm, httpClient)
 	if err != nil {
-		// t.Fatalf("[%s] error logging in to three scale: %v ", getTimeStampPrefix(), err)
-		t.Skipf("[%s] error logging in to three scale: %v Jira https://issues.redhat.com/browse/MGDAPI-525", getTimeStampPrefix(), err)
+		t.Fatalf("[%s] error logging in to three scale: %v ", getTimeStampPrefix(), err)
 	}
 }
 

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -68,15 +68,14 @@ var (
 	IDP_BASED_TESTS = []TestSuite{
 		{
 			[]TestCase{
-				/*FLAKY*/ {"A16 - Custom first broker login flow", TestAuthDelayFirstBrokerLogin},
+				{"A16 - Custom first broker login flow", TestAuthDelayFirstBrokerLogin},
 				{"B03 - Verify RHMI Developer User Permissions are Correct", TestRHMIDeveloperUserPermissions},
-				{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
-				/*FLAKY*/ {"H03 - Verify 3scale CRUDL permissions", Test3ScaleCrudlPermissions},
-				/*FLAKY*/ {"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
-				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
-				/*FLAKY*/ {"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
-				// Test that causes H03 and H07 to fail - being investigated in https://issues.redhat.com/browse/MGDAPI-557
 				{"B04 - Verify Dedicated Admin User Permissions are Correct", TestDedicatedAdminUserPermissions},
+				{"B06 - Verify users with no email get default email", TestDefaultUserEmail},
+				{"H03 - Verify 3scale CRUDL permissions", Test3ScaleCrudlPermissions},
+				{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
+				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
+				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
 		},


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

H03 & H07 can be flaky if B04 is ran beforehand. Likely cause that that by running B04 first, there can be a small window in which the dedicated admin users used in the tests are not promoted to 3scale admins before the tests is ran.

To fix this we should wait for the dedicated admin user to be an admin before running the tests H03 and H07. This should allow B04 to be run before these tests again and ideally the IDP tests can be run in a randomised fashion without any failures

Jira:
* https://issues.redhat.com/browse/MGDAPI-1439

## Test Runs
* [idp_random.log](https://github.com/integr8ly/integreatly-operator/files/6319366/idp_random.log)
* [idp_ordered.log](https://github.com/integr8ly/integreatly-operator/files/6319368/idp_ordered.log)

## Validation
* PR `e2e` and `rhoam-e2e` prow tests passed
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api 
make cluster/prepare/local
IN_PROW=true make deploy/integreatly-rhmi-cr.yml
make code/run
```
* Verify IDP tests passes in specified order
```
export INSTALLATION_TYPE=managed-api 
TEST="IDP" make test/e2e/single 
```
* Verify IDP tests passes in randomised order
```
# Remove IDP setup from tests
oc patch oauth cluster  --type=json -p='[{"op" : "remove", "path" : "/spec/identityProviders/1"}]'
oc delete user --all
oc delete identity --all
oc delete keycloakuser --all -n redhat-rhoam-user-sso
oc delete keycloakuser --all -n redhat-rhoam-rhsso
oc delete keycloakclient testing-idp-client -n redhat-rhoam-rhsso
oc delete keycloakrealm testing-idp -n redhat-rhoam-rhsso

# Run IDP tests randomized
export WATCH_NAMESPACE=redhat-rhoam-operator; go clean -testcache && go test ./test/functional -test.v -ginkgo.v -ginkgo.progress -timeout=80m -ginkgo.randomizeAllSpecs -ginkgo.focus="IDP.*"
```
## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Test fix (non-breaking change which fixes an issue)

## Checklist
- [ ] Verified independently on a cluster by reviewer