### PR TITLE
MGDAPI-3299 - Allow RHOAM install while missing the deadmanssnitch se…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -310,7 +310,7 @@ ifeq ($(INSTALLATION_TYPE), managed)
 endif
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
+cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
 
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -923,7 +923,7 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 	}
 
 	if rhmiv1alpha1.IsManaged(rhmiv1alpha1.InstallationType(installation.Spec.Type)) {
-		requiredSecrets := []string{installation.Spec.PagerDutySecret, installation.Spec.DeadMansSnitchSecret}
+		requiredSecrets := []string{installation.Spec.PagerDutySecret}
 
 		for _, secretName := range requiredSecrets {
 			secret := &corev1.Secret{

--- a/pkg/products/monitoringcommon/alertmanagerConfig.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig.go
@@ -99,7 +99,7 @@ func ReconcileAlertManagerSecrets(ctx context.Context, serverClient k8sclient.Cl
 	//Get dms credentials
 	dmsSecret, err := getDMSSecret(ctx, serverClient, *installation)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, err
+		log.Warningf("Could not get DMS secret", l.Fields{"error": err.Error()})
 	}
 
 	// only set the to address to a real value for managed deployments

--- a/pkg/products/monitoringcommon/alertmanagerConfig_test.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig_test.go
@@ -273,22 +273,22 @@ func TestReconciler_reconcileAlertManagerSecrets(t *testing.T) {
 			want:    integreatlyv1alpha1.PhaseFailed,
 		},
 		{
-			name: "fails when dead mans snitch secret cannot be found",
+			name: "succeeds when dead mans snitch secret cannot be found",
 			serverClient: func() k8sclient.Client {
-				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, alertmanagerRoute)
+				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, alertmanagerRoute, clusterInfra, clusterVersion, clusterRoute)
 			},
-			wantErr: "could not obtain dead mans snitch credentials secret: secrets \"test-dms\" not found",
-			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: "",
+			want:    integreatlyv1alpha1.PhaseCompleted,
 		},
 		{
-			name: "fails when dead mans snitch url is not defined",
+			name: "succeeds when dead mans snitch url is not defined",
 			serverClient: func() k8sclient.Client {
 				emptyDMSSecret := dmsSecret.DeepCopy()
 				emptyDMSSecret.Data = map[string][]byte{}
-				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, emptyDMSSecret, alertmanagerRoute)
+				return fakeclient.NewFakeClientWithScheme(basicScheme, smtpSecret, pagerdutySecret, emptyDMSSecret, alertmanagerRoute, clusterInfra, clusterVersion, clusterRoute)
 			},
-			wantErr: "url is undefined in dead mans snitch secret",
-			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: "",
+			want:    integreatlyv1alpha1.PhaseCompleted,
 		},
 		{
 			name: "awaiting components when alert manager route cannot be found",

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -266,6 +266,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	// creates an alert to check for the presents of DeadMansSnitch secret
+	phase, err = resources.CreateDeadMansSnitchSecretExists(ctx, client, installation)
+	r.log.Infof("create DeadMansSnitch secret alerting rule", l.Fields{"phase": phase})
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile DeadMansSnitchSecretExists alert", err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileMonitoring(ctx, client)
 	r.log.Infof("reconcileMonitoring", l.Fields{"status": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -21,6 +21,7 @@ const (
 	SopUrlAlertsAndTroubleshooting                            = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts_and_troubleshooting.md"
 	sopUrlCloudResourceDeletionStatusFailed                   = "https://github.com/RHCloudServices/integreatly-help/tree/master/sops/2.x/alerts/clean_up_cloud_resources_failed_teardown.asciidoc"
 	sopUrlSendGridSmtpSecretExists                            = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/sendgrid_smtp_secret_not_present.asciidoc"
+	SopUrlDeadMansSnitchSecretExists                          = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/DeadMansSnitchSecretNotPresent.asciidoc"
 	SopUrlMarin3rEnvoyApicastProductionContainerDown          = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/Marin3rEnvoyApicastProductionContainerDown.asciidoc"
 	SopUrlMarin3rEnvoyApicastStagingContainerDown             = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/Marin3rEnvoyApicastStagingContainerDown.asciidoc"
 	SopUrlOperatorInstallDelayed                              = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/OperatorInstallDelayed.asciidoc"

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -649,6 +649,12 @@ func commonExpectedRules(installationName string) []alertsTestRule {
 			},
 		},
 		{
+			File: ObservabilityNamespacePrefix + "deadmanssnitch-secret-exists-rule.yaml",
+			Rules: []string{
+				"DeadMansSnitchSecretExists",
+			},
+		},
+		{
 			File: ObservabilityNamespacePrefix + "multi-az-pod-distribution.yaml",
 			Rules: []string{
 				"MultiAZPodDistribution",

--- a/test/common/types.go
+++ b/test/common/types.go
@@ -27,6 +27,7 @@ var (
 	AMQOnlineOperatorNamespace        = NamespacePrefix + "amq-online"
 	ApicurioRegistryProductNamespace  = NamespacePrefix + "apicurio-registry"
 	SMTPSecretName                    = NamespacePrefix + "smtp"
+	DMSSecretName                     = NamespacePrefix + "deadmanssnitch"
 	ApicurioRegistryOperatorNamespace = ApicurioRegistryProductNamespace + "-operator"
 	ApicuritoProductNamespace         = NamespacePrefix + "apicurito"
 	ApicuritoOperatorNamespace        = ApicuritoProductNamespace + "-operator"


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-3299
Pipeline MR:  https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/640
SOP PR: https://github.com/RHCloudServices/integreatly-help/pull/812

# What
Allow RHOAM install while missing the deadmanssnitch secret - dms secret removed from required in RHMI controller.
New Alert created- alert is firing in case deadmanssnitch secret is missing, and changing back to normal when secret created later.
Makefile changed: `cluster/prepare/dms` was removed from `cluster/prepare`, and 
Pipeline was updated - added option to create Dms secret for installationType = master. The default - NOT create the secret.

# Verification steps
* run `managed-api-install-master` Pipeline  with default option for `installDms` (false - no DMS secret creation)
** check that `redhat-rhoam-deadmanssnitch` secret is not present in redhat-rhoam-operator namespace
** check that Rhoam installed correctly
** check that Test-Suite is passed, no errors
* run `managed-api-install-master` Pipeline  with `installDms = true` (DMS secret creation)
** check that secret created, Rhoam installed and Pipeline passed.
* Check that ci/prow/rhoam-e2e succeeded 
* NOTE. for local test (without running Jenkins pipeline) - Temporary delete DMS secret creation option in Makefile in targets: cluster/prepare/local and code/run, and see that Rhoam installed without dms secret