### PR TITLE
Fixed Quota name in 3scale.go

### DIFF
--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -128,23 +128,23 @@ func (t *ThreeScale) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) map[strin
 			threeScaleComponents["apicastProd"] = 2
 			threeScaleComponents["backendListener"] = 2
 			threeScaleComponents["backendWorker"] = 2
-		case "10":
+		case "1 Million":
 			threeScaleComponents["apicastProd"] = 2
 			threeScaleComponents["backendListener"] = 2
 			threeScaleComponents["backendWorker"] = 2
-		case "50":
+		case "5 Million":
 			threeScaleComponents["apicastProd"] = 3
 			threeScaleComponents["backendListener"] = 3
 			threeScaleComponents["backendWorker"] = 3
-		case "100":
+		case "10 Million":
 			threeScaleComponents["apicastProd"] = 3
 			threeScaleComponents["backendListener"] = 3
 			threeScaleComponents["backendWorker"] = 3
-		case "200":
+		case "20 Million":
 			threeScaleComponents["apicastProd"] = 3
 			threeScaleComponents["backendListener"] = 3
 			threeScaleComponents["backendWorker"] = 3
-		case "500":
+		case "50 Million":
 			threeScaleComponents["apicastProd"] = 3
 			threeScaleComponents["backendWorker"] = 4
 			threeScaleComponents["backendListener"] = 5


### PR DESCRIPTION
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
The A14 and F05 tests fails if using 1M quota. The reason is that due to mismatch in quota names the default value (3 replicas) is expected for apicast-production. But the actual value is two so the tests fails (since the actual is less than expected).

# Verification steps
Assuming you have the RHOAM cluster ready just run the A14 and F05 tests. It is enough to do this for 100k, 1M and 50M quotas (other quotas has the same replicas as the default values so no real change here).

* change the quota via OCM
* oc login into the cluster
* clone this PR
* INSTALLATION_TYPE=managed-api TEST=A14 make test/e2e/single
* INSTALLATION_TYPE=managed-api TEST=F05 make test/e2e/single

Or maybe just check that the values matches the quota from rhoam RHMI CR would be sufficient.
