### PR TITLE
fix: run C19 before H11

### DIFF
--- a/test-cases/tests/alerts/c19-validate-creation-of-invalid-username-triggers-alert.md
+++ b/test-cases/tests/alerts/c19-validate-creation-of-invalid-username-triggers-alert.md
@@ -18,4 +18,71 @@ estimate: 15m
 
 # C19 - Validate creation of invalid username triggers alert
 
-https://github.com/integr8ly/integreatly-operator/blob/master/test/common/alerts_invalid_username.go
+## Prerequisites
+
+1. Login to OpenShift console and via `oc` as a user with **cluster-admin** role (kubeadmin):
+
+   ```shell script
+   oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:6443
+   ```
+
+2. Access to OCM QE console
+
+## Steps
+
+1. Create a new user with long name (more than 40 characters)
+
+```bash
+echo '{"apiVersion": "user.openshift.io/v1", "kind": "User", "metadata": {"name": "alongusernamethatisabovefourtycharacterslong"}}' | oc apply -f -
+```
+
+2. Go to `redhat-rhoam-rhsso` namespace
+3. Search for "keycloakusers" CR
+   > Validate that there is not keycloakuser that contains the name "alongusernamethatisabovefourtycharacterslong"
+4. Get RHSSO admin password and note it down
+
+```bash
+oc get secret credential-rhsso -n redhat-rhoam-rhsso -o json | jq -r '.data.ADMIN_PASSWORD' | base64 --decode
+```
+
+5. Go to keycloak admin console and log in as `admin` and password from the previous step
+
+```bash
+open "https://$(oc get route keycloak -n redhat-rhoam-rhsso -o=jsonpath='{.spec.host}')"
+```
+
+6. Select `testing-idp` realm -> Users -> Add user
+7. Create username `alongusernamethatisabovefourtycharacterslong2` and hit Save
+8. Go to `Credentials` tab, fill in password and switch `Temporary` to OFF, hit Set password
+9. In Anonymous window, go to OpenShift console and login via testing-idp as `alongusernamethatisabovefourtycharacterslong2` user
+10. Go to alert manager and log in as kubeadmin
+
+```bash
+open "https://$(oc get route alertmanager-route -n redhat-rhoam-middleware-monitoring-operator -o jsonpath='{.spec.host}')"
+```
+
+> Validate there is "ThreeScaleUserCreationFailed" alert firing
+
+11. Delete the user from OpenShift
+
+```bash
+oc delete user alongusernamethatisabovefourtycharacterslong2
+```
+
+12. Go back to the alert manager
+    > Validate that the alert is no longer firing (it might take some time)
+13. In a new anonymous window, login to the cluster via testing-idp as customer-admin01 user
+14. Get 3scale admin password and note it down
+
+```bash
+oc get secret system-seed -n redhat-rhoam-3scale -o json | jq -r '.data.ADMIN_PASSWORD' | base64 --decode
+```
+
+15. In OpenShift console, go to 3scale namespace -> Routes and navigate to 3scale admin console
+16. Log in as `admin` and use the password from the previous step
+17. Go to settings -> Users -> Listing
+    > Verify that customer-admin01 user is listed there
+18. Go to OCM UI console and search for the testing cluster
+19. Go to Access control and delete testing-idp and all customer admin users
+20. Go back to 3scale admin console and refresh the page with user listing
+    > Verify that the customer-admin01 user is no longer present in 3scale

--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -160,7 +160,7 @@ func validateAlertIsFiring(t TestingTB, ctx *TestingContext, alertName string) {
 
 		return false, nil
 	}); err != nil {
-		t.Fatalf("%s alert was not firing: %s", err)
+		t.Fatalf("%s alert was not firing: %s", alertName, err)
 	}
 
 	t.Logf("%s alert is firing", alertName)
@@ -182,13 +182,13 @@ func validateAlertIsNotFiring(t TestingTB, ctx *TestingContext, alertName string
 		// Other alerts are firing but specified alert is no longer firing
 		return true, nil
 	}); err != nil {
-		t.Fatalf("%s alert was still firing: %s", err)
+		t.Fatalf("%s alert was still firing: %s", alertName, err)
 	}
 
 	t.Logf("%s alerts is no longer firing", alertName)
 }
 
-func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, customerAdminUsername string) {
+func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, threeScaleUsername string) {
 	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
 		users, err := getUsersIn3scale(ctx, host)
 		if err != nil {
@@ -197,15 +197,15 @@ func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, custom
 		}
 
 		for _, user := range users.Users {
-			if user.UserDetails.Username == customerAdminUsername {
-				t.Logf("Found %s user in 3scale", customerAdminUsername)
+			if user.UserDetails.Username == threeScaleUsername {
+				t.Logf("Found %s user in 3scale", threeScaleUsername)
 				return true, nil
 			}
 		}
 
 		return false, nil
 	}); err != nil {
-		t.Fatalf("Could not find %s user in 3scale", customerAdminUsername)
+		t.Fatalf("Could not find %s user in 3scale", threeScaleUsername)
 	}
 }
 
@@ -213,7 +213,7 @@ func validateUserIsNotListedIn3scale(t TestingTB, ctx *TestingContext, host, cus
 	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
 		users, err := getUsersIn3scale(ctx, host)
 		if err != nil {
-			t.Logf("Error gettting 3scale users: %s", err)
+			t.Logf("Error getting 3scale users: %s", err)
 			return false, nil
 		}
 

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -81,8 +81,10 @@ var (
 				{"H03 - Verify 3scale CRUDL permissions", Test3ScaleCrudlPermissions},
 				{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
 				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
-				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
 				{"C19 - Validate creation of invalid username triggers alert", TestInvalidUserNameAlert},
+				// Keep H11 as last 3scale IDP Test as test causes 3scale deployments to be rescaled at the end of test
+				// Can potentially cause subsequent tests be flaky due to waiting for 3scale deployments to complete
+				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-1260

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Running H11 before C19 can cause C19 to timeout waiting for alert to fire (seen in nightly runs)

The reason for this is that at the end of H11, the smtp secret is [restored](https://github.com/integr8ly/integreatly-operator/blob/master/test/common/3scale_smtp.go#L102-L106) and this causes 3scale deployments to be [rescaled](https://github.com/integr8ly/integreatly-operator/blob/62da48db2fbb22bcbb61e63338a9fbc7277ebef1/pkg/products/threescale/reconciler.go#L522-L532). However, C19 will imediately run, but at 3scale reconcile, it will wait until these deployments are fully scaled before it can reach the code for reconciling openshift users. This can cause a timeout on C19 for waiting the alert to fire due to this.

Quickest fix for this is running C19 before H11 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Sample Run of Test : [test-run.log](https://github.com/integr8ly/integreatly-operator/files/7076486/test-run.log)

* Install RHOAM using image
```
export INSTALLATION_TYPE=managed-api
IN_PROW=true make cluster/deploy
```
* Once complete, install IDP using script
```
PASSWORD=Password1 DEDICATED_ADMIN_PASSWORD=Password1 ./scripts/setup-sso-idp.sh
```
* Run IDP tests against cluster with RHOAM installed
```
INSTALLATION_TYPE=managed-api BYPASS_STORAGE_TYPE_CHECK=true TEST="IDP" make test/e2e/single 
```