### PR TITLE
MGDAPI-1404 Reduce severity level of warning

### DIFF
--- a/pkg/products/threescale/prometheusRules_test.go
+++ b/pkg/products/threescale/prometheusRules_test.go
@@ -1,0 +1,12 @@
+package threescale
+
+import "testing"
+
+func TestAlertThreeScaleContainerHighMemorySeverity(t *testing.T) {
+	alert := alertThreeScaleContainerHighMemory("dummy", "dummy-namespace")
+	severity := alert.Labels["severity"]
+
+	if severity != "info" {
+		t.Fatalf("severity level; Expected: info, Got: %v", severity)
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-1404

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Reduce the `ThreeScaleContainerHighMemory` alert severity level from warning to info 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Install RHOAM 1.13 using a catalogSource an this index: quay.io/jfitzpat/managed-api-service-index:v1.13.0
- After install the `ThreeScaleContainerHighMemory` alert should be set as warning `oc get routes -n redhat-rhoam-observability --no-headers | grep prometheus | awk '{print $2}' | xargs -I {} xdg-open https://{}`
- Upgrade to RHOAM to this branch by using index: quay.io/jfitzpat/managed-api-service-index:v1.14.0-1404  `oc patch catalogsources rhmi-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:v1.14.0-1404"}]'`
- Expected after upgrade `ThreeScaleContainerHighMemory` alert should have a severity level of `info`