### PR TITLE
MGDAPI-3146 - Self-Managed Apicast test full Automation and Pipeline integration

### DIFF
--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -88,6 +88,7 @@ var (
 				{"H07 - ThreeScale User Promotion", Test3ScaleUserPromotion},
 				{"Verify Network Policy allows cross NS access to SVC", TestNetworkPolicyAccessNSToSVC},
 				{"C19 - Validate creation of invalid username triggers alert", TestInvalidUserNameAlert},
+				{"H24 - Verify selfmanaged Apicast", TestSelfmanagedApicast},
 				// Keep H11 as last 3scale IDP Test as test causes 3scale deployments to be rescaled at the end of test
 				// Can potentially cause subsequent tests be flaky due to waiting for 3scale deployments to complete
 				{"H11 - Verify 3scale SMTP config", Test3ScaleSMTPConfig},

--- a/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/test.sh
+++ b/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/test.sh
@@ -2,19 +2,17 @@
 
 #  Prerequisites:
 # 		oc logged as cluster admin (kubeadmin)
-#  Recommended, before running current version of script, to have following:
-# 		Password for customer, if testing-idp is not yet available.
+#  Recommended, before running the script in interactive mode (- interactive-mode=true ), to have following:
 # 		Customer Token, if testing-idp and customer-admin users are already available.
 # 		Open 3scale Admin Portal, to be ready to put updates. Details will be notified by script.
-
+#  If script executed in batch mode (-interactive-mode=false) - no input required, just to be logged as admin.
 
 go run h24-verify-selfmanaged-apicast-and-custom-policy.go \
 -apicast-operator-version="0.5.0" \
 -apicast-image-stream-tag="3scale2.11.0" \
 -apicast-namespace="selfmanaged-apicast" \
--create-testing-idp=false \
 -use-customer-admin-user=true \
--promote-manually=true \
+-interactive-mode=false \
 --namespace-prefix redhat-rhoam- \
 
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3146

# What
Self-Managed Apicast test full Automation and Pipeline integration  
This task is based on Spike task - https://issues.redhat.com/browse/MGDAPI-3037  
This task is follow on https://issues.redhat.com/browse/MGDAPI-1920 
Test is integrated into Pipeline in functional tests:  {Description: "H24 - Verify selfmanaged Apicast", Test: TestSelfmanagedApicast} - test/functional/selfmanaged_apicast.go 
Standalone script is also available, and could be useful for investigation, has 2 modes - interactive and batch (similar to TestSelfmanagedApicast) - test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/h24-verify-selfmanaged-apicast-and-custom-policy.go

# Verification steps
1. Run as E2E single step:  TEST=H24 INSTALLATION_TYPE=managed-api make test/e2e/single
2. Run in pipeline
3. Run standalone script in batch and interactive mode: cd integreatly-operator/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy; ./test
4. See details for runing tests in Doc: test-cases/tests/products/h24-verify-selfmanaged-apicast-and-custom-policy.md
