### PR TITLE
test: fix: a13

### DIFF
--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	goctx "context"
+
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	"github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	"golang.org/x/net/context"
@@ -111,7 +112,7 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 		"rhssoOperatorDeployment": {
 			Name: RHSSOOperatorNamespace,
 			Products: []Product{
-				{Name: "rhsso-operator", ExpectedReplicas: 1},
+				{Name: "keycloak-operator", ExpectedReplicas: 1},
 			},
 		},
 		"solutionExplorerOperatorDeployment": {
@@ -135,7 +136,7 @@ func getDeploymentConfiguration(deploymentName string, inst *integreatlyv1alpha1
 		"rhssoUserOperatorDeployment": {
 			Name: RHSSOUserOperatorNamespace,
 			Products: []Product{
-				{Name: "rhsso-operator", ExpectedReplicas: 1},
+				{Name: "keycloak-operator", ExpectedReplicas: 1},
 			},
 		},
 		"marin3rOperatorDeployment": {


### PR DESCRIPTION
To fix the A13 test that failed in RC2

https://master-jenkins-csb-intly.apps.ocp4.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-master/26/artifact/results/integreatly-operator-test/logs/container.log/*view*/

Verified against the cluster installed from master branch
```
$ go clean -testcache && BYPASS_STORAGE_TYPE_CHECK=true WATCH_NAMESPACE=redhat-rhoam-operator go test -v ./test/functional -timeout=80m -ginkgo.focus="(A13)" -ginkgo.v -ginkgo.progress -ginkgo.trace
...
• [SLOW TEST:27.854 seconds]
integreatly
/Users/psturc/work/integr8ly/integreatly-operator/test/functional/integreatly_test.go:11
  managed-api HAPPY PATH
  /Users/psturc/work/integr8ly/integreatly-operator/test/functional/integreatly_test.go:74
    A13 - Verify Deployment resources have the expected replicas
...
Ran 1 of 52 Specs in 27.855 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 51 Skipped
```