### PR TITLE
MGDAPI-3257 - update keycloak-client

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/integr8ly/cloud-resource-operator v0.33.0
 	github.com/integr8ly/grafana-operator v2.0.0+incompatible
 	github.com/integr8ly/grafana-operator/v3 v3.10.3
-	github.com/integr8ly/keycloak-client v0.1.6-0.20211011133857-8e862bf47e7e
+	github.com/integr8ly/keycloak-client v0.1.7
 	github.com/keycloak/keycloak-operator v0.0.0-20210506103913-57d81e278bcb
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.13.0

--- a/go.sum
+++ b/go.sum
@@ -957,8 +957,8 @@ github.com/integr8ly/grafana-operator/v3 v3.5.0/go.mod h1:nie1yDLaWkgUjW+EBTLUjD
 github.com/integr8ly/grafana-operator/v3 v3.6.0/go.mod h1:pWWg9RerCkkwmTcmaygmfhkjjGilEN30han1yq2MAsA=
 github.com/integr8ly/grafana-operator/v3 v3.10.3 h1:cq+2wO0mrz2Ow36MVsugCcZNqRA9sC1bRadrVg/CeOg=
 github.com/integr8ly/grafana-operator/v3 v3.10.3/go.mod h1:5D8+MTrFKiwxz4kz2Oc36MxQu4EOHnJKaStSFAOukz0=
-github.com/integr8ly/keycloak-client v0.1.6-0.20211011133857-8e862bf47e7e h1:3VGUB7w5bUtkn+CbW00+vGbE52cLz8OGEEgypHR4mDY=
-github.com/integr8ly/keycloak-client v0.1.6-0.20211011133857-8e862bf47e7e/go.mod h1:UyM3uRRR5kpq/6xGCEvVPpneduPoPQ7hgMp+Mv9VvXs=
+github.com/integr8ly/keycloak-client v0.1.7 h1:EH4vh71WFph3hYO4HBCPSZCP9WYTpowFCTw1VuDr/Nk=
+github.com/integr8ly/keycloak-client v0.1.7/go.mod h1:R+XTU1w5C1yv1eRgb8ZdP9rLvzBp7HTUs3rgpyVI97A=
 github.com/jackc/fake v0.0.0-20150926172116-812a484cc733/go.mod h1:WrMFNQdiFJ80sQsxDoMokWK1W5TQtxBFNpzWTD84ibQ=
 github.com/jackc/pgx v3.2.0+incompatible/go.mod h1:0ZGrqGqkRlliWnWB4zKnWtjbSWbGkVEFm4TeybAXq+I=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
@@ -1960,6 +1960,7 @@ golang.org/x/sys v0.0.0-20200519105757-fe76b779f299/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200523222454-059865788121/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200602225109-6fdc65e7d980/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200724161237-0e2f3a69832c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -2388,6 +2389,7 @@ sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210702145813-742983631190/go.mod h
 sigs.k8s.io/kubebuilder/v3 v3.0.0-alpha.0.0.20210803185103-51e4a9aa5055/go.mod h1:pUhjQx9f/+cn1OtSa5zMohY1lgk9s/9Mbcvwj82lrNk=
 sigs.k8s.io/kustomize v2.0.3+incompatible/go.mod h1:MkjgH3RdOWrievjo6c9T245dYlB5QeXV4WCbnt/PEpU=
 sigs.k8s.io/kustomize/kyaml v0.10.21/go.mod h1:TYWhGwW9vjoRh3rWqBwB/ZOXyEGRVWe7Ggc3+KZIO+c=
+sigs.k8s.io/structured-merge-diff/v4 v4.0.1/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2 h1:YHQV7Dajm86OuqnIR6zAelnDWBRjo+YhYV9PmGrh1s8=
 sigs.k8s.io/structured-merge-diff/v4 v4.0.2/go.mod h1:bJZC9H9iH24zzfZ/41RGcq60oK1F7G282QMXDPYydCw=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=

--- a/products/products.yaml
+++ b/products/products.yaml
@@ -49,7 +49,7 @@ products:
     manifestsDir: "integreatly-rhsso"
     quayScan: true
   - name: keycloak-client
-    version: v0.1.4
+    version: v0.1.7
     url: "https://github.com/integr8ly/keycloak-client"
     installType: "rhmi/rhoam"
     manifestsDir: "integreatly-keycloak-client"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -515,7 +515,7 @@ github.com/integr8ly/grafana-operator/pkg/apis/integreatly/v1alpha1
 # github.com/integr8ly/grafana-operator/v3 v3.10.3
 ## explicit
 github.com/integr8ly/grafana-operator/v3/pkg/apis/integreatly/v1alpha1
-# github.com/integr8ly/keycloak-client v0.1.6-0.20211011133857-8e862bf47e7e
+# github.com/integr8ly/keycloak-client v0.1.7
 ## explicit
 github.com/integr8ly/keycloak-client/pkg/common
 # github.com/jmespath/go-jmespath v0.4.0


### PR DESCRIPTION
# Issue link
Jira: [MGDAPI-3257](https://issues.redhat.com/browse/MGDAPI-3257)

# What
Update keycloak-client version to latest commit (Go update to 1.17).

# Verification steps
Unit and e2e tests are sufficient
