### PR TITLE
MGDAPI-2940 Prometheus rules removal

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"math/rand"
 	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 
 	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
@@ -196,7 +197,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 		// temp code for RHOAM, remove once all clusters are upgraded to 1.14
 		// Remove all prometheus rules under redhat/sandbox-rhoam/rhoami-operator
-		phase, err = r.removePrometheusRules(ctx, serverClient)
+		phase, err = r.removePrometheusRules(ctx, serverClient, installation.Spec.NamespacePrefix)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			events.HandleError(r.recorder, installation, phase, "Failed to remove existing prometheus rules from rhoam-operator namespace", err)
 			return phase, errors.Wrap(err, "Failed to remove existing prometheus rules from rhoam-operator namespace")
@@ -213,25 +214,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func (r *Reconciler) removePrometheusRules(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
-
-	existingRules := &prometheusv1.PrometheusRuleList{}
-
-	err := serverClient.List(ctx, existingRules, k8sclient.InNamespace(r.ConfigManager.GetOperatorNamespace()))
+func (r *Reconciler) removePrometheusRules(ctx context.Context, serverClient k8sclient.Client, nsPrefix string) (integreatlyv1alpha1.StatusPhase, error) {
+	rhoamProductNamespaces, err := getRHOAMNamespaces(ctx, serverClient, nsPrefix)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
-	} else if k8serr.IsNotFound(err) || len(existingRules.Items) == 0 {
-		return integreatlyv1alpha1.PhaseCompleted, nil
 	}
 
-	for _, rule := range existingRules.Items {
-		err = serverClient.Delete(ctx, rule)
+	for _, namespace := range rhoamProductNamespaces {
+		namespaceRules := &prometheusv1.PrometheusRuleList{}
+
+		err := serverClient.List(ctx, namespaceRules, k8sclient.InNamespace(namespace))
 		if err != nil {
 			return integreatlyv1alpha1.PhaseFailed, err
+		} else if k8serr.IsNotFound(err) || len(namespaceRules.Items) == 0 {
+			continue
+		}
+
+		// Exclude keycloak rule from the deletion as it gets recreated by keycloak operator
+		for _, rule := range namespaceRules.Items {
+			if rule.Name != "keycloak" {
+				err := serverClient.Delete(ctx, rule)
+				if err != nil {
+					return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Failed to remove %s rule: %s", rule.ObjectMeta.Name, err)
+				}
+			}
 		}
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func getRHOAMNamespaces(ctx context.Context, serverClient k8sclient.Client, nsPrefix string) ([]string, error) {
+	var namespaces []string
+	namespaceList := &corev1.NamespaceList{}
+	err := serverClient.List(ctx, namespaceList)
+	if err != nil {
+		return nil, err
+	}
+	// Only return namespaces that have the integreatly label and nsPrefix, but also return rhoam operator ns (it does not have the integreatly label on)
+	for _, namespace := range namespaceList.Items {
+		if !strings.Contains(namespace.Name, "observability") && strings.Contains(namespace.Name, nsPrefix) || namespace.Name == fmt.Sprintf("%soperator", nsPrefix) {
+			namespaces = append(namespaces, namespace.Name)
+		}
+	}
+
+	return namespaces, nil
 }
 
 // temp code for rhmi 2.8 to 2.9.0 upgrades, remove this when all clusters upgraded to 2.9.0

--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -4,14 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
-	"testing"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	prometheusv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,17 +20,30 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
 )
 
 var (
-	rhoamTestNamespace         = "redhat-rhoam-operator"
-	observabilityTestNamespace = "redhat-rhoam-observability-operator"
+	rhoamOperatorNs         = "redhat-rhoam-operator"
+	threescaleNs            = "redhat-rhoam-3scale"
+	threescaleOperatorNs    = "redhat-rhoam-3scale-operator"
+	croNs                   = "redhat-rhoam-cloud-resources"
+	customerMonitoringNs    = "redhat-rhoam-customer-monitoring"
+	marin3rNs               = "redhat-rhoam-marin3r"
+	marin3rOperatorNs       = "redhat-rhoam-marin3r-operator"
+	monitoringNs            = "redhat-rhoam-monitoring"
+	observabilityNs         = "redhat-rhoam-observability"
+	observabilityOperatorNs = "redhat-rhoam-observability-operator"
+	rhssoNs                 = "redhat-rhoam-rhsso"
+	rhssoOperatorNs         = "redhat-rhoam-rhsso-operator"
+	userSsoNs               = "redhat-rhoam-user-sso"
+	userSsoOperatorNs       = "redhat-rhoam-user-sso-operator"
+	someRandomNs            = "some-random-nspace"
 )
 
 func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = rbacv1.SchemeBuilder.AddToScheme(scheme)
-	_ = prometheusv1.SchemeBuilder.AddToScheme(scheme)
 
 	tests := []struct {
 		Name           string
@@ -124,6 +136,7 @@ func TestReconciler_reconcileRHMIConfigPermissions(t *testing.T) {
 func TestReconciler_reconcilePrometheusRules(t *testing.T) {
 	scheme := runtime.NewScheme()
 	_ = prometheusv1.SchemeBuilder.AddToScheme(scheme)
+	_ = corev1.SchemeBuilder.AddToScheme(scheme)
 
 	tests := []struct {
 		Name           string
@@ -139,71 +152,79 @@ func TestReconciler_reconcilePrometheusRules(t *testing.T) {
 			Name: "Test that all exisiting prometheus rules in given ns are removed correctly",
 			FakeConfig: &config.ConfigReadWriterMock{
 				GetOperatorNamespaceFunc: func() string {
-					return rhoamTestNamespace
+					return rhoamOperatorNs
 				},
 			},
-			FakeMPM:        &marketplace.MarketplaceInterfaceMock{},
-			Installation:   &integreatlyv1alpha1.RHMI{},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
+			Installation: &integreatlyv1alpha1.RHMI{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: rhoamOperatorNs,
+				},
+				Spec: integreatlyv1alpha1.RHMISpec{
+					NamespacePrefix: "redhat-rhoam-",
+				},
+			},
 			Recorder:       record.NewFakeRecorder(50),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient: fake.NewFakeClientWithScheme(scheme, &prometheusv1.PrometheusRuleList{
-				Items: []*prometheusv1.PrometheusRule{
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "testrule1",
-							Namespace: rhoamTestNamespace,
-						},
-					},
-					{
-						ObjectMeta: v1.ObjectMeta{
-							Name:      "testrule2",
-							Namespace: rhoamTestNamespace,
-						},
-					},
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&prometheusv1.PrometheusRuleList{
+					Items: getPrometheusRules(),
 				},
-			}),
+				getNamespaces(),
+			),
 			Assertion: assertPrometheusRulesDeletion,
 		},
 		{
 			Name: "Test that prometheus rules in other ns are NOT removed",
 			FakeConfig: &config.ConfigReadWriterMock{
 				GetOperatorNamespaceFunc: func() string {
-					return "test-namespace"
+					return rhoamOperatorNs
 				},
 			},
-			FakeMPM:        &marketplace.MarketplaceInterfaceMock{},
-			Installation:   &integreatlyv1alpha1.RHMI{ObjectMeta: v1.ObjectMeta{Namespace: rhoamTestNamespace}},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
+			Installation: &integreatlyv1alpha1.RHMI{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: rhoamOperatorNs,
+				},
+				Spec: integreatlyv1alpha1.RHMISpec{
+					NamespacePrefix: "redhat-rhoam-",
+				},
+			},
 			Recorder:       record.NewFakeRecorder(50),
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
 			FakeClient: fake.NewFakeClientWithScheme(scheme,
 				&prometheusv1.PrometheusRuleList{
-					Items: []*prometheusv1.PrometheusRule{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "testrule1",
-								Namespace: rhoamTestNamespace,
-							},
-						},
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "testrule2",
-								Namespace: rhoamTestNamespace,
-							},
-						},
-					},
+					Items: getPrometheusRules(),
 				},
-				&prometheusv1.PrometheusRuleList{
-					Items: []*prometheusv1.PrometheusRule{
-						{
-							ObjectMeta: v1.ObjectMeta{
-								Name:      "test-rule3",
-								Namespace: observabilityTestNamespace,
-							},
-						},
-					},
-				},
+				getNamespaces(),
 			),
 			Assertion: assertPrometheusRulesNoDeletion,
+		},
+		{
+			Name: "Test that all expected namespaces are returned",
+			FakeConfig: &config.ConfigReadWriterMock{
+				GetOperatorNamespaceFunc: func() string {
+					return rhoamOperatorNs
+				},
+			},
+			FakeMPM: &marketplace.MarketplaceInterfaceMock{},
+			Installation: &integreatlyv1alpha1.RHMI{
+				ObjectMeta: v1.ObjectMeta{
+					Namespace: rhoamOperatorNs,
+				},
+				Spec: integreatlyv1alpha1.RHMISpec{
+					NamespacePrefix: "redhat-rhoam-",
+				},
+			},
+			Recorder:       record.NewFakeRecorder(50),
+			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&prometheusv1.PrometheusRuleList{
+					Items: getPrometheusRules(),
+				},
+				getNamespaces(),
+			),
+			Assertion: assertAllExpectedNamespacesAreReturned,
 		},
 	}
 	for _, tt := range tests {
@@ -213,7 +234,7 @@ func TestReconciler_reconcilePrometheusRules(t *testing.T) {
 				t.Fatalf("Error creating bootstrap reconciler: %s", err)
 			}
 
-			phase, err := reconciler.removePrometheusRules(context.TODO(), tt.FakeClient)
+			phase, err := reconciler.removePrometheusRules(context.TODO(), tt.FakeClient, "redhat-rhoam-")
 
 			if phase != tt.ExpectedStatus {
 				t.Fatalf("Expected %s phase but got %s", tt.ExpectedStatus, phase)
@@ -243,26 +264,357 @@ func assertRoleBindingNotFound(client k8sclient.Client) error {
 	return nil
 }
 
-func assertPrometheusRulesDeletion(client k8sclient.Client) error {
-	existingRules := &prometheusv1.PrometheusRuleList{}
-
-	err := client.List(context.TODO(), existingRules, k8sclient.InNamespace(rhoamTestNamespace))
+func assertAllExpectedNamespacesAreReturned(client k8sclient.Client) error {
+	existingNamespaces, err := getRHOAMNamespaces(context.TODO(), client, "redhat-rhoam-")
 	if err != nil {
 		return err
-	} else if len(existingRules.Items) != 0 {
+	} else if existingNamespaces == nil {
+		return fmt.Errorf("No namespaces were found")
+	}
+	rhoamFound := false
+	threescaleFound := false
+	threescaleOpFound := false
+	croFound := false
+	customerMonitoringFound := false
+	marin3rFound := false
+	marin3rOperatorFound := false
+	monitoringNsFound := false
+	observabilityNsFound := false
+	observabilityOperatorFound := false
+	rhssoFound := false
+	rhssoOperatorFound := false
+	userSSOFound := false
+	userSSOOperatorFound := false
+	randomNsFound := false
+
+	for _, namespaceFound := range existingNamespaces {
+		if namespaceFound == rhoamOperatorNs {
+			rhoamFound = true
+		}
+		if namespaceFound == threescaleNs {
+			threescaleFound = true
+		}
+		if namespaceFound == threescaleOperatorNs {
+			threescaleOpFound = true
+		}
+		if namespaceFound == croNs {
+			croFound = true
+		}
+		if namespaceFound == customerMonitoringNs {
+			customerMonitoringFound = true
+		}
+		if namespaceFound == marin3rNs {
+			marin3rFound = true
+		}
+		if namespaceFound == marin3rOperatorNs {
+			marin3rOperatorFound = true
+		}
+		if namespaceFound == monitoringNs {
+			monitoringNsFound = true
+		}
+		if namespaceFound == observabilityNs {
+			observabilityNsFound = true
+		}
+		if namespaceFound == observabilityOperatorNs {
+			observabilityOperatorFound = true
+		}
+		if namespaceFound == rhssoNs {
+			rhssoFound = true
+		}
+		if namespaceFound == rhssoOperatorNs {
+			rhssoOperatorFound = true
+		}
+		if namespaceFound == userSsoNs {
+			userSSOFound = true
+		}
+		if namespaceFound == userSsoOperatorNs {
+			userSSOOperatorFound = true
+		}
+		if namespaceFound == someRandomNs {
+			randomNsFound = true
+		}
+
+	}
+
+	if !rhoamFound || !croFound || !threescaleFound || !threescaleOpFound || !customerMonitoringFound || !marin3rFound || !marin3rOperatorFound || !monitoringNsFound ||
+		!rhssoFound || !rhssoOperatorFound || !userSSOFound || !userSSOOperatorFound {
+		return fmt.Errorf("Not all namespaces were found")
+	}
+
+	if observabilityNsFound || observabilityOperatorFound || randomNsFound {
+		return fmt.Errorf("observability namespace was found while it should have been skipped")
+	}
+
+	return nil
+}
+
+func assertPrometheusRulesDeletion(client k8sclient.Client) error {
+	var allExistingRules []prometheusv1.PrometheusRule
+	rhoamProductNamespaces, err := getRHOAMNamespaces(context.TODO(), client, "redhat-rhoam-")
+	if err != nil {
+		return err
+	}
+	for _, namespace := range rhoamProductNamespaces {
+		namespaceRules := &prometheusv1.PrometheusRuleList{}
+
+		err := client.List(context.TODO(), namespaceRules, k8sclient.InNamespace(namespace))
+		if err != nil {
+			return err
+		} else if k8serr.IsNotFound(err) || len(namespaceRules.Items) == 0 {
+			continue
+		}
+
+		for _, rule := range namespaceRules.Items {
+			if rule.Name != "keycloak" {
+				allExistingRules = append(allExistingRules, *rule)
+			}
+		}
+	}
+	if len(allExistingRules) != 0 {
 		return fmt.Errorf("Found prometheus rules that should have been deleted")
 	}
+
 	return nil
 }
 
 func assertPrometheusRulesNoDeletion(client k8sclient.Client) error {
 	existingRules := &prometheusv1.PrometheusRuleList{}
 
-	err := client.List(context.TODO(), existingRules, k8sclient.InNamespace(observabilityTestNamespace))
+	err := client.List(context.TODO(), existingRules, k8sclient.InNamespace(observabilityNs))
+	if err != nil {
+		return err
+	} else if len(existingRules.Items) == 0 {
+		return fmt.Errorf("Other ns prometheus rules were also removed while they should not")
+	}
+	err = client.List(context.TODO(), existingRules, k8sclient.InNamespace(observabilityOperatorNs))
 	if err != nil {
 		return err
 	} else if len(existingRules.Items) == 0 {
 		return fmt.Errorf("Other ns prometheus rules were also removed while they should not")
 	}
 	return nil
+}
+
+func getPrometheusRules() []*prometheusv1.PrometheusRule {
+	return []*prometheusv1.PrometheusRule{
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule1",
+				Namespace: rhoamOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule2",
+				Namespace: threescaleNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule3",
+				Namespace: threescaleOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule4",
+				Namespace: croNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule5",
+				Namespace: customerMonitoringNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule6",
+				Namespace: marin3rNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule7",
+				Namespace: marin3rOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule8",
+				Namespace: monitoringNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule9",
+				Namespace: observabilityNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule10",
+				Namespace: observabilityOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule11",
+				Namespace: rhoamOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule12",
+				Namespace: rhssoNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule13",
+				Namespace: userSsoNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "testrule14",
+				Namespace: userSsoOperatorNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "keycloak",
+				Namespace: rhssoNs,
+			},
+		},
+		{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "keycloak",
+				Namespace: userSsoNs,
+			},
+		},
+	}
+}
+
+func getNamespaces() *corev1.NamespaceList {
+	return &corev1.NamespaceList{
+		TypeMeta: v1.TypeMeta{},
+		ListMeta: v1.ListMeta{},
+		Items: []corev1.Namespace{
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: rhoamOperatorNs,
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: threescaleNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: threescaleOperatorNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: croNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: customerMonitoringNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: marin3rNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: marin3rOperatorNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: monitoringNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: observabilityNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: observabilityOperatorNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: rhssoNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: rhssoOperatorNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: userSsoNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: userSsoOperatorNs,
+					Labels: map[string]string{
+						"integreatly": "true",
+					},
+				},
+			},
+			{
+				ObjectMeta: v1.ObjectMeta{
+					Name: someRandomNs,
+				},
+			},
+		},
+	}
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2940

