### PR TITLE
update to premetheus rules to use sum() as expected

### DIFF
--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -65,7 +65,7 @@ func mapAlertsConfiguration(logger l.Logger, namespace, rateLimitUnit string, ra
 		switch alertConfig.Type {
 		case marin3rconfig.AlertTypeSpike:
 			expr := fmt.Sprintf(
-				"max_over_time((increase(authorized_calls[1m]) + increase(limited_calls[1m]))[%s:]) > %d",
+				"max_over_time((sum(increase(authorized_calls[1m])) + sum(increase(limited_calls[1m])))[%s:]) > %d",
 				alertConfig.Period, rateLimitRequestsPerUnit)
 			annotations := map[string]string{
 				"message":        fmt.Sprintf("hard limit of %d breached at least once in the last %s", rateLimitRequestsPerUnit, alertConfig.Period),
@@ -157,7 +157,7 @@ func increaseExpr(totalRequestsMetric, period string, comparisonOperator string,
 	}
 
 	result := fmt.Sprintf(
-		"(sum(increase(%s[%s]) %s (%f / 100 * %d)))",
+		"(sum(increase(%s[%s])) %s (%f / 100 * %d))",
 		totalRequestsMetric, period, comparisonOperator, requestsAllowedOverTimePeriod, *percenteageLimit,
 	)
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3025

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps

See ticket for verification steps and previous verification done on cluster `lfitzger`

Threshold Alerts should be `(sum(increase(authorized_calls[1m])) >= (13889 / 100 * 95))` rather than `(sum(increase(authorized_calls[1m]) >= (13889 / 100 * 95)))` note the difference in the brackets

OverLimit (Spike) Alert query should be `max_over_time((sum(increase(authorized_calls[1m])) + sum(increase(limited_calls[1m])))[10m:]) > 13889` for 20M cluster

After running the script from the test against the cluster the following alerts are observed

<img width="1679" alt="Screenshot 2021-11-04 at 13 31 20" src="https://user-images.githubusercontent.com/6498727/140322897-37577499-5aea-4f8b-8096-cf23e390405f.png">
<img width="1680" alt="Screenshot 2021-11-04 at 13 32 46" src="https://user-images.githubusercontent.com/6498727/140322937-25bdc448-ff11-4f07-98ba-ff66fb91cbc1.png">
<img width="1680" alt="Screenshot 2021-11-04 at 13 33 28" src="https://user-images.githubusercontent.com/6498727/140322983-522bd248-0e1f-42c8-820e-82adbd568933.png">

Load test output
```
  scenarios: (100.00%) 1 scenario, 200 max VUs, 10m30s max duration (incl. graceful stop):
           * default: 200 looping VUs for 10m0s (gracefulStop: 30s)


running (10m00.8s), 000/200 VUs, 150137 complete and 0 interrupted iterations
default ✓ [======================================] 200 VUs  10m0s

     ✗ is status 200
      ↳  8% — ✓ 12682 / ✗ 137455

     Errors (status 429)............: 137455 228.778415/s
     checks.........................: 8.44%  ✓ 12682  ✗ 137455
     data_received..................: 61 MB  101 kB/s
     data_sent......................: 30 MB  50 kB/s
     http_req_blocked...............: avg=2.69ms   min=1µs      med=5µs      max=7.47s   p(90)=8µs      p(95)=13µs    
     http_req_connecting............: avg=955.41µs min=0s       med=0s       max=2.18s   p(90)=0s       p(95)=0s      
     http_req_duration..............: avg=147.2ms  min=125.15ms med=140.35ms max=5.86s   p(90)=146.96ms p(95)=151.46ms
       { expected_response:true }...: avg=151.25ms min=129.3ms  med=143.27ms max=3.22s   p(90)=151.38ms p(95)=156.24ms
     http_req_failed................: 91.55% ✓ 137455 ✗ 12682 
     http_req_receiving.............: avg=55.13µs  min=11µs     med=45µs     max=14.35ms p(90)=79µs     p(95)=100µs   
     http_req_sending...............: avg=28.28µs  min=7µs      med=23µs     max=11.68ms p(90)=39µs     p(95)=50µs    
     http_req_tls_handshaking.......: avg=1.73ms   min=0s       med=0s       max=6.88s   p(90)=0s       p(95)=0s      
     http_req_waiting...............: avg=147.11ms min=124.98ms med=140.27ms max=5.86s   p(90)=146.86ms p(95)=151.37ms
     http_reqs......................: 150137 249.88618/s
     iteration_duration.............: avg=799.79ms min=132.35ms med=797.49ms max=8.29s   p(90)=805.75ms p(95)=809.5ms 
     iterations.....................: 150137 249.88618/s
     vus............................: 200    min=200  max=200 
     vus_max........................: 200    min=200  max=200 
```
