### PR TITLE
fix spelling error in alerts firing test log

### DIFF
--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -66,7 +66,7 @@ func TestIntegreatlyAlertsMechanism(t TestingTB, ctx *TestingContext) {
 		t.FailNow()
 	}
 
-	t.Log("Keycloak alerts are not firing - scaling down keycloak operator deployemnt and performing tests")
+	t.Log("Keycloak alerts are not firing - scaling down keycloak operator deployment and performing tests")
 	err = performTest(t, ctx, originalOperatorReplicas)
 	if err != nil {
 		t.Fatal("Error during testing keycloak operator alerts: %s", err)


### PR DESCRIPTION
# What
Fix spelling error in test logs