# What
With the migration to OO we have re-created our rules in the new ns, old rules from rhoam-operator ns are removed by this PR.

# Verification steps
- Provision 4.8.X OSD cluster
- Log in as kubeadmin via CLI
- Create a .yaml file with catalog source:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/integreatly-index:1.12.0
```
- Run `oc apply -f rhmi-operators.yaml`
- Run `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
- Wait a minute and navigate to OperatorsHub on your cluster and install RHOAM under redhat-rhoam-operator ns
- Wait for installation to complete and verify that there are existing prometheus rules in the `redhat-rhoam` namespaces.
- Navigate to catalog source CR called `rhmi-operators` under `openshift-marketplace` and edit the index value to `quay.io/mstoklus/integreatly-index:1.13.0` 
- Navigate to InstalledOperators, select `redhat-rhoam-operator` project and proceed with RHOAM upgrade by clicking on `Upgrade available` > `Preview install plan` and then `Approve`
- Wait for an upgrade to complete and either wait a few minutes or open rhmi-operator pod logs and wait for bootstrap stage to complete, once it's completed, verify that the Prometheus rules under redhat-rhoam namespaces are no longer present (excluding observability - where they should all now be and a single prometheus rule under redhat-rhoam-user-sso and -rhsso namespaces as these rules are re-created by keycloak ).
