### PR TITLE
Fix error in operator logs when updating SKU from 1 to 20.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -358,7 +358,6 @@ cluster/prepare/dms:
 
 .PHONY: cluster/prepare/quota
 cluster/prepare/quota:
-	@-oc delete  -n $(NAMESPACE) secret addon-managed-api-service-parameters
 	@-oc process -n $(NAMESPACE) QUOTA=$(QUOTA) -f config/secrets/quota-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/delorean


### PR DESCRIPTION
# Description
Removed oc command from cluster/prepare/quota target in Makefile that deleted the quota secret before updating and re-creating the secret with a new quota value. Now the target just updates the existing secret which prevents the error that would occur because the operator was looking for a secret that no longer existed.

**JIRA Ticket:** https://issues.redhat.com/browse/MGDAPI-1592

## Verify

- Checkout this branch
- Install the RHOAM operator
- Run Make command to update quota value: `INSTALLATION_TYPE=managed-api QUOTA=20 make cluster/prepare/quota`
- Confirm that the addon-managed-api-service value in the addon-managed-api-service-parameters secret updates to 20.
- Confirm that there are no errors in the operator logs.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
