### PR TITLE
MGDAPI-1710 fix: 3scale pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -102,13 +102,17 @@ endif
 setup/moq:
 	GO111MODULE=off go get github.com/matryer/moq
 
+.PHONY: setup/service_account/oc_login
+setup/service_account/oc_login:
+	@oc login --token=$(shell sh -c "oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE}") --server=$(shell sh -c "oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*'") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
+
 .PHONY: setup/service_account
 setup/service_account: kustomize
 	@-oc new-project $(NAMESPACE)
 	@oc project $(NAMESPACE)
 	@-oc create -f config/rbac/service_account.yaml -n $(NAMESPACE)
-	@$(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc replace --force -f -	
-	@oc login --token=$(shell oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE}) --server=$(shell sh -c "oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*'") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
+	@$(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc replace --force -f -
+	$(MAKE) setup/service_account/oc_login
 
 .PHONY: setup/git/hooks
 setup/git/hooks:
@@ -278,7 +282,7 @@ test/rhoam/products:
 
 
 .PHONY: cluster/deploy
-cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare deploy/integreatly-rhmi-cr.yml
+cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare cluster/prepare/rbac/dedicated-admins deploy/integreatly-rhmi-cr.yml
 	@ - oc create -f config/rbac/service_account.yaml
 	@ - cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_FORMAT}
 	@ - $(KUSTOMIZE) build config/redhat-$(INSTALLATION_SHORTHAND) | oc apply -f -

--- a/Makefile
+++ b/Makefile
@@ -104,7 +104,7 @@ setup/moq:
 
 .PHONY: setup/service_account/oc_login
 setup/service_account/oc_login:
-	@oc login --token=$(shell sh -c "oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE}") --server=$(shell sh -c "oc cluster-info | grep -Eo 'https?://[-a-zA-Z0-9\.:]*'") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
+	@oc login --token=$(shell sh -c "oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE}") --server=$(shell sh -c "oc whoami --show-server") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
 
 .PHONY: setup/service_account
 setup/service_account: kustomize


### PR DESCRIPTION
### Description

https://issues.redhat.com/browse/MGDAPI-1710

The pipeline for deploying RHOAM with 3scale images was failing on logging into a cluster as rhmi-operator serviceaccount.
```bash
$ make cluster/deploy
...
You must obtain an API token by visiting https://oauth-openshift.apps.<REDACTED>.org/oauth/token/request
make[1]: *** [Makefile:111: setup/service_account] Error 1
make[1]: Leaving directory '/home/jenkins/agent/workspace/ManagedAPI/managed-api-install-3scale/integreatly-operator'
make: *** [Makefile:383: cluster/prepare/delorean/pullsecret] Error 2

ERROR: script returned exit code 2
```
The error was caused by [`oc serviceaccounts get-token`](https://github.com/integr8ly/integreatly-operator/pull/2351/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L111) command that was always failing, when the make target, containing this command, was run for the first time. 

Separating the `oc` command to another make target resolves the issue.

### Additional changes

Included `cluster/prepare/rbac/dedicated-admins` make target in `cluster/deploy` target, which is used by our pipelines and e2e prow jobs


### Verification
Verified with [the pipeline run](https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/598) (see the log attached in the MR description)