### PR TITLE
update prepare/release to list related images by sha

### DIFF
--- a/products/products.yaml
+++ b/products/products.yaml
@@ -1,10 +1,17 @@
+# This file represents informations around components used within RHOAM and RHMI
+# name - the name of the components
+# version - version of the components - by github tag
+# url - url to github repo of the component
+# installType - installation type where the component is required
+# manifestDir - name of the directory where manifest is stored
+# quayScan - decide whether the image should be scanned or not 
 products:
   - name: 3scale-operator
     version: 3scale-2.10.0-GA
     url: "https://github.com/3scale/3scale-operator"
     installType: "rhmi/rhoam"
     manifestsDir: "integreatly-3scale"
-    quayScan: false
+    quayScan: true
   - name: apicurito-registry-operator
     version: 0.0.3
     url: "https://github.com/Apicurio/apicurio-registry-operator"


### PR DESCRIPTION
# Description
Adding images list and related images from components csv to annotation in RHOAM CSV

# Verification
- run `OLM_TYPE=managed-api-service SEMVER=1.9.0 make release/prepare` and confirm that the the list of containerImages is generated in rhoam CSV metadata.annotations.
- run `OLM_TYPE=integreatly-operator SEMVER=3.0.0 make release/prepare` and make sure that containerImages are not found in newly generated CSV