### PR TITLE
Fix scripts affected by AlertManager and Prometheus name change

### DIFF
--- a/scripts/capture_resource_metrics.sh
+++ b/scripts/capture_resource_metrics.sh
@@ -11,7 +11,7 @@
 START_TIME_FILENAME=${START_TIME_FILENAME:-perf-test-start-time.txt}
 END_TIME_FILENAME=${END_TIME_FILENAME:-perf-test-end-time.txt}
 TOKEN=$(oc whoami --show-token)
-RHOAM_PROMETHEUS_ROUTE=$(echo "https://$(oc get route prometheus-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')")
+RHOAM_PROMETHEUS_ROUTE=$(echo "https://$(oc get route prometheus -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')")
 CLUSTER_PROMETHEUS_ROUTE=$(echo "https://$(oc get route prometheus-k8s -n openshift-monitoring -o=jsonpath='{.spec.host}')")
 PROM_QUERY_ROUTE="$CLUSTER_PROMETHEUS_ROUTE/api/v1/query"
 PROM_QUERY_ROUTE_RHOAM="$RHOAM_PROMETHEUS_ROUTE/api/v1/query"

--- a/scripts/monitoringupgradetest.sh
+++ b/scripts/monitoringupgradetest.sh
@@ -16,8 +16,8 @@ do
   sleep 30
 done
 
-# check both stateful sets for promehtues and alertmananger in the AMO namespace.
-# when both become unavailable this indicates the unavailablility of the uninstalling monitoring stack
+# check both stateful sets for prometheus and alertmananger in the AMO namespace.
+# when both become unavailable this indicates the unavailability of the uninstalling monitoring stack
 # The time is noted and stored for use later
 while true
 do
@@ -38,15 +38,15 @@ do
   sleep 15
 done
 
-# check both statefulsets (readyReplicas) for promethues and alertmananger in the Observability namespace.
+# check both statefulsets (readyReplicas) for prometheus and alertmananger in the Observability namespace.
 # when both become available this indicates the availability of the installing monitoring stack
 # The time is noted and stored for use later
 while true
 do
-  ooPrometheus=$(oc get statefulset prometheus-rhoam-prometheus -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
+  ooPrometheus=$(oc get statefulset prometheus-prometheus -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
   if [ "$ooPrometheus" -ge 1 ]; then
-    echo "Promethues reporting 1 replica ready"
-    ooAlertManager=$(oc get statefulset alertmanager-rhoam-alertmanager -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
+    echo "Prometheus reporting 1 replica ready"
+    ooAlertManager=$(oc get statefulset alertmanager-alertmanager -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
     if [ "$ooAlertManager" -ge 1 ]; then
       echo "AlertManager reporting 1 replica ready"
       date +"%T"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2859

# What
The route names for AlertManager and Prometheus in the `redhat-rhoam-observability` namespace were changed in #2211 to remove the `rhoam-` prefix. Changing the route names broke two scripts: 
- scripts/capture_resource_metrics.sh
- scripts/monitoringupgradetest.sh

This PR fixes those scripts. 

# Verification steps
## Provision a 4.8 OSD cluster
In order to test `monitoringupgradetest.sh`, an OSD cluster running OpenShift version 4.8 is required. This is because we need to install RHOAM v1.12.0 to simulate an upgrade but v1.12.0 is incompatible with OpenShift 4.9. Use the following steps to provision a 4.8 OSD cluster:
- Clone the delorean repo and login via OCM (token can be found [here](https://qaprodauth.cloud.redhat.com/openshift/token))
  - `git clone git@github.com:integr8ly/delorean.git`
  - `cd delorean`
  - `export OCM_TOKEN=<TOKEN_VALUE>` 
  - `make ocm/login`
- Create the cluster template and then add a version block
  - `make ocm/cluster.json`
  - Open `ocm/cluster.json` in an editor and update `display_name`, `name`, `region`, and `expiration_timestamp` as needed
  - Add the following version block
```
"version": {
  "kind": "VersionLink",
  "id": "openshift-v4.8.12",
  "href": "/api/clusters_mgmt/v1/versions/openshift-v4.8.12"
},
```
- Trigger the cluster creation
  - `make ocm/cluster/create`

## Verify `monitoringupgradetest.sh` script
- Target the 4.8 cluster that was created above once it is provisioned
- Prepare the cluster for installation
  - `git checkout rhoam-v1.12.0`
  - `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
  - `INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml`
- Login to the cluster UI and create a CatalogSource under the `redhat-rhoam-operator` namespace. Set the "CatalogSource name" to `rhoam-operator` and the "Image" to `quay.io/ckyrillo/managed-api-service-index:v1.12.0`. Change the "Availability" to `Namespaced` and select `redhat-rhoam-operator` for the "Namespace".
- Once the operator is listed in OperatorHub, install it.
- Let the installation complete - aka check that `toVersion` is empty and `version` is "1.12.0" in the status of the RHMI CR.
- Checkout this pull request and start the script in a separate terminal window
  - `./scripts/monitoringupgradetest.sh`
- Go to the created CatalogSource and update the url to `quay.io/ckyrillo/managed-api-service-index:v1.13.0-upgrade`
- Go to InstalledOperators and click on the "Upgrade available" link for RHOAM under the Status column
- Preview the InstallPlan and then Approve it to trigger the upgrade
- Verify that the script runs to completion and that it outputs the time the upgrade took (some errors are expected while the script is waiting for the new StatefulSets to be created, these errors can be ignored)

## Verify `capture_resource_metrics.sh`
- `cd` into the root directory of the repository if not already there
  - `cd /path/to/integreatly-operator/`
- Create a file text file with a valid rfc3339 timestamp named `perf-test-start-time.txt`
  - `date -u +%Y-%m-%dT%TZ > perf-test-start-time.txt`
- Wait at least 60 seconds - this is to ensure the two files have sufficiently different timestamps
- Create a file text file with a valid rfc3339 timestamp named `perf-test-end-time.txt`
  - `date -u +%Y-%m-%dT%TZ > perf-test-end-time.txt`
- Run the script and verify that it completes without any errors (if you do get an error, make sure that the upgrade from the previous section has fully completed and try again)
  - `./scripts/capture_resource_metrics.sh`