### PR TITLE
remove check for alerts already removed

### DIFF
--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"errors"
-
 	"github.com/integr8ly/integreatly-operator/test/resources"
 
 	threescaleapps "github.com/3scale/3scale-operator/pkg/apis/apps"
@@ -121,6 +120,31 @@ func (t *ThreeScale) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) map[strin
 		setDefaultNumberOfReplicas(1, threeScaleComponents)
 	} else if inst.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		setDefaultNumberOfReplicas(2, threeScaleComponents)
+	}
+
+	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		switch inst.Status.Quota {
+		case "1":
+			threeScaleComponents["apicastProd"] = 1
+			threeScaleComponents["backendListener"] = 1
+			threeScaleComponents["backendWorker"] = 1
+		case "5":
+			threeScaleComponents["apicastProd"] = 3
+			threeScaleComponents["backendListener"] = 3
+			threeScaleComponents["backendWorker"] = 3
+		case "10":
+			threeScaleComponents["apicastProd"] = 3
+			threeScaleComponents["backendListener"] = 3
+			threeScaleComponents["backendWorker"] = 3
+		case "20":
+			threeScaleComponents["apicastProd"] = 3
+			threeScaleComponents["backendListener"] = 3
+			threeScaleComponents["backendWorker"] = 3
+		case "50":
+			threeScaleComponents["apicastProd"] = 3
+			threeScaleComponents["backendWorker"] = 4
+			threeScaleComponents["backendListener"] = 5
+		}
 	}
 
 	return threeScaleComponents

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -71,7 +71,7 @@ func Test3ScaleSMTPConfig(t TestingTB, ctx *TestingContext) {
 
 	// Scale down system-app and system-sidekiq in order to load new smtp config
 	for _, dc := range []string{"system-app", "system-sidekiq"} {
-		t.Logf("Scalind down dc '%s' to 0 replicas in '%s' namespace", dc, threescaleNamespace)
+		t.Logf("Scaling down dc '%s' to 0 replicas in '%s' namespace", dc, threescaleNamespace)
 		scaleDeploymentConfig(t, dc, threescaleNamespace, 0, ctx.Client)
 	}
 

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -321,14 +321,6 @@ func managedApiSpecificRules() []alertsTestRule {
 			},
 		},
 		{
-			File: NamespacePrefix + "marin3r-rate-limit-soft-limits.yaml",
-			Rules: []string{
-				"RHOAMApiUsageSoftLimitReachedTier1",
-				"RHOAMApiUsageSoftLimitReachedTier2",
-				"RHOAMApiUsageSoftLimitReachedTier3",
-			},
-		},
-		{
 			File: NamespacePrefix + "marin3r-rate-limit-spike.yaml",
 			Rules: []string{
 				"RHOAMApiUsageOverLimit",

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -106,7 +106,7 @@ var (
 
 		{
 			[]TestCase{
-				{"A34 - Verify SKU values", TestQuotaValues},
+				{"A34 - Verify QUOTA values", TestQuotaValues},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
 		},


### PR DESCRIPTION
# Description
Test changes related to https://issues.redhat.com/browse/MGDAPI-1488

H11 - Fixes
F08 - Removes for managed api
F05 - Fixes 

## Verification 
The e2e tests should pass and the rhoam-e2e tests will fail on A15 and A13 which are being address by @makslion in a sperate pr.

Install using the following commands

`INSTALLATION_TYPE=managed-api make cluster/prepare/local`
`INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
`INSTALLATION_TYPE=managed-api make code/run`

Wait for the installation to go complete

Run H11 with `INSTALLATION_TYPE=managed-api TEST=H11 make test/e2e/single` It should pass
Run  F05 with ` INSTALLATION_TYPE=managed-api TEST=F05 make test/e2e/single`


## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer