### PR TITLE
Mgdapi 2490 random password for 3Scale tenants

### DIFF
--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -211,8 +211,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 				StatusCode: http.StatusOK,
 			}, nil
 		},
-		CreateTenantFunc: func(accessToken string, account AccountDetail) (*SignUpAccount, error) {
-
+		CreateTenantFunc: func(accessToken string, account AccountDetail, pw string) (*SignUpAccount, error) {
 			return &SignUpAccount{
 				AccountDetail: AccountDetail{
 					Id:      1,

--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -44,7 +44,7 @@ type ThreeScaleInterface interface {
 	DeleteBackend(accessToken string, backendID int) error
 	DeleteAccount(accessToken, accountID string) error
 
-	CreateTenant(accessToken string, account AccountDetail) (*SignUpAccount, error)
+	CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error)
 	ListTenantAccounts(accessToken string) ([]AccountDetail, error)
 	GetTenantAccount(accessToken string, id int) (*SignUpAccount, error)
 	DeleteTenant(accessToken string, id int) error
@@ -595,7 +595,7 @@ func (tsc *threeScaleClient) ListTenantAccounts(accessToken string) ([]AccountDe
 	return accounts, nil
 }
 
-func (tsc *threeScaleClient) CreateTenant(accessToken string, account AccountDetail) (*SignUpAccount, error) {
+func (tsc *threeScaleClient) CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
 	res, err := tsc.makeRequestToMaster(
 		"POST",
 		"master/api/providers.xml",
@@ -603,7 +603,7 @@ func (tsc *threeScaleClient) CreateTenant(accessToken string, account AccountDet
 			"org_name": account.OrgName,
 			"username": account.Name,
 			"email":    fmt.Sprintf("%s@rhmi.io", account.Name),
-			"password": "MT",
+			"password": password,
 		}),
 	)
 	if err != nil {

--- a/pkg/products/threescale/three_scale_moq.go
+++ b/pkg/products/threescale/three_scale_moq.go
@@ -54,7 +54,7 @@ var _ ThreeScaleInterface = &ThreeScaleInterfaceMock{}
 // 			CreateServiceFunc: func(accessToken string, name string, systemName string) (string, error) {
 // 				panic("mock out the CreateService method")
 // 			},
-// 			CreateTenantFunc: func(accessToken string, account AccountDetail) (*SignUpAccount, error) {
+// 			CreateTenantFunc: func(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
 // 				panic("mock out the CreateTenant method")
 // 			},
 // 			DeleteAccountFunc: func(accessToken string, accountID string) error {
@@ -161,7 +161,7 @@ type ThreeScaleInterfaceMock struct {
 	CreateServiceFunc func(accessToken string, name string, systemName string) (string, error)
 
 	// CreateTenantFunc mocks the CreateTenant method.
-	CreateTenantFunc func(accessToken string, account AccountDetail) (*SignUpAccount, error)
+	CreateTenantFunc func(accessToken string, account AccountDetail, password string) (*SignUpAccount, error)
 
 	// DeleteAccountFunc mocks the DeleteAccount method.
 	DeleteAccountFunc func(accessToken string, accountID string) error
@@ -353,6 +353,8 @@ type ThreeScaleInterfaceMock struct {
 			AccessToken string
 			// Account is the account argument value.
 			Account AccountDetail
+			// Password is the password argument value.
+			Password string
 		}
 		// DeleteAccount holds details about calls to the DeleteAccount method.
 		DeleteAccount []struct {
@@ -1029,21 +1031,23 @@ func (mock *ThreeScaleInterfaceMock) CreateServiceCalls() []struct {
 }
 
 // CreateTenant calls CreateTenantFunc.
-func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account AccountDetail) (*SignUpAccount, error) {
+func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
 	if mock.CreateTenantFunc == nil {
 		panic("ThreeScaleInterfaceMock.CreateTenantFunc: method is nil but ThreeScaleInterface.CreateTenant was just called")
 	}
 	callInfo := struct {
 		AccessToken string
 		Account     AccountDetail
+		Password    string
 	}{
 		AccessToken: accessToken,
 		Account:     account,
+		Password:    password,
 	}
 	mock.lockCreateTenant.Lock()
 	mock.calls.CreateTenant = append(mock.calls.CreateTenant, callInfo)
 	mock.lockCreateTenant.Unlock()
-	return mock.CreateTenantFunc(accessToken, account)
+	return mock.CreateTenantFunc(accessToken, account, password)
 }
 
 // CreateTenantCalls gets all the calls that were made to CreateTenant.
@@ -1052,10 +1056,12 @@ func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account Ac
 func (mock *ThreeScaleInterfaceMock) CreateTenantCalls() []struct {
 	AccessToken string
 	Account     AccountDetail
+	Password    string
 } {
 	var calls []struct {
 		AccessToken string
 		Account     AccountDetail
+		Password    string
 	}
 	mock.lockCreateTenant.RLock()
 	calls = mock.calls.CreateTenant

--- a/pkg/resources/password.go
+++ b/pkg/resources/password.go
@@ -1,0 +1,47 @@
+package resources
+
+import (
+	"math/rand"
+	"strings"
+)
+
+var (
+	lowerCharSet   = "abcdedfghijklmnopqrst"
+	upperCharSet   = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	specialCharSet = "!@#$%&*"
+	numberSet      = "0123456789"
+	allCharSet     = lowerCharSet + upperCharSet + specialCharSet + numberSet
+)
+
+func GenerateRandomPassword(passwordLength, minSpecialChar, minNum, minUpperCase int) string {
+	var password strings.Builder
+
+	//Set special character
+	for i := 0; i < minSpecialChar; i++ {
+		random := rand.Intn(len(specialCharSet))
+		password.WriteString(string(specialCharSet[random]))
+	}
+
+	//Set numeric
+	for i := 0; i < minNum; i++ {
+		random := rand.Intn(len(numberSet))
+		password.WriteString(string(numberSet[random]))
+	}
+
+	//Set uppercase
+	for i := 0; i < minUpperCase; i++ {
+		random := rand.Intn(len(upperCharSet))
+		password.WriteString(string(upperCharSet[random]))
+	}
+
+	remainingLength := passwordLength - minSpecialChar - minNum - minUpperCase
+	for i := 0; i < remainingLength; i++ {
+		random := rand.Intn(len(allCharSet))
+		password.WriteString(string(allCharSet[random]))
+	}
+	inRune := []rune(password.String())
+	rand.Shuffle(len(inRune), func(i, j int) {
+		inRune[i], inRune[j] = inRune[j], inRune[i]
+	})
+	return string(inRune)
+}


### PR DESCRIPTION
# Issue link
[MGDAPI-2490](https://issues.redhat.com/browse/MGDAPI-2490) 

# What
Generate a random password for the 3scale log in for multi tenant users.
Store tenant passwords in a secret 

# Verification steps
Install a multi-tenant RHOAM `INSTALLATION_TYPE=multitenant-managed-api make code/run` based on this PR
Install the testing-idp with name "rhd"
Log into OpenShift as test-user01 and test-user02
Wait for 3scale to reconcile
Verify that test-user01 and test-user02 admin routes are created under the 3Scale namespace
Verify that secret, tenant-account-passwords, is also created under the 3scale namespace
Verify that 2 password exist in the secret for both users
Log into 3Scale as test-user01 and test-user02 with their respective routes and password.

Delete user cr for test-user01 and its related identity
Wait for 3Scale to reconcile
Verify that the password is removed from secret, tenant-account-passwords