### PR TITLE
sanitise tentant user names

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
-	userv1 "github.com/openshift/api/user/v1"
 	"math/rand"
 	"os"
 	"strings"
@@ -346,29 +345,29 @@ func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClie
 		oauthClientSecrets.Data = map[string][]byte{}
 	}
 
-	for _, tenant := range allTenants.Items {
-		if _, ok := oauthClientSecrets.Data[string(tenant.Name)]; !ok {
+	for _, tenant := range allTenants {
+		if _, ok := oauthClientSecrets.Data[tenant.TenantName]; !ok {
 			oauthClient := &oauthv1.OAuthClient{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: r.installation.Spec.NamespacePrefix + string(tenant.Name),
+					Name: r.installation.Spec.NamespacePrefix + tenant.TenantName,
 				},
 			}
 			err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: oauthClientSecrets.Name}, oauthClient)
 			if !k8serr.IsNotFound(err) && err != nil {
 				return integreatlyv1alpha1.PhaseFailed, err
 			} else if k8serr.IsNotFound(err) {
-				oauthClientSecrets.Data[string(tenant.Name)] = []byte(generateSecret(32))
+				oauthClientSecrets.Data[tenant.TenantName] = []byte(generateSecret(32))
 			} else {
 				// recover secret from existing OAuthClient object in case Secret object was deleted
-				oauthClientSecrets.Data[string(tenant.Name)] = []byte(oauthClient.Secret)
-				r.log.Warningf("OAuth client secret recovered from OAutchClient object", l.Fields{"tenant": string(tenant.Name)})
+				oauthClientSecrets.Data[tenant.TenantName] = []byte(oauthClient.Secret)
+				r.log.Warningf("OAuth client secret recovered from OAutchClient object", l.Fields{"tenant": tenant.TenantName})
 			}
 		}
 	}
 
 	// Remove redundant tenant secrets
 	for key, _ := range oauthClientSecrets.Data {
-		if !tenantExists(key, allTenants.Items) {
+		if !tenantExists(key, allTenants) {
 			delete(oauthClientSecrets.Data, key)
 		}
 	}
@@ -384,9 +383,9 @@ func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClie
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func tenantExists(user string, tenants []userv1.User) bool {
+func tenantExists(user string, tenants []userHelper.MultiTenantUser) bool {
 	for _, tenant := range tenants {
-		if tenant.Name == user {
+		if tenant.TenantName == user {
 			return true
 		}
 	}

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -245,21 +246,19 @@ func TestReconciler_config(t *testing.T) {
 	}
 }
 
-func getUser(name string) usersv1.User {
-	return usersv1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			UID:  "123",
-		},
+func getUser(name string) userHelper.MultiTenantUser {
+	return userHelper.MultiTenantUser{
+		Username:   name,
+		TenantName: name,
+		Email:      "asdf@bla.com",
+		UID:        "123",
 	}
 }
 
-func getAddedUsers() usersv1.UserList {
-	return usersv1.UserList{
-		Items: []usersv1.User{
-			getUser("user1"),
-			getUser("user2"),
-		},
+func getAddedUsers() []userHelper.MultiTenantUser {
+	return []userHelper.MultiTenantUser{
+		getUser("user1"),
+		getUser("user2"),
 	}
 }
 
@@ -348,7 +347,7 @@ func TestReconciler_reconcileTenants(t *testing.T) {
 		FakeMPM               *marketplace.MarketplaceInterfaceMock
 		Recorder              record.EventRecorder
 		ApiUrl                string
-		Users                 usersv1.UserList
+		Users                 []userHelper.MultiTenantUser
 		KeycloakClientFactory keycloakCommon.KeycloakClientFactory
 		ProductConfig         *quota.ProductConfigMock
 	}{
@@ -401,7 +400,7 @@ func TestReconciler_reconcileTenants(t *testing.T) {
 					Type: "multitenant-managed-api",
 				},
 			},
-			Users: usersv1.UserList{},
+			Users: []userHelper.MultiTenantUser{},
 			AssertFunc: func() {
 				if deleteKcRealmCalls != 2 || deleteKcUserCalls != 2 {
 					t.Fatal("expected deleteKcRealm: ", strconv.Itoa(deleteKcRealmCalls), " and deleteKcUser: ", strconv.Itoa(deleteKcUserCalls), " to be called twice each")


### PR DESCRIPTION
# Description
sanitise tentant user names before resources are created

# Verify
Verify in the same way as [PR 2011](https://github.com/integr8ly/integreatly-operator/pull/2011) except use "invalid usernames".
Create users TEST_USER_1 and TEST_USER_2 in the testing IDP and use them in place of test-user01 and test-user02
