### PR TITLE
MGDAPI-3029 - fix: install chrome onto base prow image

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -43,3 +43,7 @@ RUN curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE
     && tar -xJf "node-v$NODE_VERSION-linux-x64.tar.xz" -C /usr/local --strip-components=1 --no-same-owner \
     && rm "node-v$NODE_VERSION-linux-x64.tar.xz" \
     && ln -s /usr/local/bin/node /usr/local/bin/nodejs
+
+# install chrome
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
+    && yum install -y --setopt=tsflags=nodocs ./google-chrome-stable_current_*.rpm


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-3029

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
B01B still fails with the following error in the pipeline
```
/go/src/github.com/integr8ly/integreatly-operator/test/functional/integreatly_test.go:77 ChromeDP test failed with error: exec: "google-chrome": executable file not found in $PATH /go/src/github.com/integr8ly/integreatly-operator/test/common/product_login.go:36
```
The error looks to be due that base images in prow are replaced by image built by `Dockerfile.tools` and then mirrored. So installing `chrome` to this dockerfile should fix the issue

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Build the docker image
```
docker build -t registry.svc.ci.openshift.org/integr8ly/intly-operator-base-image:latest - < openshift-ci/Dockerfile.tools             
```
* Run the container 
```
docker run -it registry.svc.ci.openshift.org/integr8ly/intly-operator-base-image:latest 
```
* Verify chrome is available in the path
```
which google-chrome

# Sample output
# [root@845235a05abf origin]# # /usr/bin/google-chrome
```