### PR TITLE
MGDAPI-2370 scalability tests, custom kuttl image

### DIFF
--- a/config/scorecard/kuttl/02-scalability/00-assert.yaml
+++ b/config/scorecard/kuttl/02-scalability/00-assert.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rhoam-test-container
+status:
+  containerStatuses:
+    - name: sidecar
+      ready: true
+    - name: test
+      started: true
+      ready: true

--- a/config/scorecard/kuttl/02-scalability/00-before.yaml
+++ b/config/scorecard/kuttl/02-scalability/00-before.yaml
@@ -1,0 +1,7 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestStep
+delete:
+# Make sure there is no test container in the current namespace
+- apiVersion: v1
+  kind: Pod
+  name: rhoam-test-container

--- a/config/scorecard/kuttl/02-scalability/00-test-pod-template.yaml
+++ b/config/scorecard/kuttl/02-scalability/00-test-pod-template.yaml
@@ -1,0 +1,51 @@
+kind: Pod
+apiVersion: v1
+metadata:
+  name: rhoam-test-container
+  namespace: redhat-rhoam-operator
+spec:
+  restartPolicy: Never
+  serviceAccountName: rhoam-test-runner
+  containers:
+    - resources: {}
+      name: test
+      env:
+        - name: DESTRUCTIVE
+          value: 'false'
+        - name: MULTIAZ
+          value: 'false'
+        - name: WATCH_NAMESPACE
+          value: redhat-rhoam-operator
+        - name: BYPASS_STORAGE_TYPE_CHECK
+          value: 'true'
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: test-run-results
+          mountPath: /test-run-results
+      terminationMessagePolicy: File
+      image: "quay.io/integreatly/integreatly-operator-test-harness:master"
+      args:
+        - '-ginkgo.focus'
+        - '(F05)|(F08)'
+    - resources: {}
+      terminationMessagePath: /dev/termination-log
+      name: sidecar
+      command:
+        - sh
+      securityContext:
+        capabilities:
+          drop:
+            - MKNOD
+      imagePullPolicy: Always
+      volumeMounts:
+        - name: test-run-results
+          mountPath: /test-run-results
+      terminationMessagePolicy: File
+      image: quay.io/quay/busybox
+      args:
+        - '-c'
+        - 'while true; if [[ -f /tmp/done ]]; then exit 0; fi; do sleep 1; done'
+  serviceAccount: rhoam-test-runner
+  volumes:
+    - name: test-run-results
+      emptyDir: {}

--- a/config/scorecard/kuttl/02-scalability/01-assert.yaml
+++ b/config/scorecard/kuttl/02-scalability/01-assert.yaml
@@ -1,0 +1,15 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 1000
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rhoam-test-container
+status:
+  containerStatuses:
+    - name: sidecar
+      ready: true
+    # Wait for test container to finish
+    - name: test
+      started: false

--- a/config/scorecard/kuttl/02-scalability/02-assert.yaml
+++ b/config/scorecard/kuttl/02-scalability/02-assert.yaml
@@ -1,0 +1,18 @@
+apiVersion: kuttl.dev/v1beta1
+kind: TestAssert
+timeout: 10
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rhoam-test-container
+status:
+  containerStatuses:
+    - name: sidecar
+      ready: true
+    # If some tests have failed,
+    # the test container's state.terminated.reason would be "Error"
+    - name: test
+      state:
+        terminated:
+          reason: Completed

--- a/config/scorecard/kuttl/kuttl-test.yaml
+++ b/config/scorecard/kuttl/kuttl-test.yaml
@@ -4,5 +4,6 @@ namespace: redhat-rhoam-operator
 parallel: 1 # Run tests in serial
 skipDelete: true
 startControlPlane: false
-suppressLog: events
-timeout: 60 # timeout in seconds for each step
+suppress:
+  - events
+timeout: 60 # timeout in seconds for each step (unless overriden in test step)

--- a/config/scorecard/patches/kuttl.config.yaml
+++ b/config/scorecard/patches/kuttl.config.yaml
@@ -3,10 +3,22 @@
   value:
     entrypoint:
     - entrypoint
-    - happy-path
-    image: quay.io/operator-framework/scorecard-test-kuttl:v2.0.0
+    - 01-happy-path
+    image: quay.io/psturc/scorecard-test-kuttl:latest
     labels:
       cluster-product: ocp
       cluster-size: small
       phase: msp-main
       test: happy-path
+- op: add
+  path: /stages/0/tests/-
+  value:
+    entrypoint:
+    - entrypoint
+    - 02-scalability
+    image: quay.io/psturc/scorecard-test-kuttl:latest
+    labels:
+      cluster-product: ocp
+      cluster-size: small
+      phase: msp-main
+      test: scalability


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-2370

# What
* add scalability tests to MSP
* use custom kuttl image that allows handling test selection better than original image

# Verification steps
1. Run scorecard tests (and using the new test suite)
```bash
operator-sdk scorecard ./bundle --namespace=redhat-rhoam-operator --skip-cleanup --verbose --output json --service-account rhoam-test-runner --selector=test=scalability --wait-time 3000s
```
2. The output should look like following
```
{
  "kind": "TestList",
  "apiVersion": "scorecard.operatorframework.io/v1alpha3",
  "items": [
    {
      "kind": "Test",
      "apiVersion": "scorecard.operatorframework.io/v1alpha3",
      "spec": {
        "image": "quay.io/psturc/scorecard-test-kuttl:latest",
        "entrypoint": [
          "entrypoint",
          "02-scalability"
        ],
        "labels": {
          "cluster-product": "ocp",
          "cluster-size": "small",
          "phase": "msp-main",
          "test": "scalability"
        },
        "storage": {
          "spec": {
            "mountPath": {}
          }
        }
      },
      "status": {
        "results": [
          {
            "name": "02-scalability",
            "state": "pass",
            "creationTimestamp": "2022-01-21T09:55:22Z"
          }
        ]
      }
    }
  ]
}
```
