### PR TITLE
Update 3scale bundle in installation-cpaas.yaml

### DIFF
--- a/products/installation-cpaas.yaml
+++ b/products/installation-cpaas.yaml
@@ -59,7 +59,7 @@ products:
   3scale:
     channel: "alpha"
     installFrom: "implicit"
-    bundle: "registry.redhat.io/3scale-amp2/3scale-rhel7-operator@sha256:5063f838a8a7649626231edabf47debc3d4e36f69de37675d126b19fdbeb69c3"
+    bundle: "registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:ab721f45dd85c53f8e36acdc32424ecf97bd621ae601d9fe4c1c74cf2d6a8eea"
   amqonline:
     channel: "rhmi"
     installFrom: "local"


### PR DESCRIPTION
# What

The wrong image had been set for this field (operator image instead of the bundle image). Revert the change as we know now that the registry will be replaced for a valid one when building in OSBS

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
