### PR TITLE
100k quota

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,11 +16,11 @@ IN_PROW ?= "false"
 # DEV_QUOTA value is the default QUOTA when install locally and is per 100,000
 # acceptable values are
 # if 10 then 1M
-# if 50 then 5M
+# if 50 then 5:wqM
 # if 100 then 10M
-# if 20 || 200 then 20M
+# if 200 then 20M
 # if 500 then 50M
-# if 1 then 1k
+# if 1 then 100k
 DEV_QUOTA ?= "1"
 TYPE_OF_MANIFEST ?= master
 

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,14 @@ OPERATOR_SDK_VERSION=1.7.2
 AUTH_TOKEN=$(shell curl -sH "Content-Type: application/json" -XPOST https://quay.io/cnr/api/v1/users/login -d '{"user": {"username": "$(QUAY_USERNAME)", "password": "$(QUAY_PASSWORD)"}}' | jq -r '.token')
 TEMPLATE_PATH="$(shell pwd)/templates/monitoring"
 IN_PROW ?= "false"
+# DEV_QUOTA value is the default QUOTA when install locally and is per 100,000
+# acceptable values are
+# if 10 then 1M
+# if 50 then 5M
+# if 100 then 10M
+# if 20 || 200 then 20M
+# if 500 then 50M
+# if 1 then 1k
 DEV_QUOTA ?= "1"
 TYPE_OF_MANIFEST ?= master
 

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -60,5 +60,5 @@ spec:
           - name: ALERT_SMTP_FROM
             value: "default@test.com"
           - name: QUOTA
-            value: "20"
+            value: "200"
       terminationGracePeriodSeconds: 10

--- a/config/secrets/quota-secret.yaml
+++ b/config/secrets/quota-secret.yaml
@@ -11,4 +11,5 @@ objects:
       addon-managed-api-service: ${QUOTA}
 parameters:
   - name: QUOTA
+    # QUOTA value is per 100,000
     value: "1"

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -529,7 +529,7 @@ func (r *Reconciler) processQuota(installation *rhmiv1alpha1.RHMI, namespace str
 	}
 
 	// Updates the installation quota to the quota param if the quota is updated
-	quotaValue, err := quota.GetQuota(quotaParam, configMap, installationQuota)
+	err = quota.GetQuota(quotaParam, configMap, installationQuota)
 	if err != nil {
 		return err
 	}
@@ -540,8 +540,8 @@ func (r *Reconciler) processQuota(installation *rhmiv1alpha1.RHMI, namespace str
 	// to an installation which is already using the Quota functionality.
 	// if either case is true set toQuota in the rhmi cr and update the status object and set isQuotaUpdated to true
 	if (installation.Status.ToQuota == "" && installation.Status.Quota == "") ||
-		quotaValue != installation.Status.Quota {
-		installation.Status.ToQuota = quotaValue
+		installationQuota.GetName() != installation.Status.Quota {
+		installation.Status.ToQuota = installationQuota.GetName()
 		isQuotaUpdated = true
 	}
 

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -130,7 +130,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			installation.Status.LastError = err.Error()
 			return integreatlyv1alpha1.PhaseFailed, err
 		}
-		metrics.SetQuota(string(installation.Status.Stage), installation.Status.Quota, installation.Status.ToQuota)
+		metrics.SetQuota(installation.Status.Quota, installation.Status.ToQuota)
 	}
 
 	events.HandleStageComplete(r.recorder, installation, integreatlyv1alpha1.BootstrapStage)
@@ -528,23 +528,24 @@ func (r *Reconciler) processQuota(installation *rhmiv1alpha1.RHMI, namespace str
 		return fmt.Errorf("error getting quota config map %w", err)
 	}
 
+	// Updates the installation quota to the quota param if the quota is updated
+	quotaValue, err := quota.GetQuota(quotaParam, configMap, installationQuota)
+	if err != nil {
+		return err
+	}
+
 	// if both are toQuota and Quota are empty this indicates that it's either
 	// the first reconcile of an installation or it's the first reconcile of an upgrade to 1.6.0
 	// if the secretname is not the same as status.Quota this indicates there has been a quota change
 	// to an installation which is already using the Quota functionality.
 	// if either case is true set toQuota in the rhmi cr and update the status object and set isQuotaUpdated to true
 	if (installation.Status.ToQuota == "" && installation.Status.Quota == "") ||
-		quotaParam != installation.Status.Quota {
-		installation.Status.ToQuota = quotaParam
+		quotaValue != installation.Status.Quota {
+		installation.Status.ToQuota = quotaValue
 		isQuotaUpdated = true
 	}
 
-	// Updates the installation quota to the quota param if the quota is updated
-	err = quota.GetQuota(quotaParam, configMap, installationQuota, isQuotaUpdated)
-	if err != nil {
-		return err
-	}
-
+	installationQuota.SetIsUpdated(isQuotaUpdated)
 	return nil
 }
 

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -351,7 +351,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	if string(installation.Status.Stage) == "complete" {
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, installation.CreationTimestamp.Unix())
 
-		metrics.SetQuota(string(installation.Status.Stage), installation.Status.Quota, installation.Status.ToQuota)
+		metrics.SetQuota(installation.Status.Quota, installation.Status.ToQuota)
 	}
 
 	alertsClient, err := k8sclient.New(r.mgr.GetConfig(), k8sclient.Options{
@@ -426,8 +426,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 			if installationQuota.IsUpdated() {
 				installation.Status.Quota = installationQuota.GetName()
 				installation.Status.ToQuota = ""
-				metrics.SetQuota(string(installation.Status.Stage), installation.Status.Quota,
-					installation.Status.ToQuota)
+				metrics.SetQuota(installation.Status.Quota, installation.Status.ToQuota)
 			}
 		}
 	}

