### PR TITLE
MGDAPI-3192

### DIFF
--- a/pkg/config/cloudresources.go
+++ b/pkg/config/cloudresources.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -68,6 +69,14 @@ func (c *CloudResources) SetStrategiesConfigMapName(strategiesConfigMapName stri
 
 func (c *CloudResources) GetStrategiesConfigMapName() string {
 	return c.Config["STRATEGIES_CONFIG_MAP_NAME"]
+}
+
+func (c *CloudResources) SetReconcileCount(reconcileCount int) {
+	c.Config["RECONCILE_COUNT"] = fmt.Sprintf("%d", reconcileCount)
+}
+
+func (c *CloudResources) GetReconcileCount() string {
+	return c.Config["RECONCILE_COUNT"]
 }
 
 func (c *CloudResources) Read() ProductConfig {


### PR DESCRIPTION
fix to add additional reconciles on start up of the operator, allows for additional time on the upgrade
should be removed at a later date

# Issue link
https://issues.redhat.com/browse/MGDAPI-3192

# What
Add a hack to give cloud resources reconciler 5 reconciles before it reports that it's completed.


# Verification steps
Using CCS Cluster

For full upgrade verification which is recommended follow steps in -> #2291