### PR TITLE
add prow vendor check with config to pull private repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -461,6 +461,11 @@ vendor/check: vendor/fix
 	git diff --exit-code vendor/
 	git diff --exit-code go.sum
 
+.PHONY: vendor/check/prow
+vendor/check/prow:
+	sh scripts/setup-private-git-access.sh
+	make vendor/check
+
 .PHONY: vendor/fix
 vendor/fix:
 	go mod tidy

--- a/scripts/setup-private-git-access.sh
+++ b/scripts/setup-private-git-access.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e
+
+if [[ -z "$GIT_USERNAME" ]]; then
+  echo "GIT_USERNAME must be set in order to configure private repo access"
+  exit 1
+fi
+
+if [[ -z "$GIT_ACCESS_TOKEN" ]]; then
+  echo "GIT_TOKEN must be set in order to configure private repo access"
+  exit 1
+fi
+
+echo "setting up configuration for pulling private go repos"
+go env GOPRIVATE=github.com/bf2fc6cc711aee1a0c2a/observability-operator
+git config --global url."https://${GIT_USERNAME}:${GIT_ACCESS_TOKEN}@github.com".insteadOf https://github.com


### PR DESCRIPTION
# What
Adding an additional prow check in order to provide the steps required by prow to configure git/go to be able to pull a private repository. The reason we need this change is because the observability-operator repo is private. This will be needed on master soon.


# Verification steps
Run `make vendor/check/prow`
If you do not have the variables exported you the script should tell you.
export the values.
The don't really matter for now.
Run the script
There should be a new block of configuration in you `~/.gitconfig` file which looks like

```
[url "https://<the username>:<the token>@github.com@github.com"]
        insteadOf = https://github.com
```
