### PR TITLE
add relatedImages to the RHOAM CSV

### DIFF
--- a/products/products.yaml
+++ b/products/products.yaml
@@ -3,35 +3,53 @@ products:
     version: 3scale-2.10.0-GA
     url: "https://github.com/3scale/3scale-operator"
     installType: "rhmi/rhoam"
+    manifestsDir: "integreatly-3scale"
+    relatedImages: false
   - name: apicurito-registry-operator
     version: 0.0.3
     url: "https://github.com/Apicurio/apicurio-registry-operator"
     installType: "rhmi"
+    manifestsDir: "integreatly-apicurito"
+    relatedImages: false
   - name: cloud-resource-operator
     version: v0.24.0
     url: "https://github.com/integr8ly/cloud-resource-operator"
     installType: "rhoam/rhmi"
+    manifestsDir: "integreatly-cloud-resources"
+    relatedImages: true
   - name: grafana-operator
     version: v3.10.1
     url: "https://github.com/integr8ly/grafana-operator"
     installType: "rhoam/rhmi"
+    manifestsDir: "integreatly-grafana"
+    relatedImages: true
   - name: marin3r
     version: v0.7.0
     url: "https://github.com/3scale/marin3r"
     installType: "rhoam"
+    manifestsDir: "integreatly-marin3r"
+    relatedImages: true
   - name: application-monitoring-operator
     version: v1.6.0
     url: "https://github.com/integr8ly/application-monitoring-operator"
     installType: "rhmi/rhoam"
+    manifestsDir: "integreatly-monitoring"
+    relatedImages: true
   - name: keycloak-operator
     version: 13.0.1
     url: "https://github.com/keycloak/keycloak-operator"
     installType: "rhmi/rhoam"
+    manifestsDir: "integreatly-rhsso"
+    relatedImages: true
   - name: tutorial-web-app-operator
     version: v0.0.62
     url: "https://github.com/integr8ly/tutorial-web-app-operator"
     installType: "rhmi"
+    manifestsDir: "integreatly-solution-explorer"
+    relatedImages: false
   - name: unifiedpush-operator
     version: v0.5.0
     url: "https://github.com/aerogear/unifiedpush-operator"
     installType: "rhmi"
+    manifestsDir: "integreatly-uninfedpush"
+    relatedImages: false


### PR DESCRIPTION
# Description
Addresses https://issues.redhat.com/browse/MGDAPI-1807
Adding relatedImages to the RHOAM CSV for CVE scanning purposes. 

# Verification
- From this branch run `SEMVER=2.0.0 OLM_TYPE=managed-api-service make release/prepare`
- Navigate to packagemanifest/managed-api-service/2.0.0 and verify that the CSV has the relatedImages set. 
- Compare the images from each of the products quay images to confirm that they are pointing to correct tag
- Install RHOAM via OLM using the newly generated bundle and confirm that this change has no effect on the installation
- Run  `SEMVER=2.0.0 OLM_TYPE=integreatly-operator make release/prepare` and confirm that the relatedImages are not present in the CSV for RHMI.