### PR TITLE
Add Support for Multi Tenant User SSO

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
+	userv1 "github.com/openshift/api/user/v1"
 	"math/rand"
 	"os"
 	"strings"
@@ -46,6 +48,8 @@ import (
 	marin3rconfig "github.com/integr8ly/integreatly-operator/pkg/products/marin3r/config"
 )
 
+var tenantOauthclientSecretsName = "tenant-oauth-client-secrets"
+
 func NewBootstrapReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, logger l.Logger) (*Reconciler, error) {
 	return &Reconciler{
 		ConfigManager: configManager,
@@ -78,6 +82,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)
 		return phase, errors.Wrap(err, "failed to reconcile oauth secrets")
+	}
+
+	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installation.Spec.Type)) {
+		phase, err := r.reconcileTenantOauthSecrets(ctx, serverClient)
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, "Failed to reconcile tenant oauth secrets", err)
+			return phase, errors.Wrap(err, "failed to reconcile tenant oauth secrets")
+		}
 	}
 
 	phase, err = r.reconcilerGithubOauthSecret(ctx, serverClient, installation)
@@ -311,6 +323,76 @@ func (r *Reconciler) reconcilerRHMIConfigCR(ctx context.Context, serverClient k8
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
+func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+
+	allTenants, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error getting teants for OAuth clients secrets: %w", err)
+	}
+
+	oauthClientSecrets := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      tenantOauthclientSecretsName,
+			Namespace: r.ConfigManager.GetOperatorNamespace(),
+		},
+	}
+
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: oauthClientSecrets.Name, Namespace: oauthClientSecrets.Namespace}, oauthClientSecrets)
+	if !k8serr.IsNotFound(err) && err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	} else if k8serr.IsNotFound(err) {
+		oauthClientSecrets.Data = map[string][]byte{}
+	} else if oauthClientSecrets.Data == nil {
+		oauthClientSecrets.Data = map[string][]byte{}
+	}
+
+	for _, tenant := range allTenants.Items {
+		if _, ok := oauthClientSecrets.Data[string(tenant.Name)]; !ok {
+			oauthClient := &oauthv1.OAuthClient{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: r.installation.Spec.NamespacePrefix + string(tenant.Name),
+				},
+			}
+			err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: oauthClientSecrets.Name}, oauthClient)
+			if !k8serr.IsNotFound(err) && err != nil {
+				return integreatlyv1alpha1.PhaseFailed, err
+			} else if k8serr.IsNotFound(err) {
+				oauthClientSecrets.Data[string(tenant.Name)] = []byte(generateSecret(32))
+			} else {
+				// recover secret from existing OAuthClient object in case Secret object was deleted
+				oauthClientSecrets.Data[string(tenant.Name)] = []byte(oauthClient.Secret)
+				r.log.Warningf("OAuth client secret recovered from OAutchClient object", l.Fields{"tenant": string(tenant.Name)})
+			}
+		}
+	}
+
+	// Remove redundant tenant secrets
+	for key, _ := range oauthClientSecrets.Data {
+		if !tenantExists(key, allTenants.Items) {
+			delete(oauthClientSecrets.Data, key)
+		}
+	}
+
+	oauthClientSecrets.ObjectMeta.ResourceVersion = ""
+	err = resources.CreateOrUpdate(ctx, serverClient, oauthClientSecrets)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error reconciling OAuth clients secrets: %w", err)
+	}
+
+	r.log.Info("Tenant OAuth client secrets successfully reconciled")
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func tenantExists(user string, tenants []userv1.User) bool {
+	for _, tenant := range tenants {
+		if tenant.Name == user {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Reconciler) reconcileOauthSecrets(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	// List of products that require secret for OAuthClient
 	productsList := []integreatlyv1alpha1.ProductName{
@@ -374,10 +456,9 @@ func (r *Reconciler) retrieveConsoleURLAndSubdomain(ctx context.Context, serverC
 	}
 
 	r.installation.Spec.MasterURL = consoleRouteCR.Status.Ingress[0].Host
-	r.installation.Spec.RoutingSubdomain = consoleRouteCR.Status.Ingress[0].RouterCanonicalHostname
+	r.installation.Spec.RoutingSubdomain = strings.TrimPrefix(consoleRouteCR.Status.Ingress[0].RouterCanonicalHostname, "router-default.")
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
-
 }
 
 func getConsoleRouteCR(ctx context.Context, serverClient k8sclient.Client) (*routev1.Route, error) {

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -305,7 +305,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		// created because the Keycloak operator does not allow updates to
 		// the realms
 		redirectUris := []string{r.Config.GetHost() + "/auth/realms/openshift/broker/openshift-v4/endpoint"}
-		err = r.SetupOpenshiftIDP(ctx, serverClient, installation, r.Config, kcr, redirectUris)
+		err = r.SetupOpenshiftIDP(ctx, serverClient, installation, r.Config, kcr, redirectUris, "")
 		if err != nil {
 			return fmt.Errorf("failed to setup Openshift IDP: %w", err)
 		}

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -5,8 +5,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
+	croTypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	"github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"strconv"
 	"testing"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -16,17 +22,12 @@ import (
 
 	controllerruntime "sigs.k8s.io/controller-runtime"
 
-	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
-	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-
 	threescalev1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	kafkav1alpha1 "github.com/integr8ly/integreatly-operator/apis-products/kafka.strimzi.io/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
-	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
-	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	consolev1 "github.com/openshift/api/console/v1"
 
@@ -42,11 +43,10 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
-	croTypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -245,6 +245,201 @@ func TestReconciler_config(t *testing.T) {
 	}
 }
 
+func getUser(name string) usersv1.User {
+	return usersv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			UID:  "123",
+		},
+	}
+}
+
+func getAddedUsers() usersv1.UserList {
+	return usersv1.UserList{
+		Items: []usersv1.User{
+			getUser("user1"),
+			getUser("user2"),
+		},
+	}
+}
+
+func TestReconciler_reconcileTenants(t *testing.T) {
+
+	var createKcRealmCalls = 0
+	var createKcUserCalls = 0
+	var deleteKcRealmCalls = 0
+	var deleteKcUserCalls = 0
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	getSigClient := func(preReqObjects []runtime.Object, scheme *runtime.Scheme) *client.SigsClientInterfaceMock {
+		sigsFakeClient := client.NewSigsClientMoqWithScheme(scheme, preReqObjects...)
+		sigsFakeClient.CreateFunc = func(ctx context.Context, obj runtime.Object, opts ...k8sclient.CreateOption) error {
+			switch obj.(type) {
+			case *keycloak.KeycloakRealm:
+				createKcRealmCalls++
+				return nil
+			case *keycloak.KeycloakUser:
+				createKcUserCalls++
+				return nil
+			}
+			return sigsFakeClient.GetSigsClient().Create(ctx, obj)
+		}
+		sigsFakeClient.DeleteFunc = func(ctx context.Context, obj runtime.Object, opts ...k8sclient.DeleteOption) error {
+			switch obj.(type) {
+			case *keycloak.KeycloakRealm:
+				deleteKcRealmCalls++
+				return nil
+			case *keycloak.KeycloakUser:
+				deleteKcUserCalls++
+				return nil
+			}
+			return sigsFakeClient.GetSigsClient().Delete(ctx, obj)
+		}
+		return sigsFakeClient
+	}
+
+	oauthClientSecrets := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-oauth-client-secrets",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{
+			"user2": bytes.NewBufferString("test").Bytes(),
+			"user1": bytes.NewBufferString("test").Bytes(),
+		},
+	}
+
+	var kcr1 = getKcr(keycloak.KeycloakRealmStatus{
+		Phase: keycloak.PhaseReconciling,
+	}, "user1", "redhat-rhoam-user-sso")
+	var kcr2 = getKcr(keycloak.KeycloakRealmStatus{
+		Phase: keycloak.PhaseReconciling,
+	}, "user2", "redhat-rhoam-user-sso")
+
+	kcrs := keycloak.KeycloakRealmList{
+		Items: []keycloak.KeycloakRealm{},
+	}
+
+	kcrs2 := keycloak.KeycloakRealmList{
+		Items: []keycloak.KeycloakRealm{
+			*kcr1,
+			*kcr2,
+		},
+	}
+
+	kc := &keycloak.Keycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      keycloakName,
+			Namespace: defaultNamespace,
+		},
+	}
+
+	cases := []struct {
+		Name                  string
+		FakeClient            k8sclient.Client
+		FakeOauthClient       oauthClient.OauthV1Interface
+		FakeConfig            *config.ConfigReadWriterMock
+		Installation          *integreatlyv1alpha1.RHMI
+		AssertFunc            func()
+		FakeMPM               *marketplace.MarketplaceInterfaceMock
+		Recorder              record.EventRecorder
+		ApiUrl                string
+		Users                 usersv1.UserList
+		KeycloakClientFactory keycloakCommon.KeycloakClientFactory
+		ProductConfig         *quota.ProductConfigMock
+	}{
+		{
+			Name:            "Test reconcile tenant kcrealm and kcuser creation",
+			FakeClient:      getSigClient([]runtime.Object{oauthClientSecrets, &kcrs, kc}, scheme),
+			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
+			FakeConfig:      basicConfigMock(),
+			Installation: &integreatlyv1alpha1.RHMI{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "RHMI",
+					APIVersion: integreatlyv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Namespace: defaultOperatorNamespace,
+				},
+				Spec: integreatlyv1alpha1.RHMISpec{
+					Type: "multitenant-managed-api",
+				},
+			},
+			Users: getAddedUsers(),
+			AssertFunc: func() {
+				if createKcRealmCalls != 2 || createKcUserCalls != 2 {
+					t.Fatal("expected createKcRealm: ", strconv.Itoa(createKcRealmCalls), " and createKcUser: ", strconv.Itoa(createKcUserCalls), " to be called twice each")
+				}
+			},
+			Recorder:              setupRecorder(),
+			ApiUrl:                "https://serverurl",
+			KeycloakClientFactory: getMoqKeycloakClientFactory(),
+			ProductConfig: &quota.ProductConfigMock{
+				ConfigureFunc: func(obj metav1.Object) error {
+					return nil
+				},
+			},
+		},
+		{
+			Name:            "Test reconcile tenant kcrealm and kcuser deletion",
+			FakeClient:      getSigClient([]runtime.Object{oauthClientSecrets, &kcrs2, kc}, scheme),
+			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
+			FakeConfig:      basicConfigMock(),
+			Installation: &integreatlyv1alpha1.RHMI{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "RHMI",
+					APIVersion: integreatlyv1alpha1.GroupVersion.String(),
+				},
+				ObjectMeta: controllerruntime.ObjectMeta{
+					Namespace: defaultOperatorNamespace,
+				},
+				Spec: integreatlyv1alpha1.RHMISpec{
+					Type: "multitenant-managed-api",
+				},
+			},
+			Users: usersv1.UserList{},
+			AssertFunc: func() {
+				if deleteKcRealmCalls != 2 || deleteKcUserCalls != 2 {
+					t.Fatal("expected deleteKcRealm: ", strconv.Itoa(deleteKcRealmCalls), " and deleteKcUser: ", strconv.Itoa(deleteKcUserCalls), " to be called twice each")
+				}
+			},
+			Recorder:              setupRecorder(),
+			ApiUrl:                "https://serverurl",
+			KeycloakClientFactory: getMoqKeycloakClientFactory(),
+			ProductConfig: &quota.ProductConfigMock{
+				ConfigureFunc: func(obj metav1.Object) error {
+					return nil
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			reconciler, err := NewReconciler(
+				tc.FakeConfig,
+				tc.Installation,
+				tc.FakeOauthClient,
+				tc.FakeMPM,
+				tc.Recorder,
+				tc.ApiUrl,
+				tc.KeycloakClientFactory,
+				getLogger(),
+				localProductDeclaration,
+			)
+			if err != nil {
+				t.Fatal("unexpected err ", err)
+			}
+			reconciler.reconcileTenants(context.TODO(), tc.FakeClient, "redhat-rhoam-user-sso", tc.Users)
+			tc.AssertFunc()
+		})
+	}
+}
+
 func TestReconciler_reconcileComponents(t *testing.T) {
 	scheme, err := getBuildScheme()
 	if err != nil {
@@ -267,7 +462,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 
 	kcr := getKcr(keycloak.KeycloakRealmStatus{
 		Phase: keycloak.PhaseReconciling,
-	})
+	}, masterRealmName, "user-sso")
 
 	githubOauthSecret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -575,7 +770,7 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 		{
 			Name:            "test successful reconcile",
 			ExpectedStatus:  integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -808,7 +1003,7 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 		{
 			Name:            "RHOAM - test successful reconcile",
 			ExpectedStatus:  integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet),
+			FakeClient:      moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
@@ -880,17 +1075,17 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 	}
 }
 
