### PR TITLE
remove prefix from RoutingSubdomain

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -373,9 +373,9 @@ func (r *Reconciler) retrieveConsoleURLAndSubdomain(ctx context.Context, serverC
 
 	r.installation.Spec.MasterURL = consoleRouteCR.Status.Ingress[0].Host
 	r.installation.Spec.RoutingSubdomain = consoleRouteCR.Status.Ingress[0].RouterCanonicalHostname
+	r.installation.Spec.RoutingSubdomain = strings.TrimPrefix(r.installation.Spec.RoutingSubdomain, "router-default.")
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
-
 }
 
 func getConsoleRouteCR(ctx context.Context, serverClient k8sclient.Client) (*routev1.Route, error) {


### PR DESCRIPTION
# Description
remove prefix from RoutingSubdomain. router-default. was added as a prefix to the canonical router hostname. 
We use this field to create 3Scale and OAuth routes. Remove prefix to revert to a known working state

# Verify
End to end tests are sufficient here.