### PR TITLE
fix: osde2e, clusterStorage=true

### DIFF
--- a/test/common/scale_up_replicas_apicurito.go
+++ b/test/common/scale_up_replicas_apicurito.go
@@ -18,7 +18,6 @@ var (
 	scaleUpApicuritoReplicas   = 3
 	scaleDownApicuritoReplicas = 1
 	apicuritoName              = "apicurito"
-	apicuritoNamespace         = NamespacePrefix + "apicurito"
 	retryIntervalApicurito     = time.Second * 20
 	timeoutApicurito           = time.Minute * 7
 	requestURLApicturito       = "/apis/apicur.io/v1alpha1"
@@ -26,7 +25,6 @@ var (
 )
 
 func TestReplicasInApicurito(t TestingTB, ctx *TestingContext) {
-
 	apicuritoCR, err := getApicurito(ctx.Client)
 	if err != nil {
 		t.Fatalf("failed to get Apicurito : %v", err)
@@ -68,9 +66,9 @@ func checkReplicasAreReady(dynClient *TestingContext, t TestingTB, replicas int3
 
 	err := wait.Poll(retryInterval, timeout, func() (done bool, err error) {
 
-		deployment, err := dynClient.KubeClient.AppsV1().Deployments(apicuritoNamespace).Get(goctx.TODO(), apicuritoName, metav1.GetOptions{})
+		deployment, err := dynClient.KubeClient.AppsV1().Deployments(ApicuritoProductNamespace).Get(goctx.TODO(), apicuritoName, metav1.GetOptions{})
 		if err != nil {
-			t.Errorf("Failed to get Deployment %s in namespace %s with error: %s", apicuritoName, apicuritoNamespace, err)
+			t.Errorf("Failed to get Deployment %s in namespace %s with error: %s", apicuritoName, ApicuritoProductNamespace, err)
 		}
 		if deployment.Status.ReadyReplicas == replicas {
 			t.Logf("Replicas Ready %v", deployment.Status.ReadyReplicas)
@@ -87,7 +85,7 @@ func checkReplicasAreReady(dynClient *TestingContext, t TestingTB, replicas int3
 func getApicurito(dynClient k8sclient.Client) (apicuritov1alpha1.Apicurito, error) {
 	apicuritoCR := &apicuritov1alpha1.Apicurito{}
 
-	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: apicuritoName, Namespace: apicuritoNamespace}, apicuritoCR); err != nil {
+	if err := dynClient.Get(goctx.TODO(), types.NamespacedName{Name: apicuritoName, Namespace: ApicuritoProductNamespace}, apicuritoCR); err != nil {
 		return *apicuritoCR, err
 	}
 
@@ -109,7 +107,7 @@ func updateApicurito(ctx *TestingContext, replicas int32, t TestingTB) (apicurit
 	request := ctx.ExtensionClient.RESTClient().Patch(types.MergePatchType).
 		Resource(kindApicurito).
 		Name(apicuritoName).
-		Namespace(apicuritoNamespace).
+		Namespace(ApicuritoProductNamespace).
 		RequestURI(requestURLApicturito).Body(replicaBytes).Do(goctx.TODO())
 	_, err := request.Raw()
 

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -44,12 +44,12 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 		}
 
 		// Patch RHMI CR CR with cluster storage
-		if rhmi.Spec.UseClusterStorage == "true" || rhmi.Spec.UseClusterStorage == "" {
+		if rhmi.Spec.UseClusterStorage == "false" || rhmi.Spec.UseClusterStorage == "" {
 			rhmiCR := fmt.Sprintf(`{
 				"apiVersion": "integreatly.org/v1alpha1",
 				"kind": "RHMI",
 				"spec": {
-					"useClusterStorage" : "false"
+					"useClusterStorage" : "true"
 				}
 			}`)
 

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -116,7 +116,7 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 					Namespace: common.RHMIOperatorNamespace,
 				},
 				Data: map[string][]byte{
-					"url": []byte("test"),
+					"url": []byte("https://dms.example.com"),
 				},
 			}
 			if err := ctx.Client.Create(goctx.TODO(), dms.DeepCopy()); err != nil {


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1162

# What
* changed useClusterStorage to `true` for osde2e (RHMI) job based on agreement in a team discussion
* fixed apicurito scaling test that was failing in osde2e

# Verification steps
I updated `:osde2e-rhmi` image tag in quay.io with the image I built from this PR and triggered osde2e job [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24200/rehearse-24200-osde2e-stage-aws-addon-integreatly-operator-rhmi/1478506829561466880). If it passes, then it should be safe to merge this PR
