### PR TITLE
add childgroup name to setgroupchild call

### DIFF
--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -1199,7 +1199,8 @@ func reconcileGroup(kcClient keycloakCommon.KeycloakInterface, group *keycloakGr
 		}
 
 		err = kcClient.SetGroupChild(groupID, group.RealmName, &keycloakCommon.Group{
-			ID: childGroupID,
+			ID:   childGroupID,
+			Name: childGroup.Name,
 		})
 		if err != nil {
 			return "", fmt.Errorf("Error assigning child group %s to parent group %s: %v",


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2798

# What
Add sub-group name to create group call in user-sso

# Verification steps
## NOTE
This PR must be ran alongside with https://github.com/integr8ly/integreatly-operator/pull/2146, so suggest to only test it after merge of the 2146

1. Install RHOAM from this branch
2. Run `PASSWORD=Password1 DEDICATED_ADMIN_PASSWORD=Password1 scripts/setup-sso-idp.sh`
3. Log in as kubeadmin in one browser
4. In private window login as `customer-admin01`  `Password1`
5. In kubeadmin open user-sso ns and select keycloakUser CRs
6. Confirm that there is a generated user CR for customer-admin and it's state is "reconciled" and groups have "dedicated-admin" and "dedicated-admins/realm-managers"
7. As dedicated admin login to `API Management SSO`
8. In your terminal run:
```
cat << EOF | oc create -f -
---
apiVersion: user.openshift.io/v1
kind: User
metadata:
  name: test-user99
EOF
```
9. Then as customer-admin logged in to usersso, under master realm, click Users and add a new user with following:
```
Username: test-user99
First name: Test
Last name: User 99
User enabled: true
Email Verified: true
```
10. From terminal run `oc edit group dedicated-admins` and add `test-user99` to the list of dedicated admins
11. From the kubeadmin browser observe user-sso ns for new keycloakuser CR, once it gets created, confirm that status is reconciled and it has groups "dedicated-admin" and "dedictaed-admins/realm-managers"
