### PR TITLE
MGDAPI-2910 Update UIBBT alert for threescale route to allow for route without "3scale."

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -2074,12 +2074,28 @@ func (r *Reconciler) reconcilePrometheusProbes(ctx context.Context, client k8scl
 			return phase, fmt.Errorf("error creating threescale prometheus probe: %w", err)
 		}
 
-		// Create a prometheus probe for the developer console ui
+		// Get custom system-developer route by UIBBT label key
 		threescaleRoute, err := r.getThreescaleRoute(ctx, client, "system-developer", func(r routev1.Route) bool {
-			return strings.HasPrefix(r.Spec.Host, "3scale.")
+			_, ok := r.Labels["uibbt"]
+			return ok
 		})
 		if err != nil {
-			r.log.Info("Failed to retrieve threescale threescaleRoute: " + err.Error())
+			r.log.Info("Failed to get threescaleRoute by UIBBT label key: " + err.Error())
+			return integreatlyv1alpha1.PhaseInProgress, nil
+		}
+		//  If custom route does not exist - get route by 3scale Prefix
+		if threescaleRoute == nil {
+			// Create a prometheus probe for the developer console ui
+			threescaleRoute, err = r.getThreescaleRoute(ctx, client, "system-developer", func(r routev1.Route) bool {
+				return strings.HasPrefix(r.Spec.Host, "3scale.")
+			})
+			if err != nil {
+				r.log.Info("Failed to retrieve threescale threescaleRoute: " + err.Error())
+				return integreatlyv1alpha1.PhaseInProgress, nil
+			}
+		}
+		if threescaleRoute == nil {
+			r.log.Info("Failed to retrieve threescale system-developer Route with 3scale prefix or uibbt label")
 			return integreatlyv1alpha1.PhaseInProgress, nil
 		}
 		phase, err = observability.CreatePrometheusProbe(ctx, client, r.installation, cfg, "integreatly-3scale-system-developer", "http_2xx", prometheus.ProbeTargetStaticConfig{


### PR DESCRIPTION
Update UIBBT alert for threescale route to allow for routes without "3scale."

# Issue link
https://issues.redhat.com/browse/MGDAPI-2910

# What
3scale system-developer  route , that have label with key "uibbt" (for example uibbt: system-developer) - will be recognized for monitoring by ThreeScaleDeveloperUIBBT alert
  3scale system-developer  route hostname could be changed, to not have prefix 3scale; need add label "uibbt" (like uibbt: system-developer) to this route.
  Tenant system-developer route will be used for monitoring if have label "uibbt" even if 3scale original system-developer  route present.

# Verification steps
Adding custom route for 3Scale developer portal
* Method 1 of verification:  Change 3scale system-developer's route host prefix from default (3scale) to custom, and add label with key "uibbt" to customized route.  Route will be recognized by uibbt Label.
1. Check that prometheus alert ThreeScaleDeveloperUIBBT is Green and points to 3scale route, like:
probe_success{instance="https://3scale.apps.xxx.xxx.devshift.org", job="blackbox", namespace="redhat-rhoam-observability", service="3scale-developer-console-ui"}
2. Open 3scale Developer Portal /Settings Domains & Access
     - Change Developer Portal Site URL, like following
                3scale.apps.valerym02.anco.s1.devshift.org -> test1.apps.valerym02.anco.s1.devshift.org
3.  Add "uuibt" label to system-developer's route in redhat-rhoam-3scale, like in following example (route name suffix will be differ):
    - find system-developer's route:  $ oc get route -n redhat-rhoam-3scale |grep system-developer
                 zync-3scale-provider-rh9bg   test1.apps.valerym02.anco.s1.devshift.org   system-developer ....
    - edit route and add label  --  uibbt: system-developer
4. Check Prometheus Alert: ThreeScaleDeveloperUIBBT
    - Alert should be Green
    -  Probe contains updated host name, like following example:
               probe_success{instance="https://test1.apps.xxxx.anco.s1.devshift.org", job="blackbox", namespace="redhat-rhoam-observability", service="3scale-developer-console-ui"}
Notes.  In this method of verification expected alert firing after changing URL in  Developer Portal Site. After adding Label -  Alert return to Green in around 3 mins.
5. Change  Developer Portal Site URL back to 3scale, like following
                 test1.apps.valerym02.anco.s1.devshift.org -> 3scale.apps.valerym02.anco.s1.devshift.org
    - NO need add label. System-developer route will be recognized by 3scale prefix.
    -  check ThreeScaleDeveloperUIBBT alert. 
           Expected alert will be activated around a min, and  will return to Green.
           Alert will point to route with 3scale prefix.

* Method 2 of verification:
1. Check that prometheus alert ThreeScaleDeveloperUIBBT is Green and points to 3scale route, like:
probe_success{instance="https://3scale.apps.xxx.xxx.devshift.org", job="blackbox", namespace="redhat-rhoam-observability", service="3scale-developer-console-ui"}
2. Add new account 
3. Add uibbt label to system-developer's route of new account
4. Check that prometheus alert ThreeScaleDeveloperUIBBT is green and query is point to new route probe_success{instance="https://NEW.apps.xxx.xxx.devshift.org", job="blackbox", namespace="redhat-rhoam-observability", service="3scale-developer-console-ui"}