### PR TITLE
Added the option to set prefixes to the test suites and junt files.

### DIFF
--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/test/utils"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -20,9 +21,6 @@ import (
 
 const (
 	testResultsDirectory = "/test-run-results"
-	jUnitOutputFilename  = "junit-integreatly-operator.xml"
-	addonMetadataName    = "addon-metadata.json"
-	testOutputFileName   = "test-output.txt"
 	testSuiteName        = "integreatly-operator"
 )
 
@@ -61,10 +59,10 @@ func TestAPIs(t *testing.T) {
 		t.Fatalf("could not get install type %s", err)
 	}
 
-	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s/%s", testResultsDirectory, jUnitOutputFilename))
+	junitReporter := reporters.NewJUnitReporter(fmt.Sprintf("%s/%s", testResultsDirectory, utils.JUnitFileName(testSuiteName)))
 
 	RunSpecsWithDefaultAndCustomReporters(t,
-		"Functional Test Suite",
+		utils.SpecDescription("Functional Test Suite"),
 		[]Reporter{junitReporter})
 }
 

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -1,0 +1,26 @@
+package utils
+
+import (
+	"fmt"
+	"os"
+)
+
+// JUnitFileName Allow adding a prefix into the junit file name.
+// prefix using the "TEST_PREFIX" env var
+func JUnitFileName(suiteName string) string {
+	testPrefix := os.Getenv("TEST_PREFIX")
+	if len(testPrefix) > 0 {
+		return fmt.Sprintf("junit-%s-%s.xml", testPrefix, suiteName)
+	}
+	return fmt.Sprintf("junit-%s.xml", suiteName)
+}
+
+// SpecDescription Allow adding a prefix into the test spec description.
+// prefix using the "TEST_PREFIX" env var
+func SpecDescription(spec string) string {
+	testPrefix := os.Getenv("TEST_PREFIX")
+	if len(testPrefix) > 0 {
+		return fmt.Sprintf("%s %s", testPrefix, spec)
+	}
+	return spec
+}


### PR DESCRIPTION
# Description
This allows the reading of a `TEST_PREFIX` environment variable in a testing container. The variable is passed in by the nightly pipelines.

Not setting the variable has no affect on the naming on the junit or test suite.

**Jira:** https://issues.redhat.com/browse/MGDAPI-1593

Pipeline results with variable set: https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Playground/job/Playground-jfitzpat/job/rhoam-upgrade-hf/2/artifact/results/integreatly-operator-test/results/

Pipeline results with not variable set: https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Playground/job/Playground-jfitzpat/job/rhoam-upgrade-hf/1/artifact/results/integreatly-operator-test/results/

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer