### PR TITLE
MGDAPI-3237 don't send emails on info level alerts

### DIFF
--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -18,6 +18,9 @@ route:
         severity: critical
       receiver: critical
     - match:
+        alertname: ThreeScaleContainerHighMemory
+      receiver: blackhole
+    - match:
         alertname: DeadMansSwitch
       repeat_interval: 5m
       receiver: deadmansswitch
@@ -29,7 +32,7 @@ route:
       receiver: BUandCustomer
     - match:
         alertname: RHOAMApiUsageLevel3ThresholdExceeded
-      receiver: SRECustomerBU
+      receiver: BUandCustomer
     - match_re:
         alertname: RHOAMApiUsageSoftLimitReachedTier[0-9]+
       receiver: BU
@@ -38,8 +41,9 @@ route:
       receiver: BUandCustomer
     - match:
         alertname: RHOAMApiUsageRejectedRequestsMismatch
-      receiver: SRECustomerBU
+      receiver: BUandCustomer
 receivers:
+  - name: blackhole
   - name: default
     email_configs:
       - send_resolved: true


### PR DESCRIPTION
# Issue link
[JIRA](https://issues.redhat.com/browse/MGDAPI-3237)

# What
Added a `blackhole` receiver to dump alerts with `info` severity 

# Verification steps
1. Run the operator from this branch 
1.1 You might update [these](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/threescale/prometheusRules.go#L351-L352) lines to decrease the "alert" threshold and timeout to speed up verification:
```
Expr:   intstr.FromString(fmt.Sprintf("sum by(container, pod) (container_memory_usage_bytes{container!='', container!='system-provider', namespace='%[1]v'}) / sum by(container, pod) (kube_pod_container_resource_limits{namespace='%[1]v',resource='memory'}) * 100 > 0", namespace)),
For:    "1m",
``` 
2. Open alertmanager (Networking -> Routes -> `alertmanager` in `redhat-rhoam-observability` namespace) and check the `Status` tab - you should see config with a new route:
```
- receiver: blackhole
    match:
      severity: info
```
and en empty receiver: 
```
- name: blackhole
```
3. Open prometheus route (Networking -> Routes -> `prometheus` in `redhat-rhoam-observability` namespace) and ensure that  `ThreeScaleContainerHighMemory` alert is firing 
4. Check logs of the `alertmanager` pod - you should not see anything there but the deadmanssnitch (given you have only `ThreeScaleContainerHighMemory` and `DeadMansSwitch` firing) that means that alertmanager correctly processed config and does not make attempts to send out notifications on info level alerts 