### PR TITLE
Mgdapi 1355  - Update Go version

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: openshift
-  name: release
-  tag: golang-1.13

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,11 @@
 # Build the manager binary
-FROM golang:1.13 as builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
 COPY go.sum go.sum
-# cache deps before building and copying source so that we don't need to re-download as much
-# and so that source changes don't invalidate our downloaded layer
-RUN go mod download
+COPY vendor/ vendor/
 
 # Copy the go source
 COPY main.go main.go
@@ -19,7 +17,7 @@ COPY version/ version/
 COPY test/ test/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 GO111MODULE=on go build -a -o rhmi-operator main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o rhmi-operator main.go
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 

--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -1,15 +1,17 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 ENV PKG=/go/src/github.com/integr8ly/integreatly-operator/
 WORKDIR ${PKG}
 
 # compile test binary
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor ./vendor
 COPY make ./make
 COPY apis/ apis/
 COPY apis-products/ apis-products/
 COPY controllers/ controllers/
 COPY pkg ./pkg
-COPY vendor ./vendor
 COPY test ./test
 COPY Makefile ./
 COPY manifests/ ./manifests

--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -1,19 +1,22 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.13 AS builder
+FROM registry.ci.openshift.org/openshift/release:golang-1.16 AS builder
 
 ENV PKG=/go/src/github.com/integr8ly/integreatly-operator/
 WORKDIR ${PKG}
 
 # compile test binary
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor ./vendor
 COPY make ./make
 COPY apis/ apis/
 COPY apis-products/ apis-products/
 COPY controllers/ controllers/
 COPY pkg ./pkg
-COPY vendor ./vendor
 COPY test ./test
 COPY manifests ./manifests
 COPY version ./version
 COPY Makefile ./
+COPY manifests/ ./manifests
 RUN make test/compile/osde2e
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ endif
 
 .PHONY: setup/moq
 setup/moq:
-	go install github.com/matryer/moq
+	GO111MODULE=off go get github.com/matryer/moq
 
 .PHONY: setup/service_account
 setup/service_account: kustomize
@@ -177,7 +177,7 @@ code/fix:
 	@gofmt -w `find . -type f -name '*.go' -not -path "./vendor/*"`
 
 .PHONY: image/build
-image/build: code/compile
+image/build: code/gen
 	echo "build image $(OPERATOR_IMAGE)"
 	docker build . -t ${OPERATOR_IMAGE}
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The operator installs the following products:
 ## Prerequisites
 
 - [operator-sdk](https://github.com/operator-framework/operator-sdk) version v1.2.0.
-- [go](https://golang.org/dl/) version 1.13.4+
+- [go](https://golang.org/dl/) version 1.16.2+
 - [moq](https://github.com/matryer/moq)
 - [oc](https://docs.okd.io/latest/cli_reference/openshift_cli/getting-started-cli.html) version v4.6+
 - Access to an Openshift v4.6.0+ cluster

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/integr8ly/integreatly-operator
 
-go 1.13
+go 1.16
 
 require (
 	github.com/3scale/3scale-operator v0.2.1-0.20210312114906-e612e89addbf

--- a/go.sum
+++ b/go.sum
@@ -45,7 +45,6 @@ dmitri.shuralyov.com/service/change v0.0.0-20181023043359-a85b471d5412/go.mod h1
 dmitri.shuralyov.com/state v0.0.0-20180228185332-28bcc343414c/go.mod h1:0PRwlb0D6DFvNNtx+9ybjezNCa8XF0xaYcETyp6rHWU=
 git.apache.org/thrift.git v0.0.0-20180902110319-2566ecd5d999/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
 git.apache.org/thrift.git v0.12.0/go.mod h1:fPE2ZNJGynbRyZ4dJvy6G277gSllfV2HJqblrnkyeyg=
-github.com/3scale/3scale-operator v0.2.1-0.20210312114906-e612e89addbf h1:7ev7/t4QJgQqPxfKAZko/svXooB1t8Rlt5UFzWaa8gY=
 github.com/3scale/3scale-operator v0.2.1-0.20210312114906-e612e89addbf/go.mod h1:G2jfrlmdPGTOnDxyJ8JdsSZlB+xZqv3lBtwJTFtVVIo=
 github.com/3scale/3scale-porta-go-client v0.0.4/go.mod h1:nUbuVh0fU2rs/lJfowmS5YhEk2tQoybL4htDIdxxMaM=
 github.com/3scale/marin3r v0.7.0 h1:m3snY9Vi8Ho1aUSL4vEfBZJa42S+Q73Vv5nR2vWjy8o=
@@ -346,7 +345,6 @@ github.com/elastic/go-windows v1.0.1/go.mod h1:FoVvqWSun28vaDQPbj2Elfc0JahhPB7WQ
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f h1:8GDPb0tCY8LQ+OJ3dbHb5sA6YZWXFORQYZx5sdsTlMs=
 github.com/elazarl/goproxy v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
-github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f h1:AUj1VoZUfhPhOPHULCQQDnGhRelpFWHMLhQVWDsS0v4=
 github.com/elazarl/goproxy/ext v0.0.0-20190421051319-9d40249d3c2f/go.mod h1:gNh8nYJoAm43RfaxurUnxr+N1PwuFV3ZMl/efxlIlY8=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
@@ -1021,7 +1019,6 @@ github.com/operator-framework/operator-registry v1.6.2-0.20200330184612-11867930
 github.com/operator-framework/operator-sdk v1.2.0/go.mod h1:NwPDRItXPuJPI7ZHrtb+jRnim2WclZMW7zAMpGwvbqs=
 github.com/otiai10/copy v1.0.2 h1:DDNipYy6RkIkjMwy+AWzgKiNTyj2RUI9yEMeETEpVyc=
 github.com/otiai10/copy v1.0.2/go.mod h1:c7RpqBkwMom4bYTSkLSym4VSJz/XtncWRAj/J4PEIMY=
-github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95 h1:+OLn68pqasWca0z5ryit9KGfp3sUsW4Lqg32iRMJyzs=
 github.com/otiai10/curr v0.0.0-20150429015615-9b4961190c95/go.mod h1:9qAhocn7zKJG+0mI8eUu6xqkFDYS2kb2saOteoSB3cE=
 github.com/otiai10/mint v1.3.0 h1:Ady6MKVezQwHBkGzLFbrsywyp09Ah7rkmfjV3Bcr5uc=
 github.com/otiai10/mint v1.3.0/go.mod h1:F5AjcsTsWUqX+Na9fpHb52P8pcRX2CI6A3ctIT91xUo=

--- a/make/functional.mk
+++ b/make/functional.mk
@@ -15,4 +15,4 @@ image/functional/build/push: image/functional/build image/functional/push
 
 .PHONY: test/compile/functional
 test/compile/functional:
-	CGO_ENABLED=0 go test -v -c -o integreatly-operator-test-harness.test ./test/functional
+	CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go test -v -c -o integreatly-operator-test-harness.test ./test/functional

--- a/make/osde2e.mk
+++ b/make/osde2e.mk
@@ -15,4 +15,4 @@ image/osde2e/build/push: image/osde2e/build image/osde2e/push
 
 .PHONY: test/compile/osde2e
 test/compile/osde2e:
-	CGO_ENABLED=0 go test -v -c -o managed-api-test-harness.test ./test/osde2e -ginkgo.noColor
+	CGO_ENABLED=0 go test -v -c -o managed-api-test-harness.test ./test/osde2e

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
 
 # OPERATOR_SDK should match the version of operator-sdk version in go.mod
 ENV OPERATOR_SDK_VERSION=v1.2.0 \

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -416,7 +416,7 @@ github.com/imdario/mergo
 # github.com/integr8ly/application-monitoring-operator v1.4.0
 ## explicit
 github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1
-# github.com/integr8ly/cloud-resource-operator v0.24.0
+# github.com/integr8ly/cloud-resource-operator v0.25.0
 ## explicit
 github.com/integr8ly/cloud-resource-operator/apis/config/v1
 github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,11 +1,13 @@
 # cloud.google.com/go v0.56.0
 cloud.google.com/go/compute/metadata
 # github.com/3scale/3scale-operator v0.2.1-0.20210312114906-e612e89addbf
+## explicit
 github.com/3scale/3scale-operator/pkg/3scale/amp/product
 github.com/3scale/3scale-operator/pkg/apis/apps
 github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1
 github.com/3scale/3scale-operator/version
 # github.com/3scale/marin3r v0.7.0
+## explicit
 github.com/3scale/marin3r/apis/marin3r/v1alpha1
 github.com/3scale/marin3r/apis/operator/v1alpha1
 github.com/3scale/marin3r/pkg/envoy
@@ -15,30 +17,38 @@ github.com/3scale/marin3r/pkg/envoy/serializer/v3
 github.com/3scale/marin3r/pkg/util
 github.com/3scale/marin3r/pkg/version
 # github.com/Apicurio/apicurio-registry-operator v0.0.0-20200903111206-f9f14054bc16
+## explicit
 github.com/Apicurio/apicurio-registry-operator/pkg/apis/apicur/v1alpha1
 # github.com/Masterminds/semver v1.5.0
+## explicit
 github.com/Masterminds/semver
 # github.com/PuerkitoBio/goquery v1.6.1
+## explicit
 github.com/PuerkitoBio/goquery
 # github.com/PuerkitoBio/purell v1.1.1
 github.com/PuerkitoBio/purell
 # github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578
 github.com/PuerkitoBio/urlesc
 # github.com/RHsyseng/operator-utils v0.0.0-20200709142328-d5a5812a443f
+## explicit
 github.com/RHsyseng/operator-utils/pkg/olm
 # github.com/aerogear/unifiedpush-operator v0.5.0
+## explicit
 github.com/aerogear/unifiedpush-operator/pkg/apis/push/v1alpha1
 # github.com/andybalholm/cascadia v1.1.0
 github.com/andybalholm/cascadia
 # github.com/antchfx/xmlquery v1.3.5
+## explicit
 github.com/antchfx/xmlquery
 # github.com/antchfx/xpath v1.1.10
 github.com/antchfx/xpath
 # github.com/apicurio/apicurio-operators/apicurito v0.0.0-20200123142409-83e0a91dd6be
+## explicit
 github.com/apicurio/apicurio-operators/apicurito/pkg/apis/apicur/v1alpha1
 # github.com/asaskevich/govalidator v0.0.0-20200428143746-21a406dcc535
 github.com/asaskevich/govalidator
 # github.com/aws/aws-sdk-go v1.35.23
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -97,6 +107,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
+## explicit
 github.com/blang/semver
 # github.com/census-instrumentation/opencensus-proto v0.2.1
 github.com/census-instrumentation/opencensus-proto/gen-go/resource/v1
@@ -109,6 +120,7 @@ github.com/che-incubator/kubernetes-image-puller-operator/pkg/apis/che/v1alpha1
 github.com/cncf/udpa/go/udpa/annotations
 github.com/cncf/udpa/go/udpa/core/v1
 # github.com/coreos/prometheus-operator v0.40.0 => github.com/coreos/prometheus-operator v0.38.3
+## explicit
 github.com/coreos/prometheus-operator/pkg/apis/monitoring
 github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1
 # github.com/davecgh/go-spew v1.1.1
@@ -117,11 +129,13 @@ github.com/davecgh/go-spew/spew
 github.com/docker/spdystream
 github.com/docker/spdystream/spdy
 # github.com/eclipse/che-operator v0.0.0-20201214125341-cce874092f25
+## explicit
 github.com/eclipse/che-operator/pkg/apis/org/v1
 # github.com/emicklei/go-restful v2.11.1+incompatible
 github.com/emicklei/go-restful
 github.com/emicklei/go-restful/log
 # github.com/envoyproxy/go-control-plane v0.9.7
+## explicit
 github.com/envoyproxy/go-control-plane/envoy/admin/v2alpha
 github.com/envoyproxy/go-control-plane/envoy/admin/v3
 github.com/envoyproxy/go-control-plane/envoy/annotations
@@ -315,6 +329,7 @@ github.com/evanphx/json-patch
 # github.com/fsnotify/fsnotify v1.4.9
 github.com/fsnotify/fsnotify
 # github.com/ghodss/yaml v1.0.1-0.20190212211648-25d852aebe32
+## explicit
 github.com/ghodss/yaml
 # github.com/go-logr/logr v0.3.0 => github.com/go-logr/logr v0.1.0
 github.com/go-logr/logr
@@ -334,6 +349,7 @@ github.com/go-openapi/loads
 # github.com/go-openapi/runtime v0.19.15
 github.com/go-openapi/runtime
 # github.com/go-openapi/spec v0.19.12 => github.com/go-openapi/spec v0.19.6
+## explicit
 github.com/go-openapi/spec
 # github.com/go-openapi/strfmt v0.19.5
 github.com/go-openapi/strfmt
@@ -349,6 +365,7 @@ github.com/gogo/protobuf/sortkeys
 # github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e
 github.com/golang/groupcache/lru
 # github.com/golang/protobuf v1.4.3
+## explicit
 github.com/golang/protobuf/jsonpb
 github.com/golang/protobuf/proto
 github.com/golang/protobuf/protoc-gen-go/descriptor
@@ -360,18 +377,21 @@ github.com/golang/protobuf/ptypes/struct
 github.com/golang/protobuf/ptypes/timestamp
 github.com/golang/protobuf/ptypes/wrappers
 # github.com/google/go-cmp v0.4.0
+## explicit
 github.com/google/go-cmp/cmp
 github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
 # github.com/google/go-querystring v1.0.0
+## explicit
 github.com/google/go-querystring/query
 # github.com/google/gofuzz v1.1.0
 github.com/google/gofuzz
 # github.com/google/uuid v1.1.1
 github.com/google/uuid
 # github.com/googleapis/gnostic v0.5.3
+## explicit
 github.com/googleapis/gnostic/compiler
 github.com/googleapis/gnostic/extensions
 github.com/googleapis/gnostic/jsonschema
@@ -382,17 +402,22 @@ github.com/hashicorp/go-version
 github.com/hashicorp/golang-lru
 github.com/hashicorp/golang-lru/simplelru
 # github.com/headzoo/surf v1.0.0
+## explicit
 github.com/headzoo/surf
 github.com/headzoo/surf/agent
 github.com/headzoo/surf/browser
 github.com/headzoo/surf/errors
 github.com/headzoo/surf/jar
 github.com/headzoo/surf/util
+# github.com/headzoo/ut v0.0.0-20181013193318-a13b5a7a02ca
+## explicit
 # github.com/imdario/mergo v0.3.10
 github.com/imdario/mergo
 # github.com/integr8ly/application-monitoring-operator v1.4.0
+## explicit
 github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1
-# github.com/integr8ly/cloud-resource-operator v0.25.0
+# github.com/integr8ly/cloud-resource-operator v0.24.0
+## explicit
 github.com/integr8ly/cloud-resource-operator/apis/config/v1
 github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1
 github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types
@@ -403,16 +428,20 @@ github.com/integr8ly/cloud-resource-operator/pkg/providers
 github.com/integr8ly/cloud-resource-operator/pkg/providers/aws
 github.com/integr8ly/cloud-resource-operator/pkg/resources
 # github.com/integr8ly/grafana-operator v2.0.0+incompatible
+## explicit
 github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.6.0
+## explicit
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/keycloak-client v0.1.3-0.20210125112511-1972ece81982
+## explicit
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/jmespath/go-jmespath v0.4.0
 github.com/jmespath/go-jmespath
 # github.com/json-iterator/go v1.1.10
 github.com/json-iterator/go
 # github.com/keycloak/keycloak-operator v0.0.0-20210115090828-e5d4686bb8a4
+## explicit
 github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1
 github.com/keycloak/keycloak-operator/pkg/common
 github.com/keycloak/keycloak-operator/pkg/k8sutil
@@ -438,6 +467,7 @@ github.com/nxadm/tail/util
 github.com/nxadm/tail/watch
 github.com/nxadm/tail/winfile
 # github.com/onsi/ginkgo v1.15.0
+## explicit
 github.com/onsi/ginkgo
 github.com/onsi/ginkgo/config
 github.com/onsi/ginkgo/internal/codelocation
@@ -458,6 +488,7 @@ github.com/onsi/ginkgo/reporters/stenographer/support/go-colorable
 github.com/onsi/ginkgo/reporters/stenographer/support/go-isatty
 github.com/onsi/ginkgo/types
 # github.com/onsi/gomega v1.10.2
+## explicit
 github.com/onsi/gomega
 github.com/onsi/gomega/format
 github.com/onsi/gomega/gbytes
@@ -473,6 +504,7 @@ github.com/onsi/gomega/matchers/support/goraph/node
 github.com/onsi/gomega/matchers/support/goraph/util
 github.com/onsi/gomega/types
 # github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
+## explicit
 github.com/openshift/api/apps/v1
 github.com/openshift/api/authorization/v1
 github.com/openshift/api/config/v1
@@ -488,6 +520,7 @@ github.com/openshift/api/route/v1
 github.com/openshift/api/template/v1
 github.com/openshift/api/user/v1
 # github.com/openshift/client-go v3.9.0+incompatible => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
+## explicit
 github.com/openshift/client-go/apps/clientset/versioned
 github.com/openshift/client-go/apps/clientset/versioned/fake
 github.com/openshift/client-go/apps/clientset/versioned/scheme
@@ -501,6 +534,7 @@ github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1/fake
 # github.com/openshift/cloud-credential-operator v0.0.0-20190812222907-ec6f38d73a79
 github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1
 # github.com/openshift/cluster-samples-operator v0.0.0-20191113195805-9e879e661d71
+## explicit
 github.com/openshift/cluster-samples-operator/pkg/apis/samples/v1
 # github.com/operator-framework/api v0.3.20 => github.com/operator-framework/api v0.1.1
 github.com/operator-framework/api/pkg/lib/version
@@ -513,12 +547,14 @@ github.com/operator-framework/api/pkg/validation/internal
 # github.com/operator-framework/operator-lib v0.1.0
 github.com/operator-framework/operator-lib/status
 # github.com/operator-framework/operator-lifecycle-manager v0.17.0 => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88
+## explicit
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1
 github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/ownerutil
 github.com/operator-framework/operator-lifecycle-manager/pkg/lib/version
 # github.com/operator-framework/operator-registry v1.14.3 => github.com/operator-framework/operator-registry v1.6.2-0.20200330184612-11867930adb5
+## explicit
 github.com/operator-framework/operator-registry/pkg/api
 github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1
 github.com/operator-framework/operator-registry/pkg/client
@@ -528,10 +564,12 @@ github.com/operator-framework/operator-registry/pkg/registry
 # github.com/otiai10/copy v1.0.2
 github.com/otiai10/copy
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.7.1
+## explicit
 github.com/prometheus/client_golang/api
 github.com/prometheus/client_golang/api/prometheus/v1
 github.com/prometheus/client_golang/prometheus
@@ -548,6 +586,7 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/pflag v1.0.5
 github.com/spf13/pflag
@@ -555,6 +594,7 @@ github.com/spf13/pflag
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/syndesisio/syndesis/install/operator v0.0.0-20201210151747-8264b9904eab
+## explicit
 github.com/syndesisio/syndesis/install/operator/pkg/apis/syndesis/v1beta1
 # go.mongodb.org/mongo-driver v1.3.2
 go.mongodb.org/mongo-driver/bson
@@ -578,6 +618,7 @@ go.uber.org/zap/zapcore
 # golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20201110031124-69a78807bb2b
+## explicit
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
 golang.org/x/net/html
@@ -597,6 +638,7 @@ golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+## explicit
 golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44
 golang.org/x/sys/internal/unsafeheader
@@ -688,6 +730,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # google.golang.org/protobuf v1.24.0
+## explicit
 google.golang.org/protobuf/encoding/protojson
 google.golang.org/protobuf/encoding/prototext
 google.golang.org/protobuf/encoding/protowire
@@ -730,10 +773,12 @@ gopkg.in/inf.v0
 # gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
 gopkg.in/tomb.v1
 # gopkg.in/yaml.v2 v2.3.0
+## explicit
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 gopkg.in/yaml.v3
 # k8s.io/api v0.20.0 => k8s.io/api v0.0.0-20200331211856-3c24962070e9
+## explicit
 k8s.io/api/admission/v1beta1
 k8s.io/api/admissionregistration/v1
 k8s.io/api/admissionregistration/v1beta1
@@ -776,6 +821,7 @@ k8s.io/api/storage/v1
 k8s.io/api/storage/v1alpha1
 k8s.io/api/storage/v1beta1
 # k8s.io/apiextensions-apiserver v0.19.2 => k8s.io/apiextensions-apiserver v0.19.4
+## explicit
 k8s.io/apiextensions-apiserver/pkg/apihelpers
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions
 k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/install
@@ -792,6 +838,7 @@ k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1
 k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/typed/apiextensions/v1beta1
 # k8s.io/apimachinery v0.20.0 => k8s.io/apimachinery v0.19.4
+## explicit
 k8s.io/apimachinery/pkg/api/equality
 k8s.io/apimachinery/pkg/api/errors
 k8s.io/apimachinery/pkg/api/meta
@@ -854,6 +901,7 @@ k8s.io/apiserver/pkg/server/egressselector
 k8s.io/apiserver/pkg/server/egressselector/metrics
 k8s.io/apiserver/pkg/util/webhook
 # k8s.io/client-go v12.0.0+incompatible => k8s.io/client-go v0.0.0-20200331211856-d847b4c9642e
+## explicit
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/cached
 k8s.io/client-go/discovery/cached/memory
@@ -949,6 +997,7 @@ k8s.io/klog/v2
 k8s.io/kube-aggregator/pkg/apis/apiregistration
 k8s.io/kube-aggregator/pkg/apis/apiregistration/v1
 # k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6 => k8s.io/kube-openapi v0.0.0-20210113000636-45edf8a2a574
+## explicit
 k8s.io/kube-openapi/pkg/common
 k8s.io/kube-openapi/pkg/util/proto
 # k8s.io/utils v0.0.0-20201110183641-67b214c5f920
@@ -961,6 +1010,7 @@ k8s.io/utils/trace
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/pkg/client
 sigs.k8s.io/apiserver-network-proxy/konnectivity-client/proto/client
 # sigs.k8s.io/controller-runtime v0.7.0 => sigs.k8s.io/controller-runtime v0.6.3
+## explicit
 sigs.k8s.io/controller-runtime
 sigs.k8s.io/controller-runtime/pkg/builder
 sigs.k8s.io/controller-runtime/pkg/cache
@@ -1010,3 +1060,38 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
 sigs.k8s.io/yaml
+# github.com/coreos/prometheus-operator => github.com/coreos/prometheus-operator v0.38.3
+# github.com/go-logr/logr => github.com/go-logr/logr v0.1.0
+# github.com/openshift/api => github.com/openshift/api v0.0.0-20210105115604-44119421ec6b
+# github.com/operator-framework/operator-sdk => github.com/operator-framework/operator-sdk v1.2.0
+# sigs.k8s.io/controller-runtime => sigs.k8s.io/controller-runtime v0.6.3
+# github.com/go-openapi/spec => github.com/go-openapi/spec v0.19.6
+# github.com/openshift/client-go => github.com/openshift/client-go v0.0.0-20210112165513-ebc401615f47
+# github.com/operator-framework/api => github.com/operator-framework/api v0.1.1
+# github.com/operator-framework/operator-lifecycle-manager => github.com/operator-framework/operator-lifecycle-manager v0.0.0-20200321030439-57b580e57e88
+# github.com/operator-framework/operator-registry => github.com/operator-framework/operator-registry v1.6.2-0.20200330184612-11867930adb5
+# k8s.io/api => k8s.io/api v0.0.0-20200331211856-3c24962070e9
+# k8s.io/apiextensions-apiserver => k8s.io/apiextensions-apiserver v0.19.4
+# k8s.io/apimachinery => k8s.io/apimachinery v0.19.4
+# k8s.io/apiserver => k8s.io/apiserver v0.19.4
+# k8s.io/cli-runtime => k8s.io/cli-runtime v0.19.4
+# k8s.io/client-go => k8s.io/client-go v0.0.0-20200331211856-d847b4c9642e
+# k8s.io/cloud-provider => k8s.io/cloud-provider v0.19.4
+# k8s.io/cluster-bootstrap => k8s.io/cluster-bootstrap v0.19.4
+# k8s.io/code-generator => k8s.io/code-generator v0.19.4
+# k8s.io/component-base => k8s.io/component-base v0.19.4
+# k8s.io/cri-api => k8s.io/cri-api v0.19.4
+# k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.19.4
+# k8s.io/klog/v2 => k8s.io/klog/v2 v2.1.0
+# k8s.io/kube-aggregator => k8s.io/kube-aggregator v0.19.4
+# k8s.io/kube-controller-manager => k8s.io/kube-controller-manager v0.19.4
+# k8s.io/kube-openapi => k8s.io/kube-openapi v0.0.0-20210113000636-45edf8a2a574
+# k8s.io/kube-proxy => k8s.io/kube-proxy v0.19.4
+# k8s.io/kube-scheduler => k8s.io/kube-scheduler v0.19.4
+# k8s.io/kubectl => k8s.io/kubectl v0.19.4
+# k8s.io/kubelet => k8s.io/kubelet v0.19.4
+# k8s.io/kubernetes => k8s.io/kubernetes v1.19.4
+# k8s.io/metrics => k8s.io/metrics v0.19.4
+# k8s.io/sample-apiserver => k8s.io/sample-apiserver v0.19.4
+# github.com/Microsoft/hcsshim => github.com/Microsoft/hcsshim v0.8.14
+# github.com/docker/docker => github.com/docker/docker v1.4.2-0.20200203170920-46ec8731fbce


### PR DESCRIPTION
# Description
This is the feature branch that was used to check the configure for openshift/release and integr8ly/integreatly-operator for the goLang version bump.  The e2e will fail due to the change in the `docker.tools` file being required in the master branch to update the goLang version of the testing root images. 

The version bump can be seen in this closed PR https://github.com/integr8ly/integreatly-operator/pull/1694

**Jira:** https://issues.redhat.com/browse/MGDAPI-1355
 
## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer