### PR TITLE
Add back in the namespace to the serviceMonitor names

### DIFF
--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -228,7 +228,7 @@ func (r *Reconciler) reconcileMonitoring(ctx context.Context, serverClient k8scl
 
 				if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 					for _, s := range sm.Spec.NamespaceSelector.MatchNames {
-						if s == "redhat-rhoam-middleware-monitoring-operator" {
+						if s == fmt.Sprintf("%smiddleware-monitoring-operator", r.installation.Spec.NamespacePrefix) {
 							err = r.removeServiceMonitor(ctx, serverClient, sm.Namespace, sm.Name)
 							if err != nil {
 								return integreatlyv1alpha1.PhaseFailed, err
@@ -266,7 +266,7 @@ func (r *Reconciler) reconcileMonitoring(ctx context.Context, serverClient k8scl
 			// the can be removed in the case of RHOAM
 			if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(r.installation.Spec.Type)) {
 				for _, s := range sm.Spec.NamespaceSelector.MatchNames {
-					if s == "redhat-rhoam-middleware-monitoring-operator" {
+					if s == fmt.Sprintf("%smiddleware-monitoring-operator", r.installation.Spec.NamespacePrefix) {
 						err = r.removeServiceMonitor(ctx, serverClient, sm.Namespace, sm.Name)
 						if err != nil {
 							return integreatlyv1alpha1.PhaseFailed, err

--- a/pkg/products/monitoringspec/reconciler.go
+++ b/pkg/products/monitoringspec/reconciler.go
@@ -239,7 +239,7 @@ func (r *Reconciler) reconcileMonitoring(ctx context.Context, serverClient k8scl
 
 			//Create a copy of service monitors in the monitoring namespace
 			//Create the corresponding rolebindings at each of the service namespace
-			key := sm.Name
+			key := sm.Namespace + `-` + sm.Name
 			delete(monSermonMap, key) // Servicemonitor exists, remove it from the local map
 			// upgrade specific code
 
@@ -300,7 +300,7 @@ func (r *Reconciler) reconcileServiceMonitor(ctx context.Context,
 	}
 	sm := &monitoringv1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      serviceMonitor.Name,
+			Name:      serviceMonitor.Namespace + `-` + serviceMonitor.Name,
 			Namespace: r.Config.GetNamespace(),
 		},
 	}

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -431,7 +431,7 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			}
 			//Verify that a new servicemonitor is created in the namespace
 			sermon := &prometheusmonitoringv1.ServiceMonitor{}
-			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: "fuse-fuse-servicemon", Namespace: tc.Installation.Namespace}, sermon)
+			err = tc.FakeClient.Get(ctx, k8sclient.ObjectKey{Name: "fuse-fuse-fuse-servicemon", Namespace: tc.Installation.Namespace}, sermon)
 			if err != nil {
 				t.Fatalf("expected no error but got one: %v", err)
 			}

--- a/test/common/verify_metrics_scrapped.go
+++ b/test/common/verify_metrics_scrapped.go
@@ -9,9 +9,23 @@ import (
 
 func mangedApiTargets() map[string][]string {
 	return map[string][]string{
-		// TODO: Should include other expected targets
 		ObservabilityProductNamespace: {
-			"/ratelimit/0",
+			"/integreatly-3scale-admin-ui",
+			"/integreatly-3scale-system-developer",
+			"/integreatly-3scale-system-master",
+			"/integreatly-grafana",
+			"/integreatly-rhsso",
+			"/integreatly-rhssouser",
+			"/redhat-rhoam-cloud-resources-operator-cloud-resource-operator-metrics/0",
+			"/redhat-rhoam-marin3r-ratelimit/0",
+			"/redhat-rhoam-rhsso-keycloak-service-monitor/0",
+			"/redhat-rhoam-rhsso-keycloak-service-monitor/1",
+			"/redhat-rhoam-rhsso-operator-keycloak-operator-metrics/0",
+			"/redhat-rhoam-rhsso-operator-keycloak-operator-metrics/1",
+			"/redhat-rhoam-user-sso-keycloak-service-monitor/0",
+			"/redhat-rhoam-user-sso-keycloak-service-monitor/1",
+			"/redhat-rhoam-user-sso-operator-keycloak-operator-metrics/0",
+			"/redhat-rhoam-user-sso-operator-keycloak-operator-metrics/1",
 		},
 	}
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2901

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
RHSSO serviceMonitors were not getting added to the Observability NS due to a duplicate ServiceMonitor name, this pr changes the name of the serviceMonitors to include the namespace

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Checkout this branch and run the operator locally
```bash  
INSTALLATION_TYPE=managed-api make cluster/prepare/local
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml
INSTALLATION_TYPE=managed-api make code/run
```
- Or you can use the following catalogSource to deploy via olm
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators 
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/austincunningham/integreatly-index:1.13.0-servicemonitor
```

- Wait for the install to finish 
- check that the serviceMonitors in the redhat-rhoam-observability NS match the following
```bash
~ oc project redhat-rhoam-observability
~ oc get servicemonitors.monitoring.coreos.com
NAME                                                                                               AGE
redhat-rhoam-cloud-resources-operator-cloud-resource-operator-metrics                              11m
redhat-rhoam-marin3r-ratelimit                                                                     11m
redhat-rhoam-rhsso-keycloak-service-monitor                                                        11m
redhat-rhoam-rhsso-operator-keycloak-operator-metrics                                              11m
redhat-rhoam-user-sso-keycloak-service-monitor                                                     10m
redhat-rhoam-user-sso-operator-keycloak-operator-metrics                                           10m
```
- Go to the prometheus route in the redhat-rhoam-observability NS and check the targets are available under the `Status/Targets` tab
![image](https://user-images.githubusercontent.com/16667688/137900575-29f1e472-a56b-45e5-a53e-6afa94d5d819.png)

