### PR TITLE
Mgdapi 3087 - User with no identities - Edge case

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -386,7 +386,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 
 	// Sync keycloak with openshift users
-	users, err := syncronizeWithOpenshiftUsers(ctx, keycloakUsers, serverClient, r.Config.GetNamespace(), r.Installation)
+	users, err := syncronizeWithOpenshiftUsers(ctx, keycloakUsers, serverClient, r.Config.GetNamespace(), r.Installation, r.Log)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to synchronize the users: %w", err)
 	}
@@ -486,11 +486,11 @@ func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []user
 	return added, deleted
 }
 
-func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string, installation *integreatlyv1alpha1.RHMI) ([]keycloak.KeycloakAPIUser, error) {
+func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string, installation *integreatlyv1alpha1.RHMI, logger l.Logger) ([]keycloak.KeycloakAPIUser, error) {
 	var openshiftUsers *usersv1.UserList
 	var err error
 
-	openshiftUsers, err = userHelper.GetUsersInActiveIDPs(ctx, serverClient)
+	openshiftUsers, err = userHelper.GetUsersInActiveIDPs(ctx, serverClient, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get users in active IDPs")
 	}

--- a/pkg/resources/user/userHelper_test.go
+++ b/pkg/resources/user/userHelper_test.go
@@ -144,7 +144,71 @@ func TestGetUsersInActiveIDPs(t *testing.T) {
 			ExpectError: false,
 		},
 		{
-			Name:       "Test get email from identity",
+			Name:       "Test orphaned identities have no side affect",
+			FakeLogger: getLogger(),
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&userv1.Identity{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active-idp",
+					},
+					ProviderName: "exists",
+				},
+				&userv1.User{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "exists",
+					},
+					Identities: []string{"active-idp"},
+				},
+				&userv1.Identity{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "inactive-idp",
+					},
+					ProviderName: "non-existent",
+				},
+				&userv1.User{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "non-existent",
+					},
+					Identities: []string{"inactive-idp"},
+				},
+				&userv1.Identity{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "orphaned-identity-1",
+					},
+					ProviderName: "exist",
+				},
+				&userv1.Identity{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "orphaned-identity-2",
+					},
+					ProviderName: "exist",
+				},
+				&configv1.OAuth{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.OAuthSpec{
+						IdentityProviders: []configv1.IdentityProvider{
+							{Name: "exists"},
+						},
+					},
+				}),
+			ExpectedUsers: &userv1.UserList{
+				TypeMeta: v1.TypeMeta{},
+				ListMeta: v1.ListMeta{},
+				Items: []userv1.User{
+					userv1.User{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "exists",
+						},
+						Identities: []string{"active-idp"},
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Name:       "Test get user with active idp",
 			FakeLogger: getLogger(),
 			FakeClient: fake.NewFakeClientWithScheme(scheme, &userv1.Identity{
 				ObjectMeta: v1.ObjectMeta{

--- a/pkg/resources/user/userHelper_test.go
+++ b/pkg/resources/user/userHelper_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	userv1 "github.com/openshift/api/user/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -85,11 +86,66 @@ func TestGetUsersInActiveIDPs(t *testing.T) {
 	tests := []struct {
 		Name          string
 		FakeClient    k8sclient.Client
+		FakeLogger    l.Logger
 		ExpectedUsers *userv1.UserList
 		ExpectError   bool
 	}{
 		{
-			Name: "Test get email from identity",
+			Name:       "Test get user with no associated identity",
+			FakeLogger: getLogger(),
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&userv1.Identity{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "active-idp",
+					},
+					ProviderName: "exists",
+				},
+				&userv1.User{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "exists",
+					},
+					Identities: []string{"active-idp"},
+				},
+				&userv1.User{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "exits with no identity",
+					},
+					Identities: []string{"missing-identity"},
+				},
+				&configv1.OAuth{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
+					Spec: configv1.OAuthSpec{
+						IdentityProviders: []configv1.IdentityProvider{
+							{Name: "exists"},
+						},
+					},
+				},
+			),
+			ExpectedUsers: &userv1.UserList{
+				TypeMeta: v1.TypeMeta{},
+				ListMeta: v1.ListMeta{},
+				Items: []userv1.User{
+					userv1.User{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "exists",
+						},
+						Identities: []string{"active-idp"},
+					},
+					userv1.User{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "exits with no identity",
+						},
+						Identities: []string{""},
+					},
+				},
+			},
+			ExpectError: false,
+		},
+		{
+			Name:       "Test get email from identity",
+			FakeLogger: getLogger(),
 			FakeClient: fake.NewFakeClientWithScheme(scheme, &userv1.Identity{
 				ObjectMeta: v1.ObjectMeta{
 					Name: "active-idp",
@@ -141,7 +197,7 @@ func TestGetUsersInActiveIDPs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			got, err := GetUsersInActiveIDPs(context.TODO(), tt.FakeClient)
+			got, err := GetUsersInActiveIDPs(context.TODO(), tt.FakeClient, tt.FakeLogger)
 			if (err != nil) != tt.ExpectError {
 				t.Errorf("GetUsersInActiveIDPs() error = %v, ExpectedErr %v", err, tt.ExpectError)
 				return
@@ -568,4 +624,8 @@ func confirmThatUsersHaveCorrectEmailAddressesSet(users []MultiTenantUser) error
 	}
 
 	return nil
+}
+
+func getLogger() l.Logger {
+	return l.NewLoggerWithContext(l.Fields{l.ProductLogContext: integreatlyv1alpha1.ProductRHSSO})
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-3087

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
During the upgrade from 1.12 to 1.13 there was two unexpected scenario found which the cluster users could be in.
1. There may be more identity CR's than there are user CR's
2. There may be user CR's with no existing identity CR

The second scenario will cause the operator to go into a loop it can not recover from and this stops any upgrade from completing. 

This PR adds a unit test to ensure changes that affect the first scenario will be caught in the future. Changes in the code base was needed to fix the second scenario. This is also now covered with a unit test.  The number api calls have being reduced to help proformance in dev sandbox

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

* Install rhoam 1.14 using this index `quay.io/jfitzpat/managed-api-service-index:v1.14.0`
* Wait for install to complete
* Set up the testing IDP
* Log into 3scale with one of the testing users. (wait for account to be created)
* Remove the identity for that that user (`oc get identities` returns the list of current identities) 
* A error message like the following should be seen in the rhoam operator logs. Note this error will stop the operator from upgrading. The rhoam CR will also change its status to `authentication`
```
2021-11-15T11:58:40.503Z	DEBUG	controller-runtime.manager.events	Warning	{"object": {"kind":"RHMI","namespace":"redhat-rhoam-operator","name":"rhoam","uid":"bc065302-9d86-4d27-a423-f9189d89f303","apiVersion":"integreatly.org/v1alpha1","resourceVersion":"153963"}, "reason": "ProcessingError", "message": "Failed to reconcile components:\nfailed to synchronize the users: could not get users in active IDPs: could not get identities for user test-user01: could not get identity testing-idp:5107cc8b-da5d-4aca-87d7-fc8336687f62 for user test-user01: identities.user.openshift.io \"testing-idp:5107cc8b-da5d-4aca-87d7-fc8336687f62\" not found"}

```
* Fix the current identity issue by logging in as the user once again.
* Upgrade the operator to use the image for PR `oc patch catalogsources rhoam-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.15.0-3087"}]'`
* Wait of upgrade to complete
* Remove the identity CR for the test user once again
* Expected: Operator should print a warning message about the missing identity but the reconcile loop will continue.
```
WARN[2021-11-15T12:07:26Z] could not get identities for user test-user01  product=rhsso
```