### PR TITLE
Remove extra char in prepare-release.sh

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -164,7 +164,7 @@ set_images() {
 set_csv_service_affecting_field() {
   local value=$1
   echo "Update CSV for release $SEMVER to be 'serviceAffecting: $value'"
-  yq e -i   ".metadata.annotations.serviceAffecting= $value "  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml}
+  yq e -i   ".metadata.annotations.serviceAffecting= $value "  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
 }
 
 # Due to a quirk in operator-sdk v1.2.0, the `replaces` field in the generated CSV is taken from the current version in


### PR DESCRIPTION
# What
Fix a bug in prepare-release.sh script.
This is the error message that was received:

> 10:48:33  Update CSV for release 2.9.3-rc1 to be 'serviceAffecting: true'
> 10:48:33  Error: stat packagemanifests/integreatly-operator/2.9.3/integreatly-operator.clusterserviceversion.yaml}: no such file or directory
> 10:48:33  Error: exit status 1

# Verification steps
Generate a new service affecting release to and see that the script finishes successfully, and "serviceAffecting" annotation is set as expected.
