### PR TITLE
MGDAPI-2247: update postgresql-10-rhel7 image

### DIFF
--- a/manifests/integreatly-3scale/0.7.0/3scale-operator.v0.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-3scale/0.7.0/3scale-operator.v0.7.0.clusterserviceversion.yaml
@@ -486,9 +486,9 @@ spec:
                 - name: SYSTEM_MYSQL_IMAGE
                   value: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
                 - name: SYSTEM_POSTGRESQL_IMAGE
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:ba7713d570c058e61bae1adc1591b1fe834d45fe5e1fba70721c93f4fd64d535
                 - name: ZYNC_POSTGRESQL_IMAGE
-                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd
+                  value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:ba7713d570c058e61bae1adc1591b1fe834d45fe5e1fba70721c93f4fd64d535
                 - name: OC_CLI_IMAGE
                   value: registry.redhat.io/openshift4/ose-cli@sha256:353036a27e810730ce35d699dcf09141af9f8ae9e365116755016d864475c2c4
                 image: registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:655062177bc53b155b87876dc1096530c365f18f9be3ceb0d32aa2d343968f9a
@@ -743,7 +743,7 @@ spec:
     name: redis-32-rhel7
   - image: registry.redhat.io/rhscl/mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe
     name: mysql-57-rhel7
-  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd
+  - image: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:ba7713d570c058e61bae1adc1591b1fe834d45fe5e1fba70721c93f4fd64d535
     name: postgresql-10-rhel7
   - image: registry.redhat.io/openshift4/ose-cli@sha256:353036a27e810730ce35d699dcf09141af9f8ae9e365116755016d864475c2c4
     name: openshift-cli


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
MGDAPI-2247 update postgresql-10-rhel7 image
## Type of change
container image bump

## Verification

- checkout this branch
- install rhoam locally
- confirm 3scale is up and running and check the following containers to see if they have the correct images
- 3scale, zync-database pod and the postgresql container is in the ui sha256:ba7713d570c058e61bae1adc1591b1fe834d45fe5e1fba70721c93f4fd64d535
![image](https://user-images.githubusercontent.com/16667688/126304225-b1c3f6a7-6b7c-4371-88ee-a55c28fe7ee8.png)
```bash
# You can run this command 
kubectl get pods --all-namespaces -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}' | sort | grep postgres
# should return
zync-database-2-klvkw:  registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:ba7713d570c058e61bae1adc1591b1fe834d45fe5e1fba70721c93f4fd64d535, 
```
>*NOTE*: rhoam upgrade scenario doesn't change the image


## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer