### PR TITLE
MGDAPI-1606: Change the expression in RhoamOperatorInstallDelayed to no longer use absent

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -66,7 +66,7 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 							"sop_url": resources.SopUrlOperatorInstallDelayed,
 							"message": fmt.Sprintf("%s operator is taking more than 2 hours to go to a complete stage", strings.ToUpper(installationName)),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+"}`, installationName)),
+						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+", version="" }`, installationName)),
 						For:    "120m",
 						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 					},

--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -66,7 +66,7 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 							"sop_url": resources.SopUrlOperatorInstallDelayed,
 							"message": fmt.Sprintf("%s operator is taking more than 2 hours to go to a complete stage", strings.ToUpper(installationName)),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf(`absent(%s_status{stage='complete'} == 1) and absent(%s_version{version=~".+"})`, installationName, installationName)),
+						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+"}`, installationName)),
 						For:    "120m",
 						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 					},

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -288,6 +288,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		})
 	}
 	metrics.SetRHMIStatus(installation)
+	metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 
 	configManager, err := config.NewManager(context.TODO(), r.Client, request.NamespacedName.Namespace, installationCfgMap, installation)
 	if err != nil {

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -288,7 +288,6 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		})
 	}
 	metrics.SetRHMIStatus(installation)
-	metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 
 	configManager, err := config.NewManager(context.TODO(), r.Client, request.NamespacedName.Namespace, installationCfgMap, installation)
 	if err != nil {


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
Use of absent in the alert RhoamOperatorInstallDelayed can trigger if the metric is not present rather that the metric being in a certain state 
https://issues.redhat.com/browse/MGDAPI-1606

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification
**Successful Installation**
- Deploy rhoam via  addon flow 
- patch the images in the csv
```bash
oc patch ClusterServiceVersion managed-api-service.v1.6.0 -n redhat-rhoam-operator --patch '{"metadata": {"annotations": {"containerImage": "quay.io/austincunningham/managed-api-service:v1.6.0" }}}' --type=merge
oc patch ClusterServiceVersion managed-api-service.v1.6.0 -n redhat-rhoam-operator --type='json' -p='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/austincunningham/managed-api-service:v1.6.0"}]'
```
- patch the 'UserClusterStorage
```bash
oc patch rhmi rhoam -n redhat-rhoam-operator --patch '{"spec": {"useClusterStorage": "true"}}' --type=merge
```
- In openshift-monitoring Prometheus the alert should go into a pending state during install
![image](https://user-images.githubusercontent.com/16667688/117987241-3262bb00-b332-11eb-9a51-17d252ec7331.png)
if the install takes more that 2 hours it will trigger
- Check the alert exists and is not firing after the install has completed in openshift-monitoring Prometheus
![image](https://user-images.githubusercontent.com/16667688/117834556-2bbf3f80-b26f-11eb-9d76-ad042156c685.png)




## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer