### PR TITLE
change to ubi minimal base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ COPY test/ test/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o rhmi-operator main.go
 
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/rhmi-operator \
     USER_UID=1001 \

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/rhmi-operator \
     USER_UID=1001 \


### PR DESCRIPTION
# Description
change to ubi minimal base image to reduce possible attach surface and CVE respins
[JIRA](https://issues.redhat.com/browse/INTLY-10574)

# Verify
Install RHMI and RHOAM 
After 3Scale installs delete one route and confirm it recovers.

Uninstall 
Verify during the uninstall a Silence Alert is created.
Verify Uninstall successful

