### PR TITLE
[WIP]Pre-flight fails stop uninstall

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -307,6 +307,11 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		installation.Status.Stages = map[rhmiv1alpha1.StageName]rhmiv1alpha1.RHMIStageStatus{}
 	}
 
+	// If the CR is being deleted, handle uninstall and return
+	if installation.DeletionTimestamp != nil {
+		return r.handleUninstall(installation, installType)
+	}
+
 	// either not checked, or rechecking preflight checks
 	if installation.Status.PreflightStatus == rhmiv1alpha1.PreflightInProgress ||
 		installation.Status.PreflightStatus == rhmiv1alpha1.PreflightFail {
@@ -328,11 +333,6 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		}
 		metrics.SetQuota(string(installation.Status.Stage), installation.Status.Quota, installation.Status.ToQuota)
-	}
-
-	// If the CR is being deleted, handle uninstall and return
-	if installation.DeletionTimestamp != nil {
-		return r.handleUninstall(installation, installType)
 	}
 
 	// If no current or target version is set this is the first installation of rhmi.


### PR DESCRIPTION
# Description
When the operator fails in the pre-flight stage and we are trying to uninstall RHOAM via addon the uninstall fails without any errors. This pr moves the uninstall check before the preflight check meaning the uninstall takes priority over the preflight check when we reconcile.

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer