### PR TITLE
CVP-2642 add mountpoints only to rhoam tests

### DIFF
--- a/config/scorecard/bases/config.yaml
+++ b/config/scorecard/bases/config.yaml
@@ -6,7 +6,3 @@ stages:
 - parallel: true
   tests: []
 serviceaccount: rhoam-test-runner
-storage:
-  spec:
-    mountPath:
-      path: logs/artifacts

--- a/config/scorecard/patches/kuttl.config.yaml
+++ b/config/scorecard/patches/kuttl.config.yaml
@@ -10,6 +10,10 @@
       cluster-size: small
       phase: msp-main
       test: happy-path
+    storage:
+      spec:
+        mountPath:
+          path: logs/artifacts
 - op: add
   path: /stages/0/tests/-
   value:
@@ -22,3 +26,7 @@
       cluster-size: medium
       phase: msp-main
       test: scalability
+    storage:
+      spec:
+        mountPath:
+          path: logs/artifacts


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/CVP-2642

# Description
* add storage spec only to RHOAM tests, because archiving results from other custom tests does not work in CVP:
```
"errors": [
              "tar contents corrupted"
            ],
```