### PR TITLE
MGDAPI-1857: add applyImmediately flag to ups, codeready and fuse postgres cr's

### DIFF
--- a/pkg/products/amqonline/reconciler.go
+++ b/pkg/products/amqonline/reconciler.go
@@ -305,6 +305,16 @@ func (r *Reconciler) reconcileStandardAuthenticationService(ctx context.Context,
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("could not create postgresql for standard auth service: %w", err)
 	}
 
+	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, postgres, func() error {
+		if postgres != nil {
+			postgres.Spec.ApplyImmediately = true
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
+	}
+
 	if postgres.Status.Phase != cro1types.PhaseComplete {
 		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
 	}

--- a/pkg/products/codeready/reconciler.go
+++ b/pkg/products/codeready/reconciler.go
@@ -203,6 +203,15 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres: %w", err)
 	}
+	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, postgres, func() error {
+		if postgres != nil {
+			postgres.Spec.ApplyImmediately = true
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
+	}
 
 	// reconcile postgres alerts
 	phase, err := resources.ReconcilePostgresAlerts(ctx, serverClient, r.installation, postgres, r.log)

--- a/pkg/products/fuse/reconciler.go
+++ b/pkg/products/fuse/reconciler.go
@@ -292,6 +292,15 @@ func (r *Reconciler) reconcileCloudResources(ctx context.Context, rhmi *integrea
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres instance for fuse: %w", err)
 	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, postgres, func() error {
+		if postgres != nil {
+			postgres.Spec.ApplyImmediately = true
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
+	}
 
 	// reconcile postgres alerts
 	phase, err := resources.ReconcilePostgresAlerts(ctx, client, rhmi, postgres, r.log)

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -933,16 +933,6 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
 	}
 
-	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, postgres, func() error {
-		if postgres != nil {
-			postgres.Spec.ApplyImmediately = true
-		}
-		return nil
-	})
-	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
-	}
-
 	phase, err := resources.ReconcileRedisAlerts(ctx, serverClient, r.installation, backendRedis, r.log)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile redis alerts: %w", err)

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -203,6 +203,15 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile postgres request: %w", err)
 	}
+	_, err = controllerutil.CreateOrUpdate(ctx, client, postgres, func() error {
+		if postgres != nil {
+			postgres.Spec.ApplyImmediately = true
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update postgres: %w", err)
+	}
 
 	// reconcile postgres alerts
 	phase, err := resources.ReconcilePostgresAlerts(ctx, client, installation, postgres, r.log)


### PR DESCRIPTION
# Description
add the applyImmediatly flag to the posgres cr's in 
- amqonline
- codeready
- fuse
- ups

## Type of change

<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)

## Verification
- install RHMI with `useClusterStorage:false`
- check the postgres CR for 
  - fuse
  - codeready
  - ups
  - amqonline

Confirm that the `applyImmediately:true` flag is applied to the spec for the posgres cr's


