### PR TITLE
Add custom alertmanager go template to enhance email config

### DIFF
--- a/pkg/products/monitoring/templateHelper.go
+++ b/pkg/products/monitoring/templateHelper.go
@@ -33,6 +33,18 @@ func NewTemplateHelper(extraParams map[string]string) *TemplateHelper {
 		Params: extraParams,
 	}
 
+	templatePath := GetTemplatePath()
+
+	return &TemplateHelper{
+		Parameters:   param,
+		TemplatePath: templatePath,
+	}
+}
+
+// Validate if the "templates/monitoring" directory exists in the
+// filesystem & if yes, returns the same as a string
+func GetTemplatePath() string {
+
 	templatePath := "./templates/monitoring"
 	if _, err := os.Stat(templatePath); os.IsNotExist(err) {
 		templatePath = "../../../templates/monitoring"
@@ -43,11 +55,7 @@ func NewTemplateHelper(extraParams map[string]string) *TemplateHelper {
 			}
 		}
 	}
-
-	return &TemplateHelper{
-		Parameters:   param,
-		TemplatePath: templatePath,
-	}
+	return templatePath
 }
 
 // Takes a list of strings, wraps each string in double quotes and joins them

--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -4,6 +4,10 @@ global:
   smtp_from: {{ index .Params "SMTPFrom" }}
   smtp_auth_username: {{ index .Params "SMTPUsername" }}
   smtp_auth_password: {{ index .Params "SMTPPassword"}}
+
+templates:
+  - /etc/alertmanager/config/alertmanager-email-config.tmpl
+
 route:
   group_wait: 30s
   group_interval: 5m
@@ -42,18 +46,21 @@ receivers:
         to: {{ index .Params "SMTPToSREAddress" }}
         headers:
           Subject: '{{ index .Params "Subject" }}'
+        html: '{{ index .Params "html" }}'
   - name: critical
     pagerduty_configs:
       - service_key: {{ index .Params "PagerDutyServiceKey" }}
+        description: '{{ index .Params "Subject" }}'
         details:
           cluster_name: {{ index .Params "clusterName" }}
           cluster_ID: {{ index .Params "clusterID" }}
-          console: {{ index .Params "clusterConsole" }}      
+          console: {{ index .Params "clusterConsole" }}
     email_configs:
       - send_resolved: true
         to: {{ index .Params "SMTPToSREAddress" }}
         headers:
           Subject: '{{ index .Params "Subject" }}'
+        html: '{{ index .Params "html" }}'
   - name: deadmansswitch
     webhook_configs:
       - url: {{ index .Params "DeadMansSnitchURL" }}
@@ -63,18 +70,21 @@ receivers:
         to: '{{ index .Params "SMTPToBUAddress" }}'
         headers:
           Subject: '{{ index .Params "Subject" }}'
+        html: '{{ index .Params "html" }}'
   - name: BUandCustomer
     email_configs:
       - send_resolved: True
         to: '{{ index .Params "SMTPToBUAddress" }}, {{ index .Params "SMTPToCustomerAddress" }}'
         headers:
           Subject: '{{ index .Params "Subject" }}'
+        html: '{{ index .Params "html" }}'
   - name: SRECustomerBU
     email_configs:
       - send_resolved: True
         to: '{{ index .Params "SMTPToSREAddress" }}, {{ index .Params "SMTPToBUAddress" }}, {{ index .Params "SMTPToCustomerAddress" }}'
         headers:
           Subject: '{{ index .Params "Subject" }}'
+        html: '{{ index .Params "html" }}'
 inhibit_rules:
   - source_match:
       alertname: 'JobRunningTimeExceeded'

