### PR TITLE
MGDAPI-2370 revert failing test after MSP demo

### DIFF
--- a/config/scorecard/kuttl/02-scalability/00-test-pod-template.yaml
+++ b/config/scorecard/kuttl/02-scalability/00-test-pod-template.yaml
@@ -26,7 +26,7 @@ spec:
       image: "quay.io/integreatly/integreatly-operator-test-harness:master"
       args:
         - '-ginkgo.focus'
-        - '(F05)|(F01)'
+        - '(F05)|(F08)'
     - resources: {}
       terminationMessagePath: /dev/termination-log
       name: sidecar


### PR DESCRIPTION
Remove failing test (added on purpose in https://github.com/integr8ly/integreatly-operator/commit/755020ca5a91f8b2765531c028ff200656fca784)