### PR TITLE
update test case and test for J03

### DIFF
--- a/test-cases/tests/backup-restore/j03b-verify-that-namespaces-get-recreated-by-the-integreatlyoper.md
+++ b/test-cases/tests/backup-restore/j03b-verify-that-namespaces-get-recreated-by-the-integreatlyoper.md
@@ -31,10 +31,10 @@ Test that all namespace will be automatically recreated by the integreatly-opera
 2. By default, this test is not run as part of the functional test suite. To run this singular functional test, run the following command from the RHOAM operator repo against a target cluster:
 
 ```
-export DESTRUCTIVE=true; export WATCH_NAMESPACE=redhat-rhoam-operator;  go clean -testcache && go test -v ./test/functional -run="//^J03" -timeout=80m | tee test-results.log
+DESTRUCTIVE=true INSTALLATION_TYPE=managed-api TEST="J03" make test/e2e/single | tee test-results.log
 ```
 
-3. Check the namespaces in Rhoam except the `redhat-rhoam-operator` are recreated during the test run, the Active for
+3. Check the namespaces in RHOAM except the `redhat-rhoam-operator` are recreated during the test run, the Active for
    namespaces from the command below should be recent.
 
 ```


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
* Update J03 test case command
* Update J03 to include removed finalizers from `EnvoyConfigRevision` resources that is preventing `redhat-rhoam-3scale` namespace from being deleted successfully

## Test Output
[test-results.log](https://github.com/integr8ly/integreatly-operator/files/6671724/test-results.log)

## Verification
* Installation RHOAM from master
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local 
make code/run
```
* Run test 
```
DESTRUCTIVE=true INSTALLATION_TYPE=managed-api TEST="J03" make test/e2e/single
```
* Verify test passes successfully

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Test  and test case update

## Checklist
- [ ] Verified independently on a cluster by reviewer