### PR TITLE
add config for sandbox install type

### DIFF
--- a/config/redhat-sandbox/kustomization.yaml
+++ b/config/redhat-sandbox/kustomization.yaml
@@ -1,0 +1,64 @@
+# Adds namespace to all resources.
+namespace: sandbox-rhoam-operator
+
+# Labels to add to all resources and selectors.
+#commonLabels:
+#  someName: someValue
+
+bases:
+- ../crd
+- ../rbac-sandbox
+- ../manager
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- ../webhook
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
+#- ../certmanager
+# [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
+- ../prometheus
+
+patchesStrategicMerge:
+- manager_env_installation_type.yaml
+  # Protect the /metrics endpoint by putting it behind auth.
+  # If you want your controller-manager to expose the /metrics
+  # endpoint w/o any authn/z, please comment the following line.
+# - manager_auth_proxy_patch.yaml
+
+# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
+# crd/kustomization.yaml
+#- manager_webhook_patch.yaml
+
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
+# Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
+# 'CERTMANAGER' needs to be enabled to use ca injection
+#- webhookcainjection_patch.yaml
+
+# the following config is for teaching kustomize how to do var substitution
+vars:
+# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
+#- name: CERTIFICATE_NAMESPACE # namespace of the certificate CR
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: CERTIFICATE_NAME
+#  objref:
+#    kind: Certificate
+#    group: cert-manager.io
+#    version: v1alpha2
+#    name: serving-cert # this name should match the one in certificate.yaml
+#- name: SERVICE_NAMESPACE # namespace of the service
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service
+#  fieldref:
+#    fieldpath: metadata.namespace
+#- name: SERVICE_NAME
+#  objref:
+#    kind: Service
+#    version: v1
+#    name: webhook-service

--- a/config/redhat-sandbox/manager_auth_proxy_patch.yaml
+++ b/config/redhat-sandbox/manager_auth_proxy_patch.yaml
@@ -1,0 +1,28 @@
+# This patch inject a sidecar container which is a HTTP proxy for the 
+# controller manager, it performs RBAC authorization against the Kubernetes API using SubjectAccessReviews.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhmi-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: kube-rbac-proxy
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.5.0
+        env:
+          - name: DUMMY
+            value: ""
+        args:
+        - "--secure-listen-address=0.0.0.0:8443"
+        - "--upstream=http://127.0.0.1:8080/"
+        - "--logtostderr=true"
+        - "--v=10"
+        ports:
+        - containerPort: 8443
+          name: https
+      - name: rhmi-operator
+        args:
+        - "--metrics-addr=127.0.0.1:8080"
+        - "--enable-leader-election"

--- a/config/redhat-sandbox/manager_env_installation_type.yaml
+++ b/config/redhat-sandbox/manager_env_installation_type.yaml
@@ -1,0 +1,14 @@
+# This patch sets the INSTALLATION_TYPE enviroment variable to managed-api
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rhmi-operator
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: rhmi-operator
+        env:
+          - name: INSTALLATION_TYPE
+            value: "multitenant-managed-api"

--- a/config/redhat-sandbox/manager_webhook_patch.yaml
+++ b/config/redhat-sandbox/manager_webhook_patch.yaml
@@ -1,0 +1,23 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: rhmi-operator
+        ports:
+        - containerPort: 9443
+          name: webhook-server
+          protocol: TCP
+        volumeMounts:
+        - mountPath: /tmp/k8s-webhook-server/serving-certs
+          name: cert
+          readOnly: true
+      volumes:
+      - name: cert
+        secret:
+          defaultMode: 420
+          secretName: webhook-server-cert

--- a/config/redhat-sandbox/webhookcainjection_patch.yaml
+++ b/config/redhat-sandbox/webhookcainjection_patch.yaml
@@ -1,0 +1,15 @@
+# This patch add annotation to admission webhook config and
+# the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: mutating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)
+---
+apiVersion: admissionregistration.k8s.io/v1beta1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+  annotations:
+    cert-manager.io/inject-ca-from: $(CERTIFICATE_NAMESPACE)/$(CERTIFICATE_NAME)


### PR DESCRIPTION
# Issue link
n/a

# What
When installing rhoam via `make cluster/deploy` operator would not be deployed due to missing configuration

# Verification steps
From this branch run:
`INSTALLATION_TYPE=multitenant-managed-api USE_CLUSTER_STORAGE=true INSTALLATION_TYPE=multitenant-managed-api IMAGE_FORMAT=quay.io/integreatly/managed-api-service:master make cluster/deploy` and confirm that RHMI operator is running on the cluster as well as multitenant installation completes successfully. 

