### PR TITLE
MGDAPI-1463: Update OSDe2e useClusterStorage

### DIFF
--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -29,7 +29,7 @@ var (
 
 //PreTest This tests if an installation of Managed-API or RHMI was finished and is successful
 func PreTest(t common.TestingTB, ctx *common.TestingContext) {
-	err := wait.Poll(time.Second*15, time.Minute*60, func() (done bool, err error) {
+	err := wait.Poll(time.Second*15, time.Minute*70, func() (done bool, err error) {
 		rhmi, err := getRHMI(ctx.Client)
 		if err != nil {
 			t.Fatalf("error getting RHMI CR: %v", err)

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -29,7 +29,7 @@ var (
 
 //PreTest This tests if an installation of Managed-API or RHMI was finished and is successful
 func PreTest(t common.TestingTB, ctx *common.TestingContext) {
-	err := wait.Poll(time.Second*15, time.Minute*40, func() (done bool, err error) {
+	err := wait.Poll(time.Second*15, time.Minute*60, func() (done bool, err error) {
 		rhmi, err := getRHMI(ctx.Client)
 		if err != nil {
 			t.Fatalf("error getting RHMI CR: %v", err)
@@ -44,12 +44,12 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 		}
 
 		// Patch RHMI CR CR with cluster storage
-		if rhmi.Spec.UseClusterStorage == "false" || rhmi.Spec.UseClusterStorage == "" {
+		if rhmi.Spec.UseClusterStorage == "true" || rhmi.Spec.UseClusterStorage == "" {
 			rhmiCR := fmt.Sprintf(`{
 				"apiVersion": "integreatly.org/v1alpha1",
 				"kind": "RHMI",
 				"spec": {
-					"useClusterStorage" : "true"
+					"useClusterStorage" : "false"
 				}
 			}`)
 


### PR DESCRIPTION
# What
Updated useClusterStorage in pre-test.go from true to false to better emulate a production environment.

# Verification
### Prerequisites

- Access to a BYOC cluster with 2x c5.2xlarge nodes
- osde2e repo forked and cloned
### Steps

- Generate a new integreatly-operator test-harness image with the changes from this PR and push to your quay repo with tag osde2e, alternatively you can use mine which is linked in the script below.
- Create an sh script in the root folder of your cloned osde2e repo with the following content:
```shell 
#!/usr/bin/env bash
make build

OSD_ENV="stage" \
CLUSTER_ID="Your BYOC cluster id" \
OCM_TOKEN="Your OCM Token" \
ADDON_IDS="managed-api-service" \
ADDON_PARAMETERS='{"managed-api-service":{"cidr-range": "10.1.0.0/26"}}' \
ADDON_TEST_HARNESSES="quay.io/jkiely/integreatly-operator-test-harness:osde2e" \
POLLING_TIMEOUT="10000" \
SECRET_LOCATIONS="/usr/local/osde2e-common,/usr/local/integr8ly-ci-secrets" \
MUST_GATHER="false" \
SKIP_CLUSTER_HEALTH_CHECKS="true" \
./out/osde2e test --configs "addon-suite","aws","stage" --skip-health-check
```
This script will mimic the openshift release config file for running the tests, substitute any placeholder values for your values.
- Run this script and verify that the tests complete successfully by logging into the cluster console and looking at the logs of the osde2e pod.