### PR TITLE
MGDAPI-3336 - Remove the monitoring stage in the status

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -436,6 +436,13 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	}
 	metrics.SetRHMIStatus(installation)
 
+	if rhmiv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installation.Spec.Type)) {
+		if _, ok := installation.Status.Stages[rhmiv1alpha1.MonitoringStage]; ok {
+			log.Info("delete Monitoring stage from installation.Status")
+			delete(installation.Status.Stages, rhmiv1alpha1.MonitoringStage)
+		}
+	}
+
 	err = r.updateStatusAndObject(originalInstallation, installation)
 	return retryRequeue, err
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3336

# What
status.monitoring should be removed from RHMI CR after RHOAM upgrade
It is no longer present in case of installation, But need care to remove it also in case of Upgrade.

Done by adding removing Monitoring from Status of Rhoam CR, in rhmi_controller
Addition to function updateStatusAndObject() - new method cleanMonitoringStageInRhoamCRStatus()

# Verification steps
* Prepare Rhoam bundle images and indexes in Quay for:
** Any existing Rhoam version, like rhoam-v1.15.2,
** Rhoam image that include the fix
* Check that Rhoam 1.15.2 is present in OperatorHub
* Install Rhoam v1.15.2 from OperatorHub, and check that it's running no errors
* Check that Upgrade to New version (with fix) is available in OperatorHub, and do Upgrade
* Check that new Rhoam version installed correctly
* Check that status.monitoring is not present in RHMI CR

