### PR TITLE
change service references to operator-metrics-service

### DIFF
--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -28,7 +28,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 							"sop_url": resources.SopUrlRHMICloudResourceOperatorMetricsServiceEndpointDown,
 							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='cloud-resource-operator-metrics', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='operator-metrics-service', namespace='%s'} * on (namespace) group_left kube_namespace_labels{label_monitoring_key='middleware'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "critical", "product": installationName},
 					}, {

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -364,7 +364,7 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	}
 
 	// job to check time that the operator metrics are exposed
-	job := "cloud-resource-operator-metrics"
+	job := "operator-metrics-service"
 
 	// build and reconcile postgres will fill in 4 hours alert
 	alertName := "PostgresStorageWillFillIn4Hours"
@@ -534,7 +534,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	}
 
 	// job to check time that the operator metrics are exposed
-	job := "cloud-resource-operator-metrics"
+	job := "operator-metrics-service"
 
 	alertName = "RedisMemoryUsageMaxIn4Hours"
 	ruleName = fmt.Sprintf("redis-memory-usage-will-max-in-4-hours")


### PR DESCRIPTION
# Description
change service references to operator-metrics-service to match change in CRO
JIRA: [MGDAPI-2095](https://issues.redhat.com/browse/MGDAPI-2095)

# Verify
Install a CCS cluster and rhoam or rhmi 
The following modified Alerts are still valid:

**PostgresStorageWillFillIn4Hours**
Verify in prometheus that `cro_postgres_free_storage_average{job='operator-metrics-service'}` returns a value

**RedisMemoryUsageMaxIn4Hours**
Verify in prometheus that `cro_redis_memory_usage_percentage_average{job='operator-metrics-service'}` returns a value

**RHMICloudResourceOperatorMetricsServiceEndpointDown**
Verify in prometheus that `kube_endpoint_address_available{endpoint='operator-metrics-service'}` returns a value



