### PR TITLE
MGDAPI - 1584 - feat: keycloak migration strategy dependant on release type

### DIFF
--- a/pkg/products/rhssocommon/reconciler_test.go
+++ b/pkg/products/rhssocommon/reconciler_test.go
@@ -975,3 +975,275 @@ func TestReconciler_CleanupKeycloakResources(t *testing.T) {
 		})
 	}
 }
+
+func TestIsUpgrade(t *testing.T) {
+	type args struct {
+		config         *config.RHSSOCommon
+		productVersion integreatlyv1alpha1.ProductVersion
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Test - False when empty version in config - fresh install",
+			args: args{
+				config: config.NewRHSSOCommon(config.ProductConfig{}),
+			},
+			want: false,
+		},
+		{
+			name: "Test - False when version in config equals constant product version",
+			args: args{
+				config: config.NewRHSSOCommon(config.ProductConfig{
+					"VERSION": "1.1.1",
+				}),
+				productVersion: integreatlyv1alpha1.ProductVersion("1.1.1"),
+			},
+			want: false,
+		},
+		{
+			name: "Test - True when version in config does not equal constant product version",
+			args: args{
+				config: config.NewRHSSOCommon(config.ProductConfig{
+					"VERSION": "1.1.1",
+				}),
+				productVersion: integreatlyv1alpha1.ProductVersion("1.1.2"),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsUpgrade(tt.args.config, tt.args.productVersion); got != tt.want {
+				t.Errorf("IsUpgrade() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconciler_SetRollingStrategyForUpgrade(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		ConfigManager         config.ConfigReadWriter
+		mpm                   marketplace.MarketplaceInterface
+		Installation          *integreatlyv1alpha1.RHMI
+		Log                   l.Logger
+		Oauthv1Client         oauthClient.OauthV1Interface
+		APIURL                string
+		Reconciler            *resources.Reconciler
+		Recorder              record.EventRecorder
+		KeycloakClientFactory keycloakCommon.KeycloakClientFactory
+	}
+	type args struct {
+		isUpgrade      bool
+		ctx            context.Context
+		serverClient   k8sclient.Client
+		config         *config.RHSSOCommon
+		productVersion integreatlyv1alpha1.ProductVersion
+		keycloakName   string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    integreatlyv1alpha1.StatusPhase
+		wantErr bool
+	}{
+		{
+			name: "Test - Phase complete when not an upgrade ",
+			args: args{
+				isUpgrade: false,
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+		{
+			name: "Test - Phase failed when non semantic version is used in config",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "NonSemantic",
+				}},
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "Test - Phase failed when non semantic version is used in version constant",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "7.0",
+				}},
+				productVersion: integreatlyv1alpha1.ProductVersion("NonSemantic"),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "Test - Phase Complete - Patch Version Bump",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "7.4",
+				}},
+				productVersion: integreatlyv1alpha1.ProductVersion("7.4.1"),
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+		{
+			name: "Test - Phase Complete - Minor Version Bump",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "7.4",
+				}},
+				productVersion: integreatlyv1alpha1.ProductVersion("7.5"),
+				serverClient:   moqclient.NewSigsClientMoqWithScheme(scheme),
+				keycloakName:   keycloakName,
+			},
+			fields: fields{Log: getLogger()},
+			want:   integreatlyv1alpha1.PhaseCompleted,
+		},
+		{
+			name: "Test - Phase Complete - Major Version Bump",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "7.4",
+				}},
+				productVersion: integreatlyv1alpha1.ProductVersion("8.4"),
+				serverClient:   moqclient.NewSigsClientMoqWithScheme(scheme),
+				keycloakName:   keycloakName,
+			},
+			fields: fields{Log: getLogger()},
+			want:   integreatlyv1alpha1.PhaseCompleted,
+		},
+		{
+			name: "Test - Phase Failed - Keycloak CR get error",
+			args: args{
+				isUpgrade: true,
+				config: &config.RHSSOCommon{Config: map[string]string{
+					"VERSION": "7.4",
+				}},
+				productVersion: integreatlyv1alpha1.ProductVersion("8.4"),
+				serverClient: &moqclient.SigsClientInterfaceMock{GetFunc: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return fmt.Errorf("GetError")
+				}},
+				keycloakName: keycloakName,
+			},
+			fields:  fields{Log: getLogger()},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				ConfigManager:         tt.fields.ConfigManager,
+				mpm:                   tt.fields.mpm,
+				Installation:          tt.fields.Installation,
+				Log:                   tt.fields.Log,
+				Oauthv1Client:         tt.fields.Oauthv1Client,
+				APIURL:                tt.fields.APIURL,
+				Reconciler:            tt.fields.Reconciler,
+				Recorder:              tt.fields.Recorder,
+				KeycloakClientFactory: tt.fields.KeycloakClientFactory,
+			}
+			got, err := r.SetRollingStrategyForUpgrade(tt.args.isUpgrade, tt.args.ctx, tt.args.serverClient, tt.args.config, tt.args.productVersion, tt.args.keycloakName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetRollingStrategyForUpgrade() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("SetRollingStrategyForUpgrade() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconciler_IsOperatorInstallComplete(t *testing.T) {
+	type fields struct {
+		ConfigManager         config.ConfigReadWriter
+		mpm                   marketplace.MarketplaceInterface
+		Installation          *integreatlyv1alpha1.RHMI
+		Log                   l.Logger
+		Oauthv1Client         oauthClient.OauthV1Interface
+		APIURL                string
+		Reconciler            *resources.Reconciler
+		Recorder              record.EventRecorder
+		KeycloakClientFactory keycloakCommon.KeycloakClientFactory
+	}
+	type args struct {
+		kc              *keycloak.Keycloak
+		operatorVersion integreatlyv1alpha1.OperatorVersion
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Test - false when status version not equal operator version",
+			args: args{
+				kc: &keycloak.Keycloak{
+					Status: keycloak.KeycloakStatus{
+						Version: "1.0.0",
+					},
+				},
+				operatorVersion: integreatlyv1alpha1.OperatorVersion("1.1.0"),
+			},
+			want: false,
+		},
+		{
+			name: "Test - false when status not ready",
+			args: args{
+				kc: &keycloak.Keycloak{
+					Status: keycloak.KeycloakStatus{
+						Version: "1.1.0",
+						Ready:   false,
+					},
+				},
+				operatorVersion: integreatlyv1alpha1.OperatorVersion("1.1.0"),
+			},
+			want: false,
+		},
+		{
+			name: "Test - true status version equal operator version and ready",
+			args: args{
+				kc: &keycloak.Keycloak{
+					Status: keycloak.KeycloakStatus{
+						Version: "1.1.0",
+						Ready:   true,
+					},
+				},
+				operatorVersion: integreatlyv1alpha1.OperatorVersion("1.1.0"),
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				ConfigManager:         tt.fields.ConfigManager,
+				mpm:                   tt.fields.mpm,
+				Installation:          tt.fields.Installation,
+				Log:                   tt.fields.Log,
+				Oauthv1Client:         tt.fields.Oauthv1Client,
+				APIURL:                tt.fields.APIURL,
+				Reconciler:            tt.fields.Reconciler,
+				Recorder:              tt.fields.Recorder,
+				KeycloakClientFactory: tt.fields.KeycloakClientFactory,
+			}
+			if got := r.IsOperatorInstallComplete(tt.args.kc, tt.args.operatorVersion); got != tt.want {
+				t.Errorf("IsOperatorInstallComplete() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -94,6 +94,7 @@ type Reconciler struct {
 	Config *config.RHSSOUser
 	Log    l.Logger
 	*rhssocommon.Reconciler
+	isUpgrade bool
 }
 
 func NewReconciler(configManager config.ConfigReadWriter, installation *integreatlyv1alpha1.RHMI, oauthv1Client oauthClient.OauthV1Interface, mpm marketplace.MarketplaceInterface, recorder record.EventRecorder, apiUrl string, keycloakClientFactory keycloakCommon.KeycloakClientFactory, logger l.Logger, productDeclaration *marketplace.ProductDeclaration) (*Reconciler, error) {
@@ -112,6 +113,7 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		Config:     config,
 		Log:        logger,
 		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, apiUrl, keycloakClientFactory, *productDeclaration),
+		isUpgrade:  rhssocommon.IsUpgrade(config.RHSSOCommon, integreatlyv1alpha1.VersionRHSSOUser),
 	}, nil
 }
 
@@ -175,6 +177,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.ReconcileNamespace(ctx, productNamespace, installation, serverClient, r.Log)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", productNamespace), err)
+		return phase, err
+	}
+
+	phase, err = r.SetRollingStrategyForUpgrade(r.isUpgrade, ctx, serverClient, r.Config.RHSSOCommon, integreatlyv1alpha1.VersionRHSSOUser, keycloakName)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to set rolling strategy for upgrade", err)
 		return phase, err
 	}
 
@@ -311,9 +319,14 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		kc.Spec.Profile = rhsso.RHSSOProfile
 		kc.Spec.PodDisruptionBudget = keycloak.PodDisruptionBudgetConfig{Enabled: true}
 
-		//Set keycloak Update Strategy to Rolling as default
-		//Keycloak operator should make decision based on the image, and can change update strategy
-		kc.Spec.Migration.MigrationStrategy = keycloak.StrategyRolling
+		// On an upgrade, migration could have changed to recreate strategy for major and minor version bumps (SetRollingStrategyForUpgrade)
+		// Keep the current migration strategy until operator upgrades are complete. Once complete use rolling strategy.
+		// On patch upgrades, the rolling strategy will be kept and used throughout the upgrade
+		if !r.isUpgrade && r.IsOperatorInstallComplete(kc, integreatlyv1alpha1.OperatorVersionRHSSOUser) {
+			//Set keycloak Update Strategy to Rolling as default
+			r.Log.Info("Setting keycloak migration strategy to rolling")
+			kc.Spec.Migration.MigrationStrategy = keycloak.StrategyRolling
+		}
 
 		if installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) {
 			kc.Spec.KeycloakDeploymentSpec.Resources = corev1.ResourceRequirements{


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-1584
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
For major and minor version upgrades on keycloak, use the recreate strategy before upgrading to the new version.  Once the upgrade completes revert back to use rolling strategy.

If a patch version is detected, rolling strategy is kept and used

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Fresh Installation
* Checkout branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api 
make cluster/prepare/local
make code/run
```
* Once installed, verify `rolling` strategy is used in KeyCloak CRs for RHSSO and User SSO
```
oc get keycloak rhsso -n redhat-rhoam-rhsso -o json | jq '.spec.migration'
oc get keycloak rhssouser -n redhat-rhoam-user-sso -o json | jq '.spec.migration'
```
## Verify Recreate is used for minor version upgrade
* Stop the operator
* Create a 15.0.0 directory in manfiests/integreatly-rhsso
* Copy manifests from Keycloak github to this directory
  * https://github.com/keycloak/keycloak-operator/tree/master/deploy/olm-catalog/keycloak-operator/15.0.0/manifests
* Update the manifest rhsso.package.yaml to `keycloak-operator.v15.0.0`
  * https://github.com/integr8ly/integreatly-operator/blob/master/manifests/integreatly-rhsso/rhsso.package.yaml#L4
* Update RHSSO and User SSO Version to `7.5`
  * https://github.com/integr8ly/integreatly-operator/blob/master/apis/v1alpha1/rhmi_types.go#L95-L96
* Update RHSSO and User SSO Operator version to `15.0.0`
  * https://github.com/integr8ly/integreatly-operator/blob/master/apis/v1alpha1/rhmi_types.go#L118-L119
* On a terminal, watch  the pods and migration strategy of RHSSO and UserSSO
```
watch "echo RHSSO; oc get keycloak rhsso -n redhat-rhoam-rhsso -o json | jq '.spec.migration'; oc get csvs -n redhat-rhoam-rhsso-operator | grep keycloak; oc get pods -n redhat-rhoam-rhsso; echo "UserSSO"; oc get keycloak rhssouser -n redhat-rhoam-user-sso -o json | jq '.spec.migration'; oc get csvs -n redhat-rhoam-user-sso-operator | grep keycloak ; oc get pods -n redhat-rhoam-user-sso " 

```
* Run the operator
```
make code/run
```
  * Verify strategy is updated to `recreate`
  * Verity all pods are terminated before recreated for update
  * Verify strategy is updated back to `rolling` once update is complete

## Verify rolling strategy is used for patch upgrades
* Stop the operator
* Stash the changes
```
git add .
git stash 
```
* Delete the current version of RHSSO and User SSO Operator
```
oc delete project redhat-rhoam-rhsso-operator
oc delete project redhat-rhoam-user-sso-operator
```
* Reinstall old version of keycloak by running operator again
```
make code/run
```
* Verify old operators are installed and installation complete
```
oc get csvs -n redhat-rhoam-user-sso-operator | grep keycloak
oc get csvs -n redhat-rhoam-rhsso-operator | grep keycloak
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
```
* Stop the operator
* Un-stash changes
```
git stash apply
``` 
* Update RHSSO and User SSO Version to `7.4.1` instead
  * https://github.com/integr8ly/integreatly-operator/blob/master/apis/v1alpha1/rhmi_types.go#L95-L96
* Run the operator
```
make code/run
```
* From the terminal that is watching the RHSSO and USER SSO resources
  * Verify strategy is always `rolling`
  * Verity pods are terminated and recreated one at a time
  * Verify strategy is still `rolling` once update is complete