### PR TITLE
MGDAPI-1620: Add creation of quota config map at operator startup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,6 @@ cluster/prepare/dms:
 
 .PHONY: cluster/prepare/quota
 cluster/prepare/quota:
-	@-oc apply -n $(NAMESPACE) -f config/configmap/quota-config-managed-api-service.yaml
 	@-oc delete  -n $(NAMESPACE) secret addon-managed-api-service-parameters
 	@-oc process -n $(NAMESPACE) QUOTA=$(QUOTA) -f config/secrets/quota-secret.yaml | oc apply -f -
 

--- a/pkg/addon/quota.go
+++ b/pkg/addon/quota.go
@@ -1,0 +1,391 @@
+package addon
+
+import "strings"
+
+var quotaConfig string = `
+[{
+	"name": "50",
+	"rate-limiting": {
+		"unit": "minute",
+		"requests_per_unit": 34722,
+		"alert_limits": []
+	},
+	"resources": {
+		"backend_listener": {
+			"replicas": 5,
+			"resources": {
+				"requests": {
+					"cpu": 0.5,
+					"memory": "470Mi"
+				},
+				"limits": {
+					"cpu": 1,
+					"memory": "520Mi"
+				}
+			}
+		},
+		"backend_worker": {
+			"replicas": 4,
+			"resources": {
+				"requests": {
+					"cpu": 0.4,
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu": 0.6,
+					"memory": "100Mi"
+				}
+			}
+		},
+		"apicast_production": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.6,
+					"memory": "275Mi"
+				},
+				"limits": {
+					"cpu": 1,
+					"memory": "300Mi"
+				}
+			}
+		},
+	"rhssouser": {
+		"replicas": 3,
+		"resources": {
+			"requests": {
+				"cpu": 1,
+				"memory": "2000Mi"
+			},
+			"limits": {
+				"cpu": 2,
+				"memory": "2000Mi"
+			}
+		}
+	},
+	"ratelimit": {
+			"replicas": 3,
+			"resources": {
+				"resources": {
+					"requests": {
+						"cpu": 0.15,
+						"memory": "50Mi"
+					},
+					"limits": {
+						"cpu": 0.3,
+						"memory": "100Mi"
+					}
+				}
+			}
+		}
+	}
+},
+{
+	"name": "20",
+	"rate-limiting": {
+		"unit": "minute",
+		"requests_per_unit": 13889,
+		"alert_limits": []
+	},
+	"resources": {
+		"backend_listener": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.25,
+					"memory": "450Mi"
+				},
+				"limits": {
+					"cpu": 0.6,
+					"memory": "500Mi"
+				}
+			}
+		},
+		"backend_worker": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.15,
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu": 0.3,
+					"memory": "100Mi"
+				}
+			}
+		},
+		"apicast_production": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.3,
+					"memory": "250Mi"
+				},
+				"limits": {
+					"cpu": 0.6,
+					"memory": "300Mi"
+				}
+			}
+		},
+	"rhssouser": {
+		"replicas": 3,
+		"resources": {
+			"requests": {
+				"cpu": 0.75,
+				"memory": "1500Mi"
+			},
+			"limits": {
+				"cpu": 1.5,
+				"memory": "1500Mi"
+			}
+		}
+	},
+	"ratelimit": {
+			"replicas": 3,
+			"resources": {
+				"resources": {
+					"requests": {
+						"cpu": 0.10,
+						"memory": "50Mi"
+					},
+					"limits": {
+						"cpu": 0.20,
+						"memory": "100Mi"
+					}
+				}
+			}
+		}
+	}
+},
+	 {
+	"name": "10",
+	"rate-limiting": {
+		"unit": "minute",
+		"requests_per_unit": 6944,
+		"alert_limits": []
+	},
+	"resources": {
+		"backend_listener": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.15,
+					"memory": "450Mi"
+				},
+				"limits": {
+					"cpu": 0.5,
+					"memory": "500Mi"
+				}
+			}
+		},
+		"backend_worker": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.1,
+					"memory": "100Mi"
+				},
+				"limits": {
+					"cpu": 0.25,
+					"memory": "100Mi"
+				}
+			}
+		},
+		"apicast_production": {
+			"replicas": 3,
+			"resources": {
+				"requests": {
+					"cpu": 0.2,
+					"memory": "250Mi"
+				},
+				"limits": {
+					"cpu": 0.5,
+					"memory": "300Mi"
+				}
+			}
+		},
+	"rhssouser": {
+		"replicas": 3,
+		"resources": {
+			"requests": {
+				"cpu": 0.75,
+				"memory": "1500Mi"
+			},
+			"limits": {
+				"cpu": 1.5,
+				"memory": "1500Mi"
+			}
+		}
+	},
+	"ratelimit": {
+			"replicas": 3,
+			"resources": {
+				"resources": {
+					"requests": {
+						"cpu": 0.05,
+						"memory": "50Mi"
+					},
+					"limits": {
+						"cpu": 0.15,
+						"memory": "100Mi"
+					}
+				}
+			}
+		}
+	}
+},
+{
+  "name": "5",
+  "rate-limiting": {
+	  "unit": "minute",
+	  "requests_per_unit": 3472,
+	  "alert_limits": []
+  },
+  "resources": {
+	  "backend_listener": {
+		  "replicas": 3,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.1,
+				  "memory": "450Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.3,
+				  "memory": "500Mi"
+			  }
+		  }
+	  },
+	  "backend_worker": {
+		  "replicas": 3,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.05,
+				  "memory": "100Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.15,
+				  "memory": "100Mi"
+			  }
+		  }
+	  },
+	  "apicast_production": {
+		  "replicas": 3,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.1,
+				  "memory": "250Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.3,
+				  "memory": "300Mi"
+			  }
+		  }
+	  },
+	  "rhssouser": {
+		  "replicas": 3,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.75,
+				  "memory": "1500Mi"
+			  },
+			  "limits": {
+				  "cpu": 1.5,
+				  "memory": "1500Mi"
+			  }
+		  }
+	  },
+	  "ratelimit": {
+		  "replicas": 3,
+		  "resources": {
+			   "requests": {
+				   "cpu": 0.05,
+				   "memory": "50Mi"
+			   },
+			   "limits": {
+				   "cpu": 0.15,
+				   "memory": "100Mi"
+			   }
+		   }
+	  }
+  }
+},
+{
+  "name": "1",
+  "rate-limiting": {
+	  "unit": "minute",
+	  "requests_per_unit": 694,
+	  "alert_limits": []
+  },
+  "resources": {
+	  "backend_listener": {
+		  "replicas": 1,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.1,
+				  "memory": "450Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.11,
+				  "memory": "500Mi"
+			  }
+		  }
+	  },
+	  "backend_worker": {
+		  "replicas": 1,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.03,
+				  "memory": "55Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.04,
+				  "memory": "60Mi"
+			  }
+		  }
+	  },
+	  "apicast_production": {
+		  "replicas": 1,
+		  "resources": {
+			  "requests": {
+				  "cpu": 0.09,
+				  "memory": "250Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.1,
+				  "memory": "270Mi"
+			  }
+		  }
+	  },
+	"rhssouser": {
+		 "replicas": 1,
+		 "resources": {
+			 "requests": {
+				 "cpu": 0.75,
+				 "memory": "1500Mi"
+			 },
+			 "limits": {
+				 "cpu": 0.75,
+				 "memory": "1500Mi"
+			 }
+		 }
+	 },
+	  "ratelimit": {
+		  "replicas": 1,
+		"resources": {
+			"requests": {
+				"cpu": 0.05,
+				"memory": "50Mi"
+			},
+			"limits": {
+				"cpu": 0.15,
+				"memory": "100Mi"
+			}
+		}
+	  }
+  }
+}]
+`
+
+func GetQuotaConfig() string {
+	return strings.TrimSpace(quotaConfig)
+}


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-1620

This is a temporal solution to include the quota configuration in the installation. Add the logic to create the quota ConfigMap at
operator startup, after the RHMI CR is created/discovered.

## Verification steps

Run the operator locally, ensuring that the quota ConfigMap doesn't exist in the cluster, and ensure that the installation progresses and finishes successfully

1. Checkout this PR
2. Prepare the cluster
    ```sh
    INSTALLATION_TYPE=managed-api make cluster/prepare/local
    ```
3. Ensure the ConfigMap doesn't exist
    ```sh
    oc delete cm/quota-config-managed-api-service -n redhat-rhoam-operator
    ```
4. Run the operator
    ```sh
    INSTALLATION_TYPE=managed-api make code/run
    ```
5. Verify that the ConfigMap is created and the installation progresses
    ```sh
    oc get cm/quota-config-managed-api-service -n redhat-rhoam-operator
    ```
    ```
    NAME                               DATA   AGE
    quota-config-managed-api-service   1      8s
    ```

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [x] Verified independently on a cluster by reviewer