### PR TITLE
MGDAPI-3203 fix test

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -454,6 +454,7 @@ func commonExpectedRules(installationName string) []alertsTestRule {
 				"RHMICloudResourceOperatorMetricsServiceEndpointDown",
 				"RHMICloudResourceOperatorRhmiRegistryCsServiceEndpointDown",
 				"RHMICloudResourceOperatorElasticCacheSnapshotsNotFound",
+				"RHMICloudResourceOperatorVPCActionFailed",
 			},
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3203

# What
* fixes the test that is failing since https://github.com/integr8ly/integreatly-operator/pull/2377 was merged

# Verification steps
```
go clean -testcache && WATCH_NAMESPACE=redhat-rhoam-operator BYPASS_STORAGE_TYPE_CHECK=true go test -v ./test/functional -timeout=80m -ginkgo.focus="C04" -ginkgo.v -ginkgo.progress -ginkgo.trace
```