### PR TITLE
increase upgrade alert time to 60 minutes

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -81,10 +81,10 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 						Alert: fmt.Sprintf("%sUpgradeExpectedDurationExceeded", strings.ToUpper(installationName)),
 						Annotations: map[string]string{
 							"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
-							"message": fmt.Sprintf("%s operator upgrade is taking more than 10 minutes", strings.ToUpper(installationName)),
+							"message": fmt.Sprintf("%s operator upgrade is taking more than 60 minutes", strings.ToUpper(installationName)),
 						},
 						Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
-						For:    "10m",
+						For:    "60m",
 						Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 					},
 				},


### PR DESCRIPTION
# Description

Update the upgradExpectedDurationExceeded alert to 60 minutes from 10 minutes
This is to accomodate for a longer upgrade in 1.8.0 where a forced upgrade of RDS engine version happens.

# Verification
checkout master

install everything - check the prometheus rule has 10 mintues set in the cr and in the Openshift Prometheus

Stop the operator

check the prometheus rule has 60 minutes set in the cr and in the Openshift Prometheus.

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer