### PR TITLE
MGDAPI-2489 - 3scale api error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -338,11 +338,11 @@ cluster/check/operator/deployment:
 .PHONY: cluster/prepare/smtp
 cluster/prepare/smtp:
 	@-oc create secret generic $(NAMESPACE_PREFIX)smtp -n $(NAMESPACE) \
-		--from-literal=host=smtp.example.com \
-		--from-literal=username=dummy \
-		--from-literal=password=dummy \
-		--from-literal=port=587 \
-		--from-literal=tls=true
+		--from-literal=host= \
+		--from-literal=username= \
+		--from-literal=password= \
+		--from-literal=port= \
+		--from-literal=tls=
 
 .PHONY: cluster/prepare/pagerduty
 cluster/prepare/pagerduty:

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -831,6 +831,13 @@ func (r *Reconciler) reconcileAlertManagerConfigSecret(ctx context.Context, serv
 	clusterName := clusterInfra.Status.InfrastructureName
 	clusterID := string(clusterVersion.Spec.ClusterID)
 
+	if string(smtpSecret.Data["host"]) == "" {
+		smtpSecret.Data["host"] = []byte("smtp.example.com")
+	}
+	if string(smtpSecret.Data["port"]) == "" {
+		smtpSecret.Data["port"] = []byte("587")
+	}
+
 	// parse the config template into a secret object
 	templateUtil := NewTemplateHelper(map[string]string{
 		"SMTPHost":              string(smtpSecret.Data["host"]),

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -6,12 +6,13 @@ import (
 	"fmt"
 	"os"
 
-	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"net/http"
 	"strconv"
 	"strings"
+
+	hcm "github.com/envoyproxy/go-control-plane/envoy/config/filter/network/http_connection_manager/v2"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/user"
 
 	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 
@@ -1365,56 +1366,66 @@ func (r *Reconciler) reconcile3scaleMultiTenancy(ctx context.Context, serverClie
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	r.log.Infof("retrieving list of MT accounts available ",
-		l.Fields{"accounts": accounts},
+	r.log.Infof("Retrieving list of MT accounts available ",
+		l.Fields{"Accounts": accounts},
 	)
 
+	signUpAccountsSecret, err := getAccessTokenSecret(ctx, serverClient, r.Config.GetNamespace())
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	// looping through the accounts to reconcile default config back
 	for _, account := range accounts {
 		if account.State == "approved" {
 			for _, user := range account.Users.User {
 				if user.State == "pending" {
-					r.log.Infof("activating user", l.Fields{"user Activated": user.Username})
+					r.log.Infof("Activating user account",
+						l.Fields{"userAccount": user.Username},
+					)
 
 					err = r.tsClient.ActivateUser(*accessToken, account.Id, user.Id)
 					if err != nil {
-						r.log.Error("Error activating users in new tenant account:", err)
-						return integreatlyv1alpha1.PhaseFailed, err
+						r.log.Errorf("Error activating users in new tenant account:",
+							l.Fields{"userAccount": user.Username},
+							err,
+						)
 					}
 				}
 			}
 
-			signUpAccountsSecret := &corev1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "mt-signupaccount-3scale-access-token",
-					Namespace: r.Config.GetNamespace(),
+			val, ok := signUpAccountsSecret.Data[string(account.OrgName)]
+			if !ok || string(val) == "" {
+				r.log.Infof("Tenant Account does not have access token created",
+					l.Fields{"tenantAccount": account},
+				)
+				continue
+			}
+			signUpAccount := SignUpAccount{
+				AccountDetail: account,
+				AccountAccessToken: AccountAccessToken{
+					Value: string(val),
 				},
 			}
-			err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: signUpAccountsSecret.Name, Namespace: signUpAccountsSecret.Namespace}, signUpAccountsSecret)
+			r.log.Infof("Adding authentication provider to MT 3scale account",
+				l.Fields{"tenantAccount": signUpAccount},
+			)
+			// verify if the account have the auth provider already
+			err = r.AddAuthProviderToMTAccount(ctx, serverClient, signUpAccount)
 			if err != nil {
-				return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error getting access token secret: %w", err)
+				r.log.Errorf("Error adding authentication provider to 3scale account",
+					l.Fields{"tenantAccount": signUpAccount},
+					err,
+				)
 			}
 
-			if val, ok := signUpAccountsSecret.Data[string(account.OrgName)]; ok {
-				signUpAccount := SignUpAccount{
-					AccountDetail: account,
-					AccountAccessToken: AccountAccessToken{
-						Value: string(val),
-					},
-				}
-				// verify if the account have the auth provider already
-				err = r.AddAuthProviderToMTAccount(ctx, serverClient, signUpAccount)
-				r.log.Infof("Add auth provider for missing account:",
-					l.Fields{"accountsWithProvider": signUpAccount},
-				)
-				if err != nil {
-					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error adding auth provider: %w", err)
-				}
-			}
 			err = r.reconcileDashboardLink(ctx, serverClient, account.OrgName, account.AdminBaseURL)
 			if err != nil {
-				return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error reconciling console link: %v", err)
+				r.log.Errorf("Error reconciling console link for the MT account",
+					l.Fields{"tenantAccount": signUpAccount},
+					err,
+				)
 			}
-
 		}
 	}
 
@@ -1424,61 +1435,25 @@ func (r *Reconciler) reconcile3scaleMultiTenancy(ctx context.Context, serverClie
 		l.Fields{"accountsToBeCreated": accountsToBeCreated},
 	)
 
-	// TODO: create CM with account state of each account
-
 	for _, account := range accountsToBeCreated {
 		// create account
 		newSignupAccount, err := r.tsClient.CreateTenant(*accessToken, account)
 		if err != nil {
-			r.log.Error("Error creating new tenant accounts:", err)
-			return integreatlyv1alpha1.PhaseFailed, err
+			r.log.Errorf("Error creating new tenant account",
+				l.Fields{"tenantAccount": newSignupAccount},
+				err,
+			)
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error creating new tenant account: %v", err)
 		}
-		r.log.Infof("new MT account created",
-			l.Fields{"signupAccount": newSignupAccount},
+		r.log.Infof("New 3scale MT account created",
+			l.Fields{"tenantAccount": newSignupAccount},
 		)
-		// TODO: store token in a secret
-		signUpAccountsSecret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "mt-signupaccount-3scale-access-token",
-				Namespace: r.Config.GetNamespace(),
-			},
-		}
 
-		err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: signUpAccountsSecret.Name, Namespace: signUpAccountsSecret.Namespace}, signUpAccountsSecret)
-		if !k8serr.IsNotFound(err) && err != nil {
-			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error getting access token secret: %w", err)
-		} else if k8serr.IsNotFound(err) {
-			signUpAccountsSecret.Data = map[string][]byte{}
-		}
-
-		signUpAccountsSecret.ObjectMeta.ResourceVersion = ""
 		signUpAccountsSecret.Data[string(account.OrgName)] = []byte(newSignupAccount.AccountAccessToken.Value)
+		signUpAccountsSecret.ObjectMeta.ResourceVersion = ""
 		err = resources.CreateOrUpdate(ctx, serverClient, signUpAccountsSecret)
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error creating access token secret: %w", err)
-		}
-
-		for _, user := range account.Users.User {
-			if user.State == "pending" {
-				err = r.tsClient.ActivateUser(*accessToken, account.Id, user.Id)
-				if err != nil {
-					r.log.Error("Error activating users in new tenant account:", err)
-					return integreatlyv1alpha1.PhaseFailed, err
-				}
-			}
-		}
-
-		err = r.AddAuthProviderToMTAccount(ctx, serverClient, *newSignupAccount)
-		r.log.Infof("Accounts with AddAuthProviderToMTAccounts:",
-			l.Fields{"accountsWithProvider": newSignupAccount},
-		)
-		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error adding auth provider: %w", err)
-		}
-
-		err = r.reconcileDashboardLink(ctx, serverClient, newSignupAccount.AccountDetail.OrgName, newSignupAccount.AccountDetail.AdminBaseURL)
-		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error reconciling console link: %v", err)
 		}
 	}
 
@@ -1491,7 +1466,32 @@ func (r *Reconciler) reconcile3scaleMultiTenancy(ctx context.Context, serverClie
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
+	// Remove redundant access token secrets
+	for _, account := range accountsToBeDeleted {
+		_, ok := signUpAccountsSecret.Data[string(account.OrgName)]
+		if ok {
+			delete(signUpAccountsSecret.Data, string(account.OrgName))
+		}
+	}
+
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func getAccessTokenSecret(ctx context.Context, serverClient k8sclient.Client, namespace string) (*corev1.Secret, error) {
+	signUpAccountsSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mt-signupaccount-3scale-access-token",
+			Namespace: namespace,
+		},
+	}
+	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: signUpAccountsSecret.Name, Namespace: signUpAccountsSecret.Namespace}, signUpAccountsSecret)
+	if !k8serr.IsNotFound(err) && err != nil {
+		return nil, fmt.Errorf("Error getting access token secret: %w", err)
+	} else if k8serr.IsNotFound(err) {
+		signUpAccountsSecret.Data = map[string][]byte{}
+	}
+
+	return signUpAccountsSecret, nil
 }
 
 func (r *Reconciler) reconcileDashboardLink(ctx context.Context, serverClient k8sclient.Client, username string, tenantLink string) error {

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/integr8ly/integreatly-operator/test/resources"
 	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"gopkg.in/yaml.v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -121,11 +122,10 @@ func verifySecrets(kubeClient kubernetes.Interface) error {
 		return fmt.Errorf("secret key is undefined in pager duty secret")
 	}
 
-	res, err = kubeClient.CoreV1().Secrets(RHMIOperatorNamespace).Get(goctx.TODO(), NamespacePrefix+"smtp", metav1.GetOptions{})
+	smtp, err := resources.GetSMTPSecret(kubeClient, RHMIOperatorNamespace, SMTPSecretName)
 	if err != nil {
-		return fmt.Errorf("failed to get secret: %w", err)
+		return err
 	}
-	smtp := res.Data
 
 	res, err = kubeClient.CoreV1().Secrets(MonitoringOperatorNamespace).Get(goctx.TODO(), "alertmanager-application-monitoring", metav1.GetOptions{})
 	if err != nil {

--- a/test/common/sendgrid_credentials_valid.go
+++ b/test/common/sendgrid_credentials_valid.go
@@ -1,26 +1,26 @@
 package common
 
 import (
-	"context"
 	"crypto/tls"
 	"net/smtp"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
 )
 
 func TestSendgridCredentialsAreValid(t TestingTB, ctx *TestingContext) {
+
 	// Get SMTP secret from rhmi-operator namespace
 	kc := ctx.KubeClient
-	smtpSecret, err := kc.CoreV1().Secrets(RHMIOperatorNamespace).Get(context.TODO(), NamespacePrefix+"smtp", metav1.GetOptions{})
+	smtpSecret, err := resources.GetSMTPSecret(kc, RHMIOperatorNamespace, SMTPSecretName)
 	if err != nil {
 		t.Fatal("Failed to get an SMTP secret", err)
 	}
 
 	username, password, host, port :=
-		string(smtpSecret.Data["username"]),
-		string(smtpSecret.Data["password"]),
-		string(smtpSecret.Data["host"]),
-		string(smtpSecret.Data["port"])
+		string(smtpSecret["username"]),
+		string(smtpSecret["password"]),
+		string(smtpSecret["host"]),
+		string(smtpSecret["port"])
 
 	if host != "smtp.sendgrid.net" {
 		if host != "smtp.example.com" {
@@ -29,10 +29,10 @@ func TestSendgridCredentialsAreValid(t TestingTB, ctx *TestingContext) {
 		if port != "587" {
 			t.Fatal("Dummy port values have changed. Expected: 587, Actual: ", port)
 		}
-		if username != "dummy" {
+		if username != "" && username != "dummy" {
 			t.Fatal("Dummy uesrname values have changed. Expected: dummy, Actual: ", username)
 		}
-		if password != "dummy" {
+		if password != "" && password != "dummy" {
 			t.Fatal("Dummy password values have changed. Expected: dummy, Actual: %s", password)
 		}
 

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -23,6 +23,7 @@ var (
 	MonitoringFederateNamespace       = NamespacePrefix + "middleware-monitoring-federate"
 	AMQOnlineOperatorNamespace        = NamespacePrefix + "amq-online"
 	ApicurioRegistryProductNamespace  = NamespacePrefix + "apicurio-registry"
+	SMTPSecretName                    = NamespacePrefix + "smtp"
 	ApicurioRegistryOperatorNamespace = ApicurioRegistryProductNamespace + "-operator"
 	ApicuritoProductNamespace         = NamespacePrefix + "apicurito"
 	ApicuritoOperatorNamespace        = ApicuritoProductNamespace + "-operator"

--- a/test/resources/util.go
+++ b/test/resources/util.go
@@ -1,7 +1,13 @@
 package resources
 
 import (
+	goctx "context"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"k8s.io/client-go/kubernetes"
 )
 
 func RunningInProw(inst *integreatlyv1alpha1.RHMI) bool {
@@ -9,4 +15,21 @@ func RunningInProw(inst *integreatlyv1alpha1.RHMI) bool {
 		return false
 	}
 	return true
+}
+
+func GetSMTPSecret(kubeClient kubernetes.Interface, operatorNamespace string, secretName string) (map[string][]byte, error) {
+	res, err := kubeClient.CoreV1().Secrets(operatorNamespace).Get(goctx.TODO(), secretName, metav1.GetOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to get secret: %w", err)
+	}
+	smtp := res.Data
+	// sets default smtp host value as
+	// it could not be set in the smtp secret to avoid issue with the 3scale api
+	if string(smtp["host"]) == "" {
+		smtp["host"] = []byte("smtp.example.com")
+	}
+	if string(smtp["port"]) == "" {
+		smtp["port"] = []byte("587")
+	}
+	return smtp, nil
 }


### PR DESCRIPTION
# Description

There is a issue when creating new tenant accounts in 3scale and smtp is not configured correctly the 3scale API create the tenant account but returns an error, to avoid this from happening the smtp secret needs to be created with empty values so the 3scale API doesn't attempt to send an email after the creation of the new tenant account.

https://issues.redhat.com/browse/MGDAPI-2489

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Verification steps
1) Install the operator from this branch INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local && INSTALLATION_TYPE=multitenant-managed-api make code/run
2) Go to the 3scale API under the master account and create a new tenant account or run this curl command below
```
curl -v  -X POST "https://master.<CLUSTER-URL>/master/api/providers.xml" -d 'access_token=<MASTER-TOKEN>&org_name=test2&username=test2&email=test2%40test2.com&password=MT'
```
3) Make sure an error is not returned from the 3scale API.