### PR TITLE
MGDAPI-3203 - emit metric around vpc limits hit

### DIFF
--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -3,8 +3,9 @@ package cloudresources
 import (
 	"context"
 	"fmt"
-	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	"strings"
+
+	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -59,6 +60,15 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
+					}, {
+						Alert: "RHMICloudResourceOperatorVPCActionFailed",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlRHMICloudResourceOperatorVPCActionFailed,
+							"message": "CRO failed to perform an action on a VPC.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("cro_vpc_action{namespace='%s', status='failed', error!=''} > 0", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical", "product": installationName},
 					},
 				},
 			},

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -26,6 +26,7 @@ const (
 	SopUrlOperatorInstallDelayed                              = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/OperatorInstallDelayed.asciidoc"
 	SopUrlUpgradeExpectedDurationExceeded                     = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/UpgradeExpectedDurationExceeded.asciidoc"
 	SopUrlRHMICloudResourceOperatorMetricsServiceEndpointDown = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHMICloudResourceOperatorMetricsServiceEndpointDown.asciidoc"
+	SopUrlRHMICloudResourceOperatorVPCActionFailed            = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHMICloudResourceOperatorVPCActionFailed.asciidoc"
 	SopUrlRHMIThreeScaleApicastProductionServiceEndpointDown  = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHMIThreeScaleApicastProductionServiceEndpointDown.asciidoc"
 	SopUrlRHMIThreeScaleApicastStagingServiceEndpointDown     = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHMIThreeScaleApicastStagingServiceEndpointDown.asciidoc"
 	SopUrlRHMIThreeScaleBackendListenerServiceEndpointDown    = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHMIThreeScaleBackendListenerServiceEndpointDown.asciidoc"


### PR DESCRIPTION
# Issue link
[MGDAPI-3203](https://issues.redhat.com/browse/MGDAPI-3203)

# What
Addition of an alert that fires when the `cro_vpc_action` metric shows a failure for 5m. Links to appropriate SOP.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
Requires a cluster deployed in a region with no space for a new VPC:
* Try deploy RHOAM with `useClusterStorage: 'false'` and CRO version from integr8ly/cloud-resource-operator#249
* See new Prometheus alert firing