### PR TITLE
CVP-2642 def mountpath for archiving test results

### DIFF
--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -6,3 +6,7 @@ stages:
 - parallel: true
   tests: []
 serviceaccount: rhoam-test-runner
+storage:
+  spec:
+    mountPath:
+      path: logs/artifacts

--- a/config/scorecard/kuttl/00-installation/07-assert.yaml
+++ b/config/scorecard/kuttl/00-installation/07-assert.yaml
@@ -1,6 +1,6 @@
 apiVersion: kuttl.dev/v1beta1
 kind: TestAssert
-timeout: 1200
+timeout: 1500
 ---
 apiVersion: integreatly.org/v1alpha1
 kind: RHMI


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/CVP-2642

# Description
* `logs/artifact` is a path used by CVP for archiving artifacts from scorecard tests
* increased install timeout for "products" stage

# To verify

1. Target an OCP cluster with RHOAM installed using cluster storage (I can provide one)
2. From this branch run
```bash
kustomize build config/manifests-rhoam | operator-sdk generate bundle --kustomize-dir=config/manifests-rhoam
cp -r config/scorecard/kuttl bundle/tests/scorecard/
operator-sdk scorecard ./bundle --namespace=redhat-rhoam-operator --skip-cleanup --verbose --output json --service-account rhoam-test-runner  --wait-time 3000s --test-output logs/artifacts -b quay.io/quay/busybox
```
3. Tests should finish successfully and you should see logs and artifacts from tests stored in `./logs/artifacts` directory
```bash
➜  integreatly-operator git:(CVP-2642) tree logs/artifacts
logs/artifacts
├── basic
│   └── basic-check-spec-test
├── happy-path
│   ├── junit-integreatly-operator.xml
│   ├── kuttl-installation.stderr
│   ├── kuttl-installation.stdout
│   ├── kuttl-test.json
│   ├── kuttl.stderr
│   ├── kuttl.stdout
│   └── log
├── olm
│   ├── olm-bundle-validation-test
│   ├── olm-crds-have-resources-test
│   ├── olm-crds-have-validation-test
│   ├── olm-spec-descriptors-test
│   └── olm-status-descriptors-test
└── scalability
    ├── kuttl-installation.stderr
    ├── kuttl-installation.stdout
    ├── kuttl-test.json
    └── log

10 directories, 11 files
```