### PR TITLE
Examine the installPlan before approval in RHOAM upgrade test case

### DIFF
--- a/test-cases/tests/upgrade/n02b-upgrade-rhoam.md
+++ b/test-cases/tests/upgrade/n02b-upgrade-rhoam.md
@@ -56,6 +56,12 @@ Note: If [N09 test case](https://github.com/integr8ly/integreatly-operator/blob/
    oc get installplans -n redhat-rhoam-operator
    ```
 
+   You can check whether the `installplan` is for the proper RC by examining the output of the command below.
+
+   ```
+   oc get installplan install-<hash> --namespace redhat-rhoam-operator -o yaml
+   ```
+
    In case release candidate is service affecting, you need to approve the installPlan first.
 
    ```


### PR DESCRIPTION
# Issue link
N/A

# What
Small improvement of RHOAM upgrade test case. About checking that the installPlan installs the proper RC before the installPlan approval.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Eye review only, you can potentially run the command against the cluster.
