### PR TITLE
rhsso-next-7.5.0-patch-ownerref-admincredentials

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -263,8 +263,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create/update keycloak custom resource: %w", err)
 	}
 	// Patching the OwnerReference on the admin credentials secret
-	err = resources.AddOwnerRefToSSOSecret(ctx,serverClient, adminCredentialSecretName,r.Config.GetNamespace(),*kc , r.Log )
-	if err != nil  {
+	err = resources.AddOwnerRefToSSOSecret(ctx, serverClient, adminCredentialSecretName, r.Config.GetNamespace(), *kc, r.Log)
+	if err != nil {
 		events.HandleError(r.Recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to add ownerReferance admin credentials secret", err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -262,6 +262,12 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create/update keycloak custom resource: %w", err)
 	}
+	// Patching the OwnerReference on the admin credentials secret
+	err = resources.AddOwnerRefToSSOSecret(ctx,serverClient, adminCredentialSecretName,r.Config.GetNamespace(),*kc , r.Log )
+	if err != nil  {
+		events.HandleError(r.Recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to add ownerReferance admin credentials secret", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
 	host := r.Config.GetHost()
 	if host == "" {
 		r.Log.Info("URL for Keycloak not yet available")

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -272,6 +272,16 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		Phase: keycloak.PhaseReconciling,
 	})
 
+	credentialRhsso := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminCredentialSecretName,
+			Namespace: "rhsso",
+		},
+		Data: map[string][]byte{
+			"rhsso": bytes.NewBufferString("test").Bytes(),
+		},
+	}
+
 	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
@@ -334,7 +344,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
-			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kc, croPostgres, croPostgresSecret, kcr),
+			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kc, croPostgres, croPostgresSecret, kcr, credentialRhsso),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation: &integreatlyv1alpha1.RHMI{

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -341,8 +341,8 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	r.Log.Infof("Operation result", l.Fields{"keycloak": kc.Name, "res": or})
 
 	// Patching the OwnerReference on the admin credentials secret
-	err = resources.AddOwnerRefToSSOSecret(ctx,serverClient, adminCredentialSecretName,r.Config.GetNamespace(),*kc , r.Log )
-	if err != nil  {
+	err = resources.AddOwnerRefToSSOSecret(ctx, serverClient, adminCredentialSecretName, r.Config.GetNamespace(), *kc, r.Log)
+	if err != nil {
 		events.HandleError(r.Recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to add ownerReferance admin credentials secret", err)
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -340,6 +340,12 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 	r.Log.Infof("Operation result", l.Fields{"keycloak": kc.Name, "res": or})
 
+	// Patching the OwnerReference on the admin credentials secret
+	err = resources.AddOwnerRefToSSOSecret(ctx,serverClient, adminCredentialSecretName,r.Config.GetNamespace(),*kc , r.Log )
+	if err != nil  {
+		events.HandleError(r.Recorder, installation, integreatlyv1alpha1.PhaseFailed, "Failed to add ownerReferance admin credentials secret", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
 	// We want to update the master realm by adding an openshift-v4 idp. We can not add the idp until we know the host
 	if r.Config.GetHost() == "" {
 		r.Log.Warning("Can not update keycloak master realm on user sso as host is not available yet")

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -470,6 +470,16 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		},
 	}
 
+	credentialRhsso := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      adminCredentialSecretName,
+			Namespace: "user-sso",
+		},
+		Data: map[string][]byte{
+			"rhsso": bytes.NewBufferString("test").Bytes(),
+		},
+	}
+
 	oauthClientSecrets := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "oauth-client-secrets",
@@ -522,7 +532,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
-			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group, croPostgres, croPostgresSecret),
+			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group, croPostgres, croPostgresSecret,credentialRhsso),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation: &integreatlyv1alpha1.RHMI{

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -532,7 +532,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 	}{
 		{
 			Name:            "Test reconcile custom resource returns completed when successful created",
-			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group, croPostgres, croPostgresSecret,credentialRhsso),
+			FakeClient:      fakeclient.NewFakeClientWithScheme(scheme, oauthClientSecrets, githubOauthSecret, kcr, kc, group, croPostgres, croPostgresSecret, credentialRhsso),
 			FakeOauthClient: fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
 			FakeConfig:      basicConfigMock(),
 			Installation: &integreatlyv1alpha1.RHMI{

--- a/pkg/resources/pullSecret.go
+++ b/pkg/resources/pullSecret.go
@@ -63,7 +63,7 @@ func ReconcileSecretToProductNamespace(ctx context.Context, client k8sclient.Cli
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func AddOwnerRefToSSOSecret(ctx context.Context, client k8sclient.Client, secretName string, namespace string, kc keycloak.Keycloak,log l.Logger ) error{
+func AddOwnerRefToSSOSecret(ctx context.Context, client k8sclient.Client, secretName string, namespace string, kc keycloak.Keycloak, log l.Logger) error {
 	srcSecret := corev1.Secret{}
 	err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &srcSecret)
 	if err != nil {
@@ -79,10 +79,10 @@ func AddOwnerRefToSSOSecret(ctx context.Context, client k8sclient.Client, secret
 		Controller:         &istrue,
 		BlockOwnerDeletion: &istrue,
 	}
-    ownerRef := []metav1.OwnerReference{
+	ownerRef := []metav1.OwnerReference{
 		owner,
 	}
-	_ , err = controllerutil.CreateOrUpdate(ctx, client, &srcSecret, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, client, &srcSecret, func() error {
 		if srcSecret.OwnerReferences == nil {
 			srcSecret.OwnerReferences = ownerRef
 		}

--- a/pkg/resources/pullSecret.go
+++ b/pkg/resources/pullSecret.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
@@ -60,6 +61,35 @@ func ReconcileSecretToProductNamespace(ctx context.Context, client k8sclient.Cli
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func AddOwnerRefToSSOSecret(ctx context.Context, client k8sclient.Client, secretName string, namespace string, kc keycloak.Keycloak,log l.Logger ) error{
+	srcSecret := corev1.Secret{}
+	err := client.Get(ctx, types.NamespacedName{Name: secretName, Namespace: namespace}, &srcSecret)
+	if err != nil {
+		return err
+	}
+	istrue := true
+
+	owner := metav1.OwnerReference{
+		APIVersion:         "keycloak.org/v1alpha1",
+		Kind:               "Keycloak",
+		Name:               kc.Name,
+		UID:                kc.UID,
+		Controller:         &istrue,
+		BlockOwnerDeletion: &istrue,
+	}
+    ownerRef := []metav1.OwnerReference{
+		owner,
+	}
+	_ , err = controllerutil.CreateOrUpdate(ctx, client, &srcSecret, func() error {
+		if srcSecret.OwnerReferences == nil {
+			srcSecret.OwnerReferences = ownerRef
+		}
+		return nil
+	})
+
+	return err
 }
 
 // Copies a secret from a target namespace to the RHMI operator namespace


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2555

# What
patches credentials-rhsso and credentials-rhssouser with an ownerref from the Keycloak cr
Required for installation to complete with rhsso 7.5 images


# Verification steps
- Install the operator locally
- make sure that rhsso and user-sso installations complete and there routes are available
