### PR TITLE
test: test-case: h23: update machine IP

### DIFF
--- a/test-cases/tests/products/h23-validate-rate-limit-service-with-default-customer-config.md
+++ b/test-cases/tests/products/h23-validate-rate-limit-service-with-default-customer-config.md
@@ -98,7 +98,7 @@ chmod 400 /path/to/vault/libra.pem
 Then SSH to the load testing instance (using the key-file):
 
 ```bash
-ssh -i /path/to/libra.pem fedora@10.0.76.255
+ssh -i /path/to/libra.pem fedora@10.0.77.22
 ```
 
 you should now be logged into [fedora@rate-limit-testing ~]


### PR DESCRIPTION
The previous rate-limit-testing machine was accidentally deleted. New instance was created and the IP has changed.