### PR TITLE
MGDAPI-3021

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ ifeq ($(INSTALLATION_TYPE), managed)
 endif
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
+cluster/prepare: cluster/prepare/project cluster/prepare/configmaps  cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
 
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean

--- a/Makefile
+++ b/Makefile
@@ -309,7 +309,7 @@ ifeq ($(INSTALLATION_TYPE), managed)
 endif
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/configmaps  cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
+cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
 
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -171,7 +171,7 @@ func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1
 	)
 	alertDescription := fmt.Sprintf("The Sendgrid SMTP secret has not been created in the %s namespace and may need to be created manualy", cr.Namespace)
 	labels := map[string]string{
-		"severity": "warning",
+		"severity": "critical",
 		"product":  installationName,
 	}
 

--- a/test/common/sendgrid_credentials_valid.go
+++ b/test/common/sendgrid_credentials_valid.go
@@ -29,10 +29,10 @@ func TestSendgridCredentialsAreValid(t TestingTB, ctx *TestingContext) {
 		if port != "587" {
 			t.Fatal("Dummy port values have changed. Expected: 587, Actual: ", port)
 		}
-		if username != "" && username != "dummy" {
+		if username != "" && username != "smtp_username" {
 			t.Fatal("Dummy uesrname values have changed. Expected: dummy, Actual: ", username)
 		}
-		if password != "" && password != "dummy" {
+		if password != "" && password != "smtp_password" {
 			t.Fatal("Dummy password values have changed. Expected: dummy, Actual: %s", password)
 		}
 

--- a/test/resources/util.go
+++ b/test/resources/util.go
@@ -3,6 +3,7 @@ package resources
 import (
 	goctx "context"
 	"fmt"
+	k8errors "k8s.io/apimachinery/pkg/api/errors"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -20,11 +21,25 @@ func RunningInProw(inst *integreatlyv1alpha1.RHMI) bool {
 func GetSMTPSecret(kubeClient kubernetes.Interface, operatorNamespace string, secretName string) (map[string][]byte, error) {
 	res, err := kubeClient.CoreV1().Secrets(operatorNamespace).Get(goctx.TODO(), secretName, metav1.GetOptions{})
 	if err != nil {
+		if k8errors.IsNotFound(err) {
+			return map[string][]byte{
+				"username": []byte("smtp_username"),
+				"password": []byte("smtp_password"),
+				"host":     []byte("smtp.example.com"),
+				"port":     []byte("587"),
+			}, nil
+		}
 		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}
 	smtp := res.Data
 	// sets default smtp host value as
 	// it could not be set in the smtp secret to avoid issue with the 3scale api
+	if string(smtp["username"]) == "" {
+		smtp["username"] = []byte("smtp_username")
+	}
+	if string(smtp["password"]) == "" {
+		smtp["password"] = []byte("smtp_password")
+	}
 	if string(smtp["host"]) == "" {
 		smtp["host"] = []byte("smtp.example.com")
 	}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3021

# What
Provides dummy values for templateUtil which allows for RHOAM to be installed even when the SMTP secret is missing. Also includes unit tests for new get functions.

# Verification steps
1. Run the RHOAM operator locally  by running the following commands : 
```sh
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run 
```
2. In a separate terminal remove the SMTP secret and check that its been removed by running the following command 
```sh
oc delete secret redhat-rhoam-smtp -n redhat-rhoam-operator
oc get secrets -n redhat-rhoam-operator
```
3. Check that the missingSmtp alert is firing in  observability -> Prometheus
4. Verify that RHOAM has been installed successfully.


