### PR TITLE
MGDAPI-1476 Update 3scale operator alert so that it triggers correctly when down

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -148,7 +148,7 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 							"sop_url": resources.SopUrlEndpointAvailableAlert,
 							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
 						},
-						Expr:   intstr.FromString("kube_endpoint_address_available{endpoint='threescale-operator'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1"),
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='threescale-operator-metrics', namespace=`%s`} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
 					},


### PR DESCRIPTION
# Description
Closes https://issues.redhat.com/browse/MGDAPI-1476
3scale operator endpoint down alert was not triggering correctly, this should now be fixed.

## Type of change
- [ :heavy_check_mark:] Bug fix (non-breaking change which fixes an issue)

## Verification
1. Install RHOAM onto a cluster locally using this branch.
2. Scale the 3scale operator deployment to zero by navigating to workloads -> deployments in the redhat-rhoam-3scale-operator namespace.
3. Verify that the alert fires in Prometheus after 5 mins.
4. Scale the operator back up and verify that the alert stops firing.