### PR TITLE
Mgdapi 2802 metric name change in 4.9

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoringcommon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 
@@ -500,13 +501,19 @@ func (r *Reconciler) reconcileDashboards(ctx context.Context, serverClient k8scl
 
 func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClient k8sclient.Client, dashboard string) (err error) {
 
+	//clusterVersion
+	containerCpuMetric, err := metrics.GetContainerCPUMetric(ctx, serverClient, r.Log)
+	if err != nil {
+		return err
+	}
+
 	grafanaDB := &grafanav1alpha1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dashboard,
 			Namespace: r.Config.GetOperatorNamespace(),
 		},
 	}
-	specJSON, _, err := monitoringcommon.GetSpecDetailsForDashboard(dashboard, r.installation)
+	specJSON, _, err := monitoringcommon.GetSpecDetailsForDashboard(dashboard, r.installation, containerCpuMetric)
 	if err != nil {
 		return err
 	}

--- a/pkg/products/monitoring/reconciler_test.go
+++ b/pkg/products/monitoring/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	grafanav1alpha1 "github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	v1 "github.com/openshift/api/route/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	prometheusmonitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 
@@ -30,7 +31,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	rbac "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -386,6 +386,18 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		},
 		Spec: configv1.ClusterVersionSpec{
 			ClusterID: "cluster-id",
+		},
+		Status: configv1.ClusterVersionStatus{
+			History: []configv1.UpdateHistory{
+				{
+					State:          "",
+					StartedTime:    metav1.Time{},
+					CompletionTime: nil,
+					Version:        "4.9.0-rc123",
+					Image:          "",
+					Verified:       false,
+				},
+			},
 		},
 	}
 

--- a/pkg/products/monitoringcommon/dashboardHelper.go
+++ b/pkg/products/monitoringcommon/dashboardHelper.go
@@ -8,7 +8,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 )
 
-func GetSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI) (string, string, error) {
+func GetSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI, containerCpuMetric string) (string, string, error) {
 	installationName := resources.InstallationNames[rhmi.Spec.Type]
 
 	switch dashboard {
@@ -23,13 +23,13 @@ func GetSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI) (string, 
 		return monitoringcommon.GetMonitoringGrafanaDBEndpointsSummaryJSON(rhmi.ObjectMeta.Name), "endpointssummary.json", nil
 
 	case "resources-by-namespace":
-		return monitoringcommon.GetMonitoringGrafanaDBResourceByNSJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name), "resources-by-namespace.json", nil
+		return monitoringcommon.GetMonitoringGrafanaDBResourceByNSJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name, containerCpuMetric), "resources-by-namespace.json", nil
 
 	case "resources-by-pod":
-		return monitoringcommon.GetMonitoringGrafanaDBResourceByPodJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name), "resources-by-pod.json", nil
+		return monitoringcommon.GetMonitoringGrafanaDBResourceByPodJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name, containerCpuMetric), "resources-by-pod.json", nil
 
 	case "cluster-resources":
-		return monitoringcommon.GetMonitoringGrafanaDBClusterResourcesJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name), "cluster-resources-new.json", nil
+		return monitoringcommon.GetMonitoringGrafanaDBClusterResourcesJSON(rhmi.Spec.NamespacePrefix, rhmi.ObjectMeta.Name, containerCpuMetric), "cluster-resources-new.json", nil
 	case "critical-slo-rhmi-alerts":
 		return monitoringcommon.GetMonitoringGrafanaDBCriticalSLORHMIAlertsJSON(rhmi.Spec.NamespacePrefix, installationName), "critical-slo-alerts.json", nil
 

