### PR TITLE
MGDAPI-2897 Test - change of prometheus-0 pod name in ObservabilityOperator

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -918,7 +918,7 @@ func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
 
 	// exec into the prometheus pod
 	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
-		"prometheus-kafka-prometheus-0",
+		"prometheus-prometheus-0",
 		ObservabilityProductNamespace,
 		"prometheus", ctx)
 	if err != nil {

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -114,7 +114,7 @@ func TestIntegreatlyAlertsFiring(t TestingTB, ctx *TestingContext) {
 }
 func getFiringAlerts(t TestingTB, ctx *TestingContext) error {
 	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
-		"prometheus-kafka-prometheus-0",
+		"prometheus-prometheus-0",
 		ObservabilityProductNamespace,
 		"prometheus",
 		ctx)
@@ -228,7 +228,7 @@ func TestIntegreatlyAlertsPendingOrFiring(t TestingTB, ctx *TestingContext) {
 
 func getFiringOrPendingAlerts(ctx *TestingContext) error {
 	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
-		"prometheus-kafka-prometheus-0",
+		"prometheus-prometheus-0",
 		ObservabilityProductNamespace,
 		"prometheus",
 		ctx)

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -182,7 +182,7 @@ func performTest(t TestingTB, ctx *TestingContext, originalOperatorReplicas int3
 
 func checkAlertManager(ctx *TestingContext, t TestingTB) error {
 	output, err := execToPod("amtool alert --alertmanager.url=http://localhost:9093",
-		"alertmanager-kafka-alertmanager-0",
+		"alertmanager-alertmanager-0",
 		ObservabilityProductNamespace,
 		"alertmanager",
 		ctx)
@@ -235,7 +235,7 @@ func waitForKeycloakAlertState(expectedState string, ctx *TestingContext, t Test
 
 func getKeycloakAlertState(ctx *TestingContext) error {
 	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
-		"prometheus-kafka-prometheus-0",
+		"prometheus-prometheus-0",
 		ObservabilityProductNamespace,
 		"prometheus",
 		ctx)

--- a/test/common/deployment_types.go
+++ b/test/common/deployment_types.go
@@ -479,8 +479,8 @@ func TestStatefulSetsExpectedReplicas(t TestingTB, ctx *TestingContext) {
 		{
 			Name: ObservabilityProductNamespace,
 			Products: []Product{
-				{Name: "alertmanager-kafka-alertmanager", ExpectedReplicas: 1},
-				{Name: "prometheus-kafka-prometheus", ExpectedReplicas: 1},
+				{Name: "alertmanager-alertmanager", ExpectedReplicas: 1},
+				{Name: "prometheus-prometheus", ExpectedReplicas: 1},
 			},
 		},
 		{

--- a/test/common/pvc_validate.go
+++ b/test/common/pvc_validate.go
@@ -44,7 +44,7 @@ func commonPvcNamespaces() []PersistentVolumeClaim {
 
 			Namespace: NamespacePrefix + "observability",
 			PersistentVolumeClaimNames: []string{
-				"prometheus-kafka-prometheus-db-prometheus-kafka-prometheus-0",
+				"prometheus-prometheus-db-prometheus-prometheus-0",
 			},
 		},
 	}

--- a/test/common/verify_metrics_scrapped.go
+++ b/test/common/verify_metrics_scrapped.go
@@ -9,9 +9,23 @@ import (
 
 func mangedApiTargets() map[string][]string {
 	return map[string][]string{
-		// TODO: Should include other expected targets
-		Marin3rProductNamespace: {
-			"/ratelimit/0",
+		ObservabilityProductNamespace: {
+			"/integreatly-3scale-admin-ui",
+			"/integreatly-3scale-system-developer",
+			"/integreatly-3scale-system-master",
+			"/integreatly-grafana",
+			"/integreatly-rhsso",
+			"/integreatly-rhssouser",
+			"/redhat-rhoam-cloud-resources-operator-cloud-resource-operator-metrics/0",
+			"/redhat-rhoam-marin3r-ratelimit/0",
+			"/redhat-rhoam-rhsso-keycloak-service-monitor/0",
+			"/redhat-rhoam-rhsso-keycloak-service-monitor/1",
+			"/redhat-rhoam-rhsso-operator-keycloak-operator-metrics/0",
+			"/redhat-rhoam-rhsso-operator-keycloak-operator-metrics/1",
+			"/redhat-rhoam-user-sso-keycloak-service-monitor/0",
+			"/redhat-rhoam-user-sso-keycloak-service-monitor/1",
+			"/redhat-rhoam-user-sso-operator-keycloak-operator-metrics/0",
+			"/redhat-rhoam-user-sso-operator-keycloak-operator-metrics/1",
 		},
 	}
 }
@@ -19,8 +33,8 @@ func mangedApiTargets() map[string][]string {
 func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
 	// get all active targets in prometheus
 	output, err := execToPod("wget -qO - localhost:9090/api/v1/targets?state=active",
-		"prometheus-kafka-prometheus-0",
-		GetPrefixedNamespace("observability"),
+		"prometheus-prometheus-0",
+		ObservabilityProductNamespace,
 		"prometheus",
 		ctx)
 	if err != nil {


### PR DESCRIPTION


# Issue link
https://issues.redhat.com/browse/MGDAPI-2897

# What
Prometheus pod prometheus-kafka-prometheus-0 was renamed to prometheus-rhoam-prometheus-0, as below:
$ oc get pod -n redhat-rhoam-observability |grep prometheus-0
prometheus-rhoam-prometheus-0 4/4 Running 1 104m
Following tests were impacted and require updating
find . -type f |xargs grep -l prometheus-kafka-prometheus-0
./test/common/pvc_validate.go
./test/common/verify_metrics_scrapped.go
./test/common/alerts_exist.go
./test/common/alerts_firing.go

# Verification steps
Retest impacted tests:
- "Verify Alerts are not firing during or after installation apart from DeadMansSwitch"
- "Verify prometheus metrics scrapped"
- C01, C04, C03, A06
