### PR TITLE
update to mt deletion and creation logic

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -445,7 +445,7 @@ func (r *Reconciler) reconcilerRHMIConfigCR(ctx context.Context, serverClient k8
 
 func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 
-	allTenants, err := userHelper.GetMultiTenantUsers(ctx, serverClient)
+	allTenants, err := userHelper.GetMultiTenantUsers(ctx, serverClient, r.installation)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("Error getting teants for OAuth clients secrets: %w", err)
 	}

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -1376,3 +1376,101 @@ func TestReconciler_getUserDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestMTAccountsToBeDeleted(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = usersv1.AddToScheme(scheme)
+
+	existing3scaleAccounts := []AccountDetail{
+		{
+			Id:           1,
+			Name:         "test-1",
+			OrgName:      "test-1",
+			AdminBaseURL: "test-1-url",
+			State:        "approved",
+			Users:        XMLUsers{},
+		},
+		{
+			Id:           2,
+			Name:         "test-2",
+			OrgName:      "test-2",
+			AdminBaseURL: "test-2-url",
+			State:        "approved",
+			Users:        XMLUsers{},
+		},
+	}
+
+	tests := []struct {
+		Name             string
+		AccountsIn3Scale []AccountDetail
+		FakeClient       k8sclient.Client
+		Assertion        func([]AccountDetail) error
+	}{
+		{
+			Name:             "Test that no accounts are removed for deletion",
+			AccountsIn3Scale: existing3scaleAccounts,
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&usersv1.UserList{
+					Items: []usersv1.User{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-1",
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-2",
+							},
+						},
+					},
+				},
+			),
+			Assertion: assertNoAccountsAreDeleted,
+		},
+		{
+			Name:             "Test that account number 2 is going to be returned for deletion",
+			AccountsIn3Scale: existing3scaleAccounts,
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&usersv1.UserList{
+					Items: []usersv1.User{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "test-1",
+							},
+						},
+					},
+				},
+			),
+			Assertion: assertThatAnAccountGetsDeleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+
+			accountsToBeDeleted, _ := getMTAccountsToBeDeleted(context.TODO(), tt.FakeClient, tt.AccountsIn3Scale)
+
+			if err := tt.Assertion(accountsToBeDeleted); err != nil {
+				t.Fatalf("Failed assertion: %v", err)
+			}
+		})
+	}
+}
+
+func assertNoAccountsAreDeleted(accountsToBeDeleted []AccountDetail) error {
+	if len(accountsToBeDeleted) != 0 {
+		return fmt.Errorf("Accounts to be deleted found while there should be none")
+	}
+	return nil
+}
+
+func assertThatAnAccountGetsDeleted(accountsToBeDeleted []AccountDetail) error {
+	if len(accountsToBeDeleted) != 1 {
+		return fmt.Errorf("Accounts to be deleted length is %v while expected is 2", len(accountsToBeDeleted))
+	}
+
+	if accountsToBeDeleted[0].Name != "test-2" {
+		return fmt.Errorf("Wrong account has been marked for deletion")
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3074

# What
1. We want to only create tenants for users that have logged in after installation of RHOAM, not all of users
2. We want to trigger deletion of tenants based on missing user CR, not identity CR

# Verification steps
1. Provision OSD cluster
2. Download this repo https://github.com/codeready-toolchain/toolchain-e2e/tree/master/setup and from the repo run:
- `export QUAY_NAMESPACE=<YOUR_QUAY_NS>`
- `make dev-deploy-e2e`
- `go run setup/main.go --users 2 --default 2 -b 2 --custom 0 --username test1`
3. From this branch run: 
- `INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local`
- `IDENTITY_PROVIDER_NAME=rhd INSTALLATION_TYPE=multitenant-managed-api make code/run`
4. Wait for install to complete and confirm that no new routes under 3scale ns are present (for test1 users, only our regular routes should be present)
5. From toolchain repo run:
- `go run setup/main.go --users 2 --default 2 -b 2 --custom 0 --username test2`
6. Wait 3 minutes and confirm that 3scale routes for 2 new tenants have been created, confirm by navigating to the admin route and confirm that you can click on login via SSO
7. Remove user CR for one of the users of test2
8. Wait few minutes and confirm that the admin route for the user you have removed is no longer available (alternatively, login as 3scale master and confirm that the tenant is scheduled for deletion)