--- a/pkg/products/monitoringcommon/dashboards/clusterResources.go
+++ b/pkg/products/monitoringcommon/dashboards/clusterResources.go
@@ -7,7 +7,7 @@ import (
 
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
-func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName string) string {
+func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName string, containerCpuMetric string) string {
 	quota := ``
 	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] || installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeMultitenantManagedApi)] {
 		quota = `, 
@@ -158,7 +158,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 			"steppedLine": false,
 			"tableColumn": "",
 			"targets": [{
-				"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'` + nsPrefix + `.*'}) / sum(kube_node_role{role=\"worker\"} * on(node) group_left (instance) kube_node_status_allocatable{resource='cpu'})",
+				"expr": "sum(` + containerCpuMetric + `{namespace=~'` + nsPrefix + `.*'}) / sum(kube_node_role{role=\"worker\"} * on(node) group_left (instance) kube_node_status_allocatable{resource='cpu'})",
 				"format": "time_series",
 				"instant": true,
 				"intervalFactor": 2,
@@ -1240,7 +1240,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 			"stack": true,
 			"steppedLine": false,
 			"targets": [{
-				"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'` + nsPrefix + `.*'}) by (namespace)",
+				"expr": "sum(` + containerCpuMetric + `{namespace=~'` + nsPrefix + `.*'}) by (namespace)",
 				"format": "time_series",
 				"intervalFactor": 2,
 				"legendFormat": "{{namespace}}",
@@ -1449,7 +1449,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 				}
 			],
 			"targets": [{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'` + nsPrefix + `.*'}) by (namespace)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'` + nsPrefix + `.*'}) by (namespace)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -1467,7 +1467,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 					"step": 10
 				},
 				{
-					"expr": "(sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'` + nsPrefix + `.*'}) by (namespace) / sum(kube_pod_container_resource_requests{resource='cpu'}) by (namespace))",
+					"expr": "(sum(` + containerCpuMetric + `{namespace=~'` + nsPrefix + `.*'}) by (namespace) / sum(kube_pod_container_resource_requests{resource='cpu'}) by (namespace))",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -1485,7 +1485,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 					"step": 10
 				},
 				{
-					"expr": "(sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'` + nsPrefix + `.*'}) by (namespace) / sum(kube_pod_container_resource_limits{resource='cpu'}) by (namespace))",
+					"expr": "(sum(` + containerCpuMetric + `{namespace=~'` + nsPrefix + `.*'}) by (namespace) / sum(kube_pod_container_resource_limits{resource='cpu'}) by (namespace))",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -2981,7 +2981,7 @@ func GetMonitoringGrafanaDBClusterResourcesJSON(nsPrefix, installationName strin
 					"step": 10
 				},
 				{
-					"expr": "sum(kube_pod_container_resource_requests{namespace=~'` + nsPrefix + `.*',resource='memory'})",
+					"expr": "sum(kube_pod_container_resource_requests{namespace=~'` + nsPrefix + `.*',resource='memory'}) by (namespace)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,

--- a/pkg/products/monitoringcommon/dashboards/resourceByNamespace.go
+++ b/pkg/products/monitoringcommon/dashboards/resourceByNamespace.go
@@ -7,7 +7,7 @@ import (
 
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
-func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string) string {
+func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string, containerCpuMetric string) string {
 	quota := ``
 	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] || installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeMultitenantManagedApi)] {
 		quota = `,
@@ -111,7 +111,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string) s
 			"stack": false,
 			"steppedLine": false,
 			"targets": [{
-				"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace'}) by (pod)",
+				"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace'}) by (pod)",
 				"format": "time_series",
 				"intervalFactor": 2,
 				"legendFormat": "{{pod}}",
@@ -320,7 +320,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string) s
 				}
 			],
 			"targets": [{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace'}) by (pod)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace'}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -338,7 +338,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string) s
 					"step": 10
 				},
 				{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace'}) by (pod) / sum(kube_pod_container_resource_requests{namespace=~'$namespace',resource='cpu'}) by (pod)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace'}) by (pod) / sum(kube_pod_container_resource_requests{namespace=~'$namespace',resource='cpu'}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -356,7 +356,7 @@ func GetMonitoringGrafanaDBResourceByNSJSON(nsPrefix, installationName string) s
 					"step": 10
 				},
 				{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace'}) by (pod) / sum(kube_pod_container_resource_limits{namespace=~'$namespace',resource='cpu'}) by (pod)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace'}) by (pod) / sum(kube_pod_container_resource_limits{namespace=~'$namespace',resource='cpu'}) by (pod)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,

--- a/pkg/products/monitoringcommon/dashboards/resourceByPod.go
+++ b/pkg/products/monitoringcommon/dashboards/resourceByPod.go
@@ -7,7 +7,7 @@ import (
 
 // This dashboard json is dynamically configured based on installation type (rhmi or rhoam)
 // The installation name taken from the v1alpha1.RHMI.ObjectMeta.Name
-func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName string) string {
+func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName string, containerCpuMetric string) string {
 	quota := ``
 	if installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeManagedApi)] || installationName == resources.InstallationNames[string(v1alpha1.InstallationTypeMultitenantManagedApi)] {
 		quota = `,
@@ -111,7 +111,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName s
 			"stack": false,
 			"steppedLine": false,
 			"targets": [{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace', pod=~'$pod', container!='POD'}) by (pod)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace', pod=~'$pod', container!='POD'}) by (pod)",
 					"format": "time_series",
 					"intervalFactor": 2,
 					"legendFormat": "{{pod}}",
@@ -336,7 +336,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName s
 				}
 			],
 			"targets": [{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace', pod=~'$pod', container!='POD'}) by (container)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace', pod=~'$pod', container!='POD'}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -354,7 +354,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName s
 					"step": 10
 				},
 				{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_requests{namespace=~'$namespace', pod=~'$pod',resource='cpu'}) by (container)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_requests{namespace=~'$namespace', pod=~'$pod',resource='cpu'}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,
@@ -372,7 +372,7 @@ func GetMonitoringGrafanaDBResourceByPodJSON(namespacePrefix, installationName s
 					"step": 10
 				},
 				{
-					"expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_limits{namespace=~'$namespace', pod=~'$pod', resource='cpu'}) by (container)",
+					"expr": "sum(` + containerCpuMetric + `{namespace=~'$namespace', pod=~'$pod'}) by (container) / sum(kube_pod_container_resource_limits{namespace=~'$namespace', pod=~'$pod', resource='cpu'}) by (container)",
 					"format": "table",
 					"instant": true,
 					"intervalFactor": 2,

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -3,6 +3,7 @@ package observability
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
@@ -542,13 +543,19 @@ func (r *Reconciler) reconcileDashboards(ctx context.Context, serverClient k8scl
 
 func (r *Reconciler) reconcileGrafanaDashboards(ctx context.Context, serverClient k8sclient.Client, dashboard string) (err error) {
 
+	//clusterVersion
+	containerCpuMetric, err := metrics.GetContainerCPUMetric(ctx, serverClient, r.log)
+	if err != nil {
+		return err
+	}
+
 	grafanaDB := &grafanav1alpha1.GrafanaDashboard{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dashboard,
 			Namespace: r.Config.GetNamespace(),
 		},
 	}
-	specJSON, _, err := monitoringcommon.GetSpecDetailsForDashboard(dashboard, r.installation)
+	specJSON, _, err := monitoringcommon.GetSpecDetailsForDashboard(dashboard, r.installation, containerCpuMetric)
 	if err != nil {
 		return err
 	}

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -17,6 +17,7 @@ import (
 	v1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"
 
+	v12 "github.com/openshift/api/config/v1"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -703,6 +704,24 @@ var threescale = &threescalev1.APIManager{
 	},
 }
 
+var clusterVersion = &v12.ClusterVersion{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: "version",
+	},
+	Status: v12.ClusterVersionStatus{
+		History: []v12.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    metav1.Time{},
+				CompletionTime: nil,
+				Version:        "4.9.0-rc123",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
 func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallationNamespace string) []runtime.Object {
 	configManagerConfigMap.Namespace = integreatlyOperatorNamespace
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
@@ -773,5 +792,6 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		zyncDatabase,
 		zyncQue,
 		threescale,
+		clusterVersion,
 	}
 }

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -390,7 +390,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
-	alertsReconciler := r.newAlertReconciler(r.log, r.installation.Spec.Type)
+	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type, ctx, serverClient)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
 	if phase, err := alertsReconciler.ReconcileAlerts(ctx, serverClient); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile threescale alerts", err)
 		return phase, err

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	openshiftv1 "github.com/openshift/api/apps/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	appsv1 "k8s.io/api/apps/v1"
 
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
@@ -73,6 +74,8 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	err = monitoringv1.AddToScheme(scheme)
 	err = consolev1.AddToScheme(scheme)
 	err = openshiftv1.AddToScheme(scheme)
+	err = configv1.AddToScheme(scheme)
+
 	return scheme, err
 }
 

--- a/pkg/resources/cluster.go
+++ b/pkg/resources/cluster.go
@@ -1,0 +1,55 @@
+package resources
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	configv1 "github.com/openshift/api/config/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strconv"
+	"strings"
+)
+
+const clusterVersionName = "version"
+
+func ClusterVersionBefore49(ctx context.Context, serverClient k8sclient.Client, log l.Logger) (bool, error) {
+
+	clusterVersion := &configv1.ClusterVersion{}
+	if err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: clusterVersionName}, clusterVersion); err != nil {
+		return false, fmt.Errorf("failed to fetch version: %w", err)
+	}
+
+	currentVersion, err := getCurrentVersion(clusterVersion.Status.History, log)
+	if err != nil {
+		return false, err
+	}
+
+	if currentVersion >= 4.9 {
+		return false, nil
+	}
+	return true, nil
+}
+
+func getCurrentVersion(versionHistory []configv1.UpdateHistory, log l.Logger) (float64, error) {
+
+	if len(versionHistory) < 1 {
+		log.Error("Error getting cluster version, no version history", nil)
+		return 0, errors.New("Error getting cluster version, no version history")
+	}
+	s := strings.Split(versionHistory[0].Version, ".")
+	if len(s) < 2 {
+		log.Errorf("Error splitting cluster version history", l.Fields{"versionHistory": versionHistory[0].Version}, nil)
+		return 0, errors.New("Error splitting cluster version history " + versionHistory[0].Version)
+	}
+	currentVersion := s[0] + "." + s[1]
+	log.Infof("Current cluster ", l.Fields{"version": currentVersion})
+
+	version, err := strconv.ParseFloat(currentVersion, 64)
+	if err != nil {
+		log.Errorf("Error parsing cluster version", l.Fields{"currentVersion": currentVersion}, err)
+		return 0, errors.New("Error parsing cluster version " + currentVersion)
+	}
+
+	return version, nil
+}

--- a/pkg/resources/cluster_test.go
+++ b/pkg/resources/cluster_test.go
@@ -1,0 +1,199 @@
+package resources
+
+import (
+	"context"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	configv1 "github.com/openshift/api/config/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"strconv"
+	"testing"
+)
+
+type ClusterVersionTestScenario struct {
+	Name           string
+	FakeSigsClient k8sclient.Client
+	logger         l.Logger
+	ExpectedError  string
+	ExpectedValue  bool
+}
+
+var version1 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "version",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "4.9.0-rc123",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+var version2 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "version",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "4.8.0-rc123",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+var version3 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "version",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "10.8.0-rc123",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+var version4 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "wrongname",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "10.8.0-rc123",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+var version5 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "version",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "fakeversion",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+var version6 = &configv1.ClusterVersion{
+	ObjectMeta: v1.ObjectMeta{
+		Name: "version",
+	},
+	Status: configv1.ClusterVersionStatus{
+		History: []configv1.UpdateHistory{
+			{
+				State:          "",
+				StartedTime:    v1.Time{},
+				CompletionTime: nil,
+				Version:        "string1.string2.string3",
+				Image:          "",
+				Verified:       false,
+			},
+		},
+	},
+}
+
+func getClusterBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := configv1.AddToScheme(scheme)
+	return scheme, err
+}
+
+func TestVersions(t *testing.T) {
+	scheme, err := getClusterBuildScheme()
+	if err != nil {
+		t.Fatalf("Error creating build scheme")
+	}
+
+	scenarios := []ClusterVersionTestScenario{
+		{
+			Name:           "Test cluster versions 4.9",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version1),
+			ExpectedError:  "",
+			ExpectedValue:  false,
+		},
+		{
+			Name:           "Test cluster versions 4.8",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version2),
+			ExpectedError:  "",
+			ExpectedValue:  true,
+		},
+		{
+			Name:           "Test cluster versions 10.8",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version3),
+			ExpectedError:  "",
+			ExpectedValue:  false,
+		},
+		{
+			Name:           "Test when cluster CR does not exist",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version4),
+			ExpectedError:  "failed to fetch version: clusterversions.config.openshift.io \"version\" not found",
+			ExpectedValue:  false,
+		},
+		{
+			Name:           "Test invalid version syntax 1",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version5),
+			ExpectedError:  "Error splitting cluster version history fakeversion",
+			ExpectedValue:  false,
+		},
+		{
+			Name:           "Test invalid version syntax 2",
+			FakeSigsClient: fake.NewFakeClientWithScheme(scheme, version6),
+			ExpectedError:  "Error parsing cluster version string1.string2",
+			ExpectedValue:  false,
+		},
+	}
+
+	for _, s := range scenarios {
+		t.Run(s.Name, func(t *testing.T) {
+			before, err := ClusterVersionBefore49(context.TODO(), s.FakeSigsClient, getLogger())
+
+			if s.ExpectedError != "" && err == nil {
+				t.Fatal("Expected an error " + s.ExpectedError)
+			}
+
+			if s.ExpectedError != "" && s.ExpectedError != err.Error() {
+				t.Fatal("Wrong error returned, expected: " + s.ExpectedError + " got: " + err.Error())
+			}
+
+			if s.ExpectedError == "" && s.ExpectedValue != before {
+				t.Fatal("Wrong result returned, expected: " + strconv.FormatBool(s.ExpectedValue) + " got: " + strconv.FormatBool(before))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2802

# What
A metric used in the dashboards has been deprecated in 4.9
node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate
has changed to node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate
from 4.9.

# Verification steps
Install rhoam from this branch on a cluster <  version 4.9
Verify all Grafana dashboards in particular:
- Resource Usage for Cluster - CPU Utilization 
- Resource Usage for Cluster - CPU Quota - ensure 5 columns appear

Upgrade the cluster to 4.9 using the following 
```
oc patch clusterversion version --type="merge" -p '{"spec":{"channel":"candidate-4.9"}}'
then run oc adm upgrade to list available versions
then oc adm upgrade --to=<VERSION_NAME>
```

Wait for dashboards to reconcile again and verify dashboards same as previous.
