### PR TITLE
MGDAPI-3374 update bundle rhmi operators script and readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,10 +314,9 @@ cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prep
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
 
-# Temporary disable create/olm/bundle due to move from pkgman to bundle format.
-# .PHONY: create/olm/bundle
-# create/olm/bundle:
-# 	./scripts/bundle-rhmi-operators.sh
+.PHONY: create/olm/bundle
+create/olm/bundle:
+	./scripts/bundle-rhmi-operators.sh
 
 .PHONY: cluster/prepare/project
 cluster/prepare/project:

--- a/README.md
+++ b/README.md
@@ -133,14 +133,9 @@ Once the installation completed the command wil result in following output:
 
 ## Deploying to a Cluster with OLM and the Bundle Format
 
-There exists a number of variables, that can prepend the make target below. Refer to [this](/scripts/README.md#system-variables) document.
-
 In order to create a bundle and/or deploy RHMI or RHOAM with OLM follow refer to [this](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/) document.
 
-OLM will create a PackageManifest (integreatly) based on the CatalogSource (rhmi-operators) in the openshift-marketplace namespace. 
-Confirm both and then find the RHMI/RHOAM in the OperatorHub. Verify that the version references the latest version available in the index and click install
-
-For more details refer to [this](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/install-upgrade-rhoam-bundle.md#installing-rhmi-through-olm-with-bundle-format) readme file.
+For more details refer to [this](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md#installing-rhmi-through-olm-with-bundle-format) readme file.
 
 ## 	Identity Provider setup
 ### Set up testing IDP for OSD cluster

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A Kubernetes Operator based on the Operator SDK for installing and reconciling managed products.
 
-An Integreatly Operator can be installed using two different flavours: `managed` or `managed-api`
+An Integreatly Operator can be installed using three different flavours: `managed`, `managed-api` or `multitenant-managed-api`
 
-To switch between the two you can use export the `INSTALLATION_TYPE` env or use it in conjunction with any of the make commands referenced in this README
+To switch between the three you can use export the `INSTALLATION_TYPE` env or use it in conjunction with any of the make commands referenced in this README
 
 ### Installed products
 
@@ -27,6 +27,11 @@ The operator installs the following products:
 - RHSSO (both a cluster instance, and a user instance)
 - Marin3r
 
+### multitenant-managed-api
+
+- 3scale
+- RHSSO (cluster instance)
+- Marin3r
 
 ## Prerequisites
 
@@ -54,7 +59,7 @@ See [here](https://github.com/integr8ly/delorean/tree/master/docs/ocm) for an up
 ## Local Development
 Ensure that the cluster satisfies minimal requirements: 
 - RHMI (managed): 26 vCPU 
-- RHOAM (managed-api): 18 vCPU. More details can be found in the [service definition](https://access.redhat.com/articles/5534341) 
+- RHOAM (managed-api and multitenant-managed-api): 18 vCPU. More details can be found in the [service definition](https://access.redhat.com/articles/5534341) 
   under the "Resource Requirements" section
 
 ### 1. Clone the integreatly-operator
@@ -89,7 +94,7 @@ INSTALLATION_TYPE=managed-api IN_PROW=true USE_CLUSTER_STORAGE=<true/false> make
 
 | Variable | Options | Type | Default | Details |
 |----------|---------|:----:|---------|-------|
-| INSTALLATION_TYPE     | `managed` or `managed-api`| **Required** |`managed`  | Manages installation type. `managed` stands for RHMI. `managed-api` for RHOAM. |
+| INSTALLATION_TYPE     | `managed`, `managed-api` or `multitenant-managed-api` | **Required** |`managed`  | Manages installation type. `managed` stands for RHMI. `managed-api` for RHOAM. `multitenant-managed-api` for Multitenant RHOAM. |
 | IN_PROW               | `true` or `false`         | Optional      |`false`    | If `true`, reduces the number of pods created. Use for small clusters |
 | USE_CLUSTER_STORAGE   | `true` or `false`         | Optional      |`true`     | If `true`, installs application to the cloud provider. Otherwise installs to the OpenShift. |
 
@@ -98,7 +103,7 @@ INSTALLATION_TYPE=managed-api IN_PROW=true USE_CLUSTER_STORAGE=<true/false> make
 Include the `INSTALLATION_TYPE` if you haven't already exported it. 
 The operator can now be run locally:
 ```shell
-INSTALLATION_TYPE=<managed/managed-api> make code/run
+INSTALLATION_TYPE=<managed/managed-api/multitenant-managed-api> make code/run
 ```
 If you want to run the operator from a specific image, you can specify the image and run `make cluster/deploy`
 ```shell
@@ -119,6 +124,8 @@ For `RHMI` (managed): `oc get rhmi rhmi -n redhat-rhmi-operator -o json | jq .st
 
 For `RHOAM` (managed-api): `oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage `
 
+For `RHOAM Multitenant` (multitenant-managed-api): `oc get rhmi rhoam -n sandbox-rhoam-operator -o json | jq .status.stage `
+
 Once the installation completed the command wil result in following output:  
 ```yaml
 "complete"
@@ -126,17 +133,14 @@ Once the installation completed the command wil result in following output:
 
 ## Deploying to a Cluster with OLM and the Bundle Format
 
-### 1. Bundles
 There exists a number of variables, that can prepend the make target below. Refer to [this](/scripts/README.md#system-variables) document.
 
+In order to create a bundle and/or deploy RHMI or RHOAM with OLM follow refer to [this](https://sdk.operatorframework.io/docs/olm-integration/tutorial-bundle/) document.
 
-To generate bundles run the script: `./scripts/bundle-rhmi-opertors.sh `
-
-### 2. Install from OperatorHub
 OLM will create a PackageManifest (integreatly) based on the CatalogSource (rhmi-operators) in the openshift-marketplace namespace. 
-Confirm both and then find the RHMI in the OperatorHub. Verify that the version references the latest version available in the index and click install
+Confirm both and then find the RHMI/RHOAM in the OperatorHub. Verify that the version references the latest version available in the index and click install
 
-For more details refer to [this](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md#installing-rhmi-through-olm-with-bundle-format) readme file. 
+For more details refer to [this](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/install-upgrade-rhoam-bundle.md#installing-rhmi-through-olm-with-bundle-format) readme file.
 
 ## 	Identity Provider setup
 ### Set up testing IDP for OSD cluster
@@ -204,7 +208,7 @@ This may cause side effects related to the cloud resources test.
 To run E2E tests against a clean OpenShift cluster using operator-sdk, build and push an image 
 to your own quay repo, then run the command below changing the installation type based on which type you are testing:
 ```
-make test/e2e INSTALLATION_TYPE=<managed/managed-api> OPERATOR_IMAGE=<your/repo/image:tag>
+make test/e2e INSTALLATION_TYPE=<managed/managed-api/multitenant-managed-api> OPERATOR_IMAGE=<your/repo/image:tag>
 ```
 
 To run E2E tests against an existing RHMI cluster:
@@ -214,7 +218,7 @@ make test/functional
 
 To run a single E2E test against a running cluster run the command below where E03 is the start of the test description:
 ```
-INSTALLATION_TYPE=<managed/managed-api> TEST=E03 make test/e2e/single
+INSTALLATION_TYPE=<managed/managed-api/multitenant-managed-api> TEST=E03 make test/e2e/single
 ```
 ### Product tests
 

--- a/bundles/integreatly-operator/bundle.Dockerfile
+++ b/bundles/integreatly-operator/bundle.Dockerfile
@@ -3,6 +3,8 @@
 FROM scratch
 
 ARG version version
+ARG manifest_path=bundles/integreatly-operator/${version}/manifests
+ARG metadata_path=bundles/integreatly-operator/${version}/metadata
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -11,5 +13,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=integreatly-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 
-COPY bundles/integreatly-operator/${version}/manifests /manifests/
-COPY bundles/integreatly-operator/${version}/metadata /metadata/
+COPY ${manifest_path} /manifests/
+COPY ${metadata_path} /metadata/

--- a/bundles/managed-api-service/1.15.1/metadata/annotations.yaml
+++ b/bundles/managed-api-service/1.15.1/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: rhmi
-  operators.operatorframework.io.bundle.channels.v1: rhmi
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/bundles/managed-api-service/1.15.2/metadata/annotations.yaml
+++ b/bundles/managed-api-service/1.15.2/metadata/annotations.yaml
@@ -1,6 +1,6 @@
 annotations:
-  operators.operatorframework.io.bundle.channel.default.v1: rhmi
-  operators.operatorframework.io.bundle.channels.v1: rhmi
+  operators.operatorframework.io.bundle.channel.default.v1: stable
+  operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.mediatype.v1: registry+v1
   operators.operatorframework.io.bundle.metadata.v1: metadata/

--- a/bundles/managed-api-service/1.16.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.16.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -51,7 +51,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.16.0-rc1
+    containerImage: quay.io/integreatly/managed-api-service:rhoam-cpaas-1.16.0-rc2
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.9"}]'
     operatorframework.io/suggested-namespace: redhat-rhoam-operator
     operators.operatorframework.io/builder: operator-sdk-v1.11.0+git
@@ -504,7 +504,7 @@ spec:
                         value: default@test.com
                       - name: QUOTA
                         value: "200"
-                    image: quay.io/integreatly/managed-api-service:rhoam-v1.16.0-rc1
+                    image: quay.io/integreatly/managed-api-service:rhoam-cpaas-1.16.0-rc2
                     imagePullPolicy: Always
                     name: rhmi-operator
                     ports:

--- a/bundles/managed-api-service/bundle.Dockerfile
+++ b/bundles/managed-api-service/bundle.Dockerfile
@@ -2,7 +2,7 @@
 
 FROM scratch
 
-ARG version version
+ARG version
 ARG manifest_path=bundles/managed-api-service/${version}/manifests
 ARG metadata_path=bundles/managed-api-service/${version}/metadata
 

--- a/bundles/managed-api-service/bundle.Dockerfile
+++ b/bundles/managed-api-service/bundle.Dockerfile
@@ -3,6 +3,8 @@
 FROM scratch
 
 ARG version version
+ARG manifest_path=bundles/managed-api-service/${version}/manifests
+ARG metadata_path=bundles/managed-api-service/${version}/metadata
 
 LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
@@ -11,5 +13,5 @@ LABEL operators.operatorframework.io.bundle.package.v1=managed-api-service
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
 
-COPY bundles/managed-api-service/${version}/manifests /manifests/
-COPY bundles/managed-api-service/${version}/metadata /metadata/
+COPY ${manifest_path} /manifests/
+COPY ${metadata_path} /metadata/

--- a/scripts/bundle-rhmi-operators.sh
+++ b/scripts/bundle-rhmi-operators.sh
@@ -4,7 +4,7 @@
 # - opm
 # - operator-sdk
 # Function:
-# Builds and pushes the bundles and indexes for RHMI or/and RHOAM
+# Script creates olm bundle/bundles and index/indexes for RHOAM/RHMI 
 # Usage:
 # make create/olm/bundle OLM_TYPE=<managed||managed-api> UPGRADE=<true||false> BUNDLE_VERSIONS=<VERSION_n, VERSION_n-X...> ORG=<QUAY ORG> REG=<REGISTRY>
 # OLM_TYPE - must be specified, refers to type of operator lifecycle manager type, can either be integreatly-operator (RHMI) or managed-api-service (RHOAM)
@@ -40,6 +40,7 @@ BUILD_TOOL="${BUILD_TOOL:-docker}"
 UPGRADE_RHMI="${UPGRADE:-false}"
 VERSIONS="${BUNDLE_VERSIONS:-$LATEST_VERSION}"
 ROOT=$(pwd)
+INDEX=""
 
 start() {
   clean_up
@@ -49,6 +50,8 @@ start() {
   generate_bundles
   generate_index
   clean_up
+  echo "Index images are: "
+  echo $INDEX
 }
 
 create_work_area() {
@@ -128,6 +131,10 @@ push_index() {
   printf 'Pushing index image:'$INDEX_IMAGE'\n'
 
   docker push $INDEX_IMAGE
+
+  INDEX="""$INDEX
+  $INDEX_IMAGE
+  """
 }
 
 # cleans up the working space

--- a/scripts/bundle-rhmi-operators.sh
+++ b/scripts/bundle-rhmi-operators.sh
@@ -148,7 +148,7 @@ push_index() {
 
 # creates catalog source on the cluster
 create_catalog_source() {
-printf 'Creating catalog source '$INDEX_IMAGE'\n'
+printf 'Creating catalog source '$OLDEST_IMAGE'\n'
   cd $ROOT
   oc delete catalogsource rhmi-operators -n openshift-marketplace --ignore-not-found=true
   oc process -p INDEX_IMAGE=$OLDEST_IMAGE  -f ./config/olm/catalog-source-template.yml | oc apply -f - -n openshift-marketplace


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3374

# What
- update readme
- update bundle rhmi operator to support bundle format

# Verification steps
From this branch run:
```
INSTALLATION_TYPE=managed-api make cluster/preapare/local
```
```
INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml
```
```
make create/olm/bundle OLM_TYPE=managed-api-service UPGRADE=false BUNDLE_VERSIONS=1.16.0,1.15.2 ORG=<YOUR_QUAY_ORG> OC_INSTALL=true`
```
- And confirm that a catalog source for 1.15.2 has been created on your cluster, navigate to operators hub, find RHOAM, install under redhat-rhoam-operator ns. 
- Once installation completes, navigate to same catalog source that 1.15.2 was referred from, update it to 1.16.0.
- Navigate to installed operators and click approve on RHOAM upgrade. 
- Confirm that the upgrade has been successful. 

