### PR TITLE
use tenant 3scale email from identitiy and set pod priority to 0 for …

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -177,8 +177,11 @@ func (r *Reconciler) reconcilePriorityClass(ctx context.Context, serverClient k8
 			},
 		}
 		if _, err := controllerutil.CreateOrUpdate(ctx, serverClient, priorityClass, func() error {
-
-			priorityClass.Value = 1000000000
+			if integreatlyv1alpha1.IsRHOAMMultitenant(rhmiv1alpha1.InstallationType(r.installation.Spec.Type)) {
+				priorityClass.Value = 0
+			} else {
+				priorityClass.Value = 1000000000
+			}
 			priorityClass.GlobalDefault = false
 			priorityClass.Description = "Priority Class for managed-api"
 

--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -211,7 +211,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 				StatusCode: http.StatusOK,
 			}, nil
 		},
-		CreateTenantFunc: func(accessToken string, account AccountDetail, pw string) (*SignUpAccount, error) {
+		CreateTenantFunc: func(accessToken string, account AccountDetail, pw string, email string) (*SignUpAccount, error) {
 			return &SignUpAccount{
 				AccountDetail: AccountDetail{
 					Id:      1,

--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -44,7 +44,7 @@ type ThreeScaleInterface interface {
 	DeleteBackend(accessToken string, backendID int) error
 	DeleteAccount(accessToken, accountID string) error
 
-	CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error)
+	CreateTenant(accessToken string, account AccountDetail, password string, email string) (*SignUpAccount, error)
 	ListTenantAccounts(accessToken string) ([]AccountDetail, error)
 	GetTenantAccount(accessToken string, id int) (*SignUpAccount, error)
 	DeleteTenant(accessToken string, id int) error
@@ -595,15 +595,15 @@ func (tsc *threeScaleClient) ListTenantAccounts(accessToken string) ([]AccountDe
 	return accounts, nil
 }
 
-func (tsc *threeScaleClient) CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
+func (tsc *threeScaleClient) CreateTenant(accessToken string, account AccountDetail, password string, email string) (*SignUpAccount, error) {
 	res, err := tsc.makeRequestToMaster(
 		"POST",
 		"master/api/providers.xml",
 		withAccessToken(accessToken, map[string]interface{}{
 			"org_name": account.OrgName,
 			"username": account.Name,
-			"email":    fmt.Sprintf("%s@rhmi.io", account.Name),
 			"password": password,
+			"email":    email,
 		}),
 	)
 	if err != nil {

--- a/pkg/products/threescale/three_scale_moq.go
+++ b/pkg/products/threescale/three_scale_moq.go
@@ -54,7 +54,7 @@ var _ ThreeScaleInterface = &ThreeScaleInterfaceMock{}
 // 			CreateServiceFunc: func(accessToken string, name string, systemName string) (string, error) {
 // 				panic("mock out the CreateService method")
 // 			},
-// 			CreateTenantFunc: func(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
+// 			CreateTenantFunc: func(accessToken string, account AccountDetail, password string, email string) (*SignUpAccount, error) {
 // 				panic("mock out the CreateTenant method")
 // 			},
 // 			DeleteAccountFunc: func(accessToken string, accountID string) error {
@@ -161,7 +161,7 @@ type ThreeScaleInterfaceMock struct {
 	CreateServiceFunc func(accessToken string, name string, systemName string) (string, error)
 
 	// CreateTenantFunc mocks the CreateTenant method.
-	CreateTenantFunc func(accessToken string, account AccountDetail, password string) (*SignUpAccount, error)
+	CreateTenantFunc func(accessToken string, account AccountDetail, password string, email string) (*SignUpAccount, error)
 
 	// DeleteAccountFunc mocks the DeleteAccount method.
 	DeleteAccountFunc func(accessToken string, accountID string) error
@@ -355,6 +355,8 @@ type ThreeScaleInterfaceMock struct {
 			Account AccountDetail
 			// Password is the password argument value.
 			Password string
+			// Email is the email argument value.
+			Email string
 		}
 		// DeleteAccount holds details about calls to the DeleteAccount method.
 		DeleteAccount []struct {
@@ -1031,7 +1033,7 @@ func (mock *ThreeScaleInterfaceMock) CreateServiceCalls() []struct {
 }
 
 // CreateTenant calls CreateTenantFunc.
-func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account AccountDetail, password string) (*SignUpAccount, error) {
+func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account AccountDetail, password string, email string) (*SignUpAccount, error) {
 	if mock.CreateTenantFunc == nil {
 		panic("ThreeScaleInterfaceMock.CreateTenantFunc: method is nil but ThreeScaleInterface.CreateTenant was just called")
 	}
@@ -1039,15 +1041,17 @@ func (mock *ThreeScaleInterfaceMock) CreateTenant(accessToken string, account Ac
 		AccessToken string
 		Account     AccountDetail
 		Password    string
+		Email       string
 	}{
 		AccessToken: accessToken,
 		Account:     account,
 		Password:    password,
+		Email:       email,
 	}
 	mock.lockCreateTenant.Lock()
 	mock.calls.CreateTenant = append(mock.calls.CreateTenant, callInfo)
 	mock.lockCreateTenant.Unlock()
-	return mock.CreateTenantFunc(accessToken, account, password)
+	return mock.CreateTenantFunc(accessToken, account, password, email)
 }
 
 // CreateTenantCalls gets all the calls that were made to CreateTenant.
@@ -1057,11 +1061,13 @@ func (mock *ThreeScaleInterfaceMock) CreateTenantCalls() []struct {
 	AccessToken string
 	Account     AccountDetail
 	Password    string
+	Email       string
 } {
 	var calls []struct {
 		AccessToken string
 		Account     AccountDetail
 		Password    string
+		Email       string
 	}
 	mock.lockCreateTenant.RLock()
 	calls = mock.calls.CreateTenant


### PR DESCRIPTION
…multitenancy

# Issue link
https://issues.redhat.com/browse/MGDAPI-2565
and
https://issues.redhat.com/browse/MGDAPI-2557

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps - email 
Install multi-tenant RHOAM from this branch
` INSTALLATION_TYPE=multitenant-managed-api make code/run`

Install the testing-idp with "rhd" name
`NUM_REGULAR_USER=5 NUM_ADMIN=0 DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 REALM_DISPLAY_NAME="rhd" REALM="rhd" ./scripts/setup-sso-idp.sh`

Log in as test-user01 and then test-user02 to OpenShift
Verify that the identity CR has an email test-user01@example.com and test-user02@example.com

Wait for the tenants route to be created under redhat-rhoam-3Scale
Log in using SSO as both users
Go to Account => Users and verify that the email is `test-user01@example.com` and `test-user02@example.com` respectively 


# Verification steps - pod priority
Check APIcast staging and Production pods and verify pod priority is set to 0

