### PR TITLE
fix: remove manual creation of DMS alert

### DIFF
--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -330,21 +330,6 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 				},
 			},
 			{
-				AlertName: "prometheus-application-monitoring-rules",
-				GroupName: "general.rules",
-				Namespace: namespace,
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "DeadMansSwitch",
-						Annotations: map[string]string{
-							"message": " This is a DeadMansSwitch meant to ensure that the entire Alerting pipeline is functional.",
-						},
-						Expr:   intstr.FromString("vector(1)"),
-						Labels: map[string]string{"severity": "none"},
-					},
-				},
-			},
-			{
 				AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
 				Namespace: namespace,
 				GroupName: fmt.Sprintf("%s-installation.rules", installationName),


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
DMS creation will be handled by Observability Operator itself 
- https://github.com/redhat-developer/observability-operator/pull/87

If we do not remove the manually created one, there will be 2 DMS alerts created

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Just a code review should be good enough as this is just a deletion of the alert 