### PR TITLE
Fix alertmanager custom email template

### DIFF
--- a/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
+++ b/templates/monitoring/alertmanager/alertmanager-email-config.tmpl
@@ -2,35 +2,35 @@
 {{ define "__alertmanagerURL" }}{{ .ExternalURL }}/#/alerts?receiver={{ .Receiver | urlquery }}{{ end }}
 
 {{/* custom subject template */}}
-{{ define "__intlysubject" }}
+{{ define "__intlysubject" -}}
 	
-	{{/* declaring variables */}}
-	{{ $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}"}} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" }}
+	{{- /* declaring variables */ -}}
+	{{- $lenOfAlerts := ( len .Alerts ) }} {{ $clustername := "${CLUSTER_NAME}" }} {{ $alertname := "" }} {{ $severity := "" }} {{ $ifCritical := "" -}}
 
-  {{/* checking if there is single or multiple alerts */}}
-	{{if eq $lenOfAlerts 1 }} 
-		{{ $clustername }}|{{ .CommonLabels.alertname  }}|({{ .CommonLabels.severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}{{ end }}
-	{{ else }}
-		{{if gt $lenOfAlerts 1 }} 
-			{{ $alertname = "Multiple Alerts*" }}
-			{{ if eq .CommonLabels.severity "critical" }} 
-				{{ $ifCritical = "true" }}
-			{{ else }}
-				{{ $severity = ( .CommonLabels.severity ) }} 
-			{{ end }}
-		{{ end }}
-	{{ end }}
+  {{- /* checking if there is single or multiple alerts */ -}}
+	{{- if eq $lenOfAlerts 1 -}} 
+		{{- $clustername }}|{{ .CommonLabels.alertname  }}|({{ .CommonLabels.severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}{{ end -}}
+	{{- else -}}
+		{{- if gt $lenOfAlerts 1 -}} 
+			{{- $alertname = "Multiple Alerts*" -}}
+			{{- if eq .CommonLabels.severity "critical" -}} 
+				{{- $ifCritical = "true" -}}
+			{{- else -}}
+				{{- $severity = ( .CommonLabels.severity ) -}} 
+			{{- end -}}
+		{{- end -}}
+	{{- end -}}
 
-	{{/* in case of multiple alerts, checking if the severity of any alert(s) is critical*/}}
-	{{ if eq $alertname "Multiple Alerts*" }}
-		{{ if eq $ifCritical "true" }} 
-			{{ $clustername }}|{{ $alertname }}|(Critical)|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
-		{{ else }}
-			{{ $clustername }}|{{ $alertname }}|({{ $severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end }}
-		{{ end }}
-	{{ end }}
+	{{- /* in case of multiple alerts, checking if the severity of any alert(s) is critical*/ -}}
+	{{- if eq $alertname "Multiple Alerts*" -}}
+		{{- if eq $ifCritical "true" -}} 
+			{{- $clustername }}|{{ $alertname }}|(Critical)|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end -}}
+		{{- else -}}
+			{{- $clustername }}|{{ $alertname }}|({{ $severity | title }})|{{ .Status | title }}{{ if eq .Status "firing" }}:{{ .Alerts.Firing | len }}{{ end -}}
+		{{- end -}}
+	{{- end -}}
 
-{{ end }}
+{{- end }}
 
 {{ define "__description" }}{{ end }}
  


### PR DESCRIPTION
**Related Jira:** [https://issues.redhat.com/browse/MGDAPI-2484](https://issues.redhat.com/browse/MGDAPI-2484)

#### Description

Currently, the way the custom email subject template ["__intlysubject"](https://github.com/integr8ly/integreatly-operator/blob/master/templates/monitoring/alertmanager/alertmanager-email-config.tmpl) is written, it produces unwanted tabs & extra whitespaces on the PagerDuty receiver end, which breaks the CI/CD pipelines (used by CS-SRE teams) consuming Pagerduty incident webhooks.

Before PR changes, the title looks like ~

![Screenshot from 2021-08-12 11-04-38](https://user-images.githubusercontent.com/30499743/129148398-c616f32a-bb8a-4bfd-92d4-da0d18e74cfd.png)

#### The PR make the following changes:

- improve the custom email template ( [__intlysubject](https://github.com/integr8ly/integreatly-operator/blob/master/templates/monitoring/alertmanager/alertmanager-email-config.tmpl)) to remove white-spaces & indentation when the template are resolved to actual values.

After fixes, the title looks like ~

![Screenshot from 2021-08-12 11-03-45](https://user-images.githubusercontent.com/30499743/129148449-f3e0e991-f929-4158-a933-7fb5c6fa95a7.png)

## Type of change

<!-- Please delete options that are not relevant. -->

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [X] Verified independently on a cluster by reviewer