### PR TITLE
fix CSV generation for containerImages

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -231,7 +231,7 @@ set_related_images() {
 
   containerImageRemovedLastCharacter=$(echo "${containerImageField::-1}")
   containerImageField="$containerImageRemovedLastCharacter]"
-  yq e -i  ".metadata.annotations.containerImages= $containerImageField "  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  printf -v m "$containerImageField" ; m="$m" yq e -i  ".metadata.annotations.containerImages= strenv(m)"  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
 }
 
 if [[ -z "$SEMVER" ]]; then


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
[MGDAPI-2572](https://github.com/Patryk-Stefanski/integreatly-operator/tree/MGDAPI-2572)

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
containerImages generation during prepare release was generated in YAML format due to yq bump, this caused the validation of bundles to fail.containerImages are now  generated in JSON format and pass validation.


# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

1. Check out this branch and make sure you have a  `managed-api-service-bundle` repo in your quay org.
2. Generate CSV :  `ORG=<your org>  OLM_TYPE=managed-api-service SEMVER=<release version> ./scripts/prepare-release.sh`
3. `cd` to manifests directory for the release version.
4. Generate bundle : `opm alpha bundle generate -d . --channels alpha --package managed-api-service --output-dir bundle --default alpha`
5. Build and push the image : 
     `docker build -f bundle.Dockerfile -t quay.io/<quay username>/managed-api-service-bundle:<release version> .`
     `docker push quay.io/<quay username>/managed-api-service-bundle:<release version>`

6. Validate  bundles : 
     `operator-sdk bundle validate  quay.io/<quay username>/managed-api-service-bundle:<release version>`
      Note:  if using podman add `-b=podman` flag.
