### PR TITLE
bump replicas for MT install type

### DIFF
--- a/pkg/config/rhsso.go
+++ b/pkg/config/rhsso.go
@@ -39,5 +39,9 @@ func (r *RHSSO) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) int {
 	if testResources.RunningInProw(inst) {
 		return 1
 	}
+
+	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(inst.Spec.Type)) {
+		return 3
+	}
 	return 2
 }

--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -150,6 +150,14 @@ func (t *ThreeScale) GetReplicasConfig(inst *integreatlyv1alpha1.RHMI) map[strin
 			threeScaleComponents["backendListener"] = 5
 		}
 	}
+	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(inst.Spec.Type)) {
+		switch inst.Status.Quota {
+		case "10":
+			threeScaleComponents["apicastProd"] = 3
+			threeScaleComponents["backendListener"] = 3
+			threeScaleComponents["backendWorker"] = 3
+		}
+	}
 
 	return threeScaleComponents
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2582

# What
We need to increase the number of replicas for apicast, listener and worker to 3 each for 1M quota and to 6 for 50M (I've changed to 6 by default in case lower quotas would be sufficient with an increased number of replicas). 
This (numbers of replicas) is in place until we implement a quota for MT RHOAM.

# Verification steps
1. install MT RHOAM by:
```
INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local
INSTALLATION_TYPE=multitenant-managed-api make code/run      
```
2. Use following to check that replicas has been set correctly (we need 3 of each):
```
oc get apimanager 3scale -n redhat-rhoam-3scale -o yaml | yq e ".spec.backend.listenerSpec.replicas" -
oc get apimanager 3scale -n redhat-rhoam-3scale -o yaml | yq e ".spec.backend.workerSpec.replicas" -
oc get apimanager 3scale -n redhat-rhoam-3scale -o yaml | yq e ".spec.apicast.productionSpec.replicas" -
oc get keycloak rhsso -n redhat-rhoam-rhsso -o yaml | yq e ".spec.instances" -
```

This command would tell you about the stage of the installation: `watch -n5 "oc get rhmi rhoam -n redhat-rhoam-operator -o yaml | yq e '.status.stage' -"`

<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
