### PR TITLE
fix: change RHOAM quota in CVP to minimum value

### DIFF
--- a/config/scorecard/kuttl/rhoam-install/01-create-secrets.yaml
+++ b/config/scorecard/kuttl/rhoam-install/01-create-secrets.yaml
@@ -4,3 +4,4 @@ apply:
   - resources/secret-dms.yaml
   - resources/secret-pagerduty.yaml
   - resources/secret-smtp.yaml
+  - resources/secret-addon.yaml

--- a/config/scorecard/kuttl/rhoam-install/resources/secret-addon.yaml
+++ b/config/scorecard/kuttl/rhoam-install/resources/secret-addon.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: addon-managed-api-service-parameters
+stringData:
+  addon-managed-api-service: "1"


### PR DESCRIPTION
# Issue link
Related to https://issues.redhat.com/browse/MGDAPI-2370

# Description

As a part of install test, change RHOAM quota to "100k" from "20M" (which is the default value), so that RHOAM install requires less cluster resources

# Verification

Verified against OSD cluster by running `operator-sdk scorecard`