### PR TITLE
MGDAPI-2660 Removing installPlan checks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/antchfx/xmlquery v1.3.5
 	github.com/apicurio/apicurio-operators/apicurito v0.0.0-20200123142409-83e0a91dd6be
 	github.com/aws/aws-sdk-go v1.39.2
-	github.com/blang/semver v3.5.1+incompatible
 	github.com/chromedp/cdproto v0.0.0-20211126220118-81fa0469ad77
 	github.com/chromedp/chromedp v0.7.6
 	github.com/eclipse/che-operator v0.0.0-20201214125341-cce874092f25

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -120,7 +120,6 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/blang/semver v3.5.1+incompatible
-## explicit
 github.com/blang/semver
 # github.com/blang/semver/v4 v4.0.0
 github.com/blang/semver/v4


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2660
Also related https://issues.redhat.com/browse/MGDAPI-3091

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Some of our past work around the rhmiConfig CR were causing issue with the upgrade cycle. This change removes our custom logic and gives that responsibility back to OLM.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Use a openshift 4.8 cluster for Verification.

There are multiply upgrade case that will need to be covered.
While some case may seem the same they are based around service and non-service affecting upgrades.

**Important Note:** Existing installPlans on a cluster has an effect on how OLM builds the installPlans.
In cases 2 and 7 this is especially important.

In all cases the catalog source is used for create the installation.
This guide [Installing RHOAM Through OLM with Bundle Format](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/install-upgrade-rhoam-bundle.md) will help if you have not installed from catalog source before.

A clean cluster in this case is regarded as one that does not have RHOAM or any RHOAM namespaces on the cluster.
It is ok if the catalogSource is still on cluster.
Command I used to get back to this state is `make cluster/cleanup && make cluster/cleanup/crds`

## Service affecting
### Case 1: Upgrade from exist version.
Here we are testing if the current release version can be upgrade to the version created by this PR.
Current RHOAM version 1.15.2

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.15.2-2660` as the index.
* Allow installation to fully complete.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s` as the index.
 `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s"}]'`
* Manual approve the new installPlan that is created.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.16.0

### Case 2: Upgrade from skipped version.
On service affecting release we want to allow OLM manage the skipped versions.
In this case we are testing if an installed version(N) is properly upgrade to N+1, if version N+1 skips N. 
N-1 needs to be installed first to create the OLM installation tree correctly.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s` as the index.
* Allow installation to fully complete.
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s"}]'`
* Manual approve the new installPlan that is created.
* Allow installation to fully complete.
* RHOAM version is 1.17.0 now.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17"}]'`
* **Expected:** When running `watch -d oc get installplan -n redhat-rhoam-operator`, the new installPlan should not be seen to be removed or recreated. 
Best to watch this for 2~3 minutes. 
Timing is affected by the RHOAM operator cycle.
* Manual approve the new installPlan that is created.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.18.0.
* [ ] No removal or recreation of installPlans noticed.

### Case 3: Upgrade passed skipped version.
Here we need to check that the operator can skip versions that have not being installed.
The installation flow here is as follows. 
1. N is installed.
2. N+1 replaces N.
3. N+2 replaces N and skips N+1.

#### Setuped
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s` as the index.
* Allow installation to fully complete.
* RHOAM version is 1.16.0 now.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17"}]'`
* **Expected:** When running `watch -d oc get installplan -n redhat-rhoam-operator`, the new installPlan should not be seen to be removed or recreated.
  Best to watch this for 2~3 minutes.
  Timing is affected by the RHOAM operator cycle.
* **Check:** The newly created installPlan is for a 1.18.0 version. 
* Manual approve the new installPlan that is created.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.18.0.
* [ ] No removal or recreation of installPlans noticed.
* [ ] No install plan for a 1.17.0 version was created <-- this can be checked by looking at the CSV values in `watch -d oc get installplan -n redhat-rhoam-operator`

### Case 4: Unapproved installPlan upgrade with replaces.
The operator currently has issue where a mismatch in version can cause installPlans to be removed and/or recreated if there is an existing unapproved InstallPlan.
This case is testing the normal upgrades with no skipped versions.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s` as the index.
* Allow installation to fully complete.
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s"}]'`
* **DO NOT approve the installPlan**
* RHOAM version is 1.16.0 now with an installPlan for 1.17.0 waiting to be approved

#### Test
* Start running `watch -d oc get installplan -n redhat-rhoam-operator`
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s` as the index.
`oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s"}]'`
* Watch the installPlans for 2~3 minutes. 
Existing installPlans should not be removed or recreated.

#### Result
* [ ] Existing installPlans are not be removed or recreated

### Case 5: Unapproved installPlan upgrade with skipped.
This case is very like Case 4. 
The main difference here is index which is added as part of test stage is skipping the existing unapproved installPlan. 

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660s` as the index.
* Allow installation to fully complete.
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.17.0-2660s"}]'`
* **DO NOT approve the installPlan**
* RHOAM version is 1.16.0 now with an installPlan for 1.17.0 waiting to be approved

#### Test
* Start running `watch -d oc get installplan -n redhat-rhoam-operator`
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660s-R16-S17"}]'`
* Watch the installPlans for 2~3 minutes.
  Existing installPlans should not be removed or recreated.

#### Result
* [ ] Existing installPlans are not be removed or recreated

## Non-service affecting
**Note:** These cases many need to be carried out on an openshift 4.8 cluster due to the issue highlighted in [MGDAPI-3084](https://issues.redhat.com/browse/MGDAPI-3084)

These case test if the operator can auto approve non-service affecting upgrades.

### Case 6: Upgrade from exist version.
Checking if the current RHOAM operator(1.15.2) is installed we can auto upgrade to the version created in this PR.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.15.2-2660` as the index.
* Allow installation to fully complete.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660ns` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.16.0-2660ns"}]'`
* Auto approval of the new installPlan should happen.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.16.0
* [ ] InstallPlan was auto approved

### Case 7: Upgrade from skipped version.
On non-service affecting release we want to allow OLM manage the skipped versions.
In this case we are testing if an installed version(N) can upgrade to N+1, if version N+1 skips N.
N-1 needs to be installed first to create the OLM installation tree correctly.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660ns` as the index.
* Allow installation to fully complete.
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.17.0-2660ns` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.17.0-2660ns"}]'`
* Auto approval of the new installPlan should happen.
* Allow installation to fully complete.
* RHOAM version is 1.17.0 now.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns-R16-S17` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns-R16-S17"}]'`
* **Expected:** When running `watch -d oc get installplan -n redhat-rhoam-operator`, the new installPlan should not be seen to be removed or recreated.
  Best to watch this for 2~3 minutes.
  Timing is affected by the RHOAM operator cycle.
* Auto approval of the new installPlan should happen.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.18.0.
* [ ] No removal or recreation of installPlans noticed.
* [ ] InstallPlans were auto approved

### Case 8: Upgrade passed skipped version.
Here we need to check that the operator can skip versions that have not being installed.
The installation flow here is as follows.
1. N is installed.
2. N+1 replaces N.
3. N+2 replaces N and skips N+1.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660ns` as the index.
* Allow installation to fully complete.
* RHOAM version is 1.16.0 now.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns-R16-S17` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns-R16-S17"}]'`
* **Expected:** When running `watch -d oc get installplan -n redhat-rhoam-operator`, the new installPlan should not be seen to be removed or recreated.
  Best to watch this for 2~3 minutes.
  Timing is affected by the RHOAM operator cycle.
* **Check:** The newly created installPlan is for a 1.18.0 version.
* Auto approval of the new installPlan should happen.
* Allow installation to fully complete.

#### Result
* [ ] RHOAM should upgrade to version 1.18.0.
* [ ] No removal or recreation of installPlans noticed.
* [ ] No install plan for a 1.17.0 version was created <-- this can be checked by looking at the CSV values in `watch -d oc get installplan -n redhat-rhoam-operator`
* [ ] InstallPlans were auto approved

### Case 9: Upgrading to N+2
This case is checking that the RHOAM can upgrade across multiply version.

#### Setup
* From clean cluster
* Install RHOAM using `quay.io/jfitzpat/managed-api-service-index:1.16.0-2660ns` as the index.
* Allow installation to fully complete.
* RHOAM version is 1.16.0 now.

#### Test
* Update the catalogSource to use `quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns` as the index.
  `oc patch catalogsources rhoms-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": "/spec/image", "value": "quay.io/jfitzpat/managed-api-service-index:1.18.0-2660ns"}]'`
* Run `watch -d oc get installplan -n redhat-rhoam-operator`, this makes it easy to see the current state of the installPlan.
* First installPlan created should be 1.17.0
* InstallPlan for 1.17.0 is auto approved
* Operator 1.17.0 goes to a complete status
* InstallPlan for 1.18.0 is created
* InstallPlan for 1.18.0 is auto approved 
* Operator 1.18.0 goes to a complete status

#### Result
* [ ] RHOAM should upgrade to version 1.18.0.
* [ ] No removal or recreation of installPlans noticed.
* [ ] installPlans for a 1.17.0 & 1.18.0 were created <-- this can be checked by looking at the CSV values in `watch -d oc get installplan -n redhat-rhoam-operator`
* [ ] InstallPlans were auto approved