--- a/pkg/addon/quota.go
+++ b/pkg/addon/quota.go
@@ -2,12 +2,12 @@ package addon
 
 import "strings"
 
-var quotaConfig string = `
+var quotaConfig = `
 [{
-	"name": "50",
+	"name": "50M",
 	"rate-limiting": {
 		"unit": "minute",
-		"requests_per_unit": 34722,
+		"requests_per_unit": 34723,
 		"alert_limits": []
 	},
 	"resources": {
@@ -79,7 +79,7 @@ var quotaConfig string = `
 	}
 },
 {
-	"name": "20",
+	"name": "20M",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 13889,
@@ -154,10 +154,10 @@ var quotaConfig string = `
 	}
 },
 	 {
-	"name": "10",
+	"name": "10M",
 	"rate-limiting": {
 		"unit": "minute",
-		"requests_per_unit": 6944,
+		"requests_per_unit": 6945,
 		"alert_limits": []
 	},
 	"resources": {
@@ -229,10 +229,10 @@ var quotaConfig string = `
 	}
 },
 {
-  "name": "5",
+  "name": "5M",
   "rate-limiting": {
 	  "unit": "minute",
-	  "requests_per_unit": 3472,
+	  "requests_per_unit": 3473,
 	  "alert_limits": []
   },
   "resources": {
@@ -304,10 +304,10 @@ var quotaConfig string = `
   }
 },
 {
-	"name": "1",
+	"name": "1M",
 	"rate-limiting": {
 		"unit": "minute",
-		"requests_per_unit": 694,
+		"requests_per_unit": 695,
 		"alert_limits": []
 	},
 	"resources": {
@@ -379,10 +379,85 @@ var quotaConfig string = `
 	}
 },
 {
-	"name": "0",
+	"name": "0E",
 	"rate-limiting": {
 		"unit": "minute",
-		"requests_per_unit": 694,
+		"requests_per_unit": 70,
+		"alert_limits": []
+	},
+	"resources": {
+		"backend_listener": {
+			"replicas": 2,
+			"resources": {
+				"requests": {
+					"cpu": 0.06,
+					"memory": "450Mi"
+				},
+				"limits": {
+					"cpu": 0.18,
+					"memory": "500Mi"
+				}
+			}
+		},
+		"backend_worker": {
+			"replicas": 2,
+			"resources": {
+				"requests": {
+					"cpu": 0.03,
+					"memory": "60Mi"
+				},
+				"limits": {
+					"cpu": 0.09,
+					"memory": "100Mi"
+				}
+			}
+		},
+		"apicast_production": {
+			"replicas": 2,
+			"resources": {
+				"requests": {
+					"cpu": 0.06,
+					"memory": "250Mi"
+				},
+				"limits": {
+					"cpu": 0.18,
+					"memory": "300Mi"
+				}
+			}
+		},
+	  "rhssouser": {
+		   "replicas": 2,
+		   "resources": {
+			   "requests": {
+				   "cpu": 0.75,
+				   "memory": "1500Mi"
+			   },
+			   "limits": {
+				   "cpu": 1.5,
+				   "memory": "1500Mi"
+			   }
+		   }
+	   },
+		"ratelimit": {
+			"replicas": 2,
+            "resources": {
+			  "requests": {
+				  "cpu": 0.02,
+				  "memory": "40Mi"
+			  },
+			  "limits": {
+				  "cpu": 0.06,
+				  "memory": "80Mi"
+			  }
+		  }
+		}
+	}
+},
+{
+	"name": "100K",
+	"rate-limiting": {
+		"unit": "minute",
+		"requests_per_unit": 70,
 		"alert_limits": []
 	},
 	"resources": {

--- a/pkg/addon/quota.go
+++ b/pkg/addon/quota.go
@@ -4,7 +4,8 @@ import "strings"
 
 var quotaConfig = `
 [{
-	"name": "50M",
+	"name": "50 Million",
+    "param": "500",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 34723,
@@ -79,7 +80,8 @@ var quotaConfig = `
 	}
 },
 {
-	"name": "20M",
+	"name": "20 Million",
+	"param": "200",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 13889,
@@ -154,7 +156,8 @@ var quotaConfig = `
 	}
 },
 	 {
-	"name": "10M",
+	"name": "10 Million",
+    "param": "100",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 6945,
@@ -229,7 +232,8 @@ var quotaConfig = `
 	}
 },
 {
-  "name": "5M",
+  "name": "5 Million",
+  "param": "50",
   "rate-limiting": {
 	  "unit": "minute",
 	  "requests_per_unit": 3473,
@@ -304,7 +308,8 @@ var quotaConfig = `
   }
 },
 {
-	"name": "1M",
+	"name": "1 Million",
+    "param": "10",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 695,
@@ -379,7 +384,8 @@ var quotaConfig = `
 	}
 },
 {
-	"name": "0E",
+	"name": "100K - Evaluation",
+    "param": "0",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 70,
@@ -455,6 +461,7 @@ var quotaConfig = `
 },
 {
 	"name": "100K",
+	"param": "1",
 	"rate-limiting": {
 		"unit": "minute",
 		"requests_per_unit": 70,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -108,7 +108,6 @@ var (
 			Help: "Status of the current quota config",
 		},
 		[]string{
-			"stage",
 			"quota",
 			"toQuota",
 		},
@@ -158,7 +157,7 @@ func ResetThreeScaleUserAction() {
 	ThreeScaleUserAction.Reset()
 }
 
-func SetQuota(stage string, quota string, toQuota string) {
+func SetQuota(quota string, toQuota string) {
 	Quota.Reset()
-	Quota.WithLabelValues(stage, quota, toQuota).Set(float64(1))
+	Quota.WithLabelValues(quota, toQuota).Set(float64(1))
 }

--- a/pkg/products/grafana/customerDashboard.go
+++ b/pkg/products/grafana/customerDashboard.go
@@ -358,7 +358,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
           "expr": "$perMinuteRequestsPerUnit",
           "instant": false,
           "interval": "30s",
-          "legendFormat": "Active Quota - ` + activeQuota + ` Million Per Day - Rate Limit - ` + requestsPerUnit + ` per minute",
+          "legendFormat": "Active Quota - ` + activeQuota + ` Per Day - Rate Limit - ` + requestsPerUnit + ` per minute",
           "refId": "B"
         }
       ],

--- a/pkg/products/monitoring/dashboards/clusterResources.go
+++ b/pkg/products/monitoring/dashboards/clusterResources.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(installationName string) string 
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsDetailed.go
+++ b/pkg/products/monitoring/dashboards/endpointsDetailed.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBEndpointsDetailedJSON(installationName string) string
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsReport.go
+++ b/pkg/products/monitoring/dashboards/endpointsReport.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBEndpointsReportJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/endpointsSummary.go
+++ b/pkg/products/monitoring/dashboards/endpointsSummary.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBEndpointsSummaryJSON(installationName string) string 
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/errorBudgetBurnSLOAlerts.go
+++ b/pkg/products/monitoring/dashboards/errorBudgetBurnSLOAlerts.go
@@ -12,7 +12,7 @@ func GetMonitoringGrafanaDBRhssoAvailabilityErrorBudgetBurnJSON(installationName
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoring/dashboards/resourceByNamespace.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/products/monitoring/dashboards/resourceByPod.go
+++ b/pkg/products/monitoring/dashboards/resourceByPod.go
@@ -14,7 +14,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(installationName string) string {
 			{
 				"datasource": "Prometheus",
 				"enable": true,
-				"expr": "count by (stage,quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
+				"expr": "count by (quota,toQuota)(rhoam_quota{toQuota!=\"\"})",
 				"hide": false,
 				"iconColor": "#FADE2A",
 				"limit": 100,

--- a/pkg/resources/quota/quota_test.go
+++ b/pkg/resources/quota/quota_test.go
@@ -199,7 +199,7 @@ func TestGetQuota(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := GetQuota(tt.args.QuotaId, tt.args.QuotaConfig, tt.args.Quota)
+			err := GetQuota(tt.args.QuotaId, tt.args.QuotaConfig, tt.args.Quota)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetQuota() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -959,7 +959,7 @@ func getQuotaConfig(modifyFn func(*corev1.ConfigMap)) *corev1.ConfigMap {
 		ObjectMeta: metav1.ObjectMeta{Name: ConfigMapName},
 	}
 	mock.Data = map[string]string{
-		ConfigMapData: "[{\"name\": \"" + DEVQUOTACONFIGNAME + "\",\"rate-limiting\": {\"unit\": \"minute\",\"requests_per_unit\": 1, \"alert_limits\": []},\"resources\": {\"" + ApicastProductionName + "\": {\"replicas\": 1,\"resources\": {\"requests\": {\"cpu\": \"50m\",\"memory\": \"50Mi\"},\"limits\": {\"cpu\": \"150m\",\"memory\": \"100Mi\"}}}}}, {\"name\": \"" + TWENTYMILLIONQUOTACONFIGNAME + "\",\"rate-limiting\": {  \"unit\": \"minute\",  \"requests_per_unit\": 347,  \"alert_limits\": []},\"resources\": {\"" + BackendListenerName + "\": {\"replicas\": 3,\"resources\": {  \"requests\": {\"cpu\": 0.25,\"memory\": 450  },  \"limits\": {\"cpu\": 0.3,\"memory\": 500}}}}}]",
+		ConfigMapData: "[{\"name\": \"" + DEVQUOTACONFIGNAME + "\",\"param\": \"" + DEVQUOTAPARAM + "\",\"rate-limiting\": {\"unit\": \"minute\",\"requests_per_unit\": 1, \"alert_limits\": []},\"resources\": {\"" + ApicastProductionName + "\": {\"replicas\": 1,\"resources\": {\"requests\": {\"cpu\": \"50m\",\"memory\": \"50Mi\"},\"limits\": {\"cpu\": \"150m\",\"memory\": \"100Mi\"}}}}}, {\"name\": \"" + TWENTYMILLIONQUOTACONFIGNAME + "\",\"param\": \"" + TWENTYMILLIONQUOTAPARAM + "\",\"rate-limiting\": {  \"unit\": \"minute\",  \"requests_per_unit\": 347,  \"alert_limits\": []},\"resources\": {\"" + BackendListenerName + "\": {\"replicas\": 3,\"resources\": {  \"requests\": {\"cpu\": 0.25,\"memory\": 450  },  \"limits\": {\"cpu\": 0.3,\"memory\": 500}}}}}]",
 	}
 	if modifyFn != nil {
 		modifyFn(mock)


### PR DESCRIPTION
# Description
JIRA -> https://issues.redhat.com/browse/MGDAPI-2258

Changes in commit 1
- Remove stage from metric and dashboards
- Add param to config map to match new per 100k values 
- Update the env in the deployment config for 20m default
- Update to how isUpdated is being set in the bootstrap section
- Update e2e tests with new configuration

## Verification steps

Verification does not require ccs cluster

### Installation Verification

On a fresh cluster
git checkout this branch

`INSTALLATION_TYPE=managed-api make cluster/prepare`
`INSTALLATION_TYPE=managed-api make code/run`

check the status of the installation `oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status`
The quota value should be set to `100K`

Verify that the grafana Dashboard gets updated as expected by navigating to the customer dashboard using the
`open "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"`
Verify that the value at the bottom of the graph represents the 100K rate limit which has 70 requests per minute

<img width="1008" alt="Screenshot 2021-07-20 at 11 50 31" src="https://user-images.githubusercontent.com/6498727/126312075-4eff3046-c178-47db-a6af-307571533da8.png">


#### Verify Trial Quota
`INSTALLATION_TYPE=managed-api DEV_QUOTA=0 make cluster/prepare/quota`
After the reconciliation the quota value should change to `100K - Evaluation`

#### Run e2e test

Note you will need to comment out these lines https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/suite_test.go#L65-L67 so the test will run if you are using non-ccs cluster
`INSTALLATION_TYPE=managed-api TEST=A34 make test/e2e/single`

### Secret Param Upgrade Verification

On a fresh cluster

Deploy the workload web app by following the steps here -> https://github.com/integr8ly/workload-web-app#rhoam-clusters

Install 1.9.0 using the steps below.
git checkout 1.9.0 tag
`INSTALLATION_TYPE=managed-api make cluster/prepare`
`INSTALLATION_TYPE=managed-api make code/run`
Wait for the installation to complete
`oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status.quota` the value should be 1

Upgrade to this pr e.g. what would be 1.10.0
git checkout this branch
`INSTALLATION_TYPE=managed-api make cluster/prepare/sku` - to update the sku value
check the status of the installation `oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status`
Verify there is no down time

#### Run e2e test

Note you will need to comment out these lines https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/suite_test.go#L65-L67 so the test will run if you are using non-ccs cluster
`INSTALLATION_TYPE=managed-api TEST=A34 make test/e2e/single`

### QUOTA Env Var Upgrade Verification - requires OLM installation

On a fresh cluster

Deploy the workload web app by following the steps here -> https://github.com/integr8ly/workload-web-app#rhoam-clusters

Install 1.9.0 using the steps below.
git checkout 1.9.0 tag
`INSTALLATION_TYPE=managed-api make cluster/prepare`
delete the param secret, int this case the operator should fall back to using the QUOTA env var from the deployment
`oc delete secret addon-managed-api-service-parameters -n redhat-rhoam-operator`

create the following catalog source
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/laurafitzgerald/rhoam-index:1.9.0
```

Wait for the installation to complete
`oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status.quota` the value should be 20

Upgrade to 1.10.0 by updating the catalog source image to `quayl/laurafitzgerald/rhoam-index:1.10.0`
This contains a built image -> `quay.io/laurafitzgerald/managed-api-service:v1.10.0-lf` which is this branch
You will need to manually approve the subscription once it's present in the cluster.

check the upgrade is in progress `oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status` i forgot to update the version so you wont see toVersion moving, that's expected

Verify the QUOTA param in deployment config for integreatly operator is now 200
Verify the quota value in the cr `oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq r - status.quota` the value should be set to. `20 Million` after a couple of mintues/

Verify there is no down time via the workload web application - the quota will change but the values inside the quota didn't change so there shouldn't be updates to deployments/replicas etc.

Verify that there is a quota change registered in the grafana dashboards without a stage value present - see image below

<img width="802" alt="Screenshot 2021-07-21 at 12 43 26" src="https://user-images.githubusercontent.com/6498727/126483408-e5cc5139-87c5-4cc1-9a9b-f943e2eb0d69.png">
 
Prometheus graph for `rhoam_quota` should look like the following

<img width="1655" alt="Screenshot 2021-07-21 at 12 45 43" src="https://user-images.githubusercontent.com/6498727/126483674-028fb877-f1d4-4982-b050-aa807b064963.png">

Navigate to Customer Monotoring Grafana
 `open "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"`

The value below the graph should be `Active Quota - 20 Million Per Day - Rate Limit - 13889 per minute`


#### Run e2e test

Note you will need to comment out these lines https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/suite_test.go#L65-L67 so the test will run if you are using non-ccs cluster
`INSTALLATION_TYPE=managed-api TEST=A34 make test/e2e/single`

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer