### PR TITLE
MGDAPI-3453 (M02B) test to verify rhoam_version metric is exposed in Prometheus

### DIFF
--- a/test-cases/tests/monitoring/m02b-verify-rhoam-version-metric-is-exposed.md
+++ b/test-cases/tests/monitoring/m02b-verify-rhoam-version-metric-is-exposed.md
@@ -1,4 +1,6 @@
 ---
+automation:
+  - MGDAPI-3453
 products:
   - name: rhoam
     environments:
@@ -13,6 +15,8 @@ products:
       - 1.12.0
       - 1.15.0
 estimate: 15m
+tags:
+  - automated
 ---
 
 # M02B - Verify RHOAM version metric is exposed

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -83,6 +83,12 @@ var (
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
+		{
+			[]TestCase{
+				{"M02B - Verify RHOAM version metric is exposed in Prometheus", TestRhoamVersionMetricExposed},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+		},
 	}
 
 	IDP_BASED_TESTS = []TestSuite{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3453
# What
Check for the existence of a metric called `rhoam_version` in Prometheus.

# Verification steps
Run the test called M02B: 
```
export INSTALLATION_TYPE=managed-api
export BYPASS_STORAGE_TYPE_CHECK=true
export TEST=M02B
make test/e2e/single
```
