### PR TITLE
mgdapi-1163: update rbac rules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -334,7 +334,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/quota cluster/prepare/delorean cluster/prepare/croaws
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/quota cluster/prepare/delorean cluster/prepare/croaws cluster/prepare/rbac/dedicated-admins
 	@ - oc create -f config/rbac/service_account.yaml -n $(NAMESPACE)
 	@ - $(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc create -f -
 
@@ -385,6 +385,10 @@ ifneq ( ,$(findstring image_mirror_mapping,$(IMAGE_MAPPINGS)))
 	$(MAKE) cluster/cleanup/serviceaccount
 endif
 
+.PHONY:cluster/prepare/rbac/dedicated-admins
+cluster/prepare/rbac/dedicated-admins:
+	@-oc create -f config/rbac/dedicated_admins_rbac.yaml
+
 .PHONY: cluster/cleanup
 cluster/cleanup: kustomize
 	@-oc delete rhmis $(INSTALLATION_NAME) -n $(NAMESPACE) --timeout=240s --wait
@@ -414,6 +418,10 @@ cluster/cleanup/crds:
 	@-oc delete crd rhmis.integreatly.org
 	@-oc delete crd webapps.integreatly.org
 	@-oc delete crd rhmiconfigs.integreatly.org
+
+.PHONY:cluster/cleanup/rbac/dedicated-admins
+cluster/cleanup/rbac/dedicated-admins:
+	@-oc delete -f config/rbac/dedicated_admins_rbac.yaml
 
 .PHONY: deploy/integreatly-rhmi-cr.yml
 deploy/integreatly-rhmi-cr.yml:

--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ make test/unit
 
 ### E2E tests
 
+A `BYPASS_STORAGE_TYPE_CHECK=true` flag is used to allow test to run when the operator is installed using cluster storage.
+This may cause side effects related to the cloud resources test.
+
 To run E2E tests against a clean OpenShift cluster using operator-sdk, build and push an image 
 to your own quay repo, then run the command below changing the installation type based on which type you are testing:
 ```

--- a/config/rbac/dedicated_admins_rbac.yaml
+++ b/config/rbac/dedicated_admins_rbac.yaml
@@ -1,0 +1,39 @@
+# required only when installing using make code/run
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  name: rhoam-dedicated-admins-role
+rules:
+  - apiGroups:
+      - "integreatly.org"
+    resources:
+      - "rhmis"
+      - "rhmiconfigs"
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - "apiextensions.k8s.io"
+    resourceNames:
+      - "rhmis.integreatly.org"
+      - "rhmiconfigs.integreatly.org"
+    resources:
+      - "customresourcedefinitions"
+    verbs:
+      - get
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: rhoam-dedicated-admins-role-binding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: dedicated-admins
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: rhoam-dedicated-admins-role

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -272,8 +272,7 @@ func verifyCRUDLPermissions(t TestingTB, openshiftClient *resources.OpenshiftCli
 	}
 
 	if resp.StatusCode != expectedPermission.ExpectedListStatusCode {
-		t.Skip("Skipping due to a flaky behavior on managed-api addon install, JIRA: https://issues.redhat.com/browse/INTLY-10156")
-		// t.Errorf("unexpected response from LIST request, expected %d status but got: %v", expectedPermission.ExpectedListStatusCode, resp)
+		t.Errorf("unexpected response from LIST request, expected %d status but got: %v", expectedPermission.ExpectedListStatusCode, resp)
 	}
 
 	// Perform CREATE Request

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -227,10 +227,10 @@ func verifyDedicatedAdminRHMIConfigPermissions(t TestingTB, openshiftClient *res
 
 	expectedPermission := ExpectedPermissions{
 		ExpectedCreateStatusCode: 403,
-		ExpectedReadStatusCode:   403,
+		ExpectedReadStatusCode:   200,
 		ExpectedUpdateStatusCode: 403,
 		ExpectedDeleteStatusCode: 403,
-		ExpectedListStatusCode:   403,
+		ExpectedListStatusCode:   200,
 		ListPath:                 fmt.Sprintf(resources.PathListRHMIConfig, RHMIOperatorNamespace),
 		GetPath:                  fmt.Sprintf(resources.PathGetRHMIConfig, RHMIOperatorNamespace, "rhmi-config"),
 		ObjectToCreate: &integreatlyv1alpha1.RHMIConfig{

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -67,7 +67,8 @@ func TestAPIs(t *testing.T) {
 			t.Fatalf("error getting RHMI CR: %v", err)
 		}
 		if rhmi.Spec.UseClusterStorage == "true" {
-			t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false")
+			t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false" +
+				"\nOr set BYPASS_STORAGE_TYPE_CHECK=true to bypass check")
 		}
 	}
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-1163

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
When installed via addon-flow, manual creation of catalogSource or local deployment the dedicated admins get permissions on the rhmi ans rhmiconfig types.

This PR brings in line the permissions give to dedicated admins for local development with that give for installs via the addon-flow. 

The manual creation of the catalogSource gives higher permissions than installing via the addon-flow. This has not being address in this case. One of the extra permissions is `Create` which the addon-flow will never have. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Best to test with fresh clusters, you will need two.
- Install rhoam using the addon-flow
- set up the testing IDP 
- run ` ACK_GINKGO_DEPRECATIONS=1.16.4 BYPASS_STORAGE_TYPE_CHECK=true INSTALLATION_TYPE=managed-api TEST=B04 make test/e2e/single`
- Expected: Test should pass

- On fresh cluster install rhoam from this branch with running the operator locally
- Set up the testing IDP
- run ` ACK_GINKGO_DEPRECATIONS=1.16.4 BYPASS_STORAGE_TYPE_CHECK=true INSTALLATION_TYPE=managed-api TEST=B04 make test/e2e/single`
- Expected: Test should pass
