### PR TITLE
set default names for observability resources

### DIFF
--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -16,6 +16,11 @@ const (
 	AlertManagerEmailTemplateSecretFileName = "alertmanager-email-config.tmpl"
 	AlertManagerConfigTemplatePath          = "alertmanager/alertmanager-application-monitoring.yaml"
 	AlertManagerCustomTemplatePath          = "alertmanager/alertmanager-email-config.tmpl"
+
+	// CR Overrides
+	AlertManagerOverride = "rhoam-alertmanager"
+	GrafanaOverride      = "rhoam-grafana"
+	PrometheusOverride   = "rhoam-prometheus"
 )
 
 type Observability struct {
@@ -108,16 +113,32 @@ func (m *Observability) GetAlertManagerVersion() string {
 	return "v0.22.2"
 }
 
+func (m *Observability) GetAlertManagerRouteName() string {
+	return AlertManagerOverride
+}
+
+func (m *Observability) GetAlertManagerOverride() string {
+	return AlertManagerOverride
+}
+
+func (m *Observability) GetAlertManagerServiceName() string {
+	return AlertManagerOverride
+}
+
 func (m *Observability) GetPrometheusVersion() string {
 	return "v2.29.2"
 }
 
 func (m *Observability) GetPrometheusRouteName() string {
-	return "prometheus-route"
+	return PrometheusOverride
 }
 
-func (m *Observability) GetAlertManagerRouteName() string {
-	return "alertmanager-route"
+func (m *Observability) GetPrometheusOverride() string {
+	return PrometheusOverride
+}
+
+func (m *Observability) GetPrometheusServiceName() string {
+	return PrometheusOverride
 }
 
 func (m *Observability) GetPrometheusRetention() string {
@@ -126,6 +147,18 @@ func (m *Observability) GetPrometheusRetention() string {
 
 func (m *Observability) GetPrometheusStorageRequest() string {
 	return "50Gi"
+}
+
+func (m *Observability) GetGrafanaRouteName() string {
+	return "grafana-route"
+}
+
+func (m *Observability) GetGrafanaOverride() string {
+	return GrafanaOverride
+}
+
+func (m *Observability) GetGrafanaServiceName() string {
+	return "grafana-service"
 }
 
 func (m *Observability) GetAlertManagerResourceRequirements() corev1.ResourceRequirements {

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -379,7 +379,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 
 	prometheusService := &corev1.Service{}
 
-	err = client.Get(ctx, k8sclient.ObjectKey{Name: "kafka-prometheus", Namespace: observabilityConfig.GetNamespace()}, prometheusService)
+	err = client.Get(ctx, k8sclient.ObjectKey{Name: observabilityConfig.GetPrometheusOverride(), Namespace: observabilityConfig.GetNamespace()}, prometheusService)
 	if err != nil {
 		if !k8serr.IsNotFound(err) {
 			return integreatlyv1alpha1.PhaseFailed, err

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -327,9 +327,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 	op, err := controllerutil.CreateOrUpdate(ctx, serverClient, oo, func() error {
 		disabled := true
 		oo.Spec = observability.ObservabilitySpec{
-			AlertManagerDefaultName: "rhoam-alertmanager",
-			GrafanaDefaultName:      "rhoam-grafana",
-			PrometheusDefaultName:   "rhoam-prometheus",
+			AlertManagerDefaultName: r.Config.GetAlertManagerOverride(),
+			GrafanaDefaultName:      r.Config.GetGrafanaOverride(),
+			PrometheusDefaultName:   r.Config.GetPrometheusOverride(),
 			ConfigurationSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"monitoring-key": r.Config.GetLabelSelector(),
@@ -434,9 +434,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 		return nil
 	})
 	if err != nil {
-		return integreatlyv1alpha1.PhaseInProgress, err
+		return integreatlyv1alpha1.PhaseFailed, err
 	}
-	if op == controllerutil.OperationResultUpdated || op == controllerutil.OperationResultCreated {
+	if op == controllerutil.OperationResultCreated {
 		return integreatlyv1alpha1.PhaseInProgress, nil
 	}
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2717


# Verification steps

Related observability pr -> https://github.com/redhat-developer/observability-operator/pull/90
Checkout the above related pr.
add a replace statement to your go.mod similar to the following
`replace github.com/redhat-developer/observability-operator/v3 => /your/local/path/to/observability-operator`
update the index in the products/installation.yaml to `quay.io/laurafitzgerald/observability-operator-index:v3.0.9`

Run `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
Run `INSTALLATION_TYPE=managed-api make code/run`

Verify that the observability cr in the redhat-rhoam-observability namespace contains the following entries:


```
  alertManagerDefaultName: rhoam
  grafanaDefaultName: rhoam
  prometheusDefaultName: rhoam
```