### PR TITLE
MGDAPI-3256 update Dockerfile.tools for prow

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.16
+FROM registry.ci.openshift.org/openshift/release:golang-1.17
 
 # OPERATOR_SDK should match the version of operator-sdk version in go.mod
 ENV OPERATOR_SDK_VERSION=v1.12.0 \


### PR DESCRIPTION
# Issue link
[MGDAPI-3256](https://issues.redhat.com/browse/MGDAPI-3256)

# What
Updating `Dockerfile.tools` to configure prow jobs to use a new version of GO
