### PR TITLE
removed test-containers-managed-api because it is no longer needed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,13 +270,6 @@ test/products:
 	mkdir -p $(TEST_RESULTS_DIR)
 	delorean pipeline product-tests --test-config ./test-containers.yaml --output $(TEST_RESULTS_DIR) --namespace test-products
 
-.PHONY: test/rhoam/products
-test/rhoam/products: export WATCH_NAMESPACE := $(NAMESPACE)
-test/rhoam/products:
-	mkdir -p $(TEST_RESULTS_DIR)
-	delorean pipeline product-tests --test-config ./test-containers-managed-api.yaml --output $(TEST_RESULTS_DIR) --namespace test-products
-
-
 .PHONY: cluster/deploy
 cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare deploy/integreatly-rhmi-cr.yml
 	@ - oc create -f config/rbac/service_account.yaml

--- a/test-containers-managed-api.yaml
+++ b/test-containers-managed-api.yaml
@@ -1,9 +1,0 @@
----
-tests:
-  - name: 3scale-test
-    image: quay.io/rh_integration/3scale-testsuite:2.9.0
-    timeout: 3600
-    imagePullSecretEnvVar: "RH_INTEGRATION"
-    envVars:
-      - name: NAMESPACE
-        value: redhat-rhmi-3scale


### PR DESCRIPTION
in [this PR](https://github.com/integr8ly/integreatly-operator/pull/2272) we agreed that this file will be generated dynamically and outside of our use it's no longer needed. This is the PR to remove that file.