### PR TITLE
Fix prepare-release.sh - wrong quotes prevent setting container image

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -150,13 +150,13 @@ set_images() {
   case $OLM_TYPE in
    "integreatly-operator")
   : "${IMAGE_TAG:=v${SEMVER}}"
-  yq e -i  '.spec.install.spec.deployments.[0].spec.template.spec.containers[0].image="quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
-  yq e -i  '.metadata.annotations.containerImage="quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i  ".spec.install.spec.deployments.[0].spec.template.spec.containers[0].image=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i  ".metadata.annotations.containerImage=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
   ;;
   "managed-api-service")
    : "${IMAGE_TAG:=rhoam-v${SEMVER}}"
-  yq e -i '.spec.install.spec.deployments.[0].spec.template.spec.containers[0].image="quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
-  yq e -i '.metadata.annotations.containerImage="quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".spec.install.spec.deployments.[0].spec.template.spec.containers[0].image=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".metadata.annotations.containerImage=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
   ;;
   esac
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2579

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Wrong quotes prevent setting container image in the CSV.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
Run `OLM_TYPE=managed-api-service SEMVER=1.99.0 make release/prepare`
In the newly generated CSV file (packagemanifests/managed-api-service/1.99.0/managed-api-service.clusterserviceversion.yaml) check:
- `.metadata.annotations.containerImage` 
- `.spec.instal.spec.deployments[0].spec.template.spec.containers[0].image`
both of these should have correct image - `quay.io/integreatly/managed-api-service:rhoam-v1.99.0`

_Note:_ you may see the following error, but in the context of this PR it can be ignored. It will be fixed in MGDAPI-2572.
```
Adding related images to the CSV
./scripts/prepare-release.sh: line 232: -1: substring expression < 0
make: *** [release/prepare] Error 1
```