### PR TITLE
Implement on demand approach to keycloak realm provisioning for multi tenant Rhoam in user sso.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/integr8ly/cloud-resource-operator v0.30.0
 	github.com/integr8ly/grafana-operator v2.0.0+incompatible
 	github.com/integr8ly/grafana-operator/v3 v3.10.2
-	github.com/integr8ly/keycloak-client v0.1.4
+	github.com/integr8ly/keycloak-client v0.1.5
 	github.com/keycloak/keycloak-operator v0.0.0-20210506103913-57d81e278bcb
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -827,8 +827,8 @@ github.com/integr8ly/grafana-operator/v3 v3.5.0/go.mod h1:nie1yDLaWkgUjW+EBTLUjD
 github.com/integr8ly/grafana-operator/v3 v3.6.0/go.mod h1:pWWg9RerCkkwmTcmaygmfhkjjGilEN30han1yq2MAsA=
 github.com/integr8ly/grafana-operator/v3 v3.10.2 h1:CUZIS8kkCHJNO7WEeCqhbkGDiLtjgPzgidR8VlgOpQg=
 github.com/integr8ly/grafana-operator/v3 v3.10.2/go.mod h1:5D8+MTrFKiwxz4kz2Oc36MxQu4EOHnJKaStSFAOukz0=
-github.com/integr8ly/keycloak-client v0.1.4 h1:pUrfh0Q4IhvKoJ90S76oxbcxmy9+eJCv2hCOsprJTls=
-github.com/integr8ly/keycloak-client v0.1.4/go.mod h1:UyM3uRRR5kpq/6xGCEvVPpneduPoPQ7hgMp+Mv9VvXs=
+github.com/integr8ly/keycloak-client v0.1.5 h1:lD0fDLJ362VSDNReRwfC/eJzFdaFLE1D6mp53ytrdDA=
+github.com/integr8ly/keycloak-client v0.1.5/go.mod h1:UyM3uRRR5kpq/6xGCEvVPpneduPoPQ7hgMp+Mv9VvXs=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -1632,3 +1632,6 @@ func (r *Reconciler) deleteConsoleLink(ctx context.Context, serverClient k8sclie
 
 	return nil
 }
+
+
+

--- a/pkg/products/rhssouser/reconciler_multitenant.go
+++ b/pkg/products/rhssouser/reconciler_multitenant.go
@@ -4,112 +4,279 @@ import (
 	"context"
 	"fmt"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
+	kccommon "github.com/integr8ly/keycloak-client/pkg/common"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-const (
-	stagingRealmName         = "staging"
-	)
+const StagingRealmName = "staging"
 
 func (r *Reconciler) ReconcileMultiTenantUserSSO(ctx context.Context, serverClient k8sclient.Client, kc *keycloak.Keycloak) (integreatlyv1alpha1.StatusPhase, error) {
 
-
-	// Get all users
-	// Get all realms
-	// Get all staging users
-	// Create a staging Realm if it doesn't exist
-	// Reconcile Config of Events on the Staging Realm inc. Expiration
-	// ReconcileStagingUsers: newUsers: users not in staging list
-	// Create console link with "Provision SSO Account"
-
-	// GetRecentLogins() Events and return a list of users recently logged in
-	// Get added: Logged in users that don't have a realm:
-	// Delete added from staging realm
-	// ReconcileTenantRealms
-
-	// Delete from staging
-	// Delete user from staging
-	// Delete realm from staging
-
 	mtUsers, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
-	if (err != nil) {
+	if err != nil {
 		r.Log.Error("Error getting mt users", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting mt users")
 	}
 	r.Log.Infof("Found multi tenant users", l.Fields{"num": len(mtUsers)})
 
 	allRealms, err := r.getAllRealms(ctx, serverClient)
-	if (err != nil) {
+	if err != nil {
 		r.Log.Error("Error getting all Realms", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all Realms")
 	}
 	r.Log.Infof("Found realms in user sso", l.Fields{"num": len(allRealms.Items)})
 
-	err = r.reconcileStagingRealm(ctx, serverClient, *allRealms) // including adding events stuff
-	if (err != nil) {
+	err = r.reconcileStagingRealm(ctx, serverClient, *allRealms)
+	if err != nil {
 		r.Log.Error("Error reconciling staging realm", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconciling staging realms")
 	}
 
 	existingStagingUsers, err := r.getAllStagingUsers(ctx, serverClient)
-	if (err != nil) {
+	if err != nil {
 		r.Log.Error("Error getting all staging users", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all staging users")
 	}
 
 	newStagingUsers, err := r.reconcileStagingUsers(ctx, serverClient, mtUsers, existingStagingUsers, allRealms)
-	if (err != nil) {
+	if err != nil {
 		r.Log.Error("Error getting all staging users", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all staging users")
 	}
 
-	err = r.reconcileStagingConsoleLinks(ctx, serverClient, existingStagingUsers, newStagingUsers)
-	if (err != nil) {
+	err = r.reconcileStagingUsersConsoleLink(ctx, serverClient, existingStagingUsers, newStagingUsers)
+	if err != nil {
 		r.Log.Error("Error reconciling Staging Console Links", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconciling Staging Console Links")
 	}
 
-	loginEvents, err := getLoginEvents(ctx, serverClient)
-	if (err != nil) {
+	loginEventUserIds, err := r.getUserIdLoginEvents(ctx, serverClient, kc)
+	if err != nil {
 		r.Log.Error("Error getting login events", err)
 		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting login events")
 	}
 
-	reconcileTenantRealms(ctx, serverClient, loginEvents, realms, users)
+	err = r.reconcileTenantRealms(ctx, serverClient, allRealms, mtUsers, loginEventUserIds)
+	if err != nil {
+		r.Log.Error("Error reconcileTenantRealms", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconcileTenantRealms")
+	}
 
+	err = r.reconcileTenantConsoleLinks(ctx, serverClient, mtUsers)
+	if err != nil {
+		r.Log.Error("Error reconciling Tenant Console Links", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconciling Staging Console Links")
+	}
 
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
 
-	//users := []userHelper.MultiTenantUser{}
-	//users, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
-	//if err != nil {
-	//	r.Log.Error("Error getting multi tenant users", err)
-	//	return integreatlyv1alpha1.PhaseFailed, nil
-	//}
-	//
-	//r.reconcileTenants(ctx, serverClient, r.Config.GetNamespace(), users, kc)
-	//if err != nil {
-	//	return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error reconciling multi tenant users: %w", err)
-	//}
+func (r *Reconciler) reconcileTenantConsoleLinks(ctx context.Context, serverClient k8sclient.Client, users []userHelper.MultiTenantUser) error {
+	realms, err := r.getAllRealms(ctx, serverClient)
+	if err != nil {
+		r.Log.Error("Error getting all realms", err)
+		return err
+	}
 
+	for _, realm := range realms.Items {
+		if realm.Name == "master" || realm.Name == StagingRealmName {
+			continue
+		}
+		tenantLink := r.Config.GetHost() + "/auth/admin/" + realm.Name + "/console/"
+		if err := r.reconcileDashboardLink(ctx, serverClient, realm.Name, tenantLink, ""); err != nil {
+			return err
+		}
+	}
 
+	return nil
+}
+
+// If a user logged in to the staging realm but does not have a tenant realm, create one.
+func (r *Reconciler) reconcileTenantRealms(ctx context.Context, serverClient k8sclient.Client, realms *keycloak.KeycloakRealmList, users []userHelper.MultiTenantUser, loginEventUserIds []kccommon.Users) error {
+
+	added, deleted, err := r.getTenantDiff(ctx, serverClient, users, realms.Items, loginEventUserIds)
+	if err != nil {
+		return err
+	}
+
+	for _, user := range added {
+		_, err := r.createTenantRealm(ctx, serverClient, user.TenantName)
+		if err != nil {
+			return err
+		}
+		_, err = r.createTenantKCUser(ctx, serverClient, user)
+		if err != nil {
+			return err
+		}
+		if err = r.removeUserFromStagingRealm(ctx, serverClient, user); err != nil {
+			return err
+		}
+	}
+
+	// delete all tenant details
+	for _, realm := range deleted {
+		_, err = r.deleteTenant(ctx, serverClient, realm)
+		if err != nil {
+			r.Log.Errorf("Failed to delete tenant on realm ", l.Fields{"realm": realm.Name}, err)
+			return fmt.Errorf("failed to delete tenant on realm: %w", err)
+		}
+	}
+	return nil
+}
+
+func (r *Reconciler) removeUserFromStagingRealm(ctx context.Context, serverClient k8sclient.Client, user userHelper.MultiTenantUser) error {
+	kcUser, err := r.getKeycloakUserCRByUID(ctx, serverClient, user.UID)
+	if err != nil {
+		r.Log.Errorf("Error finding staging user", l.Fields{"uid": user.UID}, err)
+		return errors.Wrap(err, "Error finding staging user")
+	}
+	if kcUser == nil {
+		r.Log.Warningf("User not found in staging realm to delete ", l.Fields{"uid": user.UID})
+		return nil
+	}
+	err = serverClient.Delete(ctx, kcUser)
+	if err != nil {
+		r.Log.Errorf("Failed to delete kcUser ", l.Fields{"kcUser": kcUser.Name}, err)
+		return fmt.Errorf("failed to delete tenant kcUser: %w", err)
+	}
+	return nil
+}
+
+func (r *Reconciler) getTenantDiff(ctx context.Context, serverClient k8sclient.Client, mtUsers []userHelper.MultiTenantUser, realms []keycloak.KeycloakRealm, loginEventUserIds []kccommon.Users) (added []userHelper.MultiTenantUser, deleted []keycloak.KeycloakRealm, err error) {
+
+	for _, loginEventUserId := range loginEventUserIds {
+		mtUser, err := r.findUser(ctx, serverClient, loginEventUserId, mtUsers)
+		if err != nil {
+			r.Log.Error("Error finding user", err)
+			return nil, nil, errors.Wrap(err, "Error finding user")
+		}
+		if mtUser == nil {
+			r.Log.Warningf("User not found ", l.Fields{"loginEventUserId": loginEventUserId})
+			continue
+		}
+		if !realmExistsForTenant(realms, *mtUser) && !userInList(added, *mtUser) {
+			added = append(added, *mtUser)
+		}
+	}
+
+	// Find realms with no corresponding user. Delete it.
+	for _, realm := range realms {
+		if realm.Name == "master" || realm.Name == StagingRealmName {
+			continue
+		}
+		if !userExistsForRealm(mtUsers, realm) {
+			deleted = append(deleted, realm)
+		}
+	}
+
+	return added, deleted, nil
+}
+
+func userInList(added []userHelper.MultiTenantUser, user userHelper.MultiTenantUser) bool {
+	for _, usr := range added {
+		if usr.UID == user.UID {
+			return true
+		}
+	}
+	return false
+}
+
+// The loginEventUserId is the keycloak user id.
+// We can use this to find the KCUser CR and on that there is a UID
+// representing the user id on the user CR
+func (r *Reconciler) findUser(ctx context.Context, serverClient k8sclient.Client, loginEventUserId kccommon.Users, users []userHelper.MultiTenantUser) (*userHelper.MultiTenantUser, error) {
+	kucr, err := r.getKeycloakUserCR(ctx, serverClient, loginEventUserId)
+	if err != nil {
+		r.Log.Error("Error getting keylcoak user cr", err)
+		return nil, err
+	}
+	if kucr == nil {
+		return nil, nil
+	}
+	uid := kucr.Spec.User.FederatedIdentities[0].UserID
+	for _, user := range users {
+		if (user.UID) == uid {
+			return &user, nil
+		}
+	}
+	return nil, nil
+}
+
+func (r *Reconciler) getKeycloakUserCR(ctx context.Context, serverClient k8sclient.Client, User kccommon.Users) (*keycloak.KeycloakUser, error) {
+	var users keycloak.KeycloakUserList
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"sso": StagingRealmName,
+		}),
+		k8sclient.InNamespace(r.Config.GetNamespace()),
+	}
+	err := serverClient.List(ctx, &users, listOptions...)
+	if err != nil {
+		r.Log.Error("Error getting keylcoak user list", err)
+		return nil, err
+	}
+
+	for _, user := range users.Items {
+		if user.Spec.User.ID == User.UserID {
+			return &user, nil
+		}
+	}
+
+	r.Log.Warningf("Keycloak user not found", l.Fields{"UserId": User.UserID})
+
+	return nil, nil
+}
+
+func (r *Reconciler) getKeycloakUserCRByUID(ctx context.Context, serverClient k8sclient.Client, UserId string) (*keycloak.KeycloakUser, error) {
+	var users keycloak.KeycloakUserList
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"sso": StagingRealmName,
+		}),
+		k8sclient.InNamespace(r.Config.GetNamespace()),
+	}
+	err := serverClient.List(ctx, &users, listOptions...)
+	if err != nil {
+		r.Log.Error("Error getting keylcoak user list", err)
+		return nil, err
+	}
+
+	for _, user := range users.Items {
+		if user.Spec.User.FederatedIdentities[0].UserID == UserId {
+			return &user, nil
+		}
+	}
+
+	r.Log.Warningf("Keycloak user not found", l.Fields{"UserId": UserId})
+
+	return nil, nil
+}
+
+func (r *Reconciler) getUserIdLoginEvents(ctx context.Context, serverClient k8sclient.Client, kc *keycloak.Keycloak) ([]kccommon.Users, error) {
+
+	kcClient, err := r.KeycloakClientFactory.AuthenticatedClient(*kc)
+	if err != nil {
+		return nil, err
+	}
+	return kcClient.ListOfActivesUsersPerRealm(StagingRealmName, "", 1000)
 }
 
 func (r *Reconciler) reconcileStagingRealm(ctx context.Context, serverClient k8sclient.Client, realms keycloak.KeycloakRealmList) error {
 
-	if (stagingRealmExists(realms)) {
-		return nil
-	}
-
-	r.Log.Info("Creating staging realm")
+	r.Log.Info("Reconciling staging realm")
 	kcr := &keycloak.KeycloakRealm{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      stagingRealmName,
+			Name:      StagingRealmName,
 			Namespace: r.Config.GetNamespace(),
 		},
 	}
@@ -127,21 +294,22 @@ func (r *Reconciler) reconcileStagingRealm(ctx context.Context, serverClient k8s
 		}
 
 		kcr.Labels = map[string]string{
-			"sso": stagingRealmName,
+			"sso": StagingRealmName,
 		}
 
 		kcr.Spec.Realm = &keycloak.KeycloakAPIRealm{
-			ID:          stagingRealmName,
-			Realm:       stagingRealmName,
-			Enabled:     true,
-			DisplayName: "*************** SSO Realm Provisioning ******************",
+			ID:            StagingRealmName,
+			Realm:         StagingRealmName,
+			Enabled:       true,
+			DisplayName:   "*************** SSO Realm Provisioning ******************",
+			EventsEnabled: boolPtr(true),
 		}
 
 		// The identity providers need to be set up before the realm CR gets
 		// created because the Keycloak operator does not allow updates to
 		// the realms
-		redirectURIs := []string{r.Config.GetHost() + "/auth/realms/" + stagingRealmName + "/broker/openshift-v4/endpoint"}
-		err := r.SetupOpenshiftIDP(ctx, serverClient, r.Installation, r.Config, kcr, redirectURIs, stagingRealmName)
+		redirectURIs := []string{r.Config.GetHost() + "/auth/realms/" + StagingRealmName + "/broker/openshift-v4/endpoint"}
+		err := r.SetupOpenshiftIDP(ctx, serverClient, r.Installation, r.Config, kcr, redirectURIs, StagingRealmName)
 		if err != nil {
 			r.Log.Error("Failed to setup Openshift IDP for user-sso staging realm", err)
 			return fmt.Errorf("failed to setup Openshift IDP for user-sso staging realm: %w", err)
@@ -151,7 +319,7 @@ func (r *Reconciler) reconcileStagingRealm(ctx context.Context, serverClient k8s
 	})
 
 	if err != nil {
-		r.Log.Errorf("Failed create/update", l.Fields{"realm": stagingRealmName}, err)
+		r.Log.Errorf("Failed create/update", l.Fields{"realm": StagingRealmName}, err)
 		return fmt.Errorf("failed to create/update keycloak realm: %w", err)
 	}
 	r.Log.Infof("Operation result", l.Fields{"keycloakrealm": kcr.Name, "result": or})
@@ -159,16 +327,7 @@ func (r *Reconciler) reconcileStagingRealm(ctx context.Context, serverClient k8s
 	return nil
 }
 
-func stagingRealmExists(realms keycloak.KeycloakRealmList) bool {
-	for _, realm := range realms.Items {
-		if realm.Name == stagingRealmName {
-			return true
-		}
-	}
-	return false
-}
-
-func  (r *Reconciler) getAllRealms(ctx context.Context, serverClient k8sclient.Client) (*keycloak.KeycloakRealmList, error) {
+func (r *Reconciler) getAllRealms(ctx context.Context, serverClient k8sclient.Client) (*keycloak.KeycloakRealmList, error) {
 	realms := &keycloak.KeycloakRealmList{}
 
 	listOptions := []k8sclient.ListOption{
@@ -178,14 +337,13 @@ func  (r *Reconciler) getAllRealms(ctx context.Context, serverClient k8sclient.C
 	return realms, err
 }
 
-
 func (r *Reconciler) getAllStagingUsers(ctx context.Context, serverClient k8sclient.Client) (*keycloak.KeycloakUserList, error) {
 
 	var users keycloak.KeycloakUserList
 
 	listOptions := []k8sclient.ListOption{
 		k8sclient.MatchingLabels(map[string]string{
-			"sso": stagingRealmName,
+			"sso": StagingRealmName,
 		}),
 		k8sclient.InNamespace(r.Config.GetNamespace()),
 	}
@@ -196,25 +354,59 @@ func (r *Reconciler) getAllStagingUsers(ctx context.Context, serverClient k8scli
 	return &users, nil
 }
 
+func stagingUserExists(user userHelper.MultiTenantUser, stgUsers *keycloak.KeycloakUserList) bool {
+	for _, stgUser := range stgUsers.Items {
+		if stgUser.Spec.User.FederatedIdentities[0].UserID == user.UID {
+			return true
+		}
+	}
+	return false
+}
+
 // Create a user in staging if there is no realm, no existing user but a userCR
 func (r *Reconciler) reconcileStagingUsers(ctx context.Context, serverClient k8sclient.Client, mtUsers []userHelper.MultiTenantUser, stgUsers *keycloak.KeycloakUserList, realms *keycloak.KeycloakRealmList) ([]userHelper.MultiTenantUser, error) {
 	newUsers := []userHelper.MultiTenantUser{}
 	for _, user := range mtUsers {
-		if (!realmExistsForMtUser(user, realms.Items) && !stagingUserExists(user, stgUsers)) {
+		if !realmExistsForMtUser(user, realms.Items) && !stagingUserExists(user, stgUsers) {
 			err := r.createStagingUser(ctx, serverClient, user)
-			if (err != nil) {
-
+			if err != nil {
+				r.Log.Error("Error creating staging user", err)
+				return newUsers, errors.Wrap(err, "Error creating staging user")
 			}
 			newUsers = append(newUsers, user)
 		}
 	}
+
+	// If a staging user exists but a user CR does not exist, then delete the staging user
+	for _, stgUser := range stgUsers.Items {
+		uid := stgUser.Spec.User.FederatedIdentities[0].UserID
+		if uid == "" {
+			r.Log.Warningf("user id on staging keycloak user not found", l.Fields{"stgUser": stgUser.Name})
+		} else if !userExsitsForStagingUser(uid, mtUsers) {
+			err := serverClient.Delete(ctx, &stgUser)
+			if err != nil {
+				r.Log.Errorf("Failed to delete staging user ", l.Fields{"stgUser": stgUser.Name}, err)
+				return newUsers, fmt.Errorf("failed to delete keycloak user: %w", err)
+			}
+		}
+	}
+
 	return newUsers, nil
+}
+
+func userExsitsForStagingUser(uid string, mtUsers []userHelper.MultiTenantUser) bool {
+	for _, mtUser := range mtUsers {
+		if mtUser.UID == uid {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *Reconciler) createStagingUser(ctx context.Context, serverClient k8sclient.Client, user userHelper.MultiTenantUser) error {
 	kcUser := &keycloak.KeycloakUser{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      user.TenantName,
+			Name:      user.TenantName + "-stg",
 			Namespace: r.Config.GetNamespace(),
 		},
 	}
@@ -222,11 +414,11 @@ func (r *Reconciler) createStagingUser(ctx context.Context, serverClient k8sclie
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kcUser, func() error {
 		kcUser.Spec.RealmSelector = &metav1.LabelSelector{
 			MatchLabels: map[string]string{
-				"sso" : stagingRealmName,
+				"sso": StagingRealmName,
 			},
 		}
 		kcUser.Labels = map[string]string{
-			"sso": user.TenantName,
+			"sso": StagingRealmName,
 		}
 		kcUser.Spec.User = keycloak.KeycloakAPIUser{
 			Enabled:       true,
@@ -237,7 +429,7 @@ func (r *Reconciler) createStagingUser(ctx context.Context, serverClient k8sclie
 				{
 					IdentityProvider: idpAlias,
 					UserID:           string(user.UID),
-					UserName:         user.TenantName,
+					UserName:         user.Username,
 				},
 			},
 			ClientRoles: getStagingClientRoles("realm-management"),
@@ -263,7 +455,6 @@ func getStagingClientRoles(realm string) map[string][]string {
 	}
 }
 
-
 func realmExistsForMtUser(user userHelper.MultiTenantUser, realms []keycloak.KeycloakRealm) bool {
 	for _, realm := range realms {
 		if realm.Name == user.TenantName {
@@ -273,31 +464,247 @@ func realmExistsForMtUser(user userHelper.MultiTenantUser, realms []keycloak.Key
 	return false
 }
 
-func stagingUserExists(user userHelper.MultiTenantUser, stgUsers *keycloak.KeycloakUserList) bool {
-	for _, stgUser := range stgUsers.Items {
-		if stgUser.Name == user.TenantName {
+func (r *Reconciler) reconcileStagingUsersConsoleLink(ctx context.Context, serverClient k8sclient.Client, existingUsers *keycloak.KeycloakUserList, newUsers []userHelper.MultiTenantUser) error {
+
+	stagingLink := r.Config.GetHost() + "/auth/admin/staging/console/"
+
+	for _, user := range existingUsers.Items {
+		if err := r.reconcileDashboardLink(ctx, serverClient, user.Spec.User.UserName, stagingLink, "Provision SSO Realm"); err != nil {
+			return err
+		}
+	}
+
+	for _, user := range newUsers {
+		if err := r.reconcileDashboardLink(ctx, serverClient, user.TenantName, stagingLink, "Provision SSO Realm"); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}
+
+func realmExistsForTenant(realms []keycloak.KeycloakRealm, user userHelper.MultiTenantUser) bool {
+	for _, realm := range realms {
+		if realm.Name == user.TenantName {
 			return true
 		}
 	}
 	return false
 }
 
-func (r *Reconciler) reconcileStagingConsoleLinks(ctx context.Context, serverClient k8sclient.Client, existingUsers *keycloak.KeycloakUserList, newUsers []userHelper.MultiTenantUser) error {
+func userExistsForRealm(users []userHelper.MultiTenantUser, realm keycloak.KeycloakRealm) bool {
+	for _, user := range users {
+		if realm.Name == user.TenantName {
+			return true
+		}
+	}
+	return false
+}
 
-	stagingLink := r.Config.GetHost() + "/auth/admin/staging/console/"
+func (r *Reconciler) createTenantKCUser(ctx context.Context, serverClient k8sclient.Client, user userHelper.MultiTenantUser) (integreatlyv1alpha1.StatusPhase, error) {
 
-	for _, user := range existingUsers.Items {
-		tenantNs := user.Name + "-dev"
-		if err := r.reconcileDashboardLink(ctx, serverClient, user.Name, stagingLink, tenantNs); err != nil {
+	kcUser := &keycloak.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      user.TenantName,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+
+	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kcUser, func() error {
+		kcUser.Spec.RealmSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				masterRealmLabelKey: user.TenantName,
+			},
+		}
+		kcUser.Labels = map[string]string{
+			"sso": user.TenantName,
+		}
+		kcUser.Spec.User = keycloak.KeycloakAPIUser{
+			Enabled:       true,
+			UserName:      user.TenantName,
+			EmailVerified: true,
+			Email:         user.Email,
+			FederatedIdentities: []keycloak.FederatedIdentity{
+				{
+					IdentityProvider: idpAlias,
+					UserID:           string(user.UID),
+					UserName:         user.Username,
+				},
+			},
+			ClientRoles: getTenantClientRoles("realm-management"),
+			RealmRoles:  []string{"offline_access", "uma_authorization"},
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create/update keycloak tenant user: %w", err)
+	}
+	r.Log.Infof("Operation result", l.Fields{"keycloak user": kcUser.Name, "res": or})
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func getTenantClientRoles(realm string) map[string][]string {
+	return map[string][]string{
+		realm: {
+			"create-client",
+			"manage-authorization",
+			"manage-clients",
+			"manage-events",
+			"manage-identity-providers",
+			"manage-realm",
+			"manage-users",
+			"query-clients",
+			"query-groups",
+			"query-realms",
+			"query-users",
+			"view-authorization",
+			"view-clients",
+			"view-events",
+			"view-identity-providers",
+			"view-realm",
+			"view-users",
+		},
+	}
+}
+
+func (r *Reconciler) createTenantRealm(ctx context.Context, serverClient k8sclient.Client, username string) (integreatlyv1alpha1.StatusPhase, error) {
+	r.Log.Infof("Creating tenant realm", l.Fields{"tenant": username})
+	kcr := &keycloak.KeycloakRealm{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      username,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+
+	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kcr, func() error {
+		kcr.Spec.RealmOverrides = []*keycloak.RedirectorIdentityProviderOverride{
+			{
+				IdentityProvider: idpAlias,
+				ForFlow:          "browser",
+			},
+		}
+
+		kcr.Spec.InstanceSelector = &metav1.LabelSelector{
+			MatchLabels: getMasterLabels(),
+		}
+
+		kcr.Labels = map[string]string{
+			"sso": username,
+		}
+
+		kcr.Spec.Realm = &keycloak.KeycloakAPIRealm{
+			ID:          username,
+			Realm:       username,
+			Enabled:     true,
+			DisplayName: username,
+		}
+
+		// The identity providers need to be set up before the realm CR gets
+		// created because the Keycloak operator does not allow updates to
+		// the realms
+		redirectURIs := []string{r.Config.GetHost() + "/auth/realms/" + username + "/broker/openshift-v4/endpoint"}
+		err := r.SetupOpenshiftIDP(ctx, serverClient, r.Installation, r.Config, kcr, redirectURIs, username)
+		if err != nil {
+			return fmt.Errorf("failed to setup Openshift IDP for user-sso: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		r.Log.Errorf("Failed create/update", l.Fields{"realm": username}, err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to create/update keycloak realm: %w", err)
+	}
+	r.Log.Infof("Operation result", l.Fields{"keycloakrealm": kcr.Name, "result": or})
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) reconcileTenantDashboardLinks(ctx context.Context, serverClient k8sclient.Client) error {
+
+	users := []userHelper.MultiTenantUser{}
+	users, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
+	if err != nil {
+		r.Log.Error("Error getting multi tenant users", err)
+		return err
+	}
+
+	for _, user := range users {
+		tenantLink := r.Config.GetHost() + "/auth/admin/" + user.TenantName + "/console/"
+		if err := r.reconcileDashboardLink(ctx, serverClient, user.TenantName, tenantLink, ""); err != nil {
 			return err
 		}
 	}
 
-	for _, user := range newUsers {
-		tenantNs := user.TenantName + "-dev"
-		if err := r.reconcileDashboardLink(ctx, serverClient, user.TenantName, stagingLink, tenantNs); err != nil {
-			return err
-		}
-	}
 	return nil
+}
+
+func (r *Reconciler) reconcileDashboardLink(ctx context.Context, serverClient k8sclient.Client, username string, tenantLink string, text string) error {
+	cl := &consolev1.ConsoleLink{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: username + "-usersso",
+		},
+	}
+
+	if text == "" {
+		text = "API Management SSO"
+	}
+
+	tenantNamespaces := []string{fmt.Sprintf("%s-stage", username), fmt.Sprintf("%s-dev", username)}
+
+	_, err := controllerutil.CreateOrUpdate(ctx, serverClient, cl, func() error {
+		cl.Spec = consolev1.ConsoleLinkSpec{
+			Location: consolev1.NamespaceDashboard,
+			Link: consolev1.Link{
+				Href: tenantLink,
+				Text: text,
+			},
+			NamespaceDashboard: &consolev1.NamespaceDashboardSpec{
+				Namespaces: tenantNamespaces,
+			},
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("error reconciling console link: %v", err)
+	}
+
+	return nil
+}
+
+func (r *Reconciler) deleteTenant(ctx context.Context, serverClient k8sclient.Client, realm keycloak.KeycloakRealm) (integreatlyv1alpha1.StatusPhase, error) {
+
+	// Delete the Keycloak User
+	kcUser := &keycloak.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      realm.Name,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+	err := serverClient.Delete(ctx, kcUser)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to delete keycloak user: %w", err)
+	}
+
+	err = serverClient.Delete(ctx, &realm)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	if err := resources.RemoveOauthClient(r.Oauthv1Client, realm.Name, r.Log); err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	if err := r.deleteConsoleLink(ctx, serverClient, realm.Name); err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/rhssouser/reconciler_multitenant.go
+++ b/pkg/products/rhssouser/reconciler_multitenant.go
@@ -1,0 +1,303 @@
+package rhssouser
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	"github.com/pkg/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	stagingRealmName         = "staging"
+	)
+
+func (r *Reconciler) ReconcileMultiTenantUserSSO(ctx context.Context, serverClient k8sclient.Client, kc *keycloak.Keycloak) (integreatlyv1alpha1.StatusPhase, error) {
+
+
+	// Get all users
+	// Get all realms
+	// Get all staging users
+	// Create a staging Realm if it doesn't exist
+	// Reconcile Config of Events on the Staging Realm inc. Expiration
+	// ReconcileStagingUsers: newUsers: users not in staging list
+	// Create console link with "Provision SSO Account"
+
+	// GetRecentLogins() Events and return a list of users recently logged in
+	// Get added: Logged in users that don't have a realm:
+	// Delete added from staging realm
+	// ReconcileTenantRealms
+
+	// Delete from staging
+	// Delete user from staging
+	// Delete realm from staging
+
+	mtUsers, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
+	if (err != nil) {
+		r.Log.Error("Error getting mt users", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting mt users")
+	}
+	r.Log.Infof("Found multi tenant users", l.Fields{"num": len(mtUsers)})
+
+	allRealms, err := r.getAllRealms(ctx, serverClient)
+	if (err != nil) {
+		r.Log.Error("Error getting all Realms", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all Realms")
+	}
+	r.Log.Infof("Found realms in user sso", l.Fields{"num": len(allRealms.Items)})
+
+	err = r.reconcileStagingRealm(ctx, serverClient, *allRealms) // including adding events stuff
+	if (err != nil) {
+		r.Log.Error("Error reconciling staging realm", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconciling staging realms")
+	}
+
+	existingStagingUsers, err := r.getAllStagingUsers(ctx, serverClient)
+	if (err != nil) {
+		r.Log.Error("Error getting all staging users", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all staging users")
+	}
+
+	newStagingUsers, err := r.reconcileStagingUsers(ctx, serverClient, mtUsers, existingStagingUsers, allRealms)
+	if (err != nil) {
+		r.Log.Error("Error getting all staging users", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting all staging users")
+	}
+
+	err = r.reconcileStagingConsoleLinks(ctx, serverClient, existingStagingUsers, newStagingUsers)
+	if (err != nil) {
+		r.Log.Error("Error reconciling Staging Console Links", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error reconciling Staging Console Links")
+	}
+
+	loginEvents, err := getLoginEvents(ctx, serverClient)
+	if (err != nil) {
+		r.Log.Error("Error getting login events", err)
+		return integreatlyv1alpha1.PhaseFailed, errors.Wrap(err, "Error getting login events")
+	}
+
+	reconcileTenantRealms(ctx, serverClient, loginEvents, realms, users)
+
+
+
+	//users := []userHelper.MultiTenantUser{}
+	//users, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
+	//if err != nil {
+	//	r.Log.Error("Error getting multi tenant users", err)
+	//	return integreatlyv1alpha1.PhaseFailed, nil
+	//}
+	//
+	//r.reconcileTenants(ctx, serverClient, r.Config.GetNamespace(), users, kc)
+	//if err != nil {
+	//	return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error reconciling multi tenant users: %w", err)
+	//}
+
+
+}
+
+func (r *Reconciler) reconcileStagingRealm(ctx context.Context, serverClient k8sclient.Client, realms keycloak.KeycloakRealmList) error {
+
+	if (stagingRealmExists(realms)) {
+		return nil
+	}
+
+	r.Log.Info("Creating staging realm")
+	kcr := &keycloak.KeycloakRealm{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      stagingRealmName,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+
+	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kcr, func() error {
+		kcr.Spec.RealmOverrides = []*keycloak.RedirectorIdentityProviderOverride{
+			{
+				IdentityProvider: idpAlias,
+				ForFlow:          "browser",
+			},
+		}
+
+		kcr.Spec.InstanceSelector = &metav1.LabelSelector{
+			MatchLabels: getMasterLabels(),
+		}
+
+		kcr.Labels = map[string]string{
+			"sso": stagingRealmName,
+		}
+
+		kcr.Spec.Realm = &keycloak.KeycloakAPIRealm{
+			ID:          stagingRealmName,
+			Realm:       stagingRealmName,
+			Enabled:     true,
+			DisplayName: "*************** SSO Realm Provisioning ******************",
+		}
+
+		// The identity providers need to be set up before the realm CR gets
+		// created because the Keycloak operator does not allow updates to
+		// the realms
+		redirectURIs := []string{r.Config.GetHost() + "/auth/realms/" + stagingRealmName + "/broker/openshift-v4/endpoint"}
+		err := r.SetupOpenshiftIDP(ctx, serverClient, r.Installation, r.Config, kcr, redirectURIs, stagingRealmName)
+		if err != nil {
+			r.Log.Error("Failed to setup Openshift IDP for user-sso staging realm", err)
+			return fmt.Errorf("failed to setup Openshift IDP for user-sso staging realm: %w", err)
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		r.Log.Errorf("Failed create/update", l.Fields{"realm": stagingRealmName}, err)
+		return fmt.Errorf("failed to create/update keycloak realm: %w", err)
+	}
+	r.Log.Infof("Operation result", l.Fields{"keycloakrealm": kcr.Name, "result": or})
+
+	return nil
+}
+
+func stagingRealmExists(realms keycloak.KeycloakRealmList) bool {
+	for _, realm := range realms.Items {
+		if realm.Name == stagingRealmName {
+			return true
+		}
+	}
+	return false
+}
+
+func  (r *Reconciler) getAllRealms(ctx context.Context, serverClient k8sclient.Client) (*keycloak.KeycloakRealmList, error) {
+	realms := &keycloak.KeycloakRealmList{}
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.InNamespace(r.Config.GetNamespace()),
+	}
+	err := serverClient.List(ctx, realms, listOptions...)
+	return realms, err
+}
+
+
+func (r *Reconciler) getAllStagingUsers(ctx context.Context, serverClient k8sclient.Client) (*keycloak.KeycloakUserList, error) {
+
+	var users keycloak.KeycloakUserList
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"sso": stagingRealmName,
+		}),
+		k8sclient.InNamespace(r.Config.GetNamespace()),
+	}
+	err := serverClient.List(ctx, &users, listOptions...)
+	if err != nil {
+		return nil, err
+	}
+	return &users, nil
+}
+
+// Create a user in staging if there is no realm, no existing user but a userCR
+func (r *Reconciler) reconcileStagingUsers(ctx context.Context, serverClient k8sclient.Client, mtUsers []userHelper.MultiTenantUser, stgUsers *keycloak.KeycloakUserList, realms *keycloak.KeycloakRealmList) ([]userHelper.MultiTenantUser, error) {
+	newUsers := []userHelper.MultiTenantUser{}
+	for _, user := range mtUsers {
+		if (!realmExistsForMtUser(user, realms.Items) && !stagingUserExists(user, stgUsers)) {
+			err := r.createStagingUser(ctx, serverClient, user)
+			if (err != nil) {
+
+			}
+			newUsers = append(newUsers, user)
+		}
+	}
+	return newUsers, nil
+}
+
+func (r *Reconciler) createStagingUser(ctx context.Context, serverClient k8sclient.Client, user userHelper.MultiTenantUser) error {
+	kcUser := &keycloak.KeycloakUser{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      user.TenantName,
+			Namespace: r.Config.GetNamespace(),
+		},
+	}
+
+	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kcUser, func() error {
+		kcUser.Spec.RealmSelector = &metav1.LabelSelector{
+			MatchLabels: map[string]string{
+				"sso" : stagingRealmName,
+			},
+		}
+		kcUser.Labels = map[string]string{
+			"sso": user.TenantName,
+		}
+		kcUser.Spec.User = keycloak.KeycloakAPIUser{
+			Enabled:       true,
+			UserName:      user.TenantName,
+			EmailVerified: true,
+			Email:         user.Email,
+			FederatedIdentities: []keycloak.FederatedIdentity{
+				{
+					IdentityProvider: idpAlias,
+					UserID:           string(user.UID),
+					UserName:         user.TenantName,
+				},
+			},
+			ClientRoles: getStagingClientRoles("realm-management"),
+			RealmRoles:  []string{"offline_access", "uma_authorization"},
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("failed to create/update keycloak tenant user: %w", err)
+	}
+	r.Log.Infof("Operation result", l.Fields{"keycloak user": kcUser.Name, "res": or})
+
+	return nil
+}
+
+func getStagingClientRoles(realm string) map[string][]string {
+	return map[string][]string{
+		realm: {
+			"view-realm",
+		},
+	}
+}
+
+
+func realmExistsForMtUser(user userHelper.MultiTenantUser, realms []keycloak.KeycloakRealm) bool {
+	for _, realm := range realms {
+		if realm.Name == user.TenantName {
+			return true
+		}
+	}
+	return false
+}
+
+func stagingUserExists(user userHelper.MultiTenantUser, stgUsers *keycloak.KeycloakUserList) bool {
+	for _, stgUser := range stgUsers.Items {
+		if stgUser.Name == user.TenantName {
+			return true
+		}
+	}
+	return false
+}
+
+func (r *Reconciler) reconcileStagingConsoleLinks(ctx context.Context, serverClient k8sclient.Client, existingUsers *keycloak.KeycloakUserList, newUsers []userHelper.MultiTenantUser) error {
+
+	stagingLink := r.Config.GetHost() + "/auth/admin/staging/console/"
+
+	for _, user := range existingUsers.Items {
+		tenantNs := user.Name + "-dev"
+		if err := r.reconcileDashboardLink(ctx, serverClient, user.Name, stagingLink, tenantNs); err != nil {
+			return err
+		}
+	}
+
+	for _, user := range newUsers {
+		tenantNs := user.TenantName + "-dev"
+		if err := r.reconcileDashboardLink(ctx, serverClient, user.TenantName, stagingLink, tenantNs); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/products/rhssouser/reconciler_multitenant_test.go
+++ b/pkg/products/rhssouser/reconciler_multitenant_test.go
@@ -1,0 +1,280 @@
+package rhssouser
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
+	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
+	consolev1 "github.com/openshift/api/console/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	fakeoauthClient "github.com/openshift/client-go/oauth/clientset/versioned/fake"
+	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+type assertFunc func(context.Context, k8sclient.Client) error
+
+var confirmStagingUsers = func(ctx context.Context, client k8sclient.Client) error {
+	var users keycloak.KeycloakUserList
+	var found = false
+
+	listOptions := []k8sclient.ListOption{
+		k8sclient.MatchingLabels(map[string]string{
+			"sso": StagingRealmName,
+		}),
+	}
+
+	// 3 users are to be expected
+	err := client.List(ctx, &users, listOptions...)
+	if err != nil {
+		return err
+	}
+
+	size := len(users.Items)
+	if size != 3 {
+		return fmt.Errorf("Not all users have been created in staging realm")
+	}
+
+	kcRealms := &keycloak.KeycloakRealmList{}
+
+	err = client.List(ctx, kcRealms)
+	if err != nil {
+		return err
+	}
+
+	// Staging realm should be present
+	for i := 1; i < len(kcRealms.Items); i++ {
+		if kcRealms.Items[i].Spec.Realm.ID == "staging" {
+			found = true
+		}
+	}
+
+	if found != true {
+		return fmt.Errorf("Staging realm not present")
+	}
+
+	return nil
+}
+
+var confirmStagingConsoleLinkExist = func(ctx context.Context, client k8sclient.Client) error {
+	amountOfUsers := 3
+
+	for i := 1; i <= amountOfUsers; i++ {
+		cl := &consolev1.ConsoleLink{}
+
+		err := client.Get(ctx, k8sclient.ObjectKey{Name: fmt.Sprintf("test-user%v", i) + "-usersso"}, cl)
+		if err != nil {
+			return err
+		}
+
+		nsName := cl.Spec.NamespaceDashboard.Namespaces[0]
+		if nsName != fmt.Sprintf("test-user%v", i)+"-stage" {
+			return fmt.Errorf("Console link missing")
+		}
+		stageNs := cl.Spec.NamespaceDashboard.Namespaces[1]
+		if stageNs != fmt.Sprintf("test-user%v", i)+"-dev" {
+			return fmt.Errorf("Console link missing")
+		}
+	}
+
+	return nil
+}
+
+func TestReconciler_full_multitenant_reconcile(t *testing.T) {
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{},
+		TypeMeta:   metav1.TypeMeta{},
+	}
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	kc := &keycloak.Keycloak{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      keycloakName,
+			Namespace: defaultNamespace,
+		},
+	}
+
+	// Setup master realm - staging realm expected to be created
+	kcRealmList := &keycloak.KeycloakRealmList{
+		Items: []keycloak.KeycloakRealm{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "master",
+					Namespace: defaultNamespace,
+				},
+				Spec: keycloak.KeycloakRealmSpec{
+					Realm: &keycloak.KeycloakAPIRealm{
+						ID:            "master",
+						Realm:         "master",
+						Enabled:       true,
+						DisplayName:   "master",
+						EventsEnabled: boolPtr(true),
+					},
+				},
+			},
+		},
+	}
+
+	// Create tenant secret
+	oauthClientSecrets := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "tenant-oauth-client-secrets",
+			Namespace: defaultOperatorNamespace,
+		},
+		Data: map[string][]byte{
+			"staging":    bytes.NewBufferString("test").Bytes(),
+			"test-user1": bytes.NewBufferString("test").Bytes(),
+			"test-user2": bytes.NewBufferString("test").Bytes(),
+			"test-user3": bytes.NewBufferString("test").Bytes(),
+		},
+	}
+
+	kcUser1 := &userv1.Identity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-user1",
+			Labels: map[string]string{
+				"sso": StagingRealmName,
+			},
+		},
+		Extra: map[string]string{
+			"email": "testuser1@rhmi.io",
+		},
+		User: corev1.ObjectReference{
+			Name: "test-user1",
+			UID:  "9604284c-c30e-4e38-93c0-f34775eda9ef",
+		},
+		ProviderName: "devsandbox",
+	}
+
+	kcUser2 := &userv1.Identity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-user2",
+			Labels: map[string]string{
+				"sso": StagingRealmName,
+			},
+		},
+		User: corev1.ObjectReference{
+			Name: "test-user2",
+			UID:  "4ef04b07-1d6d-4368-9726-778c95467e24",
+		},
+		ProviderName: "devsandbox",
+	}
+
+	kcUser3 := &userv1.Identity{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "test-user3",
+			Labels: map[string]string{
+				"sso": StagingRealmName,
+			},
+		},
+		User: corev1.ObjectReference{
+			Name: "test-user3",
+			UID:  "3",
+		},
+		ProviderName: "devsandbox",
+	}
+
+	cases := []struct {
+		Name                  string
+		ExpectError           bool
+		ExpectedStatus        integreatlyv1alpha1.StatusPhase
+		ExpectedError         string
+		AssertFunc            assertFunc
+		FakeConfig            *config.ConfigReadWriterMock
+		FakeClient            k8sclient.Client
+		FakeOauthClient       oauthClient.OauthV1Interface
+		FakeMPM               *marketplace.MarketplaceInterfaceMock
+		Installation          *integreatlyv1alpha1.RHMI
+		Recorder              record.EventRecorder
+		ApiUrl                string
+		KeycloakClientFactory keycloakCommon.KeycloakClientFactory
+	}{
+		{
+			Name:                  "Confirm staging users and realm are created",
+			ExpectedStatus:        integreatlyv1alpha1.PhaseCompleted,
+			ExpectError:           false,
+			AssertFunc:            confirmStagingUsers,
+			FakeClient:            fakeclient.NewFakeClientWithScheme(scheme, kc, kcUser1, kcUser2, kcUser3, kcRealmList, oauthClientSecrets),
+			FakeOauthClient:       fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
+			FakeConfig:            basicConfigMock(),
+			FakeMPM:               &marketplace.MarketplaceInterfaceMock{},
+			Installation:          installation,
+			Recorder:              setupRecorder(),
+			ApiUrl:                "https://serverurl",
+			KeycloakClientFactory: getMoqKeycloakClientFactory(),
+		},
+		{
+			Name:                  "Confirm console links are present for users",
+			ExpectedStatus:        integreatlyv1alpha1.PhaseCompleted,
+			ExpectError:           false,
+			AssertFunc:            confirmStagingConsoleLinkExist,
+			FakeClient:            fakeclient.NewFakeClientWithScheme(scheme, kc, kcUser1, kcUser2, kcUser3, kcRealmList, oauthClientSecrets),
+			FakeOauthClient:       fakeoauthClient.NewSimpleClientset([]runtime.Object{}...).OauthV1(),
+			FakeConfig:            basicConfigMock(),
+			FakeMPM:               &marketplace.MarketplaceInterfaceMock{},
+			Installation:          installation,
+			Recorder:              setupRecorder(),
+			ApiUrl:                "https://serverurl",
+			KeycloakClientFactory: getMoqKeycloakClientFactory(),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testReconciler, err := NewReconciler(
+				tc.FakeConfig,
+				tc.Installation,
+				tc.FakeOauthClient,
+				tc.FakeMPM,
+				tc.Recorder,
+				tc.ApiUrl,
+				tc.KeycloakClientFactory,
+				getLogger(),
+				localProductDeclaration,
+			)
+			if err != nil && err.Error() != tc.ExpectedError {
+				t.Fatalf("unexpected error : '%v', expected: '%v'", err, tc.ExpectedError)
+			}
+
+			status, err := testReconciler.ReconcileMultiTenantUserSSO(context.TODO(), tc.FakeClient, kc)
+
+			if err != nil && !tc.ExpectError {
+				t.Fatalf("expected no errors, but got one: %v", err)
+			}
+
+			if err == nil && tc.ExpectError {
+				t.Fatal("expected error but got none")
+			}
+
+			if status != tc.ExpectedStatus {
+				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
+			}
+
+			err = tc.AssertFunc(context.TODO(), tc.FakeClient)
+			if err != nil {
+				t.Fatal(err.Error())
+			}
+
+			// Confirm tenants realms got created
+
+			// Confirm tenants links got updated
+		})
+	}
+}

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClientFactory_moq.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClientFactory_moq.go
@@ -14,19 +14,19 @@ var _ KeycloakClientFactory = &KeycloakClientFactoryMock{}
 
 // KeycloakClientFactoryMock is a mock implementation of KeycloakClientFactory.
 //
-//     func TestSomethingThatUsesKeycloakClientFactory(t *testing.T) {
+// 	func TestSomethingThatUsesKeycloakClientFactory(t *testing.T) {
 //
-//         // make and configure a mocked KeycloakClientFactory
-//         mockedKeycloakClientFactory := &KeycloakClientFactoryMock{
-//             AuthenticatedClientFunc: func(kc v1alpha1.Keycloak) (KeycloakInterface, error) {
-// 	               panic("mock out the AuthenticatedClient method")
-//             },
-//         }
+// 		// make and configure a mocked KeycloakClientFactory
+// 		mockedKeycloakClientFactory := &KeycloakClientFactoryMock{
+// 			AuthenticatedClientFunc: func(kc v1alpha1.Keycloak) (KeycloakInterface, error) {
+// 				panic("mock out the AuthenticatedClient method")
+// 			},
+// 		}
 //
-//         // use mockedKeycloakClientFactory in code that requires KeycloakClientFactory
-//         // and then make assertions.
+// 		// use mockedKeycloakClientFactory in code that requires KeycloakClientFactory
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type KeycloakClientFactoryMock struct {
 	// AuthenticatedClientFunc mocks the AuthenticatedClient method.
 	AuthenticatedClientFunc func(kc v1alpha1.Keycloak) (KeycloakInterface, error)

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/keycloakClient_moq.go
@@ -14,208 +14,214 @@ var _ KeycloakInterface = &KeycloakInterfaceMock{}
 
 // KeycloakInterfaceMock is a mock implementation of KeycloakInterface.
 //
-//     func TestSomethingThatUsesKeycloakInterface(t *testing.T) {
+// 	func TestSomethingThatUsesKeycloakInterface(t *testing.T) {
 //
-//         // make and configure a mocked KeycloakInterface
-//         mockedKeycloakInterface := &KeycloakInterfaceMock{
-//             AddExecutionToAuthenticatonFlowFunc: func(flowAlias string, realmName string, providerID string, requirement Requirement) error {
-// 	               panic("mock out the AddExecutionToAuthenticatonFlow method")
-//             },
-//             AddUserToGroupFunc: func(realmName string, userID string, groupID string) error {
-// 	               panic("mock out the AddUserToGroup method")
-//             },
-//             CreateAuthenticationFlowFunc: func(authFlow AuthenticationFlow, realmName string) (string, error) {
-// 	               panic("mock out the CreateAuthenticationFlow method")
-//             },
-//             CreateAuthenticatorConfigFunc: func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string, executionID string) (string, error) {
-// 	               panic("mock out the CreateAuthenticatorConfig method")
-//             },
-//             CreateClientFunc: func(client *v1alpha1.KeycloakAPIClient, realmName string) (string, error) {
-// 	               panic("mock out the CreateClient method")
-//             },
-//             CreateFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) (string, error) {
-// 	               panic("mock out the CreateFederatedIdentity method")
-//             },
-//             CreateGroupFunc: func(group string, realmName string) (string, error) {
-// 	               panic("mock out the CreateGroup method")
-//             },
-//             CreateGroupClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) (string, error) {
-// 	               panic("mock out the CreateGroupClientRole method")
-//             },
-//             CreateGroupRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, groupID string) (string, error) {
-// 	               panic("mock out the CreateGroupRealmRole method")
-//             },
-//             CreateIdentityProviderFunc: func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) (string, error) {
-// 	               panic("mock out the CreateIdentityProvider method")
-//             },
-//             CreateRealmFunc: func(realm *v1alpha1.KeycloakRealm) (string, error) {
-// 	               panic("mock out the CreateRealm method")
-//             },
-//             CreateUserFunc: func(user *v1alpha1.KeycloakAPIUser, realmName string) (string, error) {
-// 	               panic("mock out the CreateUser method")
-//             },
-//             CreateUserClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, userID string) (string, error) {
-// 	               panic("mock out the CreateUserClientRole method")
-//             },
-//             CreateUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) (string, error) {
-// 	               panic("mock out the CreateUserRealmRole method")
-//             },
-//             DeleteAuthenticatorConfigFunc: func(configID string, realmName string) error {
-// 	               panic("mock out the DeleteAuthenticatorConfig method")
-//             },
-//             DeleteClientFunc: func(clientID string, realmName string) error {
-// 	               panic("mock out the DeleteClient method")
-//             },
-//             DeleteIdentityProviderFunc: func(alias string, realmName string) error {
-// 	               panic("mock out the DeleteIdentityProvider method")
-//             },
-//             DeleteRealmFunc: func(realmName string) error {
-// 	               panic("mock out the DeleteRealm method")
-//             },
-//             DeleteUserFunc: func(userID string, realmName string) error {
-// 	               panic("mock out the DeleteUser method")
-//             },
-//             DeleteUserClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, userID string) error {
-// 	               panic("mock out the DeleteUserClientRole method")
-//             },
-//             DeleteUserFromGroupFunc: func(realmName string, userID string, groupID string) error {
-// 	               panic("mock out the DeleteUserFromGroup method")
-//             },
-//             DeleteUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error {
-// 	               panic("mock out the DeleteUserRealmRole method")
-//             },
-//             FindAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, predicate func(*v1alpha1.AuthenticationExecutionInfo) bool) (*v1alpha1.AuthenticationExecutionInfo, error) {
-// 	               panic("mock out the FindAuthenticationExecutionForFlow method")
-//             },
-//             FindAuthenticationFlowByAliasFunc: func(flowAlias string, realmName string) (*AuthenticationFlow, error) {
-// 	               panic("mock out the FindAuthenticationFlowByAlias method")
-//             },
-//             FindAvailableGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the FindAvailableGroupClientRole method")
-//             },
-//             FindGroupByNameFunc: func(groupName string, realmName string) (*Group, error) {
-// 	               panic("mock out the FindGroupByName method")
-//             },
-//             FindGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the FindGroupClientRole method")
-//             },
-//             FindUserByEmailFunc: func(email string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
-// 	               panic("mock out the FindUserByEmail method")
-//             },
-//             FindUserByUsernameFunc: func(name string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
-// 	               panic("mock out the FindUserByUsername method")
-//             },
-//             GetAuthenticatorConfigFunc: func(configID string, realmName string) (*v1alpha1.AuthenticatorConfig, error) {
-// 	               panic("mock out the GetAuthenticatorConfig method")
-//             },
-//             GetClientFunc: func(clientID string, realmName string) (*v1alpha1.KeycloakAPIClient, error) {
-// 	               panic("mock out the GetClient method")
-//             },
-//             GetClientInstallFunc: func(clientID string, realmName string) ([]byte, error) {
-// 	               panic("mock out the GetClientInstall method")
-//             },
-//             GetClientSecretFunc: func(clientID string, realmName string) (string, error) {
-// 	               panic("mock out the GetClientSecret method")
-//             },
-//             GetIdentityProviderFunc: func(alias string, realmName string) (*v1alpha1.KeycloakIdentityProvider, error) {
-// 	               panic("mock out the GetIdentityProvider method")
-//             },
-//             GetRealmFunc: func(realmName string) (*v1alpha1.KeycloakRealm, error) {
-// 	               panic("mock out the GetRealm method")
-//             },
-//             GetUserFunc: func(userID string, realmName string) (*v1alpha1.KeycloakAPIUser, error) {
-// 	               panic("mock out the GetUser method")
-//             },
-//             GetUserFederatedIdentitiesFunc: func(userName string, realmName string) ([]v1alpha1.FederatedIdentity, error) {
-// 	               panic("mock out the GetUserFederatedIdentities method")
-//             },
-//             ListAuthenticationExecutionsForFlowFunc: func(flowAlias string, realmName string) ([]*v1alpha1.AuthenticationExecutionInfo, error) {
-// 	               panic("mock out the ListAuthenticationExecutionsForFlow method")
-//             },
-//             ListAuthenticationFlowsFunc: func(realmName string) ([]*AuthenticationFlow, error) {
-// 	               panic("mock out the ListAuthenticationFlows method")
-//             },
-//             ListAvailableGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListAvailableGroupClientRoles method")
-//             },
-//             ListAvailableGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListAvailableGroupRealmRoles method")
-//             },
-//             ListAvailableUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListAvailableUserClientRoles method")
-//             },
-//             ListAvailableUserRealmRolesFunc: func(realmName string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListAvailableUserRealmRoles method")
-//             },
-//             ListClientsFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIClient, error) {
-// 	               panic("mock out the ListClients method")
-//             },
-//             ListDefaultGroupsFunc: func(realmName string) ([]*Group, error) {
-// 	               panic("mock out the ListDefaultGroups method")
-//             },
-//             ListGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListGroupClientRoles method")
-//             },
-//             ListGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListGroupRealmRoles method")
-//             },
-//             ListIdentityProvidersFunc: func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error) {
-// 	               panic("mock out the ListIdentityProviders method")
-//             },
-//             ListRealmsFunc: func() ([]*v1alpha1.KeycloakAPIRealm, error) {
-// 	               panic("mock out the ListRealms method")
-//             },
-//             ListUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListUserClientRoles method")
-//             },
-//             ListUserRealmRolesFunc: func(realmName string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
-// 	               panic("mock out the ListUserRealmRoles method")
-//             },
-//             ListUsersFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIUser, error) {
-// 	               panic("mock out the ListUsers method")
-//             },
-//             ListUsersInGroupFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakAPIUser, error) {
-// 	               panic("mock out the ListUsersInGroup method")
-//             },
-//             MakeGroupDefaultFunc: func(groupID string, realmName string) error {
-// 	               panic("mock out the MakeGroupDefault method")
-//             },
-//             PingFunc: func() error {
-// 	               panic("mock out the Ping method")
-//             },
-//             RemoveFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error {
-// 	               panic("mock out the RemoveFederatedIdentity method")
-//             },
-//             SetGroupChildFunc: func(groupID string, realmName string, childGroup *Group) error {
-// 	               panic("mock out the SetGroupChild method")
-//             },
-//             UpdateAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, execution *v1alpha1.AuthenticationExecutionInfo) error {
-// 	               panic("mock out the UpdateAuthenticationExecutionForFlow method")
-//             },
-//             UpdateAuthenticatorConfigFunc: func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string) error {
-// 	               panic("mock out the UpdateAuthenticatorConfig method")
-//             },
-//             UpdateClientFunc: func(specClient *v1alpha1.KeycloakAPIClient, realmName string) error {
-// 	               panic("mock out the UpdateClient method")
-//             },
-//             UpdateIdentityProviderFunc: func(specIdentityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error {
-// 	               panic("mock out the UpdateIdentityProvider method")
-//             },
-//             UpdatePasswordFunc: func(user *v1alpha1.KeycloakAPIUser, realmName string, newPass string) error {
-// 	               panic("mock out the UpdatePassword method")
-//             },
-//             UpdateRealmFunc: func(specRealm *v1alpha1.KeycloakRealm) error {
-// 	               panic("mock out the UpdateRealm method")
-//             },
-//             UpdateUserFunc: func(specUser *v1alpha1.KeycloakAPIUser, realmName string) error {
-// 	               panic("mock out the UpdateUser method")
-//             },
-//         }
+// 		// make and configure a mocked KeycloakInterface
+// 		mockedKeycloakInterface := &KeycloakInterfaceMock{
+// 			AddExecutionToAuthenticatonFlowFunc: func(flowAlias string, realmName string, providerID string, requirement Requirement) error {
+// 				panic("mock out the AddExecutionToAuthenticatonFlow method")
+// 			},
+// 			AddUserToGroupFunc: func(realmName string, userID string, groupID string) error {
+// 				panic("mock out the AddUserToGroup method")
+// 			},
+// 			CreateAuthenticationFlowFunc: func(authFlow AuthenticationFlow, realmName string) (string, error) {
+// 				panic("mock out the CreateAuthenticationFlow method")
+// 			},
+// 			CreateAuthenticatorConfigFunc: func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string, executionID string) (string, error) {
+// 				panic("mock out the CreateAuthenticatorConfig method")
+// 			},
+// 			CreateClientFunc: func(client *v1alpha1.KeycloakAPIClient, realmName string) (string, error) {
+// 				panic("mock out the CreateClient method")
+// 			},
+// 			CreateFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) (string, error) {
+// 				panic("mock out the CreateFederatedIdentity method")
+// 			},
+// 			CreateGroupFunc: func(group string, realmName string) (string, error) {
+// 				panic("mock out the CreateGroup method")
+// 			},
+// 			CreateGroupClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, groupID string) (string, error) {
+// 				panic("mock out the CreateGroupClientRole method")
+// 			},
+// 			CreateGroupRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, groupID string) (string, error) {
+// 				panic("mock out the CreateGroupRealmRole method")
+// 			},
+// 			CreateIdentityProviderFunc: func(identityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) (string, error) {
+// 				panic("mock out the CreateIdentityProvider method")
+// 			},
+// 			CreateRealmFunc: func(realm *v1alpha1.KeycloakRealm) (string, error) {
+// 				panic("mock out the CreateRealm method")
+// 			},
+// 			CreateUserFunc: func(user *v1alpha1.KeycloakAPIUser, realmName string) (string, error) {
+// 				panic("mock out the CreateUser method")
+// 			},
+// 			CreateUserClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, userID string) (string, error) {
+// 				panic("mock out the CreateUserClientRole method")
+// 			},
+// 			CreateUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) (string, error) {
+// 				panic("mock out the CreateUserRealmRole method")
+// 			},
+// 			DeleteAuthenticatorConfigFunc: func(configID string, realmName string) error {
+// 				panic("mock out the DeleteAuthenticatorConfig method")
+// 			},
+// 			DeleteClientFunc: func(clientID string, realmName string) error {
+// 				panic("mock out the DeleteClient method")
+// 			},
+// 			DeleteIdentityProviderFunc: func(alias string, realmName string) error {
+// 				panic("mock out the DeleteIdentityProvider method")
+// 			},
+// 			DeleteRealmFunc: func(realmName string) error {
+// 				panic("mock out the DeleteRealm method")
+// 			},
+// 			DeleteUserFunc: func(userID string, realmName string) error {
+// 				panic("mock out the DeleteUser method")
+// 			},
+// 			DeleteUserClientRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, clientID string, userID string) error {
+// 				panic("mock out the DeleteUserClientRole method")
+// 			},
+// 			DeleteUserFromGroupFunc: func(realmName string, userID string, groupID string) error {
+// 				panic("mock out the DeleteUserFromGroup method")
+// 			},
+// 			DeleteUserRealmRoleFunc: func(role *v1alpha1.KeycloakUserRole, realmName string, userID string) error {
+// 				panic("mock out the DeleteUserRealmRole method")
+// 			},
+// 			FindAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, predicate func(*v1alpha1.AuthenticationExecutionInfo) bool) (*v1alpha1.AuthenticationExecutionInfo, error) {
+// 				panic("mock out the FindAuthenticationExecutionForFlow method")
+// 			},
+// 			FindAuthenticationFlowByAliasFunc: func(flowAlias string, realmName string) (*AuthenticationFlow, error) {
+// 				panic("mock out the FindAuthenticationFlowByAlias method")
+// 			},
+// 			FindAvailableGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the FindAvailableGroupClientRole method")
+// 			},
+// 			FindGroupByNameFunc: func(groupName string, realmName string) (*Group, error) {
+// 				panic("mock out the FindGroupByName method")
+// 			},
+// 			FindGroupClientRoleFunc: func(realmName string, clientID string, groupID string, predicate func(*v1alpha1.KeycloakUserRole) bool) (*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the FindGroupClientRole method")
+// 			},
+// 			FindUserByEmailFunc: func(email string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
+// 				panic("mock out the FindUserByEmail method")
+// 			},
+// 			FindUserByUsernameFunc: func(name string, realm string) (*v1alpha1.KeycloakAPIUser, error) {
+// 				panic("mock out the FindUserByUsername method")
+// 			},
+// 			GetAuthenticatorConfigFunc: func(configID string, realmName string) (*v1alpha1.AuthenticatorConfig, error) {
+// 				panic("mock out the GetAuthenticatorConfig method")
+// 			},
+// 			GetClientFunc: func(clientID string, realmName string) (*v1alpha1.KeycloakAPIClient, error) {
+// 				panic("mock out the GetClient method")
+// 			},
+// 			GetClientInstallFunc: func(clientID string, realmName string) ([]byte, error) {
+// 				panic("mock out the GetClientInstall method")
+// 			},
+// 			GetClientSecretFunc: func(clientID string, realmName string) (string, error) {
+// 				panic("mock out the GetClientSecret method")
+// 			},
+// 			GetIdentityProviderFunc: func(alias string, realmName string) (*v1alpha1.KeycloakIdentityProvider, error) {
+// 				panic("mock out the GetIdentityProvider method")
+// 			},
+// 			GetRealmFunc: func(realmName string) (*v1alpha1.KeycloakRealm, error) {
+// 				panic("mock out the GetRealm method")
+// 			},
+// 			GetUserFunc: func(userID string, realmName string) (*v1alpha1.KeycloakAPIUser, error) {
+// 				panic("mock out the GetUser method")
+// 			},
+// 			GetUserFederatedIdentitiesFunc: func(userName string, realmName string) ([]v1alpha1.FederatedIdentity, error) {
+// 				panic("mock out the GetUserFederatedIdentities method")
+// 			},
+// 			ListAuthenticationExecutionsForFlowFunc: func(flowAlias string, realmName string) ([]*v1alpha1.AuthenticationExecutionInfo, error) {
+// 				panic("mock out the ListAuthenticationExecutionsForFlow method")
+// 			},
+// 			ListAuthenticationFlowsFunc: func(realmName string) ([]*AuthenticationFlow, error) {
+// 				panic("mock out the ListAuthenticationFlows method")
+// 			},
+// 			ListAvailableGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListAvailableGroupClientRoles method")
+// 			},
+// 			ListAvailableGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListAvailableGroupRealmRoles method")
+// 			},
+// 			ListAvailableUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListAvailableUserClientRoles method")
+// 			},
+// 			ListAvailableUserRealmRolesFunc: func(realmName string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListAvailableUserRealmRoles method")
+// 			},
+// 			ListClientsFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIClient, error) {
+// 				panic("mock out the ListClients method")
+// 			},
+// 			ListDefaultGroupsFunc: func(realmName string) ([]*Group, error) {
+// 				panic("mock out the ListDefaultGroups method")
+// 			},
+// 			ListGroupClientRolesFunc: func(realmName string, clientID string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListGroupClientRoles method")
+// 			},
+// 			ListGroupRealmRolesFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListGroupRealmRoles method")
+// 			},
+// 			ListIdentityProvidersFunc: func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error) {
+// 				panic("mock out the ListIdentityProviders method")
+// 			},
+// 			ListOfActivesUsersPerRealmFunc: func(realmName string, dateFrom string, max int) ([]Users, error) {
+// 				panic("mock out the ListOfActivesUsersPerRealm method")
+// 			},
+// 			ListRealmsFunc: func() ([]*v1alpha1.KeycloakAPIRealm, error) {
+// 				panic("mock out the ListRealms method")
+// 			},
+// 			ListUserClientRolesFunc: func(realmName string, clientID string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListUserClientRoles method")
+// 			},
+// 			ListUserRealmRolesFunc: func(realmName string, userID string) ([]*v1alpha1.KeycloakUserRole, error) {
+// 				panic("mock out the ListUserRealmRoles method")
+// 			},
+// 			ListUsersFunc: func(realmName string) ([]*v1alpha1.KeycloakAPIUser, error) {
+// 				panic("mock out the ListUsers method")
+// 			},
+// 			ListUsersInGroupFunc: func(realmName string, groupID string) ([]*v1alpha1.KeycloakAPIUser, error) {
+// 				panic("mock out the ListUsersInGroup method")
+// 			},
+// 			MakeGroupDefaultFunc: func(groupID string, realmName string) error {
+// 				panic("mock out the MakeGroupDefault method")
+// 			},
+// 			PingFunc: func() error {
+// 				panic("mock out the Ping method")
+// 			},
+// 			RemoveFederatedIdentityFunc: func(fid v1alpha1.FederatedIdentity, userID string, realmName string) error {
+// 				panic("mock out the RemoveFederatedIdentity method")
+// 			},
+// 			SetGroupChildFunc: func(groupID string, realmName string, childGroup *Group) error {
+// 				panic("mock out the SetGroupChild method")
+// 			},
+// 			UpdateAuthenticationExecutionForFlowFunc: func(flowAlias string, realmName string, execution *v1alpha1.AuthenticationExecutionInfo) error {
+// 				panic("mock out the UpdateAuthenticationExecutionForFlow method")
+// 			},
+// 			UpdateAuthenticatorConfigFunc: func(authenticatorConfig *v1alpha1.AuthenticatorConfig, realmName string) error {
+// 				panic("mock out the UpdateAuthenticatorConfig method")
+// 			},
+// 			UpdateClientFunc: func(specClient *v1alpha1.KeycloakAPIClient, realmName string) error {
+// 				panic("mock out the UpdateClient method")
+// 			},
+// 			UpdateEventsConfigFunc: func(realmName string, enabledEventTypes []string, eventsListeners []string) error {
+// 				panic("mock out the UpdateEventsConfig method")
+// 			},
+// 			UpdateIdentityProviderFunc: func(specIdentityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error {
+// 				panic("mock out the UpdateIdentityProvider method")
+// 			},
+// 			UpdatePasswordFunc: func(user *v1alpha1.KeycloakAPIUser, realmName string, newPass string) error {
+// 				panic("mock out the UpdatePassword method")
+// 			},
+// 			UpdateRealmFunc: func(specRealm *v1alpha1.KeycloakRealm) error {
+// 				panic("mock out the UpdateRealm method")
+// 			},
+// 			UpdateUserFunc: func(specUser *v1alpha1.KeycloakAPIUser, realmName string) error {
+// 				panic("mock out the UpdateUser method")
+// 			},
+// 		}
 //
-//         // use mockedKeycloakInterface in code that requires KeycloakInterface
-//         // and then make assertions.
+// 		// use mockedKeycloakInterface in code that requires KeycloakInterface
+// 		// and then make assertions.
 //
-//     }
+// 	}
 type KeycloakInterfaceMock struct {
 	// AddExecutionToAuthenticatonFlowFunc mocks the AddExecutionToAuthenticatonFlow method.
 	AddExecutionToAuthenticatonFlowFunc func(flowAlias string, realmName string, providerID string, requirement Requirement) error
@@ -361,6 +367,9 @@ type KeycloakInterfaceMock struct {
 	// ListIdentityProvidersFunc mocks the ListIdentityProviders method.
 	ListIdentityProvidersFunc func(realmName string) ([]*v1alpha1.KeycloakIdentityProvider, error)
 
+	// ListOfActivesUsersPerRealmFunc mocks the ListOfActivesUsersPerRealm method.
+	ListOfActivesUsersPerRealmFunc func(realmName string, dateFrom string, max int) ([]Users, error)
+
 	// ListRealmsFunc mocks the ListRealms method.
 	ListRealmsFunc func() ([]*v1alpha1.KeycloakAPIRealm, error)
 
@@ -396,6 +405,9 @@ type KeycloakInterfaceMock struct {
 
 	// UpdateClientFunc mocks the UpdateClient method.
 	UpdateClientFunc func(specClient *v1alpha1.KeycloakAPIClient, realmName string) error
+
+	// UpdateEventsConfigFunc mocks the UpdateEventsConfig method.
+	UpdateEventsConfigFunc func(realmName string, enabledEventTypes []string, eventsListeners []string) error
 
 	// UpdateIdentityProviderFunc mocks the UpdateIdentityProvider method.
 	UpdateIdentityProviderFunc func(specIdentityProvider *v1alpha1.KeycloakIdentityProvider, realmName string) error
@@ -779,6 +791,15 @@ type KeycloakInterfaceMock struct {
 			// RealmName is the realmName argument value.
 			RealmName string
 		}
+		// ListOfActivesUsersPerRealm holds details about calls to the ListOfActivesUsersPerRealm method.
+		ListOfActivesUsersPerRealm []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// DateFrom is the dateFrom argument value.
+			DateFrom string
+			// Max is the max argument value.
+			Max int
+		}
 		// ListRealms holds details about calls to the ListRealms method.
 		ListRealms []struct {
 		}
@@ -861,6 +882,15 @@ type KeycloakInterfaceMock struct {
 			// RealmName is the realmName argument value.
 			RealmName string
 		}
+		// UpdateEventsConfig holds details about calls to the UpdateEventsConfig method.
+		UpdateEventsConfig []struct {
+			// RealmName is the realmName argument value.
+			RealmName string
+			// EnabledEventTypes is the enabledEventTypes argument value.
+			EnabledEventTypes []string
+			// EventsListeners is the eventsListeners argument value.
+			EventsListeners []string
+		}
 		// UpdateIdentityProvider holds details about calls to the UpdateIdentityProvider method.
 		UpdateIdentityProvider []struct {
 			// SpecIdentityProvider is the specIdentityProvider argument value.
@@ -938,6 +968,7 @@ type KeycloakInterfaceMock struct {
 	lockListGroupClientRoles                 sync.RWMutex
 	lockListGroupRealmRoles                  sync.RWMutex
 	lockListIdentityProviders                sync.RWMutex
+	lockListOfActivesUsersPerRealm           sync.RWMutex
 	lockListRealms                           sync.RWMutex
 	lockListUserClientRoles                  sync.RWMutex
 	lockListUserRealmRoles                   sync.RWMutex
@@ -950,6 +981,7 @@ type KeycloakInterfaceMock struct {
 	lockUpdateAuthenticationExecutionForFlow sync.RWMutex
 	lockUpdateAuthenticatorConfig            sync.RWMutex
 	lockUpdateClient                         sync.RWMutex
+	lockUpdateEventsConfig                   sync.RWMutex
 	lockUpdateIdentityProvider               sync.RWMutex
 	lockUpdatePassword                       sync.RWMutex
 	lockUpdateRealm                          sync.RWMutex
@@ -2700,6 +2732,45 @@ func (mock *KeycloakInterfaceMock) ListIdentityProvidersCalls() []struct {
 	return calls
 }
 
+// ListOfActivesUsersPerRealm calls ListOfActivesUsersPerRealmFunc.
+func (mock *KeycloakInterfaceMock) ListOfActivesUsersPerRealm(realmName string, dateFrom string, max int) ([]Users, error) {
+	if mock.ListOfActivesUsersPerRealmFunc == nil {
+		panic("KeycloakInterfaceMock.ListOfActivesUsersPerRealmFunc: method is nil but KeycloakInterface.ListOfActivesUsersPerRealm was just called")
+	}
+	callInfo := struct {
+		RealmName string
+		DateFrom  string
+		Max       int
+	}{
+		RealmName: realmName,
+		DateFrom:  dateFrom,
+		Max:       max,
+	}
+	mock.lockListOfActivesUsersPerRealm.Lock()
+	mock.calls.ListOfActivesUsersPerRealm = append(mock.calls.ListOfActivesUsersPerRealm, callInfo)
+	mock.lockListOfActivesUsersPerRealm.Unlock()
+	return mock.ListOfActivesUsersPerRealmFunc(realmName, dateFrom, max)
+}
+
+// ListOfActivesUsersPerRealmCalls gets all the calls that were made to ListOfActivesUsersPerRealm.
+// Check the length with:
+//     len(mockedKeycloakInterface.ListOfActivesUsersPerRealmCalls())
+func (mock *KeycloakInterfaceMock) ListOfActivesUsersPerRealmCalls() []struct {
+	RealmName string
+	DateFrom  string
+	Max       int
+} {
+	var calls []struct {
+		RealmName string
+		DateFrom  string
+		Max       int
+	}
+	mock.lockListOfActivesUsersPerRealm.RLock()
+	calls = mock.calls.ListOfActivesUsersPerRealm
+	mock.lockListOfActivesUsersPerRealm.RUnlock()
+	return calls
+}
+
 // ListRealms calls ListRealmsFunc.
 func (mock *KeycloakInterfaceMock) ListRealms() ([]*v1alpha1.KeycloakAPIRealm, error) {
 	if mock.ListRealmsFunc == nil {
@@ -3111,6 +3182,45 @@ func (mock *KeycloakInterfaceMock) UpdateClientCalls() []struct {
 	mock.lockUpdateClient.RLock()
 	calls = mock.calls.UpdateClient
 	mock.lockUpdateClient.RUnlock()
+	return calls
+}
+
+// UpdateEventsConfig calls UpdateEventsConfigFunc.
+func (mock *KeycloakInterfaceMock) UpdateEventsConfig(realmName string, enabledEventTypes []string, eventsListeners []string) error {
+	if mock.UpdateEventsConfigFunc == nil {
+		panic("KeycloakInterfaceMock.UpdateEventsConfigFunc: method is nil but KeycloakInterface.UpdateEventsConfig was just called")
+	}
+	callInfo := struct {
+		RealmName         string
+		EnabledEventTypes []string
+		EventsListeners   []string
+	}{
+		RealmName:         realmName,
+		EnabledEventTypes: enabledEventTypes,
+		EventsListeners:   eventsListeners,
+	}
+	mock.lockUpdateEventsConfig.Lock()
+	mock.calls.UpdateEventsConfig = append(mock.calls.UpdateEventsConfig, callInfo)
+	mock.lockUpdateEventsConfig.Unlock()
+	return mock.UpdateEventsConfigFunc(realmName, enabledEventTypes, eventsListeners)
+}
+
+// UpdateEventsConfigCalls gets all the calls that were made to UpdateEventsConfig.
+// Check the length with:
+//     len(mockedKeycloakInterface.UpdateEventsConfigCalls())
+func (mock *KeycloakInterfaceMock) UpdateEventsConfigCalls() []struct {
+	RealmName         string
+	EnabledEventTypes []string
+	EventsListeners   []string
+} {
+	var calls []struct {
+		RealmName         string
+		EnabledEventTypes []string
+		EventsListeners   []string
+	}
+	mock.lockUpdateEventsConfig.RLock()
+	calls = mock.calls.UpdateEventsConfig
+	mock.lockUpdateEventsConfig.RUnlock()
 	return calls
 }
 

--- a/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
+++ b/vendor/github.com/integr8ly/keycloak-client/pkg/common/types.go
@@ -36,3 +36,7 @@ type UserAttributes struct {
 	User      v1alpha1.KeycloakAPIUser `json:"user,omitempty"`
 	Attribute map[string]string        `json:"attribute,omitempty"`
 }
+
+type Users struct {
+	UserID string `json:"userId"`
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -448,7 +448,7 @@ github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.10.2
 ## explicit
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
-# github.com/integr8ly/keycloak-client v0.1.4
+# github.com/integr8ly/keycloak-client v0.1.5
 ## explicit
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/jmespath/go-jmespath v0.4.0


### PR DESCRIPTION
# Issue link
Implement on demand approach to keycloak realm provisioning for multi tenant Rhoam in user sso. 

# Verify
Install MT RHOAM from this branch
Install IDP:
`NUM': NUM_REGULAR_USER=20 NUM_ADMIN=0 DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 REALM_DISPLAY_NAME="devsandbox" REALM="devsandbox" ./scripts/setup-sso-idp.sh` 
Log into OpenShift with 4 users test-user01, test-user02, test-user03, test-user04
This will create user and identity CRs

Wait for multi-tenant users to reconcile
Log in as admin to User SSO and verify that the Staging Realm exists with 4 users

Create projects and related privileges for each user
`oc new-project test-user01`
`oc adm policy add-role-to-user admin test-user01 -n test-user01-dev`
repeat for users 2

Log into OpenShift as test-user01 
Go to the test-user01-dev project and then to the Dashboard
From the Launcher Section, login to the staging Realm by clicking on 'Provision SSO' 
Repeat for test-user02

Wait for a full reconcile loop

Log in as admin to User SSO and verify that the Staging Realm exists with **2 users**: 3 and 4
Confirm that 2 new realms exist, test-user01 and test-user02

Log into OpenShift as test-user01 
Go to the test-user01-dev project and then to the Dashboard
From the Launcher Section, login to the staging Realm by clicking on 'API Management SSO' 
Verify that the user is logged into the test-user01 realm with full admin access
Repeat for test-user02

Delete 4 user crs and identity crs

Wait for a full reconcile loop

Confirm that there are no users in the staging realm and no tenant realms
Only a staging and master realm