### PR TITLE
fix for updating empty email address

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -283,7 +283,7 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	)
 	if err != nil {
 		log.Error("failed while retrieving addon parameter", err)
-	} else if ok && customerAlertingEmailAddress != "" && installation.Spec.AlertingEmailAddress != customerAlertingEmailAddress {
+	} else if ok && installation.Spec.AlertingEmailAddress != customerAlertingEmailAddress {
 		log.Info("Updating customer email address from parameter")
 		installation.Spec.AlertingEmailAddress = customerAlertingEmailAddress
 		if err := r.Update(context.TODO(), installation); err != nil {


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
[MGDAPI-2559](https://issues.redhat.com/browse/MGDAPI-2559)  There was an issue when changing email to an empty string that wouldn't update the parameter in the rhoam cr.
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Removed a check that stoped empty strings from being passed to rhoam cr. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

1. Check out this branch and run rhoam locally.
2. Add `notification-email: bWFpbEBleGFtcGxlLmNvbQ==` to yaml file in `addon-managed-api-service-parameters` .
3. Check that `alertingEmailAddress: mail@example.com `  is in the rhoam cr.
4. Change notification email to `notification-email: '' ` 
5. Check that  `alertingEmailAdress: ` is no longer in the rhoam cr.
