### PR TITLE
removed quota from rhmi dashboards

### DIFF
--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `, 
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string 
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			}, 
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `,
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			},
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `,
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			},
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `,
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string 
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			},
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `,
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			},
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -1,8 +1,33 @@
 package monitoring
 
+import (
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+)
+
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
 func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
+	quota := ``
+	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] {
+		quota = `,
+			{
+				"datasource": "Prometheus",
+				"enable": true,
+				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"hide": false,
+				"iconColor": "#FADE2A",
+				"limit": 100,
+				"name": "Quota",
+				"showIn": 0,
+				"step": "",
+				"tagKeys": "stage,quota,toQuota",
+				"tags": "",
+				"titleFormat": "Quota Change (million per day)",
+				"type": "tags",
+				"useValueForTime": false
+			}`
+	}
 	return `{
 	"annotations": {
 		"list": [{
@@ -29,23 +54,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
 				"titleFormat": "Upgrade",
 				"type": "tags",
 				"useValueForTime": false
-			},
-			{
-				"datasource": "Prometheus",
-				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
-				"hide": false,
-				"iconColor": "#FADE2A",
-				"limit": 100,
-				"name": "Quota",
-				"showIn": 0,
-				"step": "",
-				"tagKeys": "stage,quota,toQuota",
-				"tags": "",
-				"titleFormat": "Quota Change (million per day)",
-				"type": "tags",
-				"useValueForTime": false
-			}
+			}` + quota + `
 		]
 	},
 	"editable": true,


### PR DESCRIPTION
# Description
Dynamically configured dashboards for: 

- Endpoint Report
- Endpoint Detailed
- Endpoint Summary 
- Resource usage by namespace
- Resource usage by pod
- Resource usage for cluster

depending on an installation type will include (for rhoam) quota details. 

## Verification steps: 
Complete verification includes a check of RHOAM to have working dashboards with Quota and RHMI to have dashboards without quota information. 

### RHOAM: 
1. Run reconciler from this PR. 
2. Navigate to the Grafana dashboard: Networking -> Routes -> grafana-route in `redhat-rhoam-middleware-monitoring-operator` namespace. 
3. Open dashboards, mentioned in the description. 
4. Validate dashboards wasn't broken bu this PR. 

### RHMI
1. Run reconciler from this PR 
2. Navigate to the Grafana dashboard: Networking -> Routes -> grafana-route in `redhat-rhmi-middleware-monitoring-operator` namespace. 
3. Verify dashboards, mentioned in the description has no information about Quota and are working as expected. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer