### PR TITLE
Add multitenant rate limiting

### DIFF
--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -439,6 +439,9 @@ func (r *RateLimitServiceReconciler) getLimitPerTenantFromConfigMap(client k8scl
 			configMap.Data[multitenantRateLimit] = fmt.Sprint(r.getLimitPerTenant())
 			return nil
 		})
+		if err != nil {
+			return 0, fmt.Errorf("Error when creating config map %w", err)
+		}
 	}
 
 	limitPerTenant, err := strconv.ParseInt(configMap.Data[multitenantRateLimit], 10, 64)


### PR DESCRIPTION
# Description
This PR covers adding rate limiting configuration for multitenant Managed Api Service. 
Updated are:
1. Envoy configuration - additional lua filter that adds an extra header
2. Descriptors - an additional descriptor that allows rate limiting per tenant
3. Config map - additional config map that allows for manual setting of the rate limit per tenant or (by default) sets rate limit per tenant based on current quota / 3k users.

# Verification
Verification will be required on both RHOAM and RHOAM multitenant

## For RHOAM Multitenant
- prepare 6 m5xlarge cluster
- from this branch run `INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local`
- run `DEV_QUOTA=1 INSTALLATION_TYPE=multitenant-managed-api make code/run`
- Wait for RHOAM to install (verify by looking RHMI CR that it is installed)
- Follow the documentation for setting up dev sandbox integration (if you don't have access to doc reach out to me please)
- Log in as `test-user01` - approve usersignup and navigate to 3scale admin path of that user and create a sample 3scale product.
- Navigate to product integration and promote product to production
- Do same for `test-user02`
- By the end, you should have 4 routes available
NOTE: Requets must be made within 1 minute (as rate limit resets every 1 minute - you can check the time your requests has reached the server by looking at the response)
a) apicast stage for test-user01 and test-user02
b) apicast production for both tests users
- Prepare curl commands to start pinging apicasts (`curl -i "https://<APICAST_ROUTE>/user_key<USER_KEY>"`)
- Navigate to confgmaps under `redhat-rhoam-marin3r` ns and check the `multitenant-config` map, which should have value of `1`
- Hit apicast endpoint with prepared curl commands via terminal:
a) test-user01 apicast stage - should succeed 
b) test-user02 apicast stage - should succeed
c) test-user01 apicast prod - should fail
d) test-user02 apicast prod - should fail
- next, update the multitenant-config with value of 5
- wait 20 seconds and repeat hits against apicast:
a) test-user01 - perform 3 requests against stage, 2 against prod - 3rd against prod should fail
b) test-user02 - perform 3 requests against stage, 2 against pord - 3rd against prod should fail
- next, stop rhoam operator (local)
- in the config map called  `rate-limit-config` update requests_per_unit to 5 and in the `multitenant-config` to 3
- under marin3r ns delete both of rate-limit pods and wait for them to be re-created.
- once they are redeployed perform following requests:
a) test-user01 apicast stage - perform 2 requests, apicast prod perform 1 request
b) test-user02 apicast stage - perform 2 requests, apicast prod, perform 1 request - it should fail as global rate limit has been reached.
- perform following requests:
a) test-user01 apicast stage - perform 3 requests
b) test-user02 apicast prod - perform 3 requests (3rd request should fail)
- next, switch operator back on
- delete `multitenant-config` config map, it should get recreated with a value of 1

## For RHOAM 
- install rhoam locally via `INSTALLATION_TYPE=managed-api make code/run`
- once it is installed, confirm that the apicast rate-limit envoy config under 3scale ns doesn't have the lua script:
```
                    '@type': type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
                    inlineCode: function envoy_on_request(request_handle) host = request_handle:headers():get('Host')
                      local headers = request_handle:headers() split_string = Split(host, '-apicast')
                      headers:add('tenant', split_string[1]) end function Split(s, delimiter)
                      result = {}; for match in (s..delimiter):gmatch('(.-)'..delimiter) do
                      table.insert(result, match); end return result; end
```
- verify that the `multitenant-config` config map is not present under the redhat-rhoam-marin3r ns
- verify that the `rate-limit-config` config map is present under marin3r ns
- turn off the operator (local)
- edit the `rate-limit-config` to 5 requests_per_unit
- create 3scale product using 3scale-admin route found under 3scale routes 
- make 6 requests to apicast (either stage or prod) - 6th request should fail.


