### PR TITLE
[MGDAPI-3414] fix: prow images

### DIFF
--- a/test-dependancy/centos.repo
+++ b/test-dependancy/centos.repo
@@ -1,13 +1,13 @@
 [appstream]
 name=CentOS-$releasever - AppStream
-baseurl=http://mirror.centos.org/centos/8/AppStream/x86_64/os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os/
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [baseos]
 name=CentOS-$releasever - BaseOS
-baseurl=http://mirror.centos.org/centos/8/BaseOS/x86_64/os
+baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-3414

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
http://mirror.centos.org/centos/8/AppStream/x86_64/os/repodata/repomd.xml returns a 404 causing the image build to fail, possibly due to it being archived

We should switch to use centos 8 stream `centos.repo`

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Having the prow image build job passing in this job should be sufficient