### PR TITLE
change the service account back to keycloak-operator

### DIFF
--- a/manifests/integreatly-rhsso/15.0.0/rhsso-operator.15.0.0.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/15.0.0/rhsso-operator.15.0.0.clusterserviceversion.yaml
@@ -201,7 +201,7 @@ spec:
                 imagePullPolicy: Always
                 name: rhsso-operator
                 resources: {}
-              serviceAccountName: rhsso-operator
+              serviceAccountName: keycloak-operator
       permissions:
       - rules:
         - apiGroups:
@@ -335,7 +335,7 @@ spec:
           - list
           - update
           - watch
-        serviceAccountName: rhsso-operator
+        serviceAccountName: keycloak-operator
     strategy: deployment
   installModes:
   - supported: true


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2797

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
seeing an error on installation  
```yaml
lastError: 'product reconcilation errors : failed installation of rhsso: failed
      to create/update keycloak custom resource: keycloaks.keycloak.org "rhsso" is
      forbidden: User "system:serviceaccount:redhat-rhoam-operator:rhmi-operator"
      cannot get resource "keycloaks" in API group "keycloak.org" in the namespace
      "redhat-rhoam-rhsso"'
```

change the csv serviceaccount fields to point back at keycloak-operator
# Verification steps
- run the install locally 
```bash
# This will usually create a delorean pull secret
INSTALLATION_TYPE=managed-api make cluster/prepare/local
# In case it doesn't 
make cluster/prepare/delorean
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml
INSTALLATION_TYPE=managed-api make code/run

```
- make sure rhsso and user-sso complete successfully

<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
