### PR TITLE
MGDAPI-1846 - format code as part of release script

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -36,6 +36,13 @@ else
   KUSTOMIZE="/usr/local/bin/kustomize"
 fi
 
+# Path to gofmt
+if [[ -z $GOROOT ]]; then
+  GOFMT="/usr/local/go/bin/gofmt"
+else
+  GOFMT="$GOROOT/bin/gofmt"
+fi
+
 create_new_csv() {
 
   if [[ -z "$PREVIOUS_VERSION" ]]
@@ -286,3 +293,6 @@ yq w -i PROJECT projectName $current_project_name
 # package name from the PROJECT file, so in the case of RHMI it will set it
 # incorrectly to `integreatly-operator`
 yq w -i packagemanifests/integreatly-operator/integreatly-operator.package.yaml packageName integreatly
+
+# Ensure code is formatted correctly
+"${GOFMT[@]}" -w `find . -type f -name '*.go' -not -path "./vendor/*"`


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
The release script updates the version in `version.go` by replacing the whole version string and thereby removing any whitespaces provided by `gofmt`
* https://github.com/integr8ly/integreatly-operator/blob/master/scripts/prepare-release.sh#L68-L75

This works for RHOAM but not for RHMI as RHOAM version string is longer with no extra whitespaces and so doesn't not fail the `prow` code format check when the release is generated.
* https://github.com/integr8ly/integreatly-operator/blob/master/version/version.go#L16-L17

To fix this, the code is formated at the end of the release script 

## Verification
* Checkout master
* Run `OLM_TYPE=integreatly-operator SEMVER=2.10.0 make release/prepare`
* Verify version string whitespace is removed and unformated in `version/version.go`
![image](https://user-images.githubusercontent.com/24636860/125646416-e653db7a-6dc9-4b37-8226-3c7de8c0d602.png)
* Checkout this banch
* Run `OLM_TYPE=integreatly-operator SEMVER=2.10.0 make release/prepare`
* Verifiy whitespace is kept and formated in in `version/version.go`
![image](https://user-images.githubusercontent.com/24636860/125646685-7407e908-e5a9-401a-abb7-757a73a14784.png)


## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer