### PR TITLE
use new RHSSO 7.5 images

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -230,19 +230,27 @@ rules:
 - apiGroups:
   - operators.coreos.com
   resources:
+  - clusterserviceversions
+  verbs:
+  - delete
+  - get
+  - list
+  - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
   - installplans
   verbs:
   - update
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - clusterrolebindings
+  - clusterroles
   - rolebindings
+  - roles
   verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
+  - '*'
 - apiGroups:
   - route.openshift.io
   resources:
@@ -435,17 +443,5 @@ rules:
   - get
   - list
   - patch
-  - update
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  resources:
-  - rolebindings
-  - roles
-  verbs:
-  - create
-  - delete
-  - get
-  - list
   - update
   - watch

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -175,8 +175,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // Monitoring resources not covered by namespace "admin" permissions
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors;podmonitors,verbs=get;list;create;update;delete
 
-// Adding a rolebinding to the monitoring federation namespace
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;create;update;delete
+// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=*
 
 // Permission to fetch identity to get email for created Keycloak users in openshift realm
 // +kubebuilder:rbac:groups=user.openshift.io,resources=identities,verbs=get;list
@@ -219,13 +218,13 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;create;update;delete;watch,namespace=integreatly-operator
 
-// +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles;rolebindings,verbs=get;list;create;update;delete;watch,namespace=integreatly-operator
-
 // +kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch,namespace=integreatly-operator
 
 // +kubebuilder:rbac:groups=marin3r.3scale.net,resources=envoyconfigs,verbs=get;list;watch;create;update;delete,namespace=integreatly-operator
 
 // +kubebuilder:rbac:groups=operator.marin3r.3scale.net,resources=discoveryservices,verbs=get;list;watch;create;update;delete,namespace=integreatly-operator
+
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list;update
 
 func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	"github.com/integr8ly/integreatly-operator/version"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 
@@ -162,6 +163,32 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.RHSSOSubscriptionName), err)
 		return phase, err
+	}
+
+	//get the keycloak-operator CSV for v15.0.2
+	csv := &olmv1alpha1.ClusterServiceVersion{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{
+		Namespace: r.Config.GetOperatorNamespace(),
+		Name:      "keycloak-operator.v15.0.2",
+	}, csv)
+
+	if err != nil {
+		r.Log.Warning("could not get CSV 'keycloak-operator.v15.0.2' in namespace '" + r.Config.GetOperatorNamespace() + "' to inject keycloak 7.5 images into: " + err.Error())
+		return integreatlyv1alpha1.PhaseInProgress, nil
+	}
+	//update or inject the env vars required
+	csv, updated, err := r.ReconcileCSVEnvVars(csv, map[string]string{
+		"RELATED_IMAGE_RHSSO_OPENJDK": "quay.io/integreatly/rhsso:7.5-11",
+		"RELATED_IMAGE_RHSSO_OPENJ9":  "quay.io/integreatly/rhsso:7.5-11",
+	})
+
+	if updated {
+		//write the modified CSV back to the cluster
+		err = serverClient.Update(ctx, csv)
+		if err != nil {
+			r.Log.Warning("could not write CSV 'keycloak-operator-v15.0.2' in order to inject keycloak 7.5 images: " + err.Error())
+			return integreatlyv1alpha1.PhaseInProgress, nil
+		}
 	}
 
 	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"strings"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
@@ -200,6 +201,31 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.RHSSOSubscriptionName), err)
 		return phase, err
+	}
+
+	//get the keycloak-operator CSV for v15.0.2
+	csv := &olmv1alpha1.ClusterServiceVersion{}
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{
+		Namespace: r.Config.GetOperatorNamespace(),
+		Name:      "keycloak-operator.v15.0.2",
+	}, csv)
+	if err != nil {
+		r.Log.Warning("could not get CSV 'keycloak-operator.v15.0.2' in namespace '" + r.Config.GetOperatorNamespace() + "' to inject keycloak 7.5 images into: " + err.Error())
+		return integreatlyv1alpha1.PhaseInProgress, nil
+	}
+	//update or inject the env vars required
+	csv, updated, err := r.ReconcileCSVEnvVars(csv, map[string]string{
+		"RELATED_IMAGE_RHSSO_OPENJDK": "quay.io/integreatly/rhsso:7.5-11",
+		"RELATED_IMAGE_RHSSO_OPENJ9":  "quay.io/integreatly/rhsso:7.5-11",
+	})
+
+	if updated {
+		//write the modified CSV back to the cluster
+		err = serverClient.Update(ctx, csv)
+		if err != nil {
+			r.Log.Warning("could not write CSV 'keycloak-operator-v15.0.2' in order to inject keycloak 7.5 images: " + err.Error())
+			return integreatlyv1alpha1.PhaseInProgress, nil
+		}
 	}
 
 	// Setting a name for keycloak-edge to "keycloak" for managed-api install type.


### PR DESCRIPTION
# Issue link
MGDAPI-3270

# What
Force the use of new RHSSO images. All of this code needs to be removed whenever the next release of the keycloak-operator comes out.

# Verification steps
- Install RHOAM from branch `rhoam-release-v1.15`. See that RHSSO is using upstream images in both `redhat-rhoam-rhsso` and `redhat-rhoam-user-sso` namespaces.
- Stop the operator
- Checkout this branch and start the operator
- After a few minutes, see that both RHSSO are now using `quay.io/integreatly/rhsso:7.5-11` images.