--- a/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
+++ b/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
@@ -1,0 +1,193 @@
+{{ define "__alertmanager" }}Alertmanager{{ end }}
+{{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}{{ end }}
+
+{{/* custom subject template */}}
+{{ define "__intlysubject" }}
+	
+	{{/* declaring variables */}}
+	{{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
+
+  {{/* checking if there is single or multiple alerts */}}
+	{{if eq $lenOfAlerts 1 }} 
+		[{{ $clustername }}] {{ .CommonLabels.alertname  }} ({{ .CommonLabels.severity | title }}) {{ .Status | title }}{{ if eq .Status "firing" }}{{ end }}
+	{{ else }}
+		{{if gt $lenOfAlerts 1 }} 
+			{{ $alertname = "Multiple Alerts*" }}
+			{{ if eq .CommonLabels.severity "critical" }} 
+				{{ $ifCritical = "true" }}
+			{{ else }}
+				{{ $severity = ( .CommonLabels.severity ) }} 
+			{{ end }}
+		{{ end }}
+	{{ end }}
+
+	{{/* in case of multiple alerts, checking if the severity of any alert(s) is critical*/}}
+	{{ if eq $alertname "Multiple Alerts*" }}
+		{{ if eq $ifCritical "true" }} 
+			[{{ $clustername }}] {{ $alertname }} (Critical) {{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
+		{{ else }}
+			[{{ $clustername }}] {{ $alertname }} ({{ $severity | title }}) {{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
+		{{ end }}
+	{{ end }}
+{{ end }}
+
+{{ define "__description" }}{{ end }}
+ 
+{{ define "__text_alert_list" }}{{ range . }}Labels:
+{{ range .Labels.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Annotations:
+{{ range .Annotations.SortedPairs }} - {{ .Name }} = {{ .Value }}
+{{ end }}Source: {{ .GeneratorURL }}
+{{ end }}{{ end }}
+
+{{ define "email.integreatly.subject" }}{{ template "__intlysubject" . }}{{ end }}
+{{ define "email.integreatly.html" }}
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<!--
+Style and HTML derived from https://github.com/mailgun/transactional-email-templates
+
+
+The MIT License (MIT)
+
+Copyright (c) 2014 Mailgun
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns="http://www.w3.org/1999/xhtml" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<head style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+<meta name="viewport" content="width=device-width" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+<title style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">{{ template "__subject" . }}</title>
+
+</head>
+
+<body itemscope="" itemtype="http://schema.org/EmailMessage" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; -webkit-font-smoothing: antialiased; -webkit-text-size-adjust: none; height: 100%; line-height: 1.6em; width: 100% !important; background-color: #f6f6f6; margin: 0; padding: 0;" bgcolor="#f6f6f6">
+
+<table style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; background-color: #f6f6f6; margin: 0;" bgcolor="#f6f6f6">
+  <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+    <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+    <td width="600" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; display: block !important; max-width: 600px !important; clear: both !important; width: 100% !important; margin: 0 auto; padding: 0;" valign="top">
+      <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; max-width: 600px; display: block; margin: 0 auto; padding: 0;">
+        <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; border-radius: 3px; background-color: #fff; margin: 0; border: 1px solid #e9e9e9;" bgcolor="#fff">
+          <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 16px; vertical-align: top; color: #fff; font-weight: 500; text-align: center; border-radius: 3px 3px 0 0; background-color: #E6522C; margin: 0; padding: 20px;" align="center" bgcolor="#E6522C" valign="top">
+              {{ .Alerts | len }} alert{{ if gt (len .Alerts) 1 }}s{{ end }} for {{ range .GroupLabels.SortedPairs }}
+                {{ .Name }}={{ .Value }}
+              {{ end }}
+            </td>
+          </tr>
+          <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+            <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 10px;" valign="top">
+              <table width="100%" cellpadding="0" cellspacing="0" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <a href="{{ template "__alertmanagerURL" . }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #FFF; text-decoration: none; line-height: 2em; font-weight: bold; text-align: center; cursor: pointer; display: inline-block; border-radius: 5px; text-transform: capitalize; background-color: #348eda; margin: 0; border-color: #348eda; border-style: solid; border-width: 10px 20px;">View in {{ template "__alertmanager" . }}</a>
+                  </td>
+                </tr>
+
+                {{ if gt (len .Alerts.Firing) 0 }}
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">[{{ .Alerts.Firing | len }}] Firing</strong>
+                  </td>
+                </tr>
+                {{ end }}
+
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Cluster</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    name = ${CLUSTER_NAME}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    id = ${CLUSTER_ID}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    <a href="${CLUSTER_CONSOLE}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Console</a><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                  </td>
+                </tr>
+
+                {{ range .Alerts.Firing }}
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    {{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    <a href="{{ .GeneratorURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                  </td>
+                </tr>
+                {{ end }}
+
+                {{ if gt (len .Alerts.Resolved) 0 }}
+                  {{ if gt (len .Alerts.Firing) 0 }}
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    <hr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    <br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                  </td>
+                </tr>
+                  {{ end }}
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">[{{ .Alerts.Resolved | len }}] Resolved</strong>
+                  </td>
+                </tr>
+                {{ end }}
+                {{ range .Alerts.Resolved }}
+                <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+                  <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0; padding: 0 0 20px;" valign="top">
+                    <strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Labels</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                    {{ range .Labels.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    {{ if gt (len .Annotations) 0 }}<strong style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">Annotations</strong><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    {{ range .Annotations.SortedPairs }}{{ .Name }} = {{ .Value }}<br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />{{ end }}
+                    <a href="{{ .GeneratorURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; color: #348eda; text-decoration: underline; margin: 0;">Source</a><br style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;" />
+                  </td>
+                </tr>
+                {{ end }}
+              </table>
+            </td>
+          </tr>
+        </table>
+
+        <div style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; width: 100%; clear: both; color: #999; margin: 0; padding: 20px;">
+          <table width="100%" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+            <tr style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; margin: 0;">
+              <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; vertical-align: top; text-align: center; color: #999; margin: 0; padding: 0 0 20px;" align="center" valign="top"><a href="{{ .ExternalURL }}" style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 12px; color: #999; text-decoration: underline; margin: 0;">Sent by {{ template "__alertmanager" . }}</a></td>
+            </tr>
+          </table>
+        </div></div>
+    </td>
+    <td style="font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif; box-sizing: border-box; font-size: 14px; vertical-align: top; margin: 0;" valign="top"></td>
+  </tr>
+</table>
+
+</body>
+</html>
+
+{{ end }}
+
+{{ define "pushover.default.title" }}{{ template "__subject" . }}{{ end }}
+{{ define "pushover.default.message" }}{{ .CommonAnnotations.SortedPairs.Values | join " " }}
+{{ if gt (len .Alerts.Firing) 0 }}
+Alerts Firing:
+{{ template "__text_alert_list" .Alerts.Firing }}
+{{ end }}
+{{ if gt (len .Alerts.Resolved) 0 }}
+Alerts Resolved:
+{{ template "__text_alert_list" .Alerts.Resolved }}
+{{ end }}
+{{ end }}
+{{ define "pushover.default.url" }}{{ template "__alertmanagerURL" . }}{{ end }}


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->

The PR make changes to add a custom alertmanager go template (as a second data item in the `alertmanager-application-monitoring` secret). The new custom go template is aiming to enhance the pre-existing email configuration.

**Related JIRA ticket:**  https://issues.redhat.com/browse/MGDAPI-1580
**Files updated:**
- `pkg/products/monitoring/reconciler.go`
- `pkg/products/monitoring/reconciler_test.go`
- `pkg/products/monitoring/templateHelper.go`
- `templates/monitoring/alertmanager/alertmanager-email-config.tmpl` ~ **(New alertmanager custom go template)**
- `templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml` 

# Steps to verify changes

- Install `RHOAM` using this PR branch.
- Verify the following fields in the alertmanager config:
    -  email configs: 
        - `Subject: '{{template "email.integreatly.subject" . }}'`
        - `html: '{{ template "email.integreatly.html" . }}'`
    -  pagerduty configs: 
        - `description: '{{template "email.integreatly.subject" . }}'`
        - `cluster_ID: <cluster-id>`
        - `cluster_name: <cluster-name>`
        - `console: <console-url>`
        - `grafana: <grafana-url>`        
    - And finally at the bottom of the config, verify if the external custom template is linked properly
        ```
        templates:
        - /etc/alertmanager/config/alertmanager-email-config.tmpl
        ```        
- Verify all unit tests defined under the `pkg/products/monitoring/...` are passing:
   command: ~ `go test -v -coverprofile cover.out ./pkg/products/monitoring/...`

![custom_email_config](https://user-images.githubusercontent.com/30499743/115020470-4274af80-9ed8-11eb-9771-312d0d2c3212.png)
![custom_email_template](https://user-images.githubusercontent.com/30499743/115020535-591b0680-9ed8-11eb-8cbb-580445db182f.png)

- The final result of the above changes would look like:
    - **In Email:**
     
        Following is the new email subject format:

            1. For single alert: 
                   [cluster_name] alert_name (alert_severity) Firing | Resolved
           
                   For example: 
                      [psaggu-stage-2865n] ThreeScaleContainerHighMemory (Critical) Firing
                      [psaggu-stage-2865n] ThreeScaleContainerHighMemory (Critical) Resolved
           
           2. For multiple alerts clumped by alertmanager 
                  [cluster_name] Multiple Alerts* (alert_serverity) Firing | Resolved
           
                  For example:
                     [psaggu-stage-2865n] Multiple Alerts* (Critical) Firing
                     [psaggu-stage-2865n] Multiple Alerts* (Critical) Resolved

    ![email_subject_template](https://user-images.githubusercontent.com/30499743/115020803-b4e58f80-9ed8-11eb-8046-bb8d8130f83e.png)  
    ![email_html_template](https://user-images.githubusercontent.com/30499743/115020659-8667b480-9ed8-11eb-8ef5-f06757ffc4d0.png)
  
    - **In PagerDuty:**
    ![pagerduty](https://user-images.githubusercontent.com/30499743/115021060-173e9000-9ed9-11eb-97f3-ab88e6f26c9c.png)




## Type of change

<!-- Please delete options that are not relevant. -->

- [X] New feature (non-breaking change which adds functionality)

## Checklist
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have added a test case that will be used to verify my changes 
- [X] Verified independently on a cluster by reviewer