-func getKcr(status keycloak.KeycloakRealmStatus) *keycloak.KeycloakRealm {
+func getKcr(status keycloak.KeycloakRealmStatus, name string, ns string) *keycloak.KeycloakRealm {
 	return &keycloak.KeycloakRealm{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      masterRealmName,
-			Namespace: defaultNamespace,
+			Name:      name,
+			Namespace: ns,
 		},
 		Spec: keycloak.KeycloakRealmSpec{
 			Realm: &keycloak.KeycloakAPIRealm{
-				ID:          masterRealmName,
-				Realm:       masterRealmName,
-				DisplayName: masterRealmName,
+				ID:          name,
+				Realm:       name,
+				DisplayName: name,
 				Enabled:     true,
 				EventsListeners: []string{
 					"metrics-listener",


### PR DESCRIPTION
# Description
Add Support for Multi Tenant User SSO

# Verify
Install RHOAM with this branch
Immediately after rhmi CR creation, stop the operator and change type from "managed-api" to "multitenant-managed-api". 
Restart Operator
Add the testing-idp after RHSSO installed: 
``` NUM_REGULAR_USER=10 NUM_ADMIN=5 DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 ./scripts/setup-sso-idp.sh ```
Create an "sre-admin" user in the testing-idp and follow this [SOP](https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/cssre_info/info_cssre_user_sso_access_master_admin_console_2x.asciidoc) to get admin access to user-sso. NOTE: Do not log in prematurely to user-sso (as mentioned in the SOP)!!
Create dev sandbox user namespaces
``` oc new-project test-user01-dev && oc new-project test-user02-dev ``` 
Log into OpenShift with test-user01 and test-user02
Wait for new KCRealm and KCUser CRs to be created 
Give permissions for users for their namespaces:
```oc adm policy add-role-to-user admin test-user01 -n test-user01-dev```
```oc adm policy add-role-to-user admin test-user02 -n test-user02-dev```


## Verify Creation
Log into Openshift as test-user01. Navigate to the Administration view (default is Developer). 
In the Top Right Corner of main pane there should be a link to SSO.
This will be the Realm login
Login and verify that the user is brought to their realm i.e. test-user01 Realm
User should have admin access to this realm but no other realm. 
Verify User and IDP configured in Realm

## Verify as admin
In a new private window login to usersso as sre-admin
Verify 2 new Realms, test-user01 and test-user02

## Verify Delete
`oc delete user test-user01 (deleted related identity also)`
`oc delete user test-user02 (deleted related identity also)`

Wait a period of time for reconcile.
Verify KCRealm and KCUser CRs gone
Verify user `consolelink` and user `oauthclient` CRs are also deleted.
`oc get consolelinks`
`oc get oauthclients`

## Verify delete as admin
In a new private window login to usersso as sre-admin
Verify 2 new Realms, test-user01 and test-user02, no longer exist

