### PR TITLE
skip functional aws tests when useClusterStorage is true

### DIFF
--- a/test/functional/aws_rds_resources_exist.go
+++ b/test/functional/aws_rds_resources_exist.go
@@ -16,7 +16,6 @@ func AWSRDSResourcesExistTest(t common.TestingTB, ctx *common.TestingContext) {
 	if err != nil {
 		t.Fatalf("error getting RHMI CR: %v", err)
 	}
-
 	// build an array of postgres resources to check and an array of test errors
 	rdsResourceIDs, testErrors := GetRDSResourceIDs(goContext, ctx.Client, rhmi)
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -53,6 +53,19 @@ func TestAPIs(t *testing.T) {
 		Groups:   []string{"system:authenticated"},
 	}
 
+	// get RMI CR and if cluster storage set to true, skip the suite
+	context, err := common.NewTestingContext(cfg)
+	if err != nil {
+		t.Fatalf("\"failed to create testing context: %s", err)
+	}
+	rhmi, err := common.GetRHMI(context.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+	if rhmi.Spec.UseClusterStorage == "true" {
+		t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false")
+	}
+
 	// get install type
 	installType, err = common.GetInstallType(cfg)
 	if err != nil {


### PR DESCRIPTION
# Description
If useClusterStorage in RHMI CR is set to true, skip functional AWS tests. 

## Verification steps 
1. Obtain cluster with RHOAM installed and `useClusterStorage` set to `true` (true by default) 
2. Run following command:
```
INSTALLATION_TYPE=managed-api make test/functional
``` 
3. Observe tests getting skipped with a following message 
```
Aborting functional tests: "UseClusterStorage" is set to true. 
Please, run another testing suite or reinstall operator with "UseClusterStorage" set to false
```

Optional: 
- Reinstall cluster with `useClusterStorage` set to false and see functional tests being executed 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer