### PR TITLE
fix prepare release script

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -97,7 +97,7 @@ set_installation_type() {
           echo "using default INSTALLATION_TYPE found in deploy/operator.yaml"
           ;;
         "managed-api-service")
-          yq e -i '(.spec.install.spec.deployments[0].spec.template.spec.containers[0].env.[] | select(.name=="INSTALLATION_TYPE") | .value) = "managed-api" '  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+          yq e -i '(.spec.install.spec.deployments[0].spec.template.spec.containers[0].env.[] | select(.name=="INSTALLATION_TYPE") | .value) = "managed-api" ' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
           ;;
         *)
           echo "No INSTALLATION_TYPE found for install type : $(OLM_TYPE)"
@@ -140,8 +140,8 @@ set_clusterPermissions() {
       ;;
     "managed-api-service")
       echo "Updating permissions"
-      yq e -i  '.spec.maintainers[0].email="rhoam-support@redhat.com"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
-      yq e -i   '.spec.maintainers[0].name="rhoam"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+      yq e -i '.spec.maintainers[0].email="rhoam-support@redhat.com"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+      yq e -i '.spec.maintainers[0].name="rhoam"' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
       ;;
   esac
 }
@@ -150,8 +150,8 @@ set_images() {
   case $OLM_TYPE in
    "integreatly-operator")
   : "${IMAGE_TAG:=v${SEMVER}}"
-  yq e -i  ".spec.install.spec.deployments.[0].spec.template.spec.containers[0].image=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
-  yq e -i  ".metadata.annotations.containerImage=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".spec.install.spec.deployments.[0].spec.template.spec.containers[0].image=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".metadata.annotations.containerImage=\"quay.io/$ORG/$OLM_TYPE:$IMAGE_TAG\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
   ;;
   "managed-api-service")
    : "${IMAGE_TAG:=rhoam-v${SEMVER}}"
@@ -164,7 +164,7 @@ set_images() {
 set_csv_service_affecting_field() {
   local value=$1
   echo "Update CSV for release $SEMVER to be 'serviceAffecting: $value'"
-  yq e -i   ".metadata.annotations.serviceAffecting= $value "  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".metadata.annotations.serviceAffecting= \"$value\" " packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
 }
 
 # Due to a quirk in operator-sdk v1.2.0, the `replaces` field in the generated CSV is taken from the current version in
@@ -174,8 +174,8 @@ set_csv_service_affecting_field() {
 # version in the base CSV is the same as the new version, so operator-sdk generates a CSV without the `replaces` field.
 # This function addresses that by adding the `replaces` field if it was removed.
 check_csv_replaces_field() {
-  if [[ -z $(yq e  '.spec.replaces' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml) ]]; then
-    yq e -i ".spec.replaces=${PREVIOUS_REPLACES_VALUE}"  packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
+  if [[ $(yq e '.spec.replaces' packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml) == null ]]; then
+    yq e -i ".spec.replaces=\"${PREVIOUS_REPLACES_VALUE}\"" packagemanifests/$OLM_TYPE/${VERSION}/$OLM_TYPE.clusterserviceversion.yaml
   fi
 }
 
@@ -235,8 +235,7 @@ yq e -i ".projectName=\"$current_project_name\"" PROJECT
 # Ensure the RHMI package is `integreatly`: The operator-sdk CLI will take the
 # package name from the PROJECT file, so in the case of RHMI it will set it
 # incorrectly to `integreatly-operator`
-
-yq e -i  '.packageName="integreatly"' packagemanifests/integreatly-operator/integreatly-operator.package.yaml
+yq e -i '.packageName="integreatly"' packagemanifests/integreatly-operator/integreatly-operator.package.yaml
 
 # Ensure code is formatted correctly
 "${GOFMT[@]}" -w `find . -type f -name '*.go' -not -path "./vendor/*"`


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2585

This is a cherry pick of : https://github.com/integr8ly/integreatly-operator/pull/2122

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

With the bump to `yq v4`, `null` seems to be returned when trying to get a field that does not exist in a yaml file.

This had caused the `-z ` check to always be true in  the `check_csv_replaces_field()` function, which caused the `replaces` field to be missing whenever existing CSVs need to be re-generated such as from RC releases to final releases.

 To fix this:
* The above checks for null being returned instead

Additionally:
* Removed some unneeded extra whitespaces

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
##  Verify issue in master
* Checkout master
* Generate new release
```
SEMVER=1.13.0 OLM_TYPE=managed-api-service ORG=kevfan scripts/prepare-release.sh
```
* Verify `replaces` field is **present**
* Re-generated release
```
SEMVER=1.13.0 OLM_TYPE=managed-api-service ORG=kevfan scripts/prepare-release.sh
```
* Verify `replaces` field is **missing**
* Revert / Delete generated release
## Verify branch fixes issue
* Checkout this branch
* Generated a new release
```
SEMVER=1.13.0 OLM_TYPE=managed-api-service ORG=kevfan scripts/prepare-release.sh
```
* Verify `replaces` field is **present**
* Re-generate release
```
SEMVER=1.13.0 OLM_TYPE=managed-api-service ORG=kevfan scripts/prepare-release.sh
```
* Verify `replaces` field is still **present** (will be the last field at the bottom of the csv yaml file)