### PR TITLE
updated the Jenkins link to point to addon-flow pipeline

### DIFF
--- a/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
+++ b/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
@@ -16,7 +16,7 @@ Verify RHOAM installation on OSD Trial works as expected.
 
 ## Steps
 
-1. Provision an OSD Trial Cluster through [Jenkins](https://master-jenkins-csb-intly.apps.ocp4.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-master/)
+1. Provision an OSD Trial Cluster through [Jenkins](https://master-jenkins-csb-intly.apps.ocp4.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-addon-flow/)
    - Reach out for AWS credentials needed to provision an OSD Trial Cluster
    - Check `osdTrial` checkbox and for phases choose `provisionCluster` and `installProduct`
 2. After pipeline finishes log into the cluster using `oc` and the provided kubeadmin credentials


### PR DESCRIPTION
# What
during last round of release testing I was told that we're supposed to use the addon-flow pipeline for release testing so this probably should be changed

# Verification steps
click the link :)
