### PR TITLE
MGDAPI-3321 add rhoam olm subscription to reconciler

### DIFF
--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -40,6 +40,7 @@ const (
 	RHMIAddonSubscriptionEdge       = "addon-rhmi-internal"
 	ManagedAPIAddonSubscription     = "addon-managed-api-service"
 	ManagedAPIAddonSubscriptionEdge = "addon-managed-api-service-internal"
+	ManagedAPIolmSubscription       = "managed-api-service"
 )
 
 var subscriptionsToReconcile []string = []string{
@@ -48,6 +49,7 @@ var subscriptionsToReconcile []string = []string{
 	ManagedAPIAddonSubscription,
 	RHMIAddonSubscriptionEdge,
 	ManagedAPIAddonSubscriptionEdge,
+	ManagedAPIolmSubscription,
 }
 
 func New(mgr manager.Manager) (*SubscriptionReconciler, error) {


### PR DESCRIPTION
# Issue link
[MGDAPI-3321](https://issues.redhat.com/browse/MGDAPI-3321)

# What
When installed via OLM the subscription has a name `managed-api-service`. We were not reconciling that subscription and this led to a number of problems. 

# Verification steps
You would need to build bundles and image from this PR (or, alternatively, you can use mine: `quay.io/mvavilov/rhoam-index:1.17.0`)
1. Create a `rhoam-operators.yaml` file with the following content:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: <index>
```
2. Against a clean cluster run:
```
oc apply -f rhoam-operators.yaml
INSTALLATION_TYPE=managed-api make cluster/prepare/project && \  
   INSTALLATION_TYPE=managed-api make cluster/prepare/smtp && \
   INSTALLATION_TYPE=managed-api make cluster/prepare/dms && \
   INSTALLATION_TYPE=managed-api make cluster/prepare/pagerduty
```
3. Go to the OperatorHub and search for `RHOAM`. Ensure it refers to the custom image (the one you build, or if you are using my index it should be `managed-api-service:rhoam-v1.17.0`). Hit `Install` and leave the `Update approval` to be `Automatic` (the default option). 
4. Once the installation starts you want to see that the `Update approval` (in the `Subscription` tab)  was changed to the `Manual`. If it happens - RHOAM reconciles the OLM type subscription. 