### PR TITLE
fixed A13 and A15 tests

### DIFF
--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -2,6 +2,13 @@ package common
 
 import (
 	goctx "context"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"golang.org/x/net/context"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8sError "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/test/resources"
@@ -11,7 +18,6 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	appsv1 "github.com/openshift/api/apps/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -38,17 +44,17 @@ var (
 	}
 )
 
-func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1.RHMI) Namespace {
+func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1.RHMI, t TestingTB, ctx *TestingContext) Namespace {
 	threescaleConfig := config.NewThreeScale(map[string]string{})
 	replicas := threescaleConfig.GetReplicasConfig(inst)
 	deployment := map[string]Namespace{
-		"threeScaleDeployment": Namespace{
+		"threeScaleDeployment": {
 			Name: ThreeScaleOperatorNamespace,
 			Products: []Product{
 				{Name: "3scale-operator", ExpectedReplicas: 1},
 			},
 		},
-		"aMQOnlineOperatorDeployment": Namespace{
+		"aMQOnlineOperatorDeployment": {
 			Name: AMQOnlineOperatorNamespace,
 			Products: []Product{
 				{Name: "address-space-controller", ExpectedReplicas: 1},
@@ -58,19 +64,19 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 				{Name: "standard-authservice", ExpectedReplicas: 1},
 			},
 		},
-		"cloudResourceOperatorDeployment": Namespace{
+		"cloudResourceOperatorDeployment": {
 			Name: CloudResourceOperatorNamespace,
 			Products: []Product{
 				{Name: "cloud-resource-operator", ExpectedReplicas: 1},
 			},
 		},
-		"codeReadyOperatorDeployment": Namespace{
+		"codeReadyOperatorDeployment": {
 			Name: CodeReadyOperatorNamespace,
 			Products: []Product{
 				{Name: "codeready-operator", ExpectedReplicas: 1},
 			},
 		},
-		"codereadyWorkspacesDeployment": Namespace{
+		"codereadyWorkspacesDeployment": {
 			Name: NamespacePrefix + "codeready-workspaces",
 			Products: []Product{
 				{Name: "codeready", ExpectedReplicas: 1},
@@ -78,13 +84,13 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 				{Name: "plugin-registry", ExpectedReplicas: 1},
 			},
 		},
-		"fuseOperatorDeployment": Namespace{
+		"fuseOperatorDeployment": {
 			Name: FuseOperatorNamespace,
 			Products: []Product{
 				{Name: "syndesis-operator", ExpectedReplicas: 1},
 			},
 		},
-		"monitoringOperatorDeployment": Namespace{
+		"monitoringOperatorDeployment": {
 			Name: MonitoringOperatorNamespace,
 			Products: []Product{
 				{Name: "application-monitoring-operator", ExpectedReplicas: 1},
@@ -93,61 +99,54 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 				{Name: "prometheus-operator", ExpectedReplicas: 1},
 			},
 		},
-		"rhmiOperatorDeploymentForRhmi2": Namespace{
+		"rhmiOperatorDeploymentForRhmi2": {
 			Name: RHMIOperatorNamespace,
 			Products: []Product{
 				{Name: "standard-authservice-postgresql", ExpectedReplicas: 1},
 			},
 		},
-		"rhmiOperatorDeploymentForManagedApi": Namespace{
+		"rhmiOperatorDeploymentForManagedApi": {
 			Name:     RHMIOperatorNamespace,
 			Products: []Product{},
 		},
-		"rhssoOperatorDeployment": Namespace{
+		"rhssoOperatorDeployment": {
 			Name: RHSSOOperatorNamespace,
 			Products: []Product{
 				{Name: "keycloak-operator", ExpectedReplicas: 1},
 			},
 		},
-		"solutionExplorerOperatorDeployment": Namespace{
+		"solutionExplorerOperatorDeployment": {
 			Name: SolutionExplorerOperatorNamespace,
 			Products: []Product{
 				{Name: "tutorial-web-app-operator", ExpectedReplicas: 1},
 			},
 		},
-		"upsOperatorDeployment": Namespace{
+		"upsOperatorDeployment": {
 			Name: UPSOperatorNamespace,
 			Products: []Product{
 				{Name: "unifiedpush-operator", ExpectedReplicas: 1},
 			},
 		},
-		"upsDeployment": Namespace{
+		"upsDeployment": {
 			Name: NamespacePrefix + "ups",
 			Products: []Product{
 				{Name: "ups", ExpectedReplicas: 1},
 			},
 		},
-		"rhssoUserOperatorDeployment": Namespace{
+		"rhssoUserOperatorDeployment": {
 			Name: RHSSOUserOperatorNamespace,
 			Products: []Product{
 				{Name: "keycloak-operator", ExpectedReplicas: 1},
 			},
 		},
-		"marin3rOperatorDeployment": Namespace{
+		"marin3rOperatorDeployment": {
 			Name: Marin3rOperatorNamespace,
 			Products: []Product{
 				{Name: "marin3r-controller-manager", ExpectedReplicas: 1},
 				{Name: "marin3r-controller-webhook", ExpectedReplicas: 2},
 			},
 		},
-		"marin3rDeployment": Namespace{
-			Name: Marin3rProductNamespace,
-			Products: []Product{
-				{Name: "prom-statsd-exporter", ExpectedReplicas: 1},
-				{Name: "ratelimit", ExpectedReplicas: 3},
-			},
-		},
-		"threeScaleDeploymentConfig": Namespace{
+		"threeScaleDeploymentConfig": {
 			Name: NamespacePrefix + "3scale",
 			Products: []Product{
 				{Name: "apicast-production", ExpectedReplicas: int32(replicas["apicastProd"])},
@@ -164,7 +163,7 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 				{Name: "zync-que", ExpectedReplicas: int32(replicas["zyncQue"])},
 			},
 		},
-		"fuseDeploymentConfig": Namespace{
+		"fuseDeploymentConfig": {
 			Name: NamespacePrefix + "fuse",
 			Products: []Product{
 				{Name: "syndesis-meta", ExpectedReplicas: 1},
@@ -175,12 +174,40 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 				{Name: "broker-amq", ExpectedReplicas: 1},
 			},
 		},
-		"solutionExplorerDeploymentConfig": Namespace{
+		"solutionExplorerDeploymentConfig": {
 			Name: NamespacePrefix + "solution-explorer",
 			Products: []Product{
 				{Name: "tutorial-web-app", ExpectedReplicas: 1},
 			},
 		},
+	}
+
+	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		ratelimitCR := &k8sappsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      quota.RateLimitName,
+				Namespace: Marin3rProductNamespace,
+			},
+		}
+
+		key, err := k8sclient.ObjectKeyFromObject(ratelimitCR)
+		if err != nil {
+			t.Fatalf("Error getting key from ratelimit Deployment: %v", err)
+		}
+
+		err = ctx.Client.Get(context.TODO(), key, ratelimitCR)
+		if err != nil {
+			if !k8sError.IsNotFound(err) {
+				t.Fatalf("Error obtaining ratelimit CR: %v", err)
+			}
+		}
+		deployment["marin3rDeployment"] = Namespace{
+			Name: Marin3rProductNamespace,
+			Products: []Product{
+				{Name: "prom-statsd-exporter", ExpectedReplicas: 1},
+				{Name: "ratelimit", ExpectedReplicas: *ratelimitCR.Spec.Replicas},
+			},
+		}
 	}
 
 	return deployment[deploymentName]
@@ -230,7 +257,7 @@ func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
 	if err != nil {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
-	deployments := getDeployments(rhmi)
+	deployments := getDeployments(rhmi, t, ctx)
 	clusterStorageDeployments := getClusterStorageDeployments(rhmi.Name, rhmi.Spec.Type)
 
 	isClusterStorage, err := isClusterStorage(ctx)
@@ -249,7 +276,7 @@ func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
 	for _, namespace := range deployments {
 		for _, product := range namespace.Products {
 
-			deployment, err := ctx.KubeClient.AppsV1().Deployments(namespace.Name).Get(goctx.TODO(), product.Name, v1.GetOptions{})
+			deployment, err := ctx.KubeClient.AppsV1().Deployments(namespace.Name).Get(goctx.TODO(), product.Name, metav1.GetOptions{})
 			if err != nil {
 				// Fail the test without failing immideatlly
 				t.Errorf("Failed to get Deployment %s in namespace %s with error: %s", product.Name, namespace.Name, err)
@@ -266,6 +293,15 @@ func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				continue
 			}
 
+			if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && product.Name == "ratelimit" {
+				pods := &corev1.PodList{}
+				err = ctx.Client.List(context.TODO(), pods, GetListOptions(Marin3rProductNamespace, "app=ratelimit")...)
+				if err != nil {
+					t.Fatalf("failed to get pods for Ratelimit: %v", err)
+				}
+				checkDeploymentPods(t, pods, product, namespace, deployment)
+
+			}
 			// Verify that the expected replicas are also available, means they are up and running and consumable by users
 			if deployment.Status.AvailableReplicas < product.ExpectedReplicas {
 				t.Errorf("Deployment %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
@@ -275,30 +311,53 @@ func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
 					product.ExpectedReplicas,
 				)
 				continue
+
 			}
 		}
 	}
 }
 
-func getDeployments(inst *integreatlyv1alpha1.RHMI) []Namespace {
+func checkDeploymentPods(t TestingTB, pods *corev1.PodList, product Product, namespace Namespace, deployment *k8sappsv1.Deployment) {
+	if int32(len(pods.Items)) < product.ExpectedReplicas {
+		t.Errorf("Deployment %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
+			product.Name,
+			namespace.Name,
+			deployment.Status.AvailableReplicas,
+			product.ExpectedReplicas,
+		)
+	}
+}
+
+func checkDeploymentConfigPods(t TestingTB, pods *corev1.PodList, product Product, namespace Namespace, deploymentConfig *appsv1.DeploymentConfig) {
+	if int32(len(pods.Items)) < product.ExpectedReplicas {
+		t.Errorf("DeploymentConfig %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
+			product.Name,
+			namespace.Name,
+			deploymentConfig.Status.AvailableReplicas,
+			product.ExpectedReplicas,
+		)
+	}
+}
+
+func getDeployments(inst *integreatlyv1alpha1.RHMI, t TestingTB, ctx *TestingContext) []Namespace {
 	var rhmi2Deployments []Namespace
 	var commonApiDeployments []Namespace
 	var managedApiDeployments []Namespace
 
 	for _, deployment := range rhmi2DeploymentsList {
-		rhmi2Deployments = append(rhmi2Deployments, getDeploymentConfiguration(deployment, inst))
+		rhmi2Deployments = append(rhmi2Deployments, getDeploymentConfiguration(deployment, inst, t, ctx))
 	}
 	for _, deployment := range commonApiDeploymentsList {
-		commonApiDeployments = append(commonApiDeployments, getDeploymentConfiguration(deployment, inst))
+		commonApiDeployments = append(commonApiDeployments, getDeploymentConfiguration(deployment, inst, t, ctx))
 	}
 	for _, deployment := range managedApiDeploymentsList {
-		managedApiDeployments = append(managedApiDeployments, getDeploymentConfiguration(deployment, inst))
+		managedApiDeployments = append(managedApiDeployments, getDeploymentConfiguration(deployment, inst, t, ctx))
 	}
 
 	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
-		return append(append(commonApiDeployments, []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForManagedApi", inst)}...), managedApiDeployments...)
+		return append(append(commonApiDeployments, []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForManagedApi", inst, t, ctx)}...), managedApiDeployments...)
 	} else {
-		return append(append(commonApiDeployments, rhmi2Deployments...), []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForRhmi2", inst)}...)
+		return append(append(commonApiDeployments, rhmi2Deployments...), []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForRhmi2", inst, t, ctx)}...)
 	}
 }
 
@@ -308,7 +367,7 @@ func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
 
-	deploymentConfigs := getDeploymentConfigs(rhmi)
+	deploymentConfigs := getDeploymentConfigs(rhmi, t, ctx)
 
 	for _, namespace := range deploymentConfigs {
 		for _, product := range namespace.Products {
@@ -334,8 +393,32 @@ func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				)
 				continue
 			}
+			if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+				if product.Name == "apicast-production" {
+					pods := &corev1.PodList{}
+					err = ctx.Client.List(context.TODO(), pods, GetListOptions(ThreeScaleProductNamespace, "deploymentconfig=apicast-production")...)
+					if err != nil {
+						t.Fatalf("failed to get backend listener pods for 3scale: %v", err)
+					}
+					checkDeploymentConfigPods(t, pods, product, namespace, deploymentConfig)
 
-			if deploymentConfig.Status.AvailableReplicas < product.ExpectedReplicas {
+				} else if product.Name == "backend-listener" {
+					pods := &corev1.PodList{}
+					err = ctx.Client.List(context.TODO(), pods, GetListOptions(ThreeScaleProductNamespace, "deploymentConfig=backend-listener")...)
+					if err != nil {
+						t.Fatalf("failed to get backend listener pods for 3scale: %v", err)
+					}
+					checkDeploymentConfigPods(t, pods, product, namespace, deploymentConfig)
+
+				} else if product.Name == "backend-worker" {
+					pods := &corev1.PodList{}
+					err = ctx.Client.List(context.TODO(), pods, GetListOptions(ThreeScaleProductNamespace, "deploymentconfig=backend-worker")...)
+					if err != nil {
+						t.Fatalf("failed to get backend listener pods for 3scale: %v", err)
+					}
+					checkDeploymentConfigPods(t, pods, product, namespace, deploymentConfig)
+				}
+			} else if deploymentConfig.Status.AvailableReplicas < product.ExpectedReplicas {
 				t.Errorf("DeploymentConfig %s in namespace %s doesn't match the number of expected available replicas. Available Replicas: %v / Expected Replicas: %v",
 					product.Name,
 					namespace.Name,
@@ -348,16 +431,16 @@ func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
 	}
 }
 
-func getDeploymentConfigs(inst *integreatlyv1alpha1.RHMI) []Namespace {
+func getDeploymentConfigs(inst *integreatlyv1alpha1.RHMI, t TestingTB, ctx *TestingContext) []Namespace {
 	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
 		return []Namespace{
-			getDeploymentConfiguration("threeScaleDeploymentConfig", inst),
+			getDeploymentConfiguration("threeScaleDeploymentConfig", inst, t, ctx),
 		}
 	}
 	return []Namespace{
-		getDeploymentConfiguration("threeScaleDeploymentConfig", inst),
-		getDeploymentConfiguration("fuseDeploymentConfig", inst),
-		getDeploymentConfiguration("solutionExplorerDeploymentConfig", inst),
+		getDeploymentConfiguration("threeScaleDeploymentConfig", inst, t, ctx),
+		getDeploymentConfiguration("fuseDeploymentConfig", inst, t, ctx),
+		getDeploymentConfiguration("solutionExplorerDeploymentConfig", inst, t, ctx),
 	}
 }
 
@@ -376,31 +459,50 @@ func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
 		rhssoExpectedReplicas = 1
 		rhssoUserExpectedReplicas = 1
 	}
+	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		keycloakCR := &v1alpha1.Keycloak{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      quota.KeycloakName,
+				Namespace: RHSSOUserProductNamespace,
+			},
+		}
+		key, err := k8sclient.ObjectKeyFromObject(keycloakCR)
+		if err != nil {
+			t.Fatalf("Error getting Keycloak CR key: %v", err)
+		}
+
+		err = ctx.Client.Get(context.TODO(), key, keycloakCR)
+		if err != nil {
+			t.Fatalf("Error getting Keycloak CR: %v", err)
+		}
+
+		rhssoUserExpectedReplicas = int32(keycloakCR.Spec.Instances)
+	}
 	statefulSets := []Namespace{
 		{
 			Name: MonitoringOperatorNamespace,
 			Products: []Product{
-				Product{Name: "alertmanager-application-monitoring", ExpectedReplicas: 1},
-				Product{Name: "prometheus-application-monitoring", ExpectedReplicas: 1},
+				{Name: "alertmanager-application-monitoring", ExpectedReplicas: 1},
+				{Name: "prometheus-application-monitoring", ExpectedReplicas: 1},
 			},
 		},
 		{
 			Name: NamespacePrefix + "rhsso",
 			Products: []Product{
-				Product{Name: "keycloak", ExpectedReplicas: rhssoExpectedReplicas},
+				{Name: "keycloak", ExpectedReplicas: rhssoExpectedReplicas},
 			},
 		},
 		{
 			Name: NamespacePrefix + "user-sso",
 			Products: []Product{
-				Product{Name: "keycloak", ExpectedReplicas: rhssoUserExpectedReplicas},
+				{Name: "keycloak", ExpectedReplicas: rhssoUserExpectedReplicas},
 			},
 		},
 	}
 
 	for _, namespace := range statefulSets {
 		for _, product := range namespace.Products {
-			statefulSet, err := ctx.KubeClient.AppsV1().StatefulSets(namespace.Name).Get(goctx.TODO(), product.Name, v1.GetOptions{})
+			statefulSet, err := ctx.KubeClient.AppsV1().StatefulSets(namespace.Name).Get(goctx.TODO(), product.Name, metav1.GetOptions{})
 			if err != nil {
 				t.Errorf("Failed to get StatefulSet %s in namespace %s with error: %s", product.Name, namespace.Name, err)
 				continue
@@ -416,6 +518,23 @@ func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				continue
 			}
 
+			if namespace.Name == RHSSOUserProductNamespace && product.Name == "keycloak" {
+				pods := &corev1.PodList{}
+				err = ctx.Client.List(context.TODO(), pods, GetListOptions(RHSSOUserProductNamespace, "component=keycloak")...)
+				if err != nil {
+					t.Fatalf("failed to get pods for Keycloak: %v", err)
+				}
+
+				if int32(len(pods.Items)) < product.ExpectedReplicas {
+					t.Errorf("StatefulSet %s in namespace %s doesn't match the number of expected ready replicas. Ready Replicas: %v / Expected Replicas: %v",
+						product.Name,
+						namespace.Name,
+						statefulSet.Status.ReadyReplicas,
+						product.ExpectedReplicas,
+					)
+					continue
+				}
+			}
 			// Verify the number of ReadyReplicas because the SatefulSet doesn't have the concept of AvailableReplicas
 			if statefulSet.Status.ReadyReplicas < product.ExpectedReplicas {
 				t.Errorf("StatefulSet %s in namespace %s doesn't match the number of expected ready replicas. Ready Replicas: %v / Expected Replicas: %v",
@@ -427,5 +546,18 @@ func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				continue
 			}
 		}
+	}
+}
+
+func GetListOptions(namespace string, podLabels ...string) []k8sclient.ListOption {
+	selector := labels.NewSelector()
+	for _, label := range podLabels {
+		selector, _ = labels.Parse(label)
+	}
+	return []k8sclient.ListOption{
+		k8sclient.InNamespace(namespace),
+		k8sclient.MatchingLabelsSelector{
+			Selector: selector,
+		},
 	}
 }


### PR DESCRIPTION
# Description
Part of the 1488 JIRA
Fixed A13 and A15 tests to get replicas from CRs and compare them against a number of pods running on a cluster for products, configured by Quota 

## Verification steps
1. ensure you have access to a cluster with RHOAM installed from a feature branch: log in to the cluster.
2. run the following commands in your terminal:
```
INSTALLATION_TYPE=managed-api TEST=A13 make test/e2e/single
INSTALLATION_TYPE=managed-api TEST=A14 make test/e2e/single
INSTALLATION_TYPE=managed-api TEST=A15 make test/e2e/single
```


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer