### PR TITLE
fix: Renamed label to use limit in customer dashboard

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -358,7 +358,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit string) string {
           "expr": "$perMinuteRequestsPerUnit",
           "instant": false,
           "interval": "30s",
-          "legendFormat": "Hard Limit - ` + requestsPerUnit + ` per minute",
+          "legendFormat": "Limit - ` + requestsPerUnit + ` per minute",
           "refId": "B"
         }
       ],


### PR DESCRIPTION
# Description
With the addition of the dynamic sku configuration the idea of hard limits and soft limits are removed meaning relabeling the annotation to use limit.

Ticket:  https://issues.redhat.com/browse/MGDAPI-1602

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Verify
You can check the change [here](https://grafana-route-redhat-rhoam-customer-monitoring-operator.apps.jd.i5vz.s1.devshift.org/d/66ab72e0d012aacf34f907be9d81cd9e/rate-limiting?orgId=1&refresh=1m) on my cluster. Log into `jd` and click the link.

- Install Rhoam on a cluster
- Go the the customer dashboard in grafana
   - Go to grafana route exposed in *redhat-rhoam-customer-monitoring-operator*
   - Go to customer dashboard in the rate limiting folder
- Verify that the annotation on the graph displays `Limit` and not `Hard-Limit`

![Screenshot from 2021-04-23 11-19-55](https://user-images.githubusercontent.com/45426048/115857796-0f757300-a426-11eb-987c-8487884cd01a.png)


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer