### PR TITLE
MGDAPI-3295 fix script/template used by RHOAM upgrade pipeline

### DIFF
--- a/config/olm/operator-subscription-template.yml
+++ b/config/olm/operator-subscription-template.yml
@@ -19,7 +19,7 @@ objects:
     spec:
       channel: ${CHANNEL}
       installPlanApproval: Automatic
-      name: integreatly
+      name: ${SUBSCRIPTION_NAME}
       source: ${CATALOG_SOURCE_CONFIG_NAME}
       sourceNamespace: ${CATALOG_SOURCE_CONFIG_NAMESPACE}
 

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -249,7 +249,7 @@ set_related_images() {
     fi
   done
 
-  containerImageRemovedLastCharacter=$(echo "${containerImageField::-1}")
+  containerImageRemovedLastCharacter=${containerImageField%?}
   containerImageField="$containerImageRemovedLastCharacter]"
   printf -v m "$containerImageField" ; m="$m" yq e -i ".metadata.annotations.containerImages= strenv(m)" bundles/$OLM_TYPE/${VERSION}/manifests/$OLM_TYPE.clusterserviceversion.yaml
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3295

# What
* small fixes required in order to get rhoam-upgrade pipeline to function properly

# Verification steps
1. Script for creating a new release should return no errors
```bash
OLM_TYPE=managed-api-service make release/prepare SEMVER=5.0.0 IMAGE_TAG=MGDAPI-3295
```
2. Creating a new RHOAM subscription should work
```bash
# Target your cluster with oc and then run
export INSTALLATION_TYPE=managed-api
for i in project quota dms pagerduty smtp; do make cluster/prepare/$i ; done
oc process -p INDEX_IMAGE=quay.io/psturc/managed-api-service-index:1.18.2 -f config/olm/catalog-source-template.yml | oc apply -f - -n openshift-marketplace
oc process -p NAMESPACE=redhat-rhoam-operator CATALOG_SOURCE_CONFIG_NAME=rhmi-operators OPERATOR_GROUP_NAME=rhmi-registry-og SUBSCRIPTION_NAME=managed-api-service CHANNEL=stable -f config/olm/operator-subscription-template.yml | oc apply -f - -n redhat-rhoam-operator
```
(In couple of seconds you should see a RHOAM operator being installed in **Operators -> Installed operators** (`redhat-rhoam-operator` namespace)
<img width="1780" alt="Screenshot 2022-03-07 at 14 53 01" src="https://user-images.githubusercontent.com/4881144/157047270-0116b7f2-81ef-48f7-bf20-e07496b2a148.png">

