### PR TITLE
Remove the IN_PROW annotation from RHMI sample

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -410,9 +410,11 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/INSTALLATION_PREFIX/$(INSTALLATION_PREFIX)/g" | \
 	sed "s/INSTALLATION_SHORTHAND/$(INSTALLATION_SHORTHAND)/g" | \
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
-	sed "s/IN_PROW/'$(IN_PROW)'/g" | \
 	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > config/samples/integreatly-rhmi-cr.yml
+	# Workaround until in_prow annotation can be removed from prow
+	yq w -i config/samples/integreatly-rhmi-cr.yml metadata.annotations.in_prow "IN_PROW"
+	$(SED_INLINE) "s/IN_PROW/'$(IN_PROW)'/g" config/samples/integreatly-rhmi-cr.yml
 	@-oc create -f config/samples/integreatly-rhmi-cr.yml
 
 .PHONY: prepare-patch-release

--- a/Makefile
+++ b/Makefile
@@ -410,7 +410,6 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/INSTALLATION_PREFIX/$(INSTALLATION_PREFIX)/g" | \
 	sed "s/INSTALLATION_SHORTHAND/$(INSTALLATION_SHORTHAND)/g" | \
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
-	sed "s/IN_PROW/'$(IN_PROW)'/g" | \
 	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > config/samples/integreatly-rhmi-cr.yml
 	@-oc create -f config/samples/integreatly-rhmi-cr.yml

--- a/Makefile
+++ b/Makefile
@@ -410,6 +410,7 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/INSTALLATION_PREFIX/$(INSTALLATION_PREFIX)/g" | \
 	sed "s/INSTALLATION_SHORTHAND/$(INSTALLATION_SHORTHAND)/g" | \
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
+	sed "s/IN_PROW/'$(IN_PROW)'/g" | \
 	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > config/samples/integreatly-rhmi-cr.yml
 	@-oc create -f config/samples/integreatly-rhmi-cr.yml

--- a/config/samples/integreatly-rhmi-cr.yaml
+++ b/config/samples/integreatly-rhmi-cr.yaml
@@ -2,8 +2,6 @@ apiVersion: integreatly.org/v1alpha1
 kind: RHMI
 metadata:
   name: INSTALLATION_NAME
-  annotations:
-    in_prow: IN_PROW
 spec:
   type: INSTALLATION_TYPE
   namespacePrefix: INSTALLATION_PREFIX-


### PR DESCRIPTION
# Description
Removed the IN_PROW annotation from the RHMI CR sample and removed reference to IN_PROW from Makefile because it wont be needed after the SKU work is completed.

**JIRA Ticket:** https://issues.redhat.com/browse/MGDAPI-1472

## Verify
- Checkout this branch
- Run the relevant make command: `make deploy/integreatly-rhmi-cr.yml`
- Confirm that the generated sample, config/samples/integreatly-rhmi-cr.yml, doesn't have the in_prow annotation