### PR TITLE
Add script to patch the csv with dev image and rhmi cr useClusterStorage during addon flow

### DIFF
--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -6,15 +6,36 @@
 # VERSION=<your image tag>
 # ORG=<you quay org>
 # ADDON_VERSION=<version set https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/addons/managed-api-service/metadata/stage/addon.yaml#L25>
-# Set the varse.g.
+# USE_CLUSTER_STORAGE=<true/false optional will default true if not set>
+# Set the vars.g.
 # export VERSION=v1.6.0
 # export ADDON_VERSION=v1.6.0
 # export ORG=austincunningham
+# export USE_CLUSTER_STORAGE=false
 # ./patch-image-csv.sh
+#
+# Check csv exists
+oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator
+while [ $? -ne 0 ]; do
+  oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator
+done
+# Patch the csv
 oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --patch '{"metadata": {"annotations": {"containerImage": "quay.io/'$ORG'/managed-api-service:'$VERSION'" }}}' --type=merge
 oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --type='json' -p='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/'$ORG'/managed-api-service:'$VERSION'"}]'
 echo Verificaton the CSV has been patched :
 oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator -o yaml | grep "$ORG"
 echo " "
-echo You will have to patch the RHMI CR when its created with useClusterStorge e.g.
-echo oc patch rhmi rhoam -n redhat-rhoam-operator --patch \'{ \"spec\": {\"useClusterStorage\": \"true\" }}\' --type=merge
+echo Patching the RHMI CR when its created with useClusterStorge
+# Check the rhmi cr exists
+oc get rhmi rhoam -n redhat-rhoam-operator
+while [ $? -ne 0 ]; do
+  oc get rhmi rhoam -n redhat-rhoam-operator
+done
+# default USE_CLUSTER_STORAGE to true if not set
+if [ -n "$USE_CLUSTER_STORAGE"]
+  USE_CLUSTER_STORAGE=true
+fi
+# Patch rhmi CR
+oc patch rhmi rhoam -n redhat-rhoam-operator --patch '{ "spec": {"useClusterStorage": "'$USE_CLUSTER_STORAGE'" }}\' --type=merge
+echo Verification USE_CLUSTER_STORAGE is set :
+oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | grep useClusterStorage

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+#
+# About: Script to patch the csv created during addon flow with dev image
+#
+# Usage:
+# VERSION=<your image tag>
+# ORG=<you quay org>
+# ADDON_VERSION=<version set https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/addons/managed-api-service/metadata/stage/addon.yaml#L25>
+# Set the varse.g.
+# export VERSION=v1.6.0
+# export ADDON_VERSION=v1.6.0
+# export ORG=austincunningham
+# ./patch-image-csv.sh
+oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --patch '{"metadata": {"annotations": {"containerImage": "quay.io/'$ORG'/managed-api-service:'$VERSION'" }}}' --type=merge
+oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --type='json' -p='[{"op": "replace", "path": "/spec/install/spec/deployments/0/spec/template/spec/containers/0/image", "value":"quay.io/'$ORG'/managed-api-service:'$VERSION'"}]'
+echo Verificaton the CSV has been patched :
+oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator -o yaml | grep "$ORG"
+echo " "
+echo You will have to patch the RHMI CR when its created with useClusterStorge e.g.
+echo oc patch rhmi rhoam -n redhat-rhoam-operator --patch \'{ \"spec\": {\"useClusterStorage\": \"true\" }}\' --type=merge

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 # VERSION=<your image tag>
-# ORG=<you quay org>
+# ORG=<your quay org>
 # ADDON_VERSION=<version set https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/main/addons/managed-api-service/metadata/stage/addon.yaml#L25>
 # USE_CLUSTER_STORAGE=<true/false optional will default true if not set>
 # Set the vars.g.

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -32,10 +32,10 @@ while [ $? -ne 0 ]; do
   oc get rhmi rhoam -n redhat-rhoam-operator
 done
 # default USE_CLUSTER_STORAGE to true if not set
-if [ -n "$USE_CLUSTER_STORAGE"]
-  USE_CLUSTER_STORAGE=true
+if [ -z ${USE_CLUSTER_STORAGE+x} ]; then
+  export USE_CLUSTER_STORAGE=true
 fi
 # Patch rhmi CR
-oc patch rhmi rhoam -n redhat-rhoam-operator --patch '{ "spec": {"useClusterStorage": "'$USE_CLUSTER_STORAGE'" }}\' --type=merge
+oc patch rhmi rhoam -n redhat-rhoam-operator --patch '{ "spec": {"useClusterStorage": "'$USE_CLUSTER_STORAGE'" }}' --type=merge
 echo Verification USE_CLUSTER_STORAGE is set :
 oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | grep useClusterStorage

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# About: Script to patch the csv created during addon flow with dev image
+# About: Script to patch the csv created during addon flow with dev image and patch the rhmi cr with useClusterStorage
 #
 # Usage:
 # VERSION=<your image tag>

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -15,9 +15,9 @@
 # ./patch-image-csv.sh
 #
 # Check csv exists
-oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator > /dev/null 2>&1
+oc get csv managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator > /dev/null 2>&1
 while [ $? -ne 0 ]; do
-  oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator > /dev/null 2>&1
+  oc get csv managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator > /dev/null 2>&1
 done
 # Patch the csv
 oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --patch '{"metadata": {"annotations": {"containerImage": "quay.io/'$ORG'/managed-api-service:'$VERSION'" }}}' --type=merge

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -25,7 +25,7 @@ oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoa
 echo Verificaton the CSV has been patched :
 oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator -o yaml | grep "$ORG"
 echo " "
-echo Patching the RHMI CR when its created with useClusterStorge
+echo Patching the RHMI CR when its created with useClusterStorage
 # Check the rhmi cr exists
 oc get rhmi rhoam -n redhat-rhoam-operator > /dev/null 2>&1
 while [ $? -ne 0 ]; do

--- a/scripts/patch-image-csv.sh
+++ b/scripts/patch-image-csv.sh
@@ -15,9 +15,9 @@
 # ./patch-image-csv.sh
 #
 # Check csv exists
-oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator
+oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator > /dev/null 2>&1
 while [ $? -ne 0 ]; do
-  oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator
+  oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator > /dev/null 2>&1
 done
 # Patch the csv
 oc patch ClusterServiceVersion managed-api-service.$ADDON_VERSION -n redhat-rhoam-operator --patch '{"metadata": {"annotations": {"containerImage": "quay.io/'$ORG'/managed-api-service:'$VERSION'" }}}' --type=merge
@@ -27,9 +27,9 @@ oc get csv managed-api-service.$VERSION -n redhat-rhoam-operator -o yaml | grep 
 echo " "
 echo Patching the RHMI CR when its created with useClusterStorge
 # Check the rhmi cr exists
-oc get rhmi rhoam -n redhat-rhoam-operator
+oc get rhmi rhoam -n redhat-rhoam-operator > /dev/null 2>&1
 while [ $? -ne 0 ]; do
-  oc get rhmi rhoam -n redhat-rhoam-operator
+  oc get rhmi rhoam -n redhat-rhoam-operator > /dev/null 2>&1
 done
 # default USE_CLUSTER_STORAGE to true if not set
 if [ -z ${USE_CLUSTER_STORAGE+x} ]; then


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
helper script that  during addon flow
- patches csv with a developer image 
- patches rhmi cr with useClusterStorage

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)

## Verification
- build/push a development image e.g.
```bash
ORG=austincunningham OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/build
ORG=austincunningham OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/push
```
- export the vars of the script e.g.
```bash
export VERSION=v1.6.0
export ADDON_VERSION=v1.6.0
export ORG=austincunningham
```
- run the script (need to be logged in to oc for the cluster)
- Install RHOAM via the addon flow
```bash
./patch-image-csv.sh
clusterserviceversion.operators.coreos.com/managed-api-service.v1.6.0 patched
clusterserviceversion.operators.coreos.com/managed-api-service.v1.6.0 patched
Verificaton the CSV has been patched :
    containerImage: quay.io/austincunningham/managed-api-service:v1.6.0
                image: quay.io/austincunningham/managed-api-service:v1.6.0
 
Patching the RHMI CR when its created with useClusterStorage
rhmi.integreatly.org/rhoam patched
Verification USE_CLUSTER_STORAGE is set :
        f:useClusterStorage: {}
  useClusterStorage: "true"

```


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer