### PR TITLE
Added linking of destructive tasks as blockers in JIRA

### DIFF
--- a/test-cases/tools/cmd/jira.ts
+++ b/test-cases/tools/cmd/jira.ts
@@ -236,6 +236,7 @@ const jira: CommandModule<{}, Args> = {
                 logger.info(
                     `created task '${result.key}' '${issue.fields.summary}'`
                 );
+
                 if (hasDestructive) {
                     if (isDestructive(test)) {
                         if (test == tests[0]) {
@@ -261,6 +262,7 @@ const jira: CommandModule<{}, Args> = {
                         );
                     }
                 }
+
                 if (previousRun) {
                     await jiraApi.addLinkToIssue(
                         result.key,

--- a/test-cases/tools/cmd/jira.ts
+++ b/test-cases/tools/cmd/jira.ts
@@ -1,4 +1,3 @@
-import { test } from "gray-matter";
 import * as markdown2confluence from "markdown2confluence-cws";
 import { CommandModule } from "yargs";
 import { assertEpic, Issue, Jira } from "../lib/jira";
@@ -203,10 +202,14 @@ const jira: CommandModule<{}, Args> = {
         let hasDestructive = false;
         let firstDestructive = null;
         let lastDestructive = null;
-        if(tests.filter(x => isDestructive(x)).length) {
+        if (tests.filter((x) => isDestructive(x)).length) {
             hasDestructive = true;
-            tests.sort(function(x, y) {
-                return (isDestructive(x) == isDestructive(y)) ? 0 : isDestructive(x) ? -1 : 1
+            tests.sort(function (x, y) {
+                return isDestructive(x) == isDestructive(y)
+                    ? 0
+                    : isDestructive(x)
+                    ? -1
+                    : 1;
             });
         }
 
@@ -238,22 +241,24 @@ const jira: CommandModule<{}, Args> = {
                         if (test == tests[0]) {
                             lastDestructive = result;
                             firstDestructive = result;
+                        } else {
+                            await jiraApi.addLinkToIssue(
+                                lastDestructive.key,
+                                toIssueBlock(result)
+                            );
+                            logger.info(
+                                `'${result.key}' blocked by '${lastDestructive.key}'`
+                            );
+                            lastDestructive = result;
                         }
-                        else {
-                        await jiraApi.addLinkToIssue(
-                            lastDestructive.key,
-                            toIssueBlock(result)
-                        );
-                        logger.info(`'${result.key}' blocked by '${lastDestructive.key}'`);
-                        lastDestructive = result;
-                        }
-                    }
-                    else {
+                    } else {
                         await jiraApi.addLinkToIssue(
                             result.key,
                             toIssueBlock(firstDestructive)
                         );
-                        logger.info(`'${firstDestructive.key}' blocked by '${result.key}'`);
+                        logger.info(
+                            `'${firstDestructive.key}' blocked by '${result.key}'`
+                        );
                     }
                 }
                 if (previousRun) {

--- a/test-cases/tools/cmd/jira.ts
+++ b/test-cases/tools/cmd/jira.ts
@@ -204,13 +204,13 @@ const jira: CommandModule<{}, Args> = {
         let lastDestructive = null;
         if (tests.filter((x) => isDestructive(x)).length) {
             hasDestructive = true;
-            tests.sort(function (x, y) {
-                return isDestructive(x) == isDestructive(y)
+            tests.sort((x, y) =>
+                isDestructive(x) === isDestructive(y)
                     ? 0
                     : isDestructive(x)
                     ? -1
-                    : 1;
-            });
+                    : 1
+            );
         }
 
         for (const test of tests) {
@@ -239,7 +239,7 @@ const jira: CommandModule<{}, Args> = {
 
                 if (hasDestructive) {
                     if (isDestructive(test)) {
-                        if (test == tests[0]) {
+                        if (test === tests[0]) {
                             lastDestructive = result;
                             firstDestructive = result;
                         } else {

--- a/test-cases/tools/cmd/jira.ts
+++ b/test-cases/tools/cmd/jira.ts
@@ -1,3 +1,4 @@
+import { test } from "gray-matter";
 import * as markdown2confluence from "markdown2confluence-cws";
 import { CommandModule } from "yargs";
 import { assertEpic, Issue, Jira } from "../lib/jira";
@@ -101,6 +102,13 @@ function toIssueLink(run: TestRun) {
     };
 }
 
+function toIssueBlock(issue: Issue) {
+    return {
+        outwardIssue: { key: issue.key },
+        type: { name: "Blocks" },
+    };
+}
+
 interface Args {
     jiraUsername: string;
     jiraPassword: string;
@@ -192,6 +200,16 @@ const jira: CommandModule<{}, Args> = {
         let tests = loadTestCases(args.product);
         tests = releaseFilter(tests, args.environment, fixVersion.name);
 
+        let hasDestructive = false;
+        let firstDestructive = null;
+        let lastDestructive = null;
+        if(tests.filter(x => isDestructive(x)).length) {
+            hasDestructive = true;
+            tests.sort(function(x, y) {
+                return (isDestructive(x) == isDestructive(y)) ? 0 : isDestructive(x) ? -1 : 1
+            });
+        }
+
         for (const test of tests) {
             const previousRun = previousRuns.find((run) => run.id === test.id);
 
@@ -215,7 +233,29 @@ const jira: CommandModule<{}, Args> = {
                 logger.info(
                     `created task '${result.key}' '${issue.fields.summary}'`
                 );
-
+                if (hasDestructive) {
+                    if (isDestructive(test)) {
+                        if (test == tests[0]) {
+                            lastDestructive = result;
+                            firstDestructive = result;
+                        }
+                        else {
+                        await jiraApi.addLinkToIssue(
+                            lastDestructive.key,
+                            toIssueBlock(result)
+                        );
+                        logger.info(`'${result.key}' blocked by '${lastDestructive.key}'`);
+                        lastDestructive = result;
+                        }
+                    }
+                    else {
+                        await jiraApi.addLinkToIssue(
+                            result.key,
+                            toIssueBlock(firstDestructive)
+                        );
+                        logger.info(`'${firstDestructive.key}' blocked by '${result.key}'`);
+                    }
+                }
                 if (previousRun) {
                     await jiraApi.addLinkToIssue(
                         result.key,


### PR DESCRIPTION
# Description
When there are destructive tasks in a test run link all non-destructive tasks as blockers

my changes were tested on [This JIRA](https://issues.redhat.com/browse/MGDAPI-2000) with `./tools.sh jira --epic MGDAPI-2000 --product rhoam --environment osd-fresh-install` command and changing a few non-destructive issues in the `osd-fresh-install` environment to destructive to verify that destructive issues are being chained together properly

## Type of change

<!-- Please delete options that are not relevant. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer