### PR TITLE
Ensure e2e tests cater for the multitenant rhoam

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -202,6 +202,19 @@ test/e2e/rhoam/prow: export INSTALLATION_SHORTHAND := rhoam
 test/e2e/rhoam/prow: IN_PROW = "true"
 test/e2e/rhoam/prow: test/e2e
 
+.PHONY: test/e2e/multitenant-rhoam/prow
+test/e2e/multitenant-rhoam/prow: export component := integreatly-operator
+test/e2e/multitenant-rhoam/prow: export OPERATOR_IMAGE := ${IMAGE_FORMAT}
+test/e2e/multitenant-rhoam/prow: export INSTALLATION_TYPE := multitenant-managed-api
+test/e2e/multitenant-rhoam/prow: export SKIP_FLAKES := $(SKIP_FLAKES)
+test/e2e/multitenant-rhoam/prow: export WATCH_NAMESPACE := redhat-rhoam-operator
+test/e2e/multitenant-rhoam/prow: export NAMESPACE_PREFIX := redhat-rhoam-
+test/e2e/multitenant-rhoam/prow: export INSTALLATION_PREFIX := redhat-rhoam
+test/e2e/multitenant-rhoam/prow: export INSTALLATION_NAME := rhoam
+test/e2e/multitenant-rhoam/prow: export INSTALLATION_SHORTHAND := rhoam
+test/e2e/multitenant-rhoam/prow: IN_PROW = "true"
+test/e2e/multitenant-rhoam/prow: test/e2e
+
 .PHONY: test/e2e
 test/e2e: export SURF_DEBUG_HEADERS=1
 test/e2e: cluster/deploy

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -1022,7 +1022,7 @@ func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
 }
 
 func getExpectedAWSRules(installType string, installationName string) []alertsTestRule {
-	if installType == string(rhmiv1alpha1.InstallationTypeManagedApi) {
+	if rhmiv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installType)) {
 		return append(commonExpectedAWSRules(installationName), managedApiAwsExpectedRules(installationName)...)
 	} else {
 		return append(commonExpectedAWSRules(installationName), rhmi2ExpectedAWSRules(installationName)...)
@@ -1030,7 +1030,7 @@ func getExpectedAWSRules(installType string, installationName string) []alertsTe
 }
 
 func getExpectedRules(installType string, installationName string) []alertsTestRule {
-	if installType == string(rhmiv1alpha1.InstallationTypeManagedApi) {
+	if rhmiv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installType)) {
 		return append(commonExpectedRules(installationName), managedApiSpecificRules()...)
 	} else {
 		return append(commonExpectedRules(installationName), rhmi2ExpectedRules()...)

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -194,7 +194,7 @@ func podLogs(t TestingTB, ctx *TestingContext) {
 }
 
 func getPodNamespaces(installType string) []string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(commonPodNamespaces, rhoamExpectedPodNamespaces...)
 	} else {
 		return append(commonPodNamespaces, rhmi2PodNamespaces...)

--- a/test/common/cro_cr_success.go
+++ b/test/common/cro_cr_success.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
@@ -34,7 +33,7 @@ func getPostgres(installType string, installationName string) []string {
 		constants.AMQAuthServicePostgres,
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return commonPostgresToCheck
 	} else {
 		return append(commonPostgresToCheck, rhmi2PostgresToCheck...)
@@ -51,7 +50,7 @@ func getRedisToCheck(installType string, installationName string) []string {
 		fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, installationName),
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(commonRedis, managedApiRedis...)
 	} else {
 		return commonRedis
@@ -67,7 +66,7 @@ func getBlobStorageToCheck(installType, installationName string) []string {
 		fmt.Sprintf("%s%s", constants.BackupsBlobStoragePrefix, installationName),
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return common
 	}
 

--- a/test/common/dashboards_data.go
+++ b/test/common/dashboards_data.go
@@ -218,7 +218,7 @@ func getDashboardExpressions(grafanaPodIp string, curlPodName string, curlContai
 }
 
 func getExpectedServices(installType string) []string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return commonExpectedServices
 	} else {
 		return append(commonExpectedServices, rhmi2ExpectedServices...)

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -205,14 +205,14 @@ func verifyExpectedDashboards(t TestingTB, expectedDashboards []dashboardsTestRu
 }
 
 func getExpectedCustomerDashboard(installType string) []dashboardsTestRule {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return customerRHOAMDashboards
 	}
 	return nil
 }
 
 func getExpectedMiddlewareDashboard(installType string) []dashboardsTestRule {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return commonExpectedDashboards
 	} else {
 		return append(commonExpectedDashboards, rhmi2ExpectedDashboards...)

--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -182,7 +182,7 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 		},
 	}
 
