### PR TITLE
add required fields to CSV to pass scorecard tests

### DIFF
--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -15,7 +15,86 @@ metadata:
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
-  customresourcedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - kind: RHMIConfig
+        name: rhmiconfigs.integreatly.org
+        version: v1alpha1
+        description: RHOAMConfig is the Schema for the rhoamconfigs API
+        displayName: RHOAMConfig
+        resources:
+          - kind: ConfigMap
+            name: 'rhoam-config'
+            version: v1
+        statusDescriptors:
+          - description: The status of each of the RHMI Config CR
+            displayName: RHMI Config CR Status
+            path: status
+      - kind: RHMI
+        name: rhmis.integreatly.org
+        version: v1alpha1
+        description: RHOAM is the Schema for the RHOAM API
+        displayName: RHOAM installation
+        resources:
+          - kind: Deployment
+            name: 'rhoam-operator'
+            version: v1
+          - kind: Pod
+            name: 'rhoam'
+            version: v1
+        specDescriptors:
+          - description: namespacePrefix
+            displayName: namespacePrefix
+            path: namespacePrefix
+          - description: operatorsInProductNamespace
+            displayName: operatorsInProductNamespace
+            path: operatorsInProductNamespace
+          - description: pagerDutySecret
+            displayName: pagerDutySecret
+            path: pagerDutySecret
+          - description: selfSignedCerts
+            displayName: selfSignedCerts
+            path: selfSignedCerts
+          - description: deadMansSnitchSecret
+            displayName: deadMansSnitchSecret
+            path: deadMansSnitchSecret
+          - description: type
+            displayName: type
+            path: type
+          - description: useClusterStorage
+            displayName: useClusterStorage
+            path: useClusterStorage
+          - description: priorityClassName
+            displayName: priorityClassName
+            path: priorityClassName
+          - description: smtpSecret
+            displayName: smtpSecret
+            path: smtpSecret
+          - description: pagerDutySecret
+            displayName: pagerDutySecret
+            path: pagerDutySecret
+          - description: priorityClassName
+            displayName: priorityClassName
+            path: priorityClassName
+          - description: selfSignedCerts
+            displayName: selfSignedCerts
+            path: selfSignedCerts
+          - description: smtpSecret
+            displayName: smtpSecret
+            path: smtpSecret
+          - description: type
+            displayName: type
+            path: type
+          - description: useClusterStorage
+            displayName: useClusterStorage
+            path: useClusterStorage
+          - description: deadMansSnitchSecret
+            displayName: deadMansSnitchSecret
+            path: deadMansSnitchSecret
+        statusDescriptors:
+          - description: The status of each of the RHMI CR
+            displayName: RHMI CR Status
+            path: status
   description: RHOAM integration suite of tools
   displayName: RHOAM
   icon:

--- a/packagemanifests/managed-api-service/1.14.0/managed-api-service.clusterserviceversion.yaml
+++ b/packagemanifests/managed-api-service/1.14.0/managed-api-service.clusterserviceversion.yaml
@@ -71,11 +71,79 @@ spec:
         version: v1alpha1
         description: RHOAMConfig is the Schema for the rhoamconfigs API
         displayName: RHOAMConfig
+        resources:
+          - kind: ConfigMap
+            name: 'rhoam-config'
+            version: v1
+        statusDescriptors:
+          - description: The status of each of the RHMI Config CR
+            displayName: RHMI Config CR Status
+            path: status
       - kind: RHMI
         name: rhmis.integreatly.org
         version: v1alpha1
         description: RHOAM is the Schema for the RHOAM API
         displayName: RHOAM installation
+        resources:
+          - kind: Deployment
+            name: 'rhoam-operator'
+            version: v1
+          - kind: Pod
+            name: 'rhoam'
+            version: v1
+        specDescriptors:
+          - description: namespacePrefix
+            displayName: namespacePrefix
+            path: namespacePrefix
+          - description: operatorsInProductNamespace
+            displayName: operatorsInProductNamespace
+            path: operatorsInProductNamespace
+          - description: pagerDutySecret
+            displayName: pagerDutySecret
+            path: pagerDutySecret
+          - description: selfSignedCerts
+            displayName: selfSignedCerts
+            path: selfSignedCerts
+          - description: deadMansSnitchSecret
+            displayName: deadMansSnitchSecret
+            path: deadMansSnitchSecret
+          - description: type
+            displayName: type
+            path: type
+          - description: useClusterStorage
+            displayName: useClusterStorage
+            path: useClusterStorage
+          - description: priorityClassName
+            displayName: priorityClassName
+            path: priorityClassName
+          - description: smtpSecret
+            displayName: smtpSecret
+            path: smtpSecret
+          - description: pagerDutySecret
+            displayName: pagerDutySecret
+            path: pagerDutySecret
+          - description: priorityClassName
+            displayName: priorityClassName
+            path: priorityClassName
+          - description: selfSignedCerts
+            displayName: selfSignedCerts
+            path: selfSignedCerts
+          - description: smtpSecret
+            displayName: smtpSecret
+            path: smtpSecret
+          - description: type
+            displayName: type
+            path: type
+          - description: useClusterStorage
+            displayName: useClusterStorage
+            path: useClusterStorage
+          - description: deadMansSnitchSecret
+            displayName: deadMansSnitchSecret
+            path: deadMansSnitchSecret
+        statusDescriptors:
+          - description: The status of each of the RHMI CR
+            displayName: RHMI CR Status
+            path: status
   description: RHOAM integration suite of tools
   displayName: RHOAM
   icon:


### PR DESCRIPTION
# Issue link
[JIRA](https://issues.redhat.com/browse/MGDAPI-3090)

Scorecard tests are failing validation because of issues in the CSV

# Verification steps
Checkout this branch
Ensure targeting an OSD cluster
From the root of the branch run `make bundle`
Copy the manifest files from the [1.14](https://github.com/briangallagher/integreatly-operator/tree/MGDAPI-3090-scorecard/packagemanifests/managed-api-service/1.14.0) folder into the manifests subfolder of the bundle folder generated from the previous command.
Create [config.yaml](https://gist.github.com/briangallagher/e8760d23530a746115cb0aaf79551cb6) under bundle > tests > scorecard > config.yaml
Run `operator-sdk scorecard ./` from the bundle folder and ensure no errors. Search for "errors" in the output. 

Confirm that the errors specified in the JIRA do not appear. 

Run:
`OLM_TYPE=managed-api-service SEMVER=1.15.0 make release/prepare`
Compare CSV 1.15 and 1.14 - verify differences are as expected.

Run:
`OLM_TYPE=managed-api-service BUNDLE_VERSIONS=1.15.0 ORG=<YOUR_ORG> make create/olm/bundle`
To confirm bundle and index images generate
Confirm also `rhmi-operators` Catalog Source created

**Build and push RHOAM 1.15 image**
INSTALLATION_TYPE=managed-api ORG=<YOUR_ORG> make image/build/push

**Install RHOAM**
INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local
Install RHOAM through Console
Confirm install. 




