### PR TITLE
add active sku to grafana

### DIFF
--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -7,7 +7,7 @@ package grafana
 //
 // Each of the hard limit and soft limits are calculated to a perMinute amount.
 
-func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit string) string {
+func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota string) string {
 	return `{
   "annotations": {
     "list": [
@@ -358,7 +358,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit string) string {
           "expr": "$perMinuteRequestsPerUnit",
           "instant": false,
           "interval": "30s",
-          "legendFormat": "Limit - ` + requestsPerUnit + ` per minute",
+          "legendFormat": "Active Quota - ` + activeQuota + ` Million Per Day - Rate Limit - ` + requestsPerUnit + ` per minute",
           "refId": "B"
         }
       ],

--- a/pkg/resources/quota/product_config_moq.go
+++ b/pkg/resources/quota/product_config_moq.go
@@ -23,6 +23,9 @@ var _ ProductConfig = &ProductConfigMock{}
 // 			ConfigureFunc: func(obj metav1.Object) error {
 // 				panic("mock out the Configure method")
 // 			},
+// 			GetActiveQuotaFunc: func() string {
+// 				panic("mock out the GetActiveQuota method")
+// 			},
 // 			GetRateLimitConfigFunc: func() marin3rconfig.RateLimitConfig {
 // 				panic("mock out the GetRateLimitConfig method")
 // 			},
@@ -42,6 +45,9 @@ type ProductConfigMock struct {
 	// ConfigureFunc mocks the Configure method.
 	ConfigureFunc func(obj metav1.Object) error
 
+	// GetActiveQuotaFunc mocks the GetActiveQuota method.
+	GetActiveQuotaFunc func() string
+
 	// GetRateLimitConfigFunc mocks the GetRateLimitConfig method.
 	GetRateLimitConfigFunc func() marin3rconfig.RateLimitConfig
 
@@ -58,6 +64,9 @@ type ProductConfigMock struct {
 			// Obj is the obj argument value.
 			Obj metav1.Object
 		}
+		// GetActiveQuota holds details about calls to the GetActiveQuota method.
+		GetActiveQuota []struct {
+		}
 		// GetRateLimitConfig holds details about calls to the GetRateLimitConfig method.
 		GetRateLimitConfig []struct {
 		}
@@ -73,6 +82,7 @@ type ProductConfigMock struct {
 		}
 	}
 	lockConfigure          sync.RWMutex
+	lockGetActiveQuota     sync.RWMutex
 	lockGetRateLimitConfig sync.RWMutex
 	lockGetReplicas        sync.RWMutex
 	lockGetResourceConfig  sync.RWMutex
@@ -106,6 +116,32 @@ func (mock *ProductConfigMock) ConfigureCalls() []struct {
 	mock.lockConfigure.RLock()
 	calls = mock.calls.Configure
 	mock.lockConfigure.RUnlock()
+	return calls
+}
+
+// GetActiveQuota calls GetActiveQuotaFunc.
+func (mock *ProductConfigMock) GetActiveQuota() string {
+	if mock.GetActiveQuotaFunc == nil {
+		panic("ProductConfigMock.GetActiveQuotaFunc: method is nil but ProductConfig.GetActiveQuota was just called")
+	}
+	callInfo := struct {
+	}{}
+	mock.lockGetActiveQuota.Lock()
+	mock.calls.GetActiveQuota = append(mock.calls.GetActiveQuota, callInfo)
+	mock.lockGetActiveQuota.Unlock()
+	return mock.GetActiveQuotaFunc()
+}
+
+// GetActiveQuotaCalls gets all the calls that were made to GetActiveQuota.
+// Check the length with:
+//     len(mockedProductConfig.GetActiveQuotaCalls())
+func (mock *ProductConfigMock) GetActiveQuotaCalls() []struct {
+} {
+	var calls []struct {
+	}
+	mock.lockGetActiveQuota.RLock()
+	calls = mock.calls.GetActiveQuota
+	mock.lockGetActiveQuota.RUnlock()
 	return calls
 }
 

--- a/pkg/resources/quota/quota.go
+++ b/pkg/resources/quota/quota.go
@@ -63,6 +63,7 @@ type ProductConfig interface {
 	GetResourceConfig(ddcssName string) (corev1.ResourceRequirements, bool)
 	GetReplicas(ddcssName string) int32
 	GetRateLimitConfig() marin3rconfig.RateLimitConfig
+	GetActiveQuota() string
 }
 
 var _ ProductConfig = QuotaProductConfig{}
@@ -153,6 +154,10 @@ func (p QuotaProductConfig) GetRateLimitConfig() marin3rconfig.RateLimitConfig {
 
 func (s *Quota) GetRateLimitConfig() marin3rconfig.RateLimitConfig {
 	return s.rateLimitConfig
+}
+
+func (p QuotaProductConfig) GetActiveQuota() string {
+	return p.quota.name
 }
 
 func (p QuotaProductConfig) GetReplicas(ddcssName string) int32 {


### PR DESCRIPTION
# Description
Add active quota to rate limit graph

## Verification

Run t he installation

`INSTALLATION_TYPE=managed-api make cluster/prepare/local`
`INSTALLATION_TYPE=managed-api IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
`INSTALLATION_TYPE=managed-api make code/run`

Let the installation complete

Verify that the text `Active Quota - 1 Million Per Day - Rate Limit - 694 per minute` appears on the dashboard under the graph -> see image below.

<img width="1583" alt="Screenshot 2021-04-30 at 09 24 24" src="https://user-images.githubusercontent.com/6498727/116668946-e6109600-a995-11eb-988e-2a3b4d46a1f5.png">

Update the quota

`INSTALLATION_TYPE=managed-api DEV_QUOTA="20" make cluster/prepare/quota`

Wait for the quota to update, aka the install to go complete again

Recheck the graph, the text should be -> `Active Quota - 20 Million Per Day`

Rinse & Repeat for all quotas if the desire takes you.


## Type of change


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer