### PR TITLE
MGDAPI-1260 - C19 e2e Test

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1309,8 +1309,8 @@ func (r *Reconciler) updateKeycloakUsersAttributeWith3ScaleUserId(ctx context.Co
 	for _, user := range kcu {
 		tsUser, err := r.tsClient.GetUser(strings.ToLower(user.UserName), *accessToken)
 		if err != nil {
-			return integreatlyv1alpha1.PhaseInProgress,
-				fmt.Errorf("failed to get 3scale user with keycloak username %s, err: %s", user.UserName, err)
+			// Continue installation to not block for when users could not be created in 3scale (i.e. too many characters in username)
+			continue
 		}
 
 		if user.Attributes == nil {

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -939,7 +939,7 @@ func TestReconciler_updateKeycloakUsersAttributeWith3ScaleUserId(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "Test - Get 3scale User failed - PhaseInProgress",
+			name: "Test - Get 3scale User failed - Continued - PhaseCompleted",
 			fields: fields{
 				ConfigManager: &config.ConfigReadWriterMock{ReadRHSSOFunc: func() (*config.RHSSO, error) {
 					return config.NewRHSSO(config.ProductConfig{
@@ -964,8 +964,7 @@ func TestReconciler_updateKeycloakUsersAttributeWith3ScaleUserId(t *testing.T) {
 				},
 				accessToken: &accessToken,
 			},
-			want:    integreatlyv1alpha1.PhaseInProgress,
-			wantErr: true,
+			want: integreatlyv1alpha1.PhaseCompleted,
 		},
 		{
 			name: "Test - Update Keycloak User failed - PhaseInProgress",

--- a/test-cases/tests/alerts/c19-validate-creation-of-invalid-username-triggers-alert.md
+++ b/test-cases/tests/alerts/c19-validate-creation-of-invalid-username-triggers-alert.md
@@ -11,77 +11,11 @@ products:
       - 1.6.0
       - 1.9.0
 tags:
+  - automated
   - destructive
 estimate: 15m
 ---
 
 # C19 - Validate creation of invalid username triggers alert
 
-## Prerequisites
-
-1. Login to OpenShift console and via `oc` as a user with **cluster-admin** role (kubeadmin):
-
-   ```shell script
-   oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:6443
-   ```
-
-2. Access to OCM QE console
-
-## Steps
-
-1. Create a new user with long name (more than 40 characters)
-
-```bash
-echo '{"apiVersion": "user.openshift.io/v1", "kind": "User", "metadata": {"name": "alongusernamethatisabovefourtycharacterslong"}}' | oc apply -f -
-```
-
-2. Go to `redhat-rhoam-rhsso` namespace
-3. Search for "keycloakusers" CR
-   > Validate that there is not keycloakuser that contains the name "alongusernamethatisabovefourtycharacterslong"
-4. Get RHSSO admin password and note it down
-
-```bash
-oc get secret credential-rhsso -n redhat-rhoam-rhsso -o json | jq -r '.data.ADMIN_PASSWORD' | base64 --decode
-```
-
-5. Go to keycloak admin console and log in as `admin` and password from the previous step
-
-```bash
-open "https://$(oc get route keycloak -n redhat-rhoam-rhsso -o=jsonpath='{.spec.host}')"
-```
-
-6. Select `testing-idp` realm -> Users -> Add user
-7. Create username `alongusernamethatisabovefourtycharacterslong2` and hit Save
-8. Go to `Credentials` tab, fill in password and switch `Temporary` to OFF, hit Set password
-9. In Anonymous window, go to OpenShift console and login via testing-idp as `alongusernamethatisabovefourtycharacterslong2` user
-10. Go to alert manager and log in as kubeadmin
-
-```bash
-open "https://$(oc get route alertmanager-route -n redhat-rhoam-middleware-monitoring-operator -o jsonpath='{.spec.host}')"
-```
-
-> Validate there is "ThreeScaleUserCreationFailed" alert firing
-
-11. Delete the user from OpenShift
-
-```bash
-oc delete user alongusernamethatisabovefourtycharacterslong2
-```
-
-12. Go back to the alert manager
-    > Validate that the alert is no longer firing (it might take some time)
-13. In a new anonymous window, login to the cluster via testing-idp as customer-admin01 user
-14. Get 3scale admin password and note it down
-
-```bash
-oc get secret system-seed -n redhat-rhoam-3scale -o json | jq -r '.data.ADMIN_PASSWORD' | base64 --decode
-```
-
-15. In OpenShift console, go to 3scale namespace -> Routes and navigate to 3scale admin console
-16. Log in as `admin` and use the password from the previous step
-17. Go to settings -> Users -> Listing
-    > Verify that customer-admin01 user is listed there
-18. Go to OCM UI console and search for the testing cluster
-19. Go to Access control and delete testing-idp and all customer admin users
-20. Go back to 3scale admin console and refresh the page with user listing
-    > Verify that the customer-admin01 user is no longer present in 3scale
+https://github.com/integr8ly/integreatly-operator/blob/master/test/common/alerts_invalid_username.go

--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -1,0 +1,259 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	configv1 "github.com/openshift/api/config/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strings"
+	"time"
+)
+
+const (
+	userFailedCreateAlertName = "ThreeScaleUserCreationFailed"
+	userLong1                 = "alongusernamethatisabovefourtycharacterslong"
+	userLong2                 = "alongusernamethatisabovefourtycharacterslong2"
+)
+
+var (
+	userLongName = &userv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userLong1,
+		},
+	}
+	usersToCreateInTestingIDP = []TestUser{
+		{
+			UserName:  userLong2,
+			FirstName: "TooMuch",
+			LastName:  "Character",
+		},
+	}
+	clusterOauthPreTest = &configv1.OAuth{}
+)
+
+func TestInvalidUserNameAlert(t TestingTB, ctx *TestingContext) {
+	goCtx := context.TODO()
+
+	// Get resources before test execution and always try to restore cluster to pre test state
+	if err := ctx.Client.Get(goCtx, types.NamespacedName{Name: clusterOauthName}, clusterOauthPreTest); err != nil {
+		t.Fatalf("error occurred while getting cluster oauth: %w", err)
+	}
+	defer restoreClusterStatePreTest(t, ctx)
+
+	// Create Testing IDP
+	if err := createTestingIDP(t, goCtx, ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts); err != nil {
+		t.Fatalf("error while creating testing idp: %v", err)
+	}
+
+	// Get RHMI CR details for test
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Create User
+	if err := ctx.Client.Create(goCtx, userLongName); err != nil {
+		t.Fatalf("Error creating openshift user: %s", err)
+	}
+	t.Logf("Openshift user %s created", userLongName.Name)
+
+	// List Keycloak User CRs and validate there is no CR with username
+	validateUserNotListedInKeyCloakCR(t, ctx, goCtx, userLongName.Name)
+
+	// Create User in RHSSO
+	if err := createOrUpdateKeycloakUserCR(goCtx, ctx.Client, usersToCreateInTestingIDP, rhmi.Name); err != nil {
+		t.Fatalf("Failed to created keycloak user cr: %s with err: %s", err)
+	}
+	t.Logf("Created keycloak cr %s on %s", userLong2, TestingIDPRealm)
+
+	// Login with User
+	masterURL := rhmi.Spec.MasterURL
+	pollOpenshiftUserLogin(t, ctx, masterURL, userLong2)
+
+	// Validate ThreeScaleUserCreationFailed alerts is firing
+	validateAlertIsFiring(t, ctx, userFailedCreateAlertName)
+
+	// Delete user from Openshift
+	if err := ctx.Client.Delete(goCtx, &userv1.User{ObjectMeta: metav1.ObjectMeta{Name: userLong2}}); err != nil {
+		t.Fatalf("Failed to delete openshift user %s: %s", userLong2, err)
+	}
+	t.Logf("Deleted %s openshift user", userLong2)
+
+	// Validate ThreeScaleUserCreationFailed alert is no longer firing
+	validateAlertIsNotFiring(t, ctx, userFailedCreateAlertName)
+
+	// Login as dedicated admin user
+	customerAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
+	pollOpenshiftUserLogin(t, ctx, masterURL, customerAdminUsername)
+
+	// List user in 3scale and ensure dedicated admin is listed
+	host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
+	validateUserIsListedIn3scale(t, ctx, host, customerAdminUsername)
+
+	// Delete IDP
+	if err := deleteIDPsFromOauth(goCtx, ctx.Client); err != nil {
+		t.Fatalf("Error deleting IDP from cluster Oauth: %w", err)
+	}
+
+	// List user in 3scale and ensure dedicated admin is not listed
+	validateUserIsNotListedIn3scale(t, ctx, host, customerAdminUsername)
+
+	t.Logf("Test passed")
+}
+
+func validateUserNotListedInKeyCloakCR(t TestingTB, ctx *TestingContext, goCtx context.Context, userName string) {
+	keycloakUsers := &keycloak.KeycloakUserList{}
+	if err := ctx.Client.List(goCtx, keycloakUsers, []k8sclient.ListOption{k8sclient.InNamespace(RHSSOProductNamespace)}...); err != nil {
+		t.Fatalf("Error listing keycloak users: %s", err)
+	}
+
+	for _, keycloakUser := range keycloakUsers.Items {
+		if strings.Contains(keycloakUser.Name, userName) {
+			t.Fatalf("Expected no keycloak user cr with name %s but found %s", userName, keycloakUser.Name)
+		}
+	}
+
+	t.Logf("No keycloak cr found containing %s in name in %s namespace", userName, RHSSOProductNamespace)
+}
+
+func pollOpenshiftUserLogin(t TestingTB, ctx *TestingContext, masterURL, userName string) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		tempHttpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+		if err != nil {
+			return false, nil
+		}
+
+		if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), userName, DefaultPassword, tempHttpClient, TestingIDPRealm, t); err != nil {
+			t.Logf("Error trying to sign in as %s to openshift : %v", userName, err)
+			return false, nil
+		}
+
+		t.Logf("Logged into openshift using %s user", userName)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Error trying to login to openshift with user %s: %s", userName, err)
+	}
+}
+
+func validateAlertIsFiring(t TestingTB, ctx *TestingContext, alertName string) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		getAlertErr := getFiringAlerts(t, ctx)
+
+		// getAlertErr should not be nil as DeadMansSwitch & at least specific alert should be firing
+		if getAlertErr == nil {
+			return false, nil
+		}
+
+		for _, alert := range getAlertErr.(*alertsFiringError).alertsFiring {
+			if alert.alertName == alertName {
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}); err != nil {
+		t.Fatalf("%s alert was not firing: %s", err)
+	}
+
+	t.Logf("%s alert is firing", alertName)
+}
+
+func validateAlertIsNotFiring(t TestingTB, ctx *TestingContext, alertName string) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		// getAlertErr will be nil if only DeadMansSwitch alert is firing
+		getAlertErr := getFiringAlerts(t, ctx)
+		if getAlertErr == nil {
+			return true, nil
+		}
+
+		for _, alert := range getAlertErr.(*alertsFiringError).alertsFiring {
+			if alert.alertName == alertName {
+				return false, nil
+			}
+		}
+		// Other alerts are firing but specified alert is no longer firing
+		return true, nil
+	}); err != nil {
+		t.Fatalf("%s alert was still firing: %s", err)
+	}
+
+	t.Logf("%s alerts is no longer firing", alertName)
+}
+
+func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, customerAdminUsername string) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		users, err := getUsersIn3scale(ctx, host)
+		if err != nil {
+			t.Logf("Error gettting 3scale users: %s", err)
+			return false, nil
+		}
+
+		for _, user := range users.Users {
+			if user.UserDetails.Username == customerAdminUsername {
+				t.Logf("Found %s user in 3scale", customerAdminUsername)
+				return true, nil
+			}
+		}
+
+		return false, nil
+	}); err != nil {
+		t.Fatalf("Could not find %s user in 3scale", customerAdminUsername)
+	}
+}
+
+func validateUserIsNotListedIn3scale(t TestingTB, ctx *TestingContext, host, customerAdminUsername string) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+		users, err := getUsersIn3scale(ctx, host)
+		if err != nil {
+			t.Logf("Error gettting 3scale users: %s", err)
+			return false, nil
+		}
+
+		for _, user := range users.Users {
+			if user.UserDetails.Username == customerAdminUsername {
+				return false, nil
+			}
+		}
+
+		t.Logf("Did not find %s user in 3scale", customerAdminUsername)
+		return true, nil
+	}); err != nil {
+		t.Fatalf("Found %s user in 3scale", customerAdminUsername)
+	}
+}
+
+func restoreClusterStatePreTest(t TestingTB, ctx *TestingContext) {
+	t.Logf("Cleaning up resources created from test")
+	goCtx := context.TODO()
+
+	// Ensure Oauth is restored to pre-test state
+	clusterOauth := &configv1.OAuth{ObjectMeta: metav1.ObjectMeta{Name: clusterOauthName}}
+	controllerutil.CreateOrUpdate(goCtx, ctx.Client, clusterOauth, func() error {
+		clusterOauth.Spec = clusterOauthPreTest.Spec
+		return nil
+	})
+	// Ensure openshift users are deleted
+	ctx.Client.Delete(goCtx, userLongName)
+	ctx.Client.Delete(goCtx, &userv1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: userLong2,
+		},
+	})
+	// Ensure Keycloak CR created are deleted
+	ctx.Client.Delete(goCtx, &keycloak.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      fmt.Sprintf("%s-%s", TestingIDPRealm, userLong2),
+			Namespace: RHSSOProductNamespace,
+		},
+	})
+
+	t.Logf("Finished cleaning up test resources")
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -82,6 +82,7 @@ var (
 				{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
 				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
 				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
+				{"C19 - Validate creation of invalid username triggers alert", TestInvalidUserNameAlert},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -3,6 +3,7 @@ package functional
 import (
 	"fmt"
 	"github.com/integr8ly/integreatly-operator/test/utils"
+	"os"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
@@ -53,17 +54,20 @@ func TestAPIs(t *testing.T) {
 		Groups:   []string{"system:authenticated"},
 	}
 
-	// get RMI CR and if cluster storage set to true, skip the suite
-	context, err := common.NewTestingContext(cfg)
-	if err != nil {
-		t.Fatalf("\"failed to create testing context: %s", err)
-	}
-	rhmi, err := common.GetRHMI(context.Client, true)
-	if err != nil {
-		t.Fatalf("error getting RHMI CR: %v", err)
-	}
-	if rhmi.Spec.UseClusterStorage == "true" {
-		t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false")
+	// Allow overriding via environment variable
+	if os.Getenv("BYPASS_STORAGE_TYPE_CHECK") != "true" {
+		// get RMI CR and if cluster storage set to true, skip the suite
+		context, err := common.NewTestingContext(cfg)
+		if err != nil {
+			t.Fatalf("\"failed to create testing context: %s", err)
+		}
+		rhmi, err := common.GetRHMI(context.Client, true)
+		if err != nil {
+			t.Fatalf("error getting RHMI CR: %v", err)
+		}
+		if rhmi.Spec.UseClusterStorage == "true" {
+			t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false")
+		}
 	}
 
 	// get install type


### PR DESCRIPTION
# Description
<!-- Please include a summary of the change and a link to the JIRA ticket. Please add any additional motivation and context as needed -->
* Fix installation blocked bug when 3scale user could not be found
* e2e test for c19 test case

Jira:
* https://issues.redhat.com/browse/MGDAPI-1260

## Verification
* Install from this branch by deployment operator image to cluster (required for fix and to properly expose metrics from operator to cluster)
  * Update to use image built from this branch and apply to cluster
  ```
  export INSTALLATION_TYPE=managed-api 
  make cluster/prepare/local
  cd config/manager
  kustomize edit set image controller=quay.io/kevfan/managed-api-service:vMGDAPI-1260
  kustomize build ../redhat-rhoam | oc create -f - 
  cd -
  ```
* Once installation completes,  run C19 test and ensure it passes
```
INSTALLATION_TYPE=managed-api BYPASS_STORAGE_TYPE_CHECK=true TEST="C19" make test/e2e/single 
```

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] E2E Test

## Checklist
- [ ] Verified independently on a cluster by reviewer