### PR TITLE
MGDAPI-2236: update 3scale-operator image

### DIFF
--- a/manifests/integreatly-3scale/0.7.0/3scale-operator.v0.7.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-3scale/0.7.0/3scale-operator.v0.7.0.clusterserviceversion.yaml
@@ -318,7 +318,7 @@ metadata:
     capabilities: Full Lifecycle
     categories: Integration & Delivery
     certified: "false"
-    containerImage: registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:655062177bc53b155b87876dc1096530c365f18f9be3ceb0d32aa2d343968f9a
+    containerImage: registry.redhat.io/3scale-amp2/3scale-rhel7-operatorsha256:5063f838a8a7649626231edabf47debc3d4e36f69de37675d126b19fdbeb69c3
     createdAt: "2019-05-30T22:40:00Z"
     description: 3scale Operator to provision 3scale and publish/manage API
     operators.openshift.io/infrastructure-features: '["Disconnected"]'
@@ -491,7 +491,7 @@ spec:
                   value: registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd
                 - name: OC_CLI_IMAGE
                   value: registry.redhat.io/openshift4/ose-cli@sha256:353036a27e810730ce35d699dcf09141af9f8ae9e365116755016d864475c2c4
-                image: registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:655062177bc53b155b87876dc1096530c365f18f9be3ceb0d32aa2d343968f9a
+                image: registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:5063f838a8a7649626231edabf47debc3d4e36f69de37675d126b19fdbeb69c3
                 name: 3scale-operator
                 resources:
                   requests:


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
MGDAPI-2236 update 3scale-operator image
## Type of change
3scale operator image update

## Verification

- checkout this branch
- install rhoam locally
- confirm 3scale is up and running and check the following containers to see if they have the correct image
  - in the redhat-rhoam-3scale-operator namespace the operator pod and the 3scale-operator container has the following sha sha256:5063f838a8a7649626231edabf47debc3d4e36f69de37675d126b19fdbeb69c3 in the ui
![image](https://user-images.githubusercontent.com/16667688/126317523-ef7edc75-db68-4ef3-b3c1-431120d3c736.png)
```bash
# you can also use the following command  
kubectl get pods --all-namespaces -o=jsonpath='{range .items[*]}{"\n"}{.metadata.name}{":\t"}{range .spec.containers[*]}{.image}{", "}{end}{end}' | sort | grep 3scale-rhel7-operator
# should return something similar to 
3scale-operator-6b4849b6f8-gtv65:       registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:5063f838a8a7649626231edabf47debc3d4e36f69de37675d126b19fdbeb69c3,
```

> *NOTE*: The rhoam upgrade scenario will not upgrade this image

## Checklist
- [ ] This change requires a documentation update <!-- Update JIRA with Affects -> Documentation -->
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added a test case that will be used to verify my changes 
- [ ] Verified independently on a cluster by reviewer