### PR TITLE
Removed the filter for AMI public image

### DIFF
--- a/scripts/ec2_deploy_teardown/deployEC2.sh
+++ b/scripts/ec2_deploy_teardown/deployEC2.sh
@@ -21,7 +21,7 @@ else
 fi
 
 echo "Getting image"
-AMI=`aws ec2 describe-images --filters "Name=is-public,Values=true" "Name=description,Values=Provided by Red Hat*" "Name=name,Values=${IMAGE}" --region ${CLUSTER_REGION} --output text --query 'Images[0].ImageId'`
+AMI=`aws ec2 describe-images --filters "Name=description,Values=Provided by Red Hat*" "Name=name,Values=${IMAGE}" --region ${CLUSTER_REGION} --output text --query 'Images[0].ImageId'`
 if [[ $AMI =~ "ami-" ]]; then
   echo "AMI "${AMI}" is available"
 else


### PR DESCRIPTION
# Description
Removed the filter from the Getting image section of deployEC2.sh.  It is set as true as default and means we cannot use private images we create.

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] New feature (non-breaking change which adds functionality)


