### PR TITLE
removed "ksm-monitoring-arelts" and "rate-limit-soft-limits" alerts

### DIFF
--- a/pkg/products/monitoring/prometheusRules.go
+++ b/pkg/products/monitoring/prometheusRules.go
@@ -9,14 +9,9 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func (r *Reconciler) newAlertsReconciler(isClusterMultiAZ bool, logger l.Logger, installType string) resources.AlertReconciler {
+func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
 	nsPrefix := r.installation.Spec.NamespacePrefix
-
-	monitoringExpectedPodCount := 7
-	if isClusterMultiAZ {
-		monitoringExpectedPodCount = 11
-	}
 
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "monitoring",
@@ -191,23 +186,6 @@ func (r *Reconciler) newAlertsReconciler(isClusterMultiAZ bool, logger l.Logger,
 						},
 						Expr:   intstr.FromString("(sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~'Failed|Pending|Lost'}) * on ( namespace) group_left(label_monitoring_key) kube_namespace_labels{label_monitoring_key='middleware'}) > 0"),
 						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-
-			{
-				AlertName: "ksm-monitoring-alerts",
-				Namespace: r.Config.GetOperatorNamespace(),
-				GroupName: "general.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "MiddlewareMonitoringPodCount",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": fmt.Sprintf("Pod count for namespace {{ $labels.namespace }} is {{ $value }}. Expected exactly %d pods.", monitoringExpectedPodCount),
-						},
-						Expr: intstr.FromString(fmt.Sprintf("(1 - absent(kube_pod_status_ready{condition='true',namespace='"+nsPrefix+"middleware-monitoring-operator'})) or sum(kube_pod_status_ready{condition='true',namespace='"+nsPrefix+"middleware-monitoring-operator'}) != %d", monitoringExpectedPodCount)), For: "5m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
 					},
 				},

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -306,7 +306,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.newAlertsReconciler(isMultiAZCluster, r.Log, r.installation.Spec.Type).ReconcileAlerts(ctx, serverClient)
+	phase, err = r.newAlertsReconciler(r.Log, r.installation.Spec.Type).ReconcileAlerts(ctx, serverClient)
 	r.Log.Infof("reconcilePrometheusRule", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)

--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -63,6 +63,28 @@ func (r *AlertReconcilerImpl) ReconcileAlerts(ctx context.Context, client k8scli
 		}
 	}
 
+	rule := &monitoringv1.PrometheusRule{}
+	err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      "ksm-monitoring-alerts",
+		Namespace: "redhat-rhoam-middleware-monitoring-operator",
+	}, rule)
+	if !errors.IsNotFound(err) {
+		if err := client.Delete(ctx, rule); err != nil {
+			r.Log.Info("Alert \"ksm-monitoring-alerts\" was deleted")
+		}
+	}
+
+	rule = &monitoringv1.PrometheusRule{}
+	err = client.Get(ctx, k8sclient.ObjectKey{
+		Name:      "rate-limit-soft-limits",
+		Namespace: "redhat-rhoam-marin3r",
+	}, rule)
+	if !errors.IsNotFound(err) {
+		if err := client.Delete(ctx, rule); err != nil {
+			r.Log.Info("Alert \"rate-limit-soft-limits\" was deleted")
+		}
+	}
+
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -399,12 +399,6 @@ func commonExpectedRules() []alertsTestRule {
 			},
 		},
 		{
-			File: NamespacePrefix + "middleware-monitoring-operator-ksm-monitoring-alerts.yaml",
-			Rules: []string{
-				"MiddlewareMonitoringPodCount",
-			},
-		},
-		{
 			File: NamespacePrefix + "3scale-ksm-3scale-alerts.yaml",
 			Rules: []string{
 				"ThreeScaleApicastStagingPod",


### PR DESCRIPTION
# Description
MiddlewareMonitoringPodCount alert (serverity = warning) are firing during installation and gets resolved in about 15 minutes. It was decided to remove the alert as it has no value for an SRE team rather then fixing it. 
rate-limit-soft-limits Prometheus rule was removed from creation as part of 1.6.0, but we newer ensured that this alert will not be present on a cluster while upgrading from 1.5.0 to 1.6.0, so it stayed on a cluster.

## Verification steps
1. Ensure you have a cluster with 'ksm-monitoring-alerts" PrometheusRule [present](https://i.imgur.com/ZLhHLE0.png) and with "rate-limit-soft-limits" (you can run master of 1.5.0 against a cluster to obtain those) 
2. Run the reconciler from this PR 
3. Verify that the PrometheusRule CRs were [removed](https://i.imgur.com/QU70t5p.png) 


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer

Optional step: grub a cup of coffee or a tea and enjoy the day for 1 minute 43 seconds