### PR TITLE
MGDAPI-3475 skip only AWS tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ make test/unit
 
 ### E2E tests
 
-A `BYPASS_STORAGE_TYPE_CHECK=true` flag is used to allow test to run when the operator is installed using cluster storage.
-This may cause side effects related to the cloud resources test.
+If you have RHOAM operator installed using cluster storage (`useClusterStorage: true`), all [AWS tests](https://github.com/integr8ly/integreatly-operator/blob/27c4a8c4fdf3461247fad2bb20fe958d4b709a99/test/functional/tests.go#L6-L12) are being skipped (because all AWS tests would fail).
+To override this, you can provide an env var `BYPASS_STORAGE_TYPE_CHECK=true`.
 
 To run E2E tests against a clean OpenShift cluster using operator-sdk, build and push an image 
 to your own quay repo, then run the command below changing the installation type based on which type you are testing:

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -2,7 +2,6 @@ package functional
 
 import (
 	"fmt"
-	"os"
 	"testing"
 
 	threescaleBv1 "github.com/3scale/3scale-operator/pkg/apis/capabilities/v1beta1"
@@ -55,23 +54,6 @@ func TestAPIs(t *testing.T) {
 	cfg.Impersonate = rest.ImpersonationConfig{
 		UserName: "system:admin",
 		Groups:   []string{"system:authenticated"},
-	}
-
-	// Allow overriding via environment variable
-	if os.Getenv("BYPASS_STORAGE_TYPE_CHECK") != "true" {
-		// get RMI CR and if cluster storage set to true, skip the suite
-		context, err := common.NewTestingContext(cfg)
-		if err != nil {
-			t.Fatalf("\"failed to create testing context: %s", err)
-		}
-		rhmi, err := common.GetRHMI(context.Client, true)
-		if err != nil {
-			t.Fatalf("error getting RHMI CR: %v", err)
-		}
-		if rhmi.Spec.UseClusterStorage == "true" {
-			t.Skip("Aborting functional tests: \"UseClusterStorage\" is set to true. \nPlease, run another testing suite or reinstall operator with \"UseClusterStorage\" set to false" +
-				"\nOr set BYPASS_STORAGE_TYPE_CHECK=true to bypass check")
-		}
 	}
 
 	// get install type


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3475

# What
When running functional test suite, by default skip only AWS tests in case RHOAM is installed using cluster storage
(`useClusterStorage: true`)

# Verification steps

```bash
export INSTALLATION_TYPE=managed-api
```

**On a cluster with RHOAM installed using cluster storage (`useClusterStorage: true`):**

Test should pass
```bash
make test/e2e/single TEST="A01"
```

(AWS) Test should be skipped, because we're using cluster storage
```bash
make test/e2e/single TEST="F01"
```

(AWS) Test should fail, because we're using cluster storage, but it's overridden with `BYPASS_STORAGE_TYPE_CHECK`
```bash
BYPASS_STORAGE_TYPE_CHECK=true make test/e2e/single TEST="F01"
```

**On a cluster with RHOAM installed using AWS storage (`useClusterStorage: false`):**

All commands below should pass (i.e. all tests should be run and should succeed)

```bash
make test/e2e/single TEST="A01"

make test/e2e/single TEST="F01"

BYPASS_STORAGE_TYPE_CHECK=true make test/e2e/single TEST="F01"
```
