### PR TITLE
MGDAPI-3080 Remove the monitoring and monitoring-spec reconcilers #1

### DIFF
--- a/controllers/rhmi/types.go
+++ b/controllers/rhmi/types.go
@@ -26,13 +26,6 @@ var (
 				},
 			},
 			{
-				Name: integreatlyv1alpha1.MonitoringStage,
-				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring, Uninstall: true},
-					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec, Uninstall: true},
-				},
-			},
-			{
 				Name: integreatlyv1alpha1.ObservabilityStage,
 				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
 					integreatlyv1alpha1.ProductObservability: {
@@ -80,13 +73,6 @@ var (
 				},
 			},
 			{
-				Name: integreatlyv1alpha1.UninstallMonitoringStage,
-				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
-					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
-				},
-			},
-			{
 				Name: integreatlyv1alpha1.UninstallBootstrap,
 			},
 		},
@@ -102,13 +88,6 @@ var (
 					integreatlyv1alpha1.ProductCloudResources: {
 						Name: integreatlyv1alpha1.ProductCloudResources,
 					},
-				},
-			},
-			{
-				Name: integreatlyv1alpha1.MonitoringStage,
-				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring, Uninstall: true},
-					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec, Uninstall: true},
 				},
 			},
 			{
@@ -158,13 +137,6 @@ var (
 				Name: integreatlyv1alpha1.UninstallObservabilityStage,
 				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
 					integreatlyv1alpha1.ProductObservability: {Name: integreatlyv1alpha1.ProductObservability},
-				},
-			},
-			{
-				Name: integreatlyv1alpha1.UninstallMonitoringStage,
-				Products: map[integreatlyv1alpha1.ProductName]integreatlyv1alpha1.RHMIProductStatus{
-					integreatlyv1alpha1.ProductMonitoring:     {Name: integreatlyv1alpha1.ProductMonitoring},
-					integreatlyv1alpha1.ProductMonitoringSpec: {Name: integreatlyv1alpha1.ProductMonitoringSpec},
 				},
 			},
 			{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3080
Remove the monitoring and monitoring-spec reconcilers

# What
Remove the monitoring and monitoring-spec reconcilers from the installation types which now have migrated from AMO to OO  in RHOAM.
Remove monitoring and monitoring-spec in controllers/rhmi/types.go from  allMultitenantManagedApiStages and allManagedApiStages

# Verification steps
- On fresh install and upgrade to a newer version than 1.14.0 the monitoring and monitoring-spec  reconcilers are not called anymore and are removed from the rhmi cr
- There is no more reference to any redhat-rhoam-monitoring namespaces on upgrade
