### PR TITLE
copy catalog source rhoam operator to 3scale to allow 3scale subscrip…

### DIFF
--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,6 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]'
     support: RHOAM
   name: managed-api-service.v1.15.0
   namespace: placeholder

--- a/config/scorecard/kuttl/rhoam-install/02-cluster-storage.yaml
+++ b/config/scorecard/kuttl/rhoam-install/02-cluster-storage.yaml
@@ -4,3 +4,4 @@ metadata:
   name: rhoam
 spec:
   useClusterStorage: 'true'
+  selfSignedCerts: true

--- a/pkg/resources/marketplace/catalog_source_reconciler.go
+++ b/pkg/resources/marketplace/catalog_source_reconciler.go
@@ -7,7 +7,7 @@ import (
 )
 
 type CatalogSourceReconciler interface {
-	Reconcile(ctx context.Context) (reconcile.Result, error)
+	Reconcile(ctx context.Context, subName string) (reconcile.Result, error)
 	CatalogSourceName() string
 	CatalogSourceNamespace() string
 }

--- a/pkg/resources/marketplace/configmap_catalog_source_reconciler.go
+++ b/pkg/resources/marketplace/configmap_catalog_source_reconciler.go
@@ -43,7 +43,7 @@ func (r *ConfigMapCatalogSourceReconciler) CatalogSourceNamespace() string {
 	return r.Namespace
 }
 
-func (r *ConfigMapCatalogSourceReconciler) Reconcile(ctx context.Context) (reconcile.Result, error) {
+func (r *ConfigMapCatalogSourceReconciler) Reconcile(ctx context.Context, subName string) (reconcile.Result, error) {
 	configMapData, err := GenerateRegistryConfigMapFromManifest(r.ManifestsProductDirectory)
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("Failed to generated config map data from manifest: %w", err)

--- a/pkg/resources/marketplace/grpc_image_catalog_source_reconciler.go
+++ b/pkg/resources/marketplace/grpc_image_catalog_source_reconciler.go
@@ -33,7 +33,7 @@ func NewGRPCImageCatalogSourceReconciler(image string, client client.Client, nam
 	}
 }
 
-func (r *GRPCImageCatalogSourceReconciler) Reconcile(ctx context.Context) (reconcile.Result, error) {
+func (r *GRPCImageCatalogSourceReconciler) Reconcile(ctx context.Context, subName string) (reconcile.Result, error) {
 	r.Log.Infof("Reconciling registry catalog source for namespace", l.Fields{"ns": r.Namespace})
 
 	catalogSource := &coreosv1alpha1.CatalogSource{

--- a/pkg/resources/marketplace/grpc_image_catalog_source_reconciler_test.go
+++ b/pkg/resources/marketplace/grpc_image_catalog_source_reconciler_test.go
@@ -154,7 +154,7 @@ func TestGRPCImageCatalogSourceReconcilerReconcile(t *testing.T) {
 	for _, scenario := range scenarios {
 		t.Run(scenario.Name, func(t *testing.T) {
 			csReconciler := NewGRPCImageCatalogSourceReconciler(scenario.DesiredGRPCImage, scenario.FakeClient, testNameSpace, scenario.DesiredCatalogSourceName, l.NewLogger())
-			res, err := csReconciler.Reconcile(context.TODO())
+			res, err := csReconciler.Reconcile(context.TODO(), "test")
 			scenario.Verify(scenario.DesiredCatalogSourceName, scenario.DesiredGRPCImage, res, err, scenario.FakeClient)
 		})
 	}

--- a/pkg/resources/marketplace/implicit_catalog_source_reconciler_test.go
+++ b/pkg/resources/marketplace/implicit_catalog_source_reconciler_test.go
@@ -1,0 +1,135 @@
+package marketplace
+
+import (
+	"context"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"os"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := integreatlyv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	if err := olmv1alpha1.SchemeBuilder.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+	return scheme, nil
+}
+
+func basicInstallation() *integreatlyv1alpha1.RHMI {
+	return &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhoam",
+			Namespace: "redhat-rhoam-operator",
+		},
+	}
+}
+
+func getSubscription() *olmv1alpha1.Subscription {
+	return &olmv1alpha1.Subscription{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "managed-api-sub",
+			Namespace: "redhat-rhoam-operator",
+			Labels: map[string]string{
+				"operators.coreos.com/managed-api-service.redhat-rhoam-operator": "operators.coreos.com/managed-api-service.redhat-rhoam-operator",
+			},
+		},
+		Spec: &olmv1alpha1.SubscriptionSpec{
+			CatalogSource:          "redhat-rhoam-cs",
+			CatalogSourceNamespace: "redhat-rhoam-operator",
+		},
+	}
+}
+
+func TestImplicitCatalogSourceReconcile(t *testing.T) {
+
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	installation := basicInstallation()
+
+	rhmiSubscription := getSubscription()
+
+	cs := &operatorsv1alpha1.CatalogSource{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "redhat-rhoam-cs",
+			Namespace: "redhat-rhoam-operator",
+		},
+	}
+
+	cases := []struct {
+		Name          string
+		FakeClient    k8sclient.Client
+		Log           l.Logger
+		ExpectError   bool
+		ExpectedError string
+		VerifyCS      bool
+	}{
+		{
+			Name:          "Test Reconcile",
+			FakeClient:    moqclient.NewSigsClientMoqWithScheme(scheme, installation, rhmiSubscription, cs),
+			Log:           l.NewLogger(),
+			ExpectError:   false,
+			ExpectedError: "",
+			VerifyCS:      true,
+		},
+		{
+			Name:          "Test Reconcile, no subscription",
+			FakeClient:    moqclient.NewSigsClientMoqWithScheme(scheme, installation, cs),
+			Log:           l.NewLogger(),
+			ExpectError:   true,
+			ExpectedError: "catalog source not found for implicit product installation type",
+			VerifyCS:      false,
+		},
+		{
+			Name:          "Test Reconcile, no catalog source",
+			FakeClient:    moqclient.NewSigsClientMoqWithScheme(scheme, installation, cs),
+			Log:           l.NewLogger(),
+			ExpectError:   true,
+			ExpectedError: "catalog source not found for implicit product installation type",
+			VerifyCS:      false,
+		},
+	}
+
+	os.Setenv("WATCH_NAMESPACE", "redhat-rhoam-operator")
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			testReconciler, err := NewImplicitCatalogSourceReconciler(
+				tc.Log,
+				tc.FakeClient,
+			)
+
+			_, err = testReconciler.Reconcile(context.TODO(), "3scale")
+
+			if err != nil && tc.ExpectError == false {
+				t.Fatalf("unexpected error : '%v'", err)
+			}
+
+			if err != nil && tc.ExpectError == true && tc.ExpectedError != err.Error() {
+				t.Fatalf("unexpected error : '%v', expected: %s", err, tc.ExpectedError)
+			}
+
+			if err == nil && tc.ExpectError == true {
+				t.Fatalf("Expected error : '%s', but got none", tc.ExpectedError)
+			}
+
+			if tc.VerifyCS {
+				if testReconciler.selfCatalogSource.Name != "redhat-rhoam-cs" || testReconciler.selfCatalogSource.Namespace != "redhat-rhoam-3scale-operator" {
+					t.Fatal("Expected catalog source name: redhat-rhoam-cs, namespace: redhat-rhoam-3ccale-operator")
+				}
+			}
+
+		})
+	}
+}

--- a/pkg/resources/marketplace/manager.go
+++ b/pkg/resources/marketplace/manager.go
@@ -53,7 +53,7 @@ func (m *Manager) InstallOperator(ctx context.Context, serverClient k8sclient.Cl
 		},
 	}
 
-	res, err := catalogSourceReconciler.Reconcile(ctx)
+	res, err := catalogSourceReconciler.Reconcile(ctx, t.SubscriptionName)
 	if res.Requeue {
 		return fmt.Errorf("Requeue")
 	}
@@ -117,11 +117,14 @@ func (m *Manager) getSubscription(ctx context.Context, serverClient k8sclient.Cl
 }
 
 func (m *Manager) GetSubscriptionInstallPlan(ctx context.Context, serverClient k8sclient.Client, subName, ns string) (*coreosv1alpha1.InstallPlan, *coreosv1alpha1.Subscription, error) {
+	log.Infof("Get", l.Fields{"Subscription Name": subName, "ns": ns})
+
 	sub, err := m.getSubscription(ctx, serverClient, subName, ns)
 	if err != nil {
 		return nil, nil, fmt.Errorf("GetSubscriptionInstallPlan: %w", err)
 	}
 	if sub.Status.Install == nil || sub.Status.InstallPlanRef == nil {
+		log.Error("Error getting install plan ref on subscription, %v", err)
 		return nil, sub, k8serr.NewNotFound(coreosv1alpha1.Resource("installplan"), "")
 	}
 

--- a/products/installation-cpaas.yaml
+++ b/products/installation-cpaas.yaml
@@ -59,7 +59,7 @@ products:
   3scale:
     channel: "threescale-2.11"
     installFrom: "implicit"
-    bundle: "registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:6c916f91899e1c280859ccc49aea9c16554d92e33857151b1050bffc905cb872"
+    bundle: "registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:a5bd262966f0c384e08559a07d2a12e0272e5778f2fce4e21af8fc2f6407b18d"
     package: 3scale-operator
   amqonline:
     channel: "rhmi"


### PR DESCRIPTION
# Issue link
[MGDAPI-3280](https://issues.redhat.com/browse/MGDAPI-3280)


# What
CPaaS specific changes. 
With CPaaS, 3Scale uses the same index image (Catalog Source) as the rhoam operator. The CS is created in the rhoam operator ns. This prevents the 3Scale Subscription from being reconciled. 
The change copies the CS to the 3Scale operator ns to allow the Subscription be reconciled. 

# Verification steps
- Scan code base for an obvious issues
- e2e tests passing 
