### PR TITLE
[WIP] MGDAPI-2910 - Update UIBBT alert for threescale route to allow for ro…

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -795,3 +795,12 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		clusterVersion,
 	}
 }
+
+func getTestPreReqsReconcileBlackboxTargetsPhaseInProgress() []runtime.Object {
+	return []runtime.Object{
+		threescaleRoute1,
+		threescaleRoute4,
+		threescaleRoute5,
+		threescaleRoute6,
+	}
+}


### PR DESCRIPTION
[WIP]
Update UIBBT alert for threescale route to allow for routes without "3scale."

# Issue link
https://issues.redhat.com/browse/MGDAPI-2910

# What
1) 3 scale Routes , that have labels "system-developer" or "system-provider", could have Hostname without "3scale" prefix. The route will be recognized by Label.
2) If getThreescaleRoute(ctx, client, "system-developer"...) returns nil Route - it should be handled as PhaseInProgress

# Verification steps
1) Unit test (UT) (in progress) - create UT for reconcileBlackboxTargets() method; 2 cases:
  - phase completed - when all routes called in reconcileBlackboxTargets() are available
  - phase inProgress - when route that has label "system-developer" is missing (reconcileBlackboxTargets returns nil for "system-developer" route ).

2) E2E . In Task - existing end to end tests should cover us as alerts should be firing (? discuss)
