### PR TITLE
set image pull policy to IfNotPresent

### DIFF
--- a/pkg/resources/backup.go
+++ b/pkg/resources/backup.go
@@ -229,7 +229,7 @@ func reconcileCronjob(ctx context.Context, serverClient k8sclient.Client, config
 								{
 									Name:            "backup-cronjob",
 									Image:           "quay.io/integreatly/backup-container:1.0.16",
-									ImagePullPolicy: "Always",
+									ImagePullPolicy: "IfNotPresent",
 									Command: []string{
 										"/opt/intly/tools/entrypoint.sh",
 										"-c",


### PR DESCRIPTION
# Description
Current pull policy on the integreatly operator is "Always". Set to "IfNotPresent" to mitigate against the risk of quay being down
See JIRA: https://issues.redhat.com/browse/MGDAPI-1473

# Verify
Install RHMI from this branch
Check the YAML on the Cronjobs in ns redhat-rhmi-amq-online for imagePullPolicy: IfNotPresent
Modify the cron time in the YAML 
Verify a new job runs as the specified time
Verify that the IfNotPresent is set in the pod yaml
Verify the the image pulls successfully and runs. 

