### PR TITLE
add QUOTA env to operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,3 +103,5 @@ test/*.json
 # Kubernetes Generated files - skip generated files, except for vendored files
 
 !vendor/**/zz_generated.*
+
+test-cases/package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ OPERATOR_SDK_VERSION=1.2.0
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "$(QUAY_PASSWORD)"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 IN_PROW ?= "false"
-QUOTA ?= "1"
+DEV_QUOTA ?= "1"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker
@@ -358,7 +358,7 @@ cluster/prepare/dms:
 
 .PHONY: cluster/prepare/quota
 cluster/prepare/quota:
-	@-oc process -n $(NAMESPACE) QUOTA=$(QUOTA) -f config/secrets/quota-secret.yaml | oc apply -f -
+	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) -f config/secrets/quota-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/delorean
 cluster/prepare/delorean: cluster/prepare/delorean/pullsecret

--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -138,6 +138,7 @@ var (
 	DefaultOriginPullSecretNamespace = "openshift-config"
 
 	EnvKeyAlertSMTPFrom = "ALERT_SMTP_FROM"
+	EnvKeyQuota         = "QUOTA"
 )
 
 // RHMISpec defines the desired state of RHMI

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,4 +59,6 @@ spec:
           # this should be set for production and development via MT repo
           - name: ALERT_SMTP_FROM
             value: "default@test.com"
+          - name: QUOTA
+            value: "20"
       terminationGracePeriodSeconds: 10

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	"os"
 	"reflect"
@@ -308,7 +309,9 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	installationQuota := &quota.Quota{}
 	if installation.Spec.Type == string(rhmiv1alpha1.InstallationTypeManagedApi) {
 		if err = r.processQuota(installation, request.Namespace, installationQuota); err != nil {
-			log.Error("Error while processing the Quota", err)
+			eventRecorder := r.mgr.GetEventRecorderFor("rhmi-controller")
+			events.HandleError(eventRecorder, installation, rhmiv1alpha1.PhaseFailed, "Error while processing the Quota", err)
+			installation.Status.LastError = err.Error()
 			if err = r.Status().Update(context.TODO(), installation); err != nil {
 				return ctrl.Result{}, err
 			}
@@ -1127,22 +1130,32 @@ func (r *RHMIReconciler) processQuota(installation *rhmiv1alpha1.RHMI, namespace
 	isQuotaUpdated := false
 	quotaParam, found, err := addon.GetStringParameterByInstallType(context.TODO(), r.Client, rhmiv1alpha1.InstallationTypeManagedApi, namespace, addon.QuotaParamName)
 	if err != nil {
-		return errors.Wrap(err, "Error checking for Quota secret")
+		return fmt.Errorf("error checking for quota secret %w", err)
 	}
 
-	//!found means the param wasn't found so we want to default rather than return
-	//if the param is not found after the installation is 1 minute old it means that it wasn't provided to the installation
-	//a quota value is required for the installation to begin, the dev value is provided by the make cluster/prepare/quota for local installs
-	//or as a required value from an ocm add-on installation
-	if !found && !installation.ObjectMeta.CreationTimestamp.Time.Before(time.Now().Add(-(1 * time.Minute))) {
-		return errors.Wrap(err, "no quota value provided, quota is a required parameter for a managed-api install")
+	// if !found or the param is found but empty and installation is less than one minute old, return an error
+	// to stop the installation until either the installation is older than 1 minute or a paramater is found
+	if (!found || quotaParam == "") && installation.ObjectMeta.CreationTimestamp.Time.After(time.Now().Add(-(1 * time.Minute))) {
+		return fmt.Errorf("waiting for quota parameter for 1 minute after creation of cr")
 	}
 
-	// get a configmap from the cluster
+	// if the param is not found after the installation is 1 minute old it means that it wasn't provided to the installation
+	// in this case check for an Environment Variable QUOTA
+	// if neither are found then return an error as there is no QUOTA value for the installation to use and it's required by the reconcilers.
+	if (!found || quotaParam == "") && installation.ObjectMeta.CreationTimestamp.Time.Before(time.Now().Add(-(1 * time.Minute))) {
+		log.Info(fmt.Sprintf("no secret param found after one minute so falling back to env var '%s' for sku value", rhmiv1alpha1.EnvKeyQuota))
+		quotaValue, exists := os.LookupEnv(rhmiv1alpha1.EnvKeyQuota)
+		if !exists || quotaValue == "" {
+			return fmt.Errorf("no quota value provided by add on parameter '%s' or by env var '%s'", addon.QuotaParamName, rhmiv1alpha1.EnvKeyQuota)
+		}
+		quotaParam = quotaValue
+	}
+
+	// get the quota config map from the cluster
 	cm := &corev1.ConfigMap{}
 	err = r.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: quota.ConfigMapName}, cm)
 	if err != nil {
-		return errors.Wrap(err, "Error getting quota config map")
+		return fmt.Errorf("error getting quota config map %w", err)
 	}
 
 	// if both are toQuota and Quota are empty this indicates that it's either
@@ -1160,6 +1173,5 @@ func (r *RHMIReconciler) processQuota(installation *rhmiv1alpha1.RHMI, namespace
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/pkg/addon/quota.go
+++ b/pkg/addon/quota.go
@@ -66,15 +66,13 @@ var quotaConfig string = `
 	"ratelimit": {
 			"replicas": 3,
 			"resources": {
-				"resources": {
-					"requests": {
-						"cpu": 0.15,
-						"memory": "50Mi"
-					},
-					"limits": {
-						"cpu": 0.3,
-						"memory": "100Mi"
-					}
+				"requests": {
+					"cpu": 0.15,
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu": 0.3,
+					"memory": "100Mi"
 				}
 			}
 		}
@@ -143,15 +141,13 @@ var quotaConfig string = `
 	"ratelimit": {
 			"replicas": 3,
 			"resources": {
-				"resources": {
-					"requests": {
-						"cpu": 0.10,
-						"memory": "50Mi"
-					},
-					"limits": {
-						"cpu": 0.20,
-						"memory": "100Mi"
-					}
+				"requests": {
+					"cpu": 0.10,
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu": 0.20,
+					"memory": "100Mi"
 				}
 			}
 		}
@@ -220,15 +216,13 @@ var quotaConfig string = `
 	"ratelimit": {
 			"replicas": 3,
 			"resources": {
-				"resources": {
-					"requests": {
-						"cpu": 0.05,
-						"memory": "50Mi"
-					},
-					"limits": {
-						"cpu": 0.15,
-						"memory": "100Mi"
-					}
+				"requests": {
+					"cpu": 0.05,
+					"memory": "50Mi"
+				},
+				"limits": {
+					"cpu": 0.15,
+					"memory": "100Mi"
 				}
 			}
 		}
@@ -371,7 +365,7 @@ var quotaConfig string = `
 	   },
 		"ratelimit": {
 			"replicas": 2,
-		  "resources": {
+            "resources": {
 			  "requests": {
 				  "cpu": 0.02,
 				  "memory": "40Mi"

--- a/test-cases/tests/installation/a34-verify-quota-values.md
+++ b/test-cases/tests/installation/a34-verify-quota-values.md
@@ -13,6 +13,9 @@ tags:
 
 # A34 - Verify Quota values
 
+Note: There is also an automated version of this test, so the steps below are just initial checks to validate the quota
+parameter is as expected and to validate an upgrade scenario. Please also check that the A34 automated test is passing.
+
 ## Prerequisites
 
 - Logged in to a testing cluster as a kubeadmin
@@ -33,10 +36,19 @@ oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toQuota'
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.quota'
 ```
 
-3. Get the parameter value
+3. Get the param value from the Secret
 
 ```bash
-oc get secret addon-managed-api-service-parameters -n redhat-rhoam-operator -o yaml | yq r - 'data.addon-managed-api-service' | base64 --decode
+oc get secret addon-managed-api-service-parameters -n redhat-rhoam-operator -o json | jq -r '.data.addon-managed-api-service' | base64 --decode
 ```
 
-Validate that the value of the status.quota matches the parameter from the secret.
+Verify that the quota value matches the parameter from the secret.
+
+If there is no value in the secret, the cluster has been upgraded from a version of rhoam which did not have
+the quota paramater. aka pre 1.6.0. If this is the case go to step 4.
+
+4. Get the param value from the container Environment Variable.
+
+```bash
+oc get $(oc get pods -n redhat-rhoam-operator -o name | grep rhmi-operator) -n redhat-rhoam-operator -o json | jq -r '.spec.containers[0].env[] | select(.name=="QUOTA")'
+```

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -106,7 +106,7 @@ var (
 
 		{
 			[]TestCase{
-				{"A34 - Verify QUOTA values", TestQuotaValues},
+				{"A34 - Verify Quota values", TestQuotaValues},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
 		},


### PR DESCRIPTION
# Description
Adding an env to handle cases where the user is upgrading from lower versions.
Setting the default to 20

# Verification

## Upgrade Scenario

Install from 1.5.0 tag -> using all the fancy bundling stuff

Verify there is no QUOTA env in the rhmi-operator pod
Verify there is no quota or toquota entry in the rhmi cr.
Verify there is no rhoam_quota metric in prometheus

Verify that there is no QUOTA env and no reference to toQuota or Quota in the cr.

upgrade to this branch -> using all the fancy bundling stuff

verify that the QUOTA value is present in the deployment/pod and has the value 20. 
Verify that cr now has toQuota: 20 or Quota: 20 depending on how long you wait.
Verify there is a rhoam_quota metric in prometheus

## Installation Scenario

Install from this branch using 

`INSTALLATION_TYPE=managed-api make cluster/prepare/local`
`INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
`INSTALLATION_TYPE=managed-api make code/run`

Verify that the installation defaults to `1` as this is the value provided by the secret in make cluster/prepate/local
If the value is 20 then it has taken from the env and there is a problem. 

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer