### PR TITLE
Include suggested-namespace annotation in base CSV

### DIFF
--- a/config/manifests-rhmi/bases/integreatly-operator.clusterserviceversion.yaml
+++ b/config/manifests-rhmi/bases/integreatly-operator.clusterserviceversion.yaml
@@ -2,6 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    operatorframework.io/suggested-namespace: redhat-rhmi-operator
     alm-examples: '[]'
     capabilities: Basic Install
     categories: RHMI integration

--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -2,6 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   annotations:
+    operatorframework.io/suggested-namespace: redhat-rhoam-operator
     alm-examples: '[]'
     capabilities: Basic Install
     categories: RHOAM integration


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

# What

The `operatorframework.io/suggested-namespace` is supported by OLM and operator-sdk to specify the default/recommended namespace where the operator might be installed. This provides a better user experience, as well as advantages when testing using the scorecard format.

Include this annotation in the base CSVs of both RHOAM and RHMI. The CSV generated will also include the annotation.

# Verification steps

Verify that generating a new set of manifests will result in the generated CSV containing the new annotation

> Perform this test both for RHMI and RHOAM 

1. Run the prepare release script
2. Check that the generated CSV has the corresponding value for the `operatorframework.io/suggested-namespace` annotation