### PR TITLE
ensure missing identities do not block the install

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -386,7 +386,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	}
 
 	// Sync keycloak with openshift users
-	users, err := syncronizeWithOpenshiftUsers(ctx, keycloakUsers, serverClient, r.Config.GetNamespace(), r.Installation)
+	users, err := syncronizeWithOpenshiftUsers(ctx, keycloakUsers, serverClient, r.Config.GetNamespace(), r.Installation, r.Log)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to synchronize the users: %w", err)
 	}
@@ -486,11 +486,11 @@ func getUserDiff(keycloakUsers []keycloak.KeycloakAPIUser, openshiftUsers []user
 	return added, deleted
 }
 
-func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string, installation *integreatlyv1alpha1.RHMI) ([]keycloak.KeycloakAPIUser, error) {
+func syncronizeWithOpenshiftUsers(ctx context.Context, keycloakUsers []keycloak.KeycloakAPIUser, serverClient k8sclient.Client, ns string, installation *integreatlyv1alpha1.RHMI, logger l.Logger) ([]keycloak.KeycloakAPIUser, error) {
 	var openshiftUsers *usersv1.UserList
 	var err error
 
-	openshiftUsers, err = userHelper.GetUsersInActiveIDPs(ctx, serverClient)
+	openshiftUsers, err = userHelper.GetUsersInActiveIDPs(ctx, serverClient, logger)
 	if err != nil {
 		return nil, errors.Wrap(err, "could not get users in active IDPs")
 	}


### PR DESCRIPTION
# Issue link
[MGDAPI_3087](https://issues.redhat.com/browse/MGDAPI-3087)

# Verification steps
Install RHOAM based on this branch
Install the testing IDP with 10 users
Login to OpenShift as testuser01, testuser02, testuser03
Verify a User CR and Identity CR exist for each
For test_user01, delete the identity id on the user 
For test_user02, delete the identity cr 
Leave test_user03 as is
Ensure only test_user03 gets created as a Keycloak User CR in rhsso
After confirming delete the identity for test_user03
Verify that the Keycloak User CR also gets deleted


