### PR TITLE
[MGDAPI-2891] fix: read from config when silencing alerts

### DIFF
--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -1,0 +1,107 @@
+package controllers
+
+import (
+	"context"
+	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"reflect"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"testing"
+)
+
+func TestRHMIReconciler_getAlertingNamespace(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.SchemeBuilder.AddToScheme(scheme)
+
+	type fields struct {
+		Client                     client.Client
+		Scheme                     *runtime.Scheme
+		mgr                        controllerruntime.Manager
+		controller                 controller.Controller
+		restConfig                 *rest.Config
+		customInformers            map[string]map[string]*cache.Informer
+		productsInstallationLoader marketplace.ProductsInstallationLoader
+	}
+	type args struct {
+		installation  *rhmiv1alpha1.RHMI
+		configManager *config.Manager
+	}
+
+	resourceName := "test"
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "Test - RHOAM - openshift-monitoring and Observability is returned",
+			args: args{
+				installation:  &rhmiv1alpha1.RHMI{Spec: rhmiv1alpha1.RHMISpec{Type: string(rhmiv1alpha1.InstallationTypeManagedApi)}},
+				configManager: &config.Manager{},
+			},
+			fields: fields{Client: fakeclient.NewFakeClientWithScheme(scheme, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: resourceName},
+				Data: map[string]string{
+					"observability": "NAMESPACE: redhat-rhoam-observability",
+				},
+			})},
+			want: map[string]string{
+				"openshift-monitoring":       "alertmanager-main",
+				"redhat-rhoam-observability": "rhoam-alertmanager",
+			},
+		},
+		{
+			name: "Test - RHMI / Other install types - openshift-monitoring and middleware monitoring is returned",
+			args: args{
+				installation:  &rhmiv1alpha1.RHMI{Spec: rhmiv1alpha1.RHMISpec{Type: string(rhmiv1alpha1.InstallationTypeManaged)}},
+				configManager: &config.Manager{},
+			},
+			fields: fields{Client: fakeclient.NewFakeClientWithScheme(scheme, &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: resourceName, Namespace: resourceName},
+				Data: map[string]string{
+					"middleware-monitoring": "OPERATOR_NAMESPACE: redhat-rhmi-middleware-monitoring-operator",
+				},
+			})},
+			want: map[string]string{
+				"openshift-monitoring":                       "alertmanager-main",
+				"redhat-rhmi-middleware-monitoring-operator": "alertmanager-route",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &RHMIReconciler{
+				Client:                     tt.fields.Client,
+				Scheme:                     tt.fields.Scheme,
+				mgr:                        tt.fields.mgr,
+				controller:                 tt.fields.controller,
+				restConfig:                 tt.fields.restConfig,
+				customInformers:            tt.fields.customInformers,
+				productsInstallationLoader: tt.fields.productsInstallationLoader,
+			}
+
+			configManager, _ := config.NewManager(context.TODO(), tt.fields.Client, resourceName, resourceName, tt.args.installation)
+
+			got, err := r.getAlertingNamespace(tt.args.installation, configManager)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAlertingNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("getAlertingNamespace() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -201,3 +201,7 @@ func (m *Monitoring) GetExtraParamWithDefault(key string, v string) string {
 	}
 	return v
 }
+
+func (m *Monitoring) GetAlertManagerRouteName() string {
+	return "alertmanager-route"
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2891

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Read from config when geting the namespace and route name for silenecing alerts in the monitoring stack installed by the operator

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Once RHSSO stage is complete:
  * Open openshift alertmanager and login to later check for silences
  ```
  oc get routes  -n openshift-monitoring --no-headers | grep alertmanager | awk '{print $2}' | xargs -I {} echo https://\{\}      
  ```
  * Open observability alertmanager and login to later check for silences
  ```
  oc get routes -n redhat-rhoam-observability --no-headers | grep alertmanager | awk '{print $2}' | xargs -I {} echo https://\{\}                             
  ```
   * Trigger uninstall
  ```
  oc delete rhmi rhoam -n redhat-rhoam-operator
  ```
   * Verify logs successfully created silences and verify in the above alertmanager UIs that the silences were successfuly created