### PR TITLE
[MGDAPI-2654] fix: do not append default domain to users with username that are email compliant

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,15 +3,13 @@ package rhsso
 import (
 	"context"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
-	"github.com/pkg/errors"
-
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
-	"github.com/integr8ly/integreatly-operator/version"
-
 	"github.com/integr8ly/integreatly-operator/pkg/resources/events"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
+	"github.com/integr8ly/integreatly-operator/version"
+	"github.com/pkg/errors"
 
 	corev1 "k8s.io/api/core/v1"
 
@@ -491,7 +489,7 @@ func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.
 		}
 
 		if email == "" {
-			email = osUser.Name + "@rhmi.io"
+			email = userHelper.SetUserNameAsEmail(osUser.Name)
 		}
 
 		newKeycloakUser := keycloak.KeycloakAPIUser{

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1714,7 +1714,7 @@ func getMTAccountsToBeCreated(usersIdentity []userHelper.MultiTenantUser, accoun
 			if identity.Email != "" {
 				email = identity.Email
 			} else {
-				email = fmt.Sprintf("%s@rhmi.io", identity.TenantName)
+				email = userHelper.SetUserNameAsEmail(identity.TenantName)
 			}
 			emailAddrs = append(emailAddrs, email)
 		}

--- a/pkg/resources/user/userHelper_test.go
+++ b/pkg/resources/user/userHelper_test.go
@@ -254,3 +254,37 @@ func TestGetValidGeneratedUserName(t *testing.T) {
 		})
 	}
 }
+
+func TestSetUserNameAsEmail(t *testing.T) {
+	type args struct {
+		userName string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "Test: username returned if already contains @ character",
+			args: args{userName: "test@test.com"},
+			want: "test@test.com",
+		},
+		{
+			name: "Test: username with default domain appended if does not contain @ character",
+			args: args{userName: "test"},
+			want: fmt.Sprintf("test%s", defaultEmailDomain),
+		},
+		{
+			name: "Test: sanitise of user name with default domain",
+			args: args{userName: "test&sanitise"},
+			want: fmt.Sprintf("test-sanitise%s", defaultEmailDomain),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SetUserNameAsEmail(tt.args.userName); got != tt.want {
+				t.Errorf("SetUserNameAsEmail() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2654

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
When a user signs into openshift via IDP, the `Identity` resource created on openshift may not have an `email` field assoicated with it. In this case, a default email using their username and appending `@rhmi.io` is used when creating the keycloak user.

This normally is fine, but when the username is an email (e.g. `test@test.com`), `@rhmi.io` is still appended to it (e.g. `test@test.com@rhmi.io`) and when the operator attempts to create the user in 3scale, it will fail due to the double domain appended email address as it is is not valid. This will give a `422` error during the 3scale user creation and cause the `ThreeScaleUserCreationFailed` alert to fire

To further prevent this scenario:
* Use username directly as email if following standard email format
* Otherwise sanitise username before appending default domain for use as generated email address

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Authomated Verification
* Install RHOAM from this branch
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Once installed, run IDP script
```
PASSWORD=Password1 DEDICATED_ADMIN_PASSWORD=Password1 ./scripts/setup-sso-idp.sh    
```
* Run the e2e test:
```
INSTALLATION_TYPE=managed-api BYPASS_STORAGE_TYPE_CHECK=true TEST="B06" make test/e2e/single
```
* Verify test completes successfully

## Manual Verification
If you want to do a full manual verification involving checking 3scale and alerts:
* In RHSSO, create a new user with an email as their username (`test@test.com`) in testing-idp
* Set a password for this user, ensuring the temporary checkbox is switched off
* Sign into openshift through testing idp as this user
* Verify 3scale reconcile completes successfully
* Verify the `email` of the generated `KeycloakUser` for this user does not contain an extra `@rhmi.io` and is just using the username as email
* Verify this user can sign into 3scale
* Verify `ThreeScaleUserCreationFailed` alert is **not** firing