-	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(inst.Spec.Type)) {
 		ratelimitCR := &k8sappsv1.Deployment{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      quota.RateLimitName,
@@ -244,7 +244,7 @@ func getClusterStorageDeployments(installationName string, installType string) [
 		},
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return managedApiClusterStorageDeployments
 	} else {
 		return rhmi2ClusterStorageDeployments
@@ -293,7 +293,7 @@ func TestDeploymentExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				continue
 			}
 
-			if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && product.Name == "ratelimit" {
+			if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) && product.Name == "ratelimit" {
 				pods := &corev1.PodList{}
 				err = ctx.Client.List(context.TODO(), pods, GetListOptions(Marin3rProductNamespace, "app=ratelimit")...)
 				if err != nil {
@@ -354,7 +354,7 @@ func getDeployments(inst *integreatlyv1alpha1.RHMI, t TestingTB, ctx *TestingCon
 		managedApiDeployments = append(managedApiDeployments, getDeploymentConfiguration(deployment, inst, t, ctx))
 	}
 
-	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(inst.Spec.Type)) {
 		return append(append(commonApiDeployments, []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForManagedApi", inst, t, ctx)}...), managedApiDeployments...)
 	} else {
 		return append(append(commonApiDeployments, rhmi2Deployments...), []Namespace{getDeploymentConfiguration("rhmiOperatorDeploymentForRhmi2", inst, t, ctx)}...)
@@ -393,7 +393,7 @@ func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
 				)
 				continue
 			}
-			if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+			if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 				if product.Name == "apicast-production" {
 					pods := &corev1.PodList{}
 					err = ctx.Client.List(context.TODO(), pods, GetListOptions(ThreeScaleProductNamespace, "deploymentconfig=apicast-production")...)
@@ -432,7 +432,7 @@ func TestDeploymentConfigExpectedReplicas(t TestingTB, ctx *TestingContext) {
 }
 
 func getDeploymentConfigs(inst *integreatlyv1alpha1.RHMI, t TestingTB, ctx *TestingContext) []Namespace {
-	if inst.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(inst.Spec.Type)) {
 		return []Namespace{
 			getDeploymentConfiguration("threeScaleDeploymentConfig", inst, t, ctx),
 		}
@@ -459,7 +459,7 @@ func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
 		rhssoExpectedReplicas = 1
 		rhssoUserExpectedReplicas = 1
 	}
-	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 		keycloakCR := &v1alpha1.Keycloak{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      quota.KeycloakName,

--- a/test/common/integreatly_stages.go
+++ b/test/common/integreatly_stages.go
@@ -126,7 +126,7 @@ func TestIntegreatlyStagesStatus(t TestingTB, ctx *TestingContext) {
 }
 
 func getExpectedStageProducts(installType string) map[string][]string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return managedApiExpectedStageProducts
 	} else {
 		return rhmi2ExpectedStageProducts

--- a/test/common/monitoringspec.go
+++ b/test/common/monitoringspec.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	goctx "context"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	monitoringv1 "github.com/coreos/prometheus-operator/pkg/apis/monitoring/v1"
@@ -170,7 +169,7 @@ func checkRoleExists(ctx *TestingContext, name, namespace string) (err error) {
 }
 
 func getExpectedServiceMonitors(installType string) []string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(getServiceMonitorsByType("commonExpectedServiceMonitors"), getServiceMonitorsByType("managedApiServiceMonitors")...)
 	} else {
 		return append(getServiceMonitorsByType("commonExpectedServiceMonitors"), getServiceMonitorsByType("rhmi2ExpectedServiceMonitors")...)

--- a/test/common/namespace_created.go
+++ b/test/common/namespace_created.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	goctx "context"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,7 +72,7 @@ func getNamespaces(t TestingTB, ctx *TestingContext) []string {
 		t.Errorf("error getting RHMI CR: %v", err)
 	}
 
-	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 		return managedApiNamespaces()
 	} else {
 		return rhmi2Namespaces()

--- a/test/common/namespace_restoration.go
+++ b/test/common/namespace_restoration.go
@@ -3,7 +3,6 @@ package common
 import (
 	goctx "context"
 	marin3rv1alpha1 "github.com/3scale/marin3r/apis/marin3r/v1alpha1"
-
 	monitoringv1alpha1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	keycloakv1alpha1 "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
@@ -411,7 +410,7 @@ func removeEnvoyConfigRevisionFinalizers(ctx *TestingContext, nameSpace string) 
 }
 
 func getStagesForInstallType(installType string) []StageDeletion {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(commonStages, managedApiStages...)
 	} else {
 		return append(commonStages, rhmiSpecificStages...)

--- a/test/common/operand_versions.go
+++ b/test/common/operand_versions.go
@@ -69,7 +69,7 @@ func TestProductVersions(t TestingTB, ctx *TestingContext) {
 }
 
 func getProductVersions(installType string) map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.ProductVersion {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return managedApiProductVersions
 	} else {
 		return rhmi2ProductVersions

--- a/test/common/operator_versions.go
+++ b/test/common/operator_versions.go
@@ -67,7 +67,7 @@ func TestProductOperatorVersions(t TestingTB, ctx *TestingContext) {
 
 func getOperatorVersions(installType string) map[integreatlyv1alpha1.StageName]map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.OperatorVersion {
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return managedApiProductOperatorVersions
 	} else {
 		return rhmiProductOperatorVersions

--- a/test/common/priority_validate.go
+++ b/test/common/priority_validate.go
@@ -3,7 +3,6 @@ package common
 import (
 	goctx "context"
 	"fmt"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	appsv1 "k8s.io/api/apps/v1"
@@ -86,7 +85,7 @@ func TestPriorityClass(t TestingTB, ctx *TestingContext) {
 		t.Fatalf("failed to get the RHMI: %s", err)
 	}
 
-	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 		t.Skip("Skipping test as this is not a managed api install")
 	}
 

--- a/test/common/pvc_validate.go
+++ b/test/common/pvc_validate.go
@@ -3,7 +3,6 @@ package common
 import (
 	goctx "context"
 	"fmt"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -80,7 +79,7 @@ func TestPVClaims(t TestingTB, ctx *TestingContext) {
 }
 
 func getPvcNamespaces(installType string) []PersistentVolumeClaim {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return commonPvcNamespaces()
 	} else {
 		return append(commonPvcNamespaces(), rhmi2PvcNamespaces()...)

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"fmt"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	goctx "context"
@@ -210,7 +209,7 @@ func TestIntegreatlyRoutesExist(t TestingTB, ctx *TestingContext) {
 }
 
 func getExpectedRoutes(installType string) map[string][]ExpectedRoute {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return managedApiExpectedRoutes
 	} else {
 		return rhmi2ExpectedRoutes

--- a/test/common/subscription_install_plan.go
+++ b/test/common/subscription_install_plan.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
@@ -128,7 +127,7 @@ func TestSubscriptionInstallPlanType(t TestingTB, ctx *TestingContext) {
 }
 
 func getSubscriptionsToCheck(installType string) []SubscriptionCheck {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(commonSubscriptionsToCheck(), managedApiSubscriptionsToCheck()...)
 	} else {
 		return append(commonSubscriptionsToCheck(), rhmi2SubscriptionsToCheck()...)

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -15,7 +15,7 @@ var (
 				{"Verify RHMI CRD Exists", TestIntegreatlyCRDExists},
 				{"Verify RHMI Config CRD Exists", TestRHMIConfigCRDExists},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 	}
 
@@ -33,7 +33,7 @@ var (
 				/*FLAKY on RHOAM*/ {"E10 - Verify Customer Grafana Route is accessible", TestCustomerGrafanaExternalRouteAccessible},
 				{"A32 - Validate SSO config", TestSSOconfig},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 		{
 			[]TestCase{
@@ -67,7 +67,7 @@ var (
 				{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
 				{"A27 + A28 - Verify pod priority class is created and set", TestPriorityClass},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 	}
 
@@ -83,7 +83,7 @@ var (
 				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
 				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 		{
 			[]TestCase{
@@ -101,14 +101,14 @@ var (
 				{"F08 - Verify Replicas Scale correctly in RHSSO", TestReplicasInRHSSO},
 				{"F08 - Verify Replicas Scale correctly in User SSO", TestReplicasInUserSSO},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 
 		{
 			[]TestCase{
 				{"A34 - Verify Quota values", TestQuotaValues},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 	}
 

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -108,7 +108,7 @@ func TestDedicatedAdminUserPermissions(t TestingTB, ctx *TestingContext) {
 
 	verifyDedicatedAdmin3ScaleRoutePermissions(t, openshiftClient)
 
-	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 
 		// Verify dedicated admin permissions around StandardInfraConfig
 		verifyDedicatedAdminStandardInfraConfigPermissions(t, openshiftClient)
@@ -214,7 +214,7 @@ func verifyDedicatedAdminSecretPermissions(t TestingTB, openshiftClient *resourc
 }
 
 func getProductNamespaces(installType string) []string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return commonNamespaces
 	} else {
 		return append(commonNamespaces, rhmi2NamespacesPermissions...)

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -58,7 +58,7 @@ func TestRHMIDeveloperUserPermissions(t TestingTB, ctx *TestingContext) {
 	openshiftClient := resources.NewOpenshiftClient(ctx.HttpClient, masterURL)
 
 	fuseNamespace := fmt.Sprintf("%sfuse", NamespacePrefix)
-	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 		// test rhmi developer projects are as expected
 		t.Log("testing rhmi 2 developer projects")
 		if err := testRHMI2DeveloperProjects(masterURL, fuseNamespace, openshiftClient); err != nil {
@@ -72,7 +72,7 @@ func TestRHMIDeveloperUserPermissions(t TestingTB, ctx *TestingContext) {
 		}
 	}
 
-	if rhmi.Spec.Type != string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 		// get fuse pods for rhmi developer
 		podlist, err := openshiftClient.ListPods(fuseNamespace)
 		if err != nil {

--- a/test/common/verify_metrics_scrapped.go
+++ b/test/common/verify_metrics_scrapped.go
@@ -3,7 +3,6 @@ package common
 import (
 	"encoding/json"
 	"fmt"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 )
@@ -67,7 +66,7 @@ func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
 }
 
 func getTargets(installType string) map[string][]string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return mangedApiTargets()
 	} else {
 		// TODO - return list for managed install type

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -131,7 +131,7 @@ var _ = BeforeSuite(func(done Done) {
 		"apicurito":            "apicurito-operator",
 	}
 
-	if installType == string(rhmiv1alpha1.InstallationTypeManagedApi) {
+	if rhmiv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installType)) {
 		products = map[string]string{
 			"3scale":   "3scale-operator",
 			"user-sso": "keycloak-operator",

--- a/test/functional/aws_s3_resources_exist.go
+++ b/test/functional/aws_s3_resources_exist.go
@@ -3,7 +3,6 @@ package functional
 import (
 	goctx "context"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
@@ -43,7 +42,7 @@ func TestAWSs3BlobStorageResourcesExist(t common.TestingTB, ctx *common.TestingC
 		t.Fatalf("There should be exactly 2 blob resources for %s install type: actual: %d", rhmi.Spec.Type, len(s3ResourceIDs))
 	}
 
-	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && len(s3ResourceIDs) != 1 {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) && len(s3ResourceIDs) != 1 {
 		t.Fatalf("There should be exactly 1 blob resources for %s install type: actual: %d", rhmi.Spec.Type, len(s3ResourceIDs))
 	}
 
@@ -81,7 +80,7 @@ func TestAWSs3BlobStorageResourcesExist(t common.TestingTB, ctx *common.TestingC
 	}
 
 	// Expect just three scale bucket for managed api install
-	if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) && *threeScaleFound == false {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) && *threeScaleFound == false {
 		testErrors = append(testErrors, fmt.Sprintf("Failed to find appropriate resource names for buckets for managed api install"))
 	}
 

--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
@@ -31,7 +30,7 @@ const (
 )
 
 func getExpectedPostgres(installType string, installationName string) []string {
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		// expected postgres resources provisioned per product
 		return []string{
 			fmt.Sprintf("%s%s", constants.ThreeScalePostgresPrefix, installationName),
@@ -62,7 +61,7 @@ func getExpectedRedis(installType string, installationName string) []string {
 		fmt.Sprintf("%s%s", constants.RateLimitRedisPrefix, installationName),
 	}
 
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return append(commonRedis, managedApiRedis...)
 	} else {
 		return commonRedis
@@ -81,7 +80,7 @@ func getExpectedBlobStorage(installType string, installationName string) []strin
 	}
 
 	// Managed API (RHOAM) contains only 3scale blobstorage
-	if installType == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
 		return threescaleBlobStorage
 	}
 	return append(backupsBlobStorage, threescaleBlobStorage...)

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -36,7 +36,7 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 		}
 
 		if resourceName == "" {
-			if rhmi.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+			if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(rhmi.Spec.Type)) {
 				resourceName = "rhoam"
 			} else {
 				resourceName = "rhmi"


### PR DESCRIPTION
# Description
Update existing tests so they could run with the multitenant rhoam installation. Additionally, add multitenant installation type to the array of suitable install typoes for tests that were used on rhoam. Also, added new make command `make test/e2e/multitenant-rhoam/prow`

# Verification steps 
- watch e2e and multitenant e2e tests succeed on this PR 

Currently, this PR in progress due to the [new installation type](https://github.com/integr8ly/integreatly-operator/pull/1988) being in review. Once it merged, I'll rebase against master and would remove the "WIP". But code could be reviewed anyway, 