### PR TITLE
MGDAPI-1162 fix c04 a26, osde2e: useclusterstorage

### DIFF
--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -44,12 +44,12 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 		}
 
 		// Patch RHMI CR CR with cluster storage
-		if rhmi.Spec.UseClusterStorage == "true" || rhmi.Spec.UseClusterStorage == "" {
+		if rhmi.Spec.UseClusterStorage == "false" || rhmi.Spec.UseClusterStorage == "" {
 			rhmiCR := fmt.Sprintf(`{
 				"apiVersion": "integreatly.org/v1alpha1",
 				"kind": "RHMI",
 				"spec": {
-					"useClusterStorage" : "false"
+					"useClusterStorage" : "true"
 				}
 			}`)
 

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -116,7 +116,7 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 					Namespace: common.RHMIOperatorNamespace,
 				},
 				Data: map[string][]byte{
-					"url": []byte("test"),
+					"url": []byte("https://dms.example.com"),
 				},
 			}
 			if err := ctx.Client.Create(goctx.TODO(), dms.DeepCopy()); err != nil {

--- a/test/osde2e/suite_test.go
+++ b/test/osde2e/suite_test.go
@@ -2,17 +2,18 @@ package osde2e
 
 import (
 	"fmt"
+	"os"
+	"testing"
+
 	. "github.com/onsi/ginkgo"
 	"github.com/onsi/ginkgo/reporters"
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	"testing"
 
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/test/common"
@@ -103,6 +104,7 @@ func setVars(possibleWN, possibleNS string, t *testing.T) {
 	common.RHMIOperatorNamespace = common.NamespacePrefix + "operator"
 	common.MonitoringOperatorNamespace = common.NamespacePrefix + "middleware-monitoring-operator"
 	common.MonitoringFederateNamespace = common.NamespacePrefix + "middleware-monitoring-federate"
+	common.ObservabilityNamespacePrefix = common.NamespacePrefix + "observability-"
 	common.ObservabilityOperatorNamespace = common.NamespacePrefix + "observability-operator"
 	common.ObservabilityProductNamespace = common.NamespacePrefix + "observability"
 	common.AMQOnlineOperatorNamespace = common.NamespacePrefix + "amq-online"
@@ -129,4 +131,5 @@ func setVars(possibleWN, possibleNS string, t *testing.T) {
 	common.Marin3rOperatorNamespace = common.NamespacePrefix + "marin3r-operator"
 	common.Marin3rProductNamespace = common.NamespacePrefix + "marin3r"
 	common.CustomerGrafanaNamespace = common.NamespacePrefix + "customer-monitoring-operator"
+	common.SMTPSecretName = common.NamespacePrefix + "smtp"
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1162

# What
* changed useClusterStorage to `true` for osde2e (RHOAM) job based on agreement in a team discussion
* fixed c04 & a26 tests that were failing because of missing variables in osde2e tests

# Verification steps
I updated `:osde2e` image tag in quay.io with the image I built from this PR and triggered osde2e job [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24200/rehearse-24200-osde2e-stage-aws-addon-integreatly-operator/1478506829406277632). If it passes, then it should be safe to merge this PR
