### PR TITLE
MGDAPI-1613 Fix RHOAMUpgradeExpectedDurationExceeded so it doesnt throw many-to-one error

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -83,7 +83,7 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 							"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
 							"message": fmt.Sprintf("%s operator upgrade is taking more than 10 minutes", strings.ToUpper(installationName)),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installation.Namespace, installationName)),
+						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
 						For:    "10m",
 						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 					},


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
bug  see issue https://issues.redhat.com/browse/MGDAPI-1613
In production eng cluster rhoam_version returns two values

```
rhoam_version{endpoint="http-metrics",instance="10.128.4.177:8383",job="rhmi-operator-metrics",namespace="redhat-rhoam-operator",pod="rhmi-operator-fbf89f99-j4wqc",service="rhmi-operator-metrics",stage="complete",version="1.3.0"}

rhoam_version{endpoint="http-metrics",instance="10.128.4.177:8383",job="rhoam-operator-metrics-service",namespace="redhat-rhoam-operator",pod="rhmi-operator-fbf89f99-j4wqc",service="rhoam-operator-metrics-service",stage="complete",version="1.3.0"}
```
This causes an error in **RHOAMUpgradeExpectedDurationExceeded** when **csv_succeeded** returns also

![image](https://user-images.githubusercontent.com/16667688/116992943-b384d700-acce-11eb-91f3-992a3ce38465.png)

This change uses wildcard and the installationName  on the job to only return one value for (rhoam/rhmi)_version 

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification 

On the Production Eng cluster check the `rhoam_version{job=~"rhoam.+"}` filter to see it only returns one rhoam_version


![image](https://user-images.githubusercontent.com/16667688/117645293-52ec1300-b182-11eb-9e92-aa2f08496717.png)


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer