### PR TITLE
update 3.0.7 manifests with new release

### DIFF
--- a/manifests/integreatly-observability-operator/3.0.7/observability-operator-webhook-service_v1_service.yaml
+++ b/manifests/integreatly-observability-operator/3.0.7/observability-operator-webhook-service_v1_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  name: observability-operator-webhook-service
+spec:
+  ports:
+  - port: 443
+    targetPort: 9443
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/manifests/integreatly-observability-operator/3.0.7/observability-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-observability-operator/3.0.7/observability-operator.clusterserviceversion.yaml
@@ -58,7 +58,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    operators.operatorframework.io/builder: operator-sdk-v1.3.2
+    operators.operatorframework.io/builder: operator-sdk-v1.1.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
   name: observability-operator.v3.0.7
   namespace: placeholder
@@ -298,6 +298,10 @@ spec:
                 image: quay.io/rhoas/observability-operator:v3.0.7
                 imagePullPolicy: Always
                 name: manager
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
                 resources:
                   limits:
                     cpu: 100m
@@ -305,8 +309,17 @@ spec:
                   requests:
                     cpu: 100m
                     memory: 50Mi
+                volumeMounts:
+                - mountPath: /tmp/k8s-webhook-server/serving-certs
+                  name: cert
+                  readOnly: true
               priorityClassName: observability-operator-priority-class
               terminationGracePeriodSeconds: 10
+              volumes:
+              - name: cert
+                secret:
+                  defaultMode: 420
+                  secretName: webhook-server-cert
       permissions:
       - rules:
         - apiGroups:
@@ -360,4 +373,25 @@ spec:
   maturity: alpha
   provider:
     name: Red Hat
+  replaces: observability-operator.v3.0.6
   version: 3.0.7
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1beta1
+    containerPort: 443
+    deploymentName: observability-operator-controller-manager
+    failurePolicy: Fail
+    generateName: vobservability.kb.io
+    rules:
+    - apiGroups:
+      - observability.redhat.com
+      apiVersions:
+      - v1
+      operations:
+      - UPDATE
+      resources:
+      - observabilities
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-observability-redhat-com-v1-observability

--- a/manifests/integreatly-observability-operator/3.0.7/observability.redhat.com_observabilities.yaml
+++ b/manifests/integreatly-observability-operator/3.0.7/observability.redhat.com_observabilities.yaml
@@ -371,6 +371,8 @@ spec:
                         type: array
                     type: object
                 type: object
+              alertManagerDefaultName:
+                type: string
               clusterId:
                 description: Cluster ID. If not provided, the operator tries to obtain it.
                 type: string
@@ -404,6 +406,10 @@ spec:
                     description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
                     type: object
                 type: object
+              grafanaDefaultName:
+                type: string
+              prometheusDefaultName:
+                type: string
               resyncPeriod:
                 type: string
               retention:
@@ -434,8 +440,6 @@ spec:
                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  alertManagerRoute:
-                    type: string
                   alertManagerVersion:
                     type: string
                   disableBlackboxExporter:
@@ -692,8 +696,6 @@ spec:
                         description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
                         type: object
                     type: object
-                  prometheusRoute:
-                    type: string
                   prometheusVersion:
                     type: string
                   ruleLabelSelector:


### PR DESCRIPTION
# Issue link
Update the Observability manifest with the new 3.0.7 release
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
Run the prepare-release.sh script and verify that the related images are the same.
