### PR TITLE
fix: Updating alerting email subject for easy email filtering.

### DIFF
--- a/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
+++ b/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
@@ -5,7 +5,7 @@
 {{ define "__intlysubject" }}
 	
 	{{/* declaring variables */}}
-  {{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
+	{{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
 
   {{/* checking if there is single or multiple alerts */}}
 	{{if eq $lenOfAlerts 1 }} 

--- a/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
+++ b/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
@@ -5,11 +5,11 @@
 {{ define "__intlysubject" }}
 	
 	{{/* declaring variables */}}
-	{{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
+  {{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
 
   {{/* checking if there is single or multiple alerts */}}
 	{{if eq $lenOfAlerts 1 }} 
-		[{{ $clustername }}] {{ .CommonLabels.alertname  }} ({{ .CommonLabels.severity | title }}) {{ .Status | title }}{{ if eq .Status "firing" }}{{ end }}
+		{{ $clustername }}|{{ .CommonLabels.alertname  }}|({{ .CommonLabels.severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}{{ end }}
 	{{ else }}
 		{{if gt $lenOfAlerts 1 }} 
 			{{ $alertname = "Multiple Alerts*" }}
@@ -24,11 +24,12 @@
 	{{/* in case of multiple alerts, checking if the severity of any alert(s) is critical*/}}
 	{{ if eq $alertname "Multiple Alerts*" }}
 		{{ if eq $ifCritical "true" }} 
-			[{{ $clustername }}] {{ $alertname }} (Critical) {{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
+			{{ $clustername }}|{{ $alertname }}|(Critical)|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
 		{{ else }}
-			[{{ $clustername }}] {{ $alertname }} ({{ $severity | title }}) {{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
+			{{ $clustername }}|{{ $alertname }}|({{ $severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
 		{{ end }}
 	{{ end }}
+
 {{ end }}
 
 {{ define "__description" }}{{ end }}


### PR DESCRIPTION
# Description
There is a difficulty in Gmail filtering due to spaces in Subject.
In this PR we are replacing " "(spaces) with | (Pipes) for easy filtering.

**CSSRE Jira**: https://issues.redhat.com/browse/CSSRE-1572  
**MGDAPI Jira**: https://issues.redhat.com/browse/MGDAPI-2368


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] Verified independently on a cluster by reviewer