### PR TITLE
[MGDAPI-2581] C19: Ensure user cr is created before progressing test

### DIFF
--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -136,6 +136,13 @@ func pollOpenshiftUserLogin(t TestingTB, ctx *TestingContext, masterURL, userNam
 			return false, nil
 		}
 
+		// Additional check for User CR successfully created if user logged into cluster successfully
+		user := &userv1.User{ObjectMeta: metav1.ObjectMeta{Name: userName}}
+		if err := ctx.Client.Get(context.TODO(), types.NamespacedName{Name: userName}, user); err != nil {
+			t.Logf("Failed to find User CR with name %s: %s", userName, err)
+			return false, nil
+		}
+
 		t.Logf("Logged into openshift using %s user", userName)
 		return true, nil
 	}); err != nil {

--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -125,7 +125,7 @@ func validateUserNotListedInKeyCloakCR(t TestingTB, ctx *TestingContext, goCtx c
 }
 
 func pollOpenshiftUserLogin(t TestingTB, ctx *TestingContext, masterURL, userName string) {
-	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*8, func() (done bool, err error) {
 		tempHttpClient, err := NewTestingHTTPClient(ctx.KubeConfig)
 		if err != nil {
 			return false, nil
@@ -151,7 +151,7 @@ func pollOpenshiftUserLogin(t TestingTB, ctx *TestingContext, masterURL, userNam
 }
 
 func validateAlertIsFiring(t TestingTB, ctx *TestingContext, alertName string) {
-	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*8, func() (done bool, err error) {
 		getAlertErr := getFiringAlerts(t, ctx)
 
 		// getAlertErr should not be nil as DeadMansSwitch & at least specific alert should be firing
@@ -175,7 +175,7 @@ func validateAlertIsFiring(t TestingTB, ctx *TestingContext, alertName string) {
 }
 
 func validateAlertIsNotFiring(t TestingTB, ctx *TestingContext, alertName string) {
-	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*8, func() (done bool, err error) {
 		// getAlertErr will be nil if only DeadMansSwitch alert is firing
 		getAlertErr := getFiringAlerts(t, ctx)
 		if getAlertErr == nil {
@@ -197,7 +197,7 @@ func validateAlertIsNotFiring(t TestingTB, ctx *TestingContext, alertName string
 }
 
 func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, threeScaleUsername string) {
-	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*8, func() (done bool, err error) {
 		users, err := getUsersIn3scale(ctx, host)
 		if err != nil {
 			t.Logf("Error gettting 3scale users: %s", err)
@@ -218,7 +218,7 @@ func validateUserIsListedIn3scale(t TestingTB, ctx *TestingContext, host, threeS
 }
 
 func validateUserIsNotListedIn3scale(t TestingTB, ctx *TestingContext, host, customerAdminUsername string) {
-	if err := wait.PollImmediate(time.Second*10, time.Minute*5, func() (done bool, err error) {
+	if err := wait.PollImmediate(time.Second*10, time.Minute*8, func() (done bool, err error) {
 		users, err := getUsersIn3scale(ctx, host)
 		if err != nil {
 			t.Logf("Error getting 3scale users: %s", err)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2581

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
C19 consistently fails on nightly runs due to a timeout waiting for `ThreeScaleUserCreationFailed` to fire.

The current theory to why this happens is that for some reason when `alongusernamethatisabovefourtycharacterslong2` logs into openshift, the associated User CR is never created, and so causes the alert to never fire as the user hasn't truly logged in.
This is supported by the fact that  in the operator logs, the user controller never picks up the `alongusernamethatisabovefourtycharacterslong2` user. 
* https://master-jenkins-csb-intly.apps.ocp4.prod.psi.redhat.com/job/Nightly/job/managed-api-install-master/82/artifact/operators-pods-logs-post-tests/redhat-rhoam-operator_rhmi-operator-798c9fccbd-2vrz8_rhmi-operator.log
  * Search for `Successfully Reconciled	{"reconcilerGroup": "user.openshift.io",`

The reason to why this happens on nightly runs but not locally is unknown but a fix for this from the test is ensuring the User CR is created once logged into openshift before progressing the test

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Install RHOAM by deploying the operator image (as operator metrics are needed for C19 test case)
```
export INSTALLATION_TYPE=managed-api
IN_PROW=true make cluster/deploy
```
* Once installed, run C19 e2e test
```
INSTALLATION_TYPE=managed-api BYPASS_STORAGE_TYPE_CHECK=true TEST="C19" make test/e2e/single
```
* Verify test passes
