### PR TITLE
MGDAPI-3483 Changed all info level alerts to blackhole

### DIFF
--- a/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
+++ b/templates/monitoring/alertmanager/alertmanager-application-monitoring.yaml
@@ -18,7 +18,7 @@ route:
         severity: critical
       receiver: critical
     - match:
-        alertname: ThreeScaleContainerHighMemory
+        severity: info
       receiver: blackhole
     - match:
         alertname: DeadMansSwitch


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3483

# What
All Info level alerts are being sent to the blackhole.

# Verification steps

1. In pkg -> products -> threescale -> prometheusRules.go, on line: 242 (ThreescaleBackendWorkerPod) change the severity level to info.
2. Install RHOAM off of this branch. 
3. In your cluster go to Deployments under the 3cale-operator namespace and scale the pod to 0.
4. In Deployment Configs under the 3scale namespace find the backend worker pods and scale those down to 0.
5. In Routes under the Observability namespace, go to the prometheus location and go into alerts. After a few minutes you should see the backend worker alert change from inactive to pending and then to firing.
6. Once it's firing go to Pods under the observability namespace and go into alertmanager-alertmanager-0, then access the logs.
7. You should see the deadman switch alert firing but you shouldn't see the info severity alert.
![alerts with info to blackhole](https://user-images.githubusercontent.com/59964862/155373700-1290aa22-c796-4212-a73f-c7a65a967f20.png)


- To see the info level alert firing.

1. Go to Secrets and find alertmanager-application-monitoring.
2. In Actions, edit the secret and remove the added code and save.
3. Back in pods, delete the alert manager pods and wait for them to start up again.
4. Going back into the alert manager you should see ![this](https://user-images.githubusercontent.com/59964862/155373514-3979b2e3-389b-4aa2-b2b9-147c00253af3.png)



