### PR TITLE
MGDAPI-3476 Added 3Scale cluster scoped tests to new test case

### DIFF
--- a/test/common/3scale_backend_via_CR.go
+++ b/test/common/3scale_backend_via_CR.go
@@ -20,16 +20,6 @@ const (
 )
 
 func Test3scaleBackendViaCR(t TestingTB, ctx *TestingContext) {
-	// verify that 3scale is cluster scoped and if not, skip the test
-	isThreescaleClusterScoped, err := isClusterScoped(ctx)
-	if err != nil {
-		t.Fatalf("failed to establish if 3scale is cluster scoped or not %v", err)
-	}
-
-	if !isThreescaleClusterScoped {
-		t.Skip("skipping as 3scale is not cluster scoped")
-	}
-
 	// make project
 	project, err := makeProject(ctx)
 	if err != nil {

--- a/test/common/3scale_product_via_CR.go
+++ b/test/common/3scale_product_via_CR.go
@@ -16,16 +16,6 @@ const (
 )
 
 func Test3scaleProductViaCR(t TestingTB, ctx *TestingContext) {
-	// verify that 3scale is cluster scoped and if not, skip the test
-	isThreescaleClusterScoped, err := isClusterScoped(ctx)
-	if err != nil {
-		t.Fatalf("failed to establish if 3scale is cluster scoped or not %v", err)
-	}
-
-	if !isThreescaleClusterScoped {
-		t.Skip("skipping as 3scale is not cluster scoped")
-	}
-
 	// make project
 	project, err := makeProject(ctx)
 	if err != nil {

--- a/test/common/3scale_tenant_via_CR.go
+++ b/test/common/3scale_tenant_via_CR.go
@@ -11,7 +11,6 @@ import (
 	portaClient "github.com/3scale/3scale-porta-go-client/client"
 	projectv1 "github.com/openshift/api/project/v1"
 	routev1 "github.com/openshift/api/route/v1"
-	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -36,16 +35,6 @@ const (
 
 // Tests that a user in group dedicated-admins can create an integration
 func Test3scaleTenantViaCr(t TestingTB, ctx *TestingContext) {
-	// verify that 3scale is cluster scoped and if not, skip the test
-	isThreescaleClusterScoped, err := isClusterScoped(ctx)
-	if err != nil {
-		t.Fatalf("failed to establish if 3scale is cluster scoped or not %v", err)
-	}
-
-	if !isThreescaleClusterScoped {
-		t.Skip("skipping as 3scale is not cluster scoped")
-	}
-
 	// make project
 	project, err := makeProject(ctx)
 	if err != nil {
@@ -258,26 +247,4 @@ func getTenantID(ctx *TestingContext) (int64, error) {
 	}
 
 	return tenantID, nil
-}
-
-func isClusterScoped(ctx *TestingContext) (bool, error) {
-	threeScaleOperatorGroup := &operatorsv1.OperatorGroup{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "rhmi-registry-og",
-			Namespace: ThreeScaleOperatorNamespace,
-		},
-	}
-
-	err := ctx.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: "rhmi-registry-og", Namespace: ThreeScaleOperatorNamespace}, threeScaleOperatorGroup)
-	if err != nil {
-		return false, err
-	}
-
-	for _, namespace := range threeScaleOperatorGroup.Status.Namespaces {
-		if namespace == "" {
-			return true, nil
-		}
-	}
-
-	return false, nil
 }

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -428,7 +428,7 @@ func writeObjToYAMLFile(obj interface{}, out string) error {
 func WriteRHMICRToFile(client dynclient.Client, file string) error {
 	rhmi, err := GetRHMI(client, true)
 	if err != nil {
-		return fmt.Errorf("Failed to write RHMI cr due to error %w", err)
+		return fmt.Errorf("failed to write RHMI cr due to error %w", err)
 	}
 	return writeObjToYAMLFile(rhmi, file)
 }

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -8,13 +8,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/onsi/ginkgo"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http"
 	"net/http/cookiejar"
 	"strings"
 	"time"
+
+	"github.com/onsi/ginkgo"
+	"k8s.io/apimachinery/pkg/util/wait"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -35,6 +36,10 @@ import (
 	"k8s.io/client-go/tools/remotecommand"
 	dynclient "sigs.k8s.io/controller-runtime/pkg/client"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	goctx "context"
+	operatorsv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func NewTestingContext(kubeConfig *rest.Config) (*TestingContext, error) {
@@ -177,7 +182,7 @@ func GetRHMI(client k8sclient.Client, failNotExist bool) (*rhmiv1alpha1.RHMI, er
 		return nil, nil
 	}
 	if len(installationList.Items) != 1 {
-		return nil, fmt.Errorf("Unexpected number of rhmi CRs: %w", err)
+		return nil, fmt.Errorf("unexpected number of rhmi CRs: %w", err)
 	}
 	return &installationList.Items[0], nil
 }
@@ -372,6 +377,44 @@ func GetScalabilityTestCases(installType string) []TestCase {
 		}
 	}
 	return testCases
+}
+
+func GetClusterScopedTestCases(installType string) []TestCase {
+	testCases := []TestCase{}
+	for _, testSuite := range THREESCALE_CLUSTER_SCOPED_TESTS {
+		for _, tsInstallType := range testSuite.InstallType {
+			if string(tsInstallType) == installType {
+				testCases = append(testCases, testSuite.TestCases...)
+			}
+		}
+	}
+	return testCases
+}
+
+func IsClusterScoped(restConfig *rest.Config) (bool, error) {
+	context, err := NewTestingContext(restConfig)
+	if err != nil {
+		return false, err
+	}
+	threeScaleOperatorGroup := &operatorsv1.OperatorGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhmi-registry-og",
+			Namespace: ThreeScaleOperatorNamespace,
+		},
+	}
+
+	err = context.Client.Get(goctx.TODO(), k8sclient.ObjectKey{Name: "rhmi-registry-og", Namespace: ThreeScaleOperatorNamespace}, threeScaleOperatorGroup)
+	if err != nil {
+		return false, err
+	}
+
+	for _, namespace := range threeScaleOperatorGroup.Status.Namespaces {
+		if namespace == "" {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func writeObjToYAMLFile(obj interface{}, out string) error {

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -71,9 +71,6 @@ var (
 				/*FLAKY on RHMI*/ {"Verify Alerts are not firing during or after installation apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
 				{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
 				{"A27 + A28 - Verify pod priority class is created and set", TestPriorityClass},
-				{"H29 - Verify that backend can be created via backend CR", Test3scaleBackendViaCR},
-				{"H30 - Verify that product can be created via product CR", Test3scaleProductViaCR},
-				{"H31 - Verify that tenant can be created via tenant CR", Test3scaleTenantViaCr},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
@@ -82,6 +79,17 @@ var (
 				{"M01 - Verify multitenancy works as expected", TestMultitenancy},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeMultitenantManagedApi},
+		},
+	}
+
+	THREESCALE_CLUSTER_SCOPED_TESTS = []TestSuite{
+		{
+			[]TestCase{
+				{"H29 - Verify that backend can be created via backend CR", Test3scaleBackendViaCR},
+				{"H30 - Verify that product can be created via product CR", Test3scaleProductViaCR},
+				{"H31 - Verify that tenant can be created via tenant CR", Test3scaleTenantViaCr},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 	}
 

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -82,14 +82,15 @@ var (
 		},
 	}
 
+	//Threescale cluster scoped test suite to be used when Threescale becomes cluster scoped.
 	THREESCALE_CLUSTER_SCOPED_TESTS = []TestSuite{
 		{
 			[]TestCase{
-				{"H29 - Verify that backend can be created via backend CR", Test3scaleBackendViaCR},
-				{"H30 - Verify that product can be created via product CR", Test3scaleProductViaCR},
-				{"H31 - Verify that tenant can be created via tenant CR", Test3scaleTenantViaCr},
+				//{"H29 - Verify that backend can be created via backend CR", Test3scaleBackendViaCR},
+				//{"H30 - Verify that product can be created via product CR", Test3scaleProductViaCR},
+				//{"H31 - Verify that tenant can be created via tenant CR", Test3scaleTenantViaCr},
 			},
-			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManaged, v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},
 	}
 

--- a/test/e2e/integretly_test.go
+++ b/test/e2e/integretly_test.go
@@ -43,6 +43,17 @@ var _ = Describe("integreatly", func() {
 			},
 		}
 
+		clusterScoped, err := common.IsClusterScoped(restConfig)
+		if err != nil {
+			t.Error(err)
+		}
+		if clusterScoped {
+			tests = append(tests, common.Tests{
+				Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
+				TestCases: common.GetClusterScopedTestCases(installType),
+			})
+		}
+
 		if os.Getenv("DESTRUCTIVE") == "true" {
 			tests = append(tests, common.Tests{
 				Type:      "Destructive Tests",

--- a/test/e2e/integretly_test.go
+++ b/test/e2e/integretly_test.go
@@ -43,16 +43,17 @@ var _ = Describe("integreatly", func() {
 			},
 		}
 
-		clusterScoped, err := common.IsClusterScoped(restConfig)
-		if err != nil {
-			t.Error(err)
-		}
-		if clusterScoped {
-			tests = append(tests, common.Tests{
-				Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
-				TestCases: common.GetClusterScopedTestCases(installType),
-			})
-		}
+		//Function to be used when Threescale becomes cluster scoped.
+		// clusterScoped, err := common.IsClusterScoped(restConfig)
+		// if err != nil {
+		// 	t.Error(err)
+		// }
+		// if clusterScoped {
+		// 	tests = append(tests, common.Tests{
+		// 		Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
+		// 		TestCases: common.GetClusterScopedTestCases(installType),
+		// 	})
+		// }
 
 		if os.Getenv("DESTRUCTIVE") == "true" {
 			tests = append(tests, common.Tests{

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -63,6 +63,17 @@ var _ = Describe("integreatly", func() {
 			})
 		}
 
+		clusterScoped, err := common.IsClusterScoped(restConfig)
+		if err != nil {
+			t.Error(err)
+		}
+		if clusterScoped {
+			tests = append(tests, common.Tests{
+				Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
+				TestCases: common.GetClusterScopedTestCases(installType),
+			})
+		}
+
 		if os.Getenv("DESTRUCTIVE") == "true" {
 			tests = append(tests, common.Tests{
 				Type:      "Destructive Tests",

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -62,17 +62,17 @@ var _ = Describe("integreatly", func() {
 				TestCases: MULTIAZ_TESTS,
 			})
 		}
-
-		clusterScoped, err := common.IsClusterScoped(restConfig)
-		if err != nil {
-			t.Error(err)
-		}
-		if clusterScoped {
-			tests = append(tests, common.Tests{
-				Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
-				TestCases: common.GetClusterScopedTestCases(installType),
-			})
-		}
+		//Function to be used when Threescale becomes cluster scoped.
+		// clusterScoped, err := common.IsClusterScoped(restConfig)
+		// if err != nil {
+		// 	t.Error(err)
+		// }
+		// if clusterScoped {
+		// 	tests = append(tests, common.Tests{
+		// 		Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
+		// 		TestCases: common.GetClusterScopedTestCases(installType),
+		// 	})
+		// }
 
 		if os.Getenv("DESTRUCTIVE") == "true" {
 			tests = append(tests, common.Tests{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3476 

# What
Previously these tests were testing whether or not the run was cluster scoped within each individual test and skipping it during the test, therefore failing it. 
The tests are now grouped in a test suite and the suite checks whether or not the run is cluster scoped before running the tests. 

# Verification steps
1. Install RHOAM off of master and make sure the tests fail.

2. Uninstall RHOAM
3. Install RHOAM from [here](https://github.com/integr8ly/integreatly-operator/pull/2409)
```
INSTALLATION_TYPE=managed-api make cluster/prepare/local
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
INSTALLATION_TYPE=managed-api make code/run
```
4. Run the tests and make sure they now pass.
Note: If you are getting an error in relation to the operator namespace being nil, change GetNamespacePrefix() to "redhat-rhoam-" [here](https://github.com/integr8ly/integreatly-operator/blob/master/test/common/types.go#L18)

# Running the tests
-  In [here](https://github.com/integr8ly/integreatly-operator/blob/master/test/common/tests.go) and [here](https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/tests.go) comment out all the tests other than the THREESCALE_CLUSTER_SCOPED_TESTS.

- Go into this file [here](https://github.com/integr8ly/integreatly-operator/blob/master/test/functional/suite_test.go) and run the TestAPI functon.


