### PR TITLE
WIP MGDAPI-3377 webhook block tenant apimanger

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,36 @@ func setupWebhooks(mgr ctrl.Manager) error {
 		},
 	})
 
+	//webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
+	//	Name: "3scale-apimanager-block-create",
+	//	Rule: webhooks.NewRule().
+	//		OneResource("apps.3scale.net", "v1alpha1", "apimanagers").
+	//		ForCreate().
+	//		NamespacedScope(),
+	//	Register: webhooks.AdmissionWebhookRegister{
+	//		Type: webhooks.ValidatingType,
+	//		Path: "/3scale-apimanager-block-create",
+	//		Hook: &admission.Webhook{
+	//			Handler: addon.New3scaleCRBlockCreateHandler(mgr.GetConfig(), mgr.GetScheme()),
+	//		},
+	//	},
+	//})
+
+	webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{
+		Name: "3scale-tenant-block-create",
+		Rule: webhooks.NewRule().
+			OneResource("capabilities.3scale.net", "v1alpha1", "tenants").
+			ForCreate().
+			NamespacedScope(),
+		Register: webhooks.AdmissionWebhookRegister{
+			Type: webhooks.ValidatingType,
+			Path: "/3scale-tenant-block-create",
+			Hook: &admission.Webhook{
+				Handler: addon.New3scaleCRBlockCreateHandler(mgr.GetConfig(), mgr.GetScheme()),
+			},
+		},
+	})
+
 	// Delete webhook for the RHMI CR that uninstalls the operator if there
 	// are no finalizers left
 	webhooks.Config.AddWebhook(webhooks.IntegreatlyWebhook{

--- a/pkg/addon/addon.go
+++ b/pkg/addon/addon.go
@@ -1,8 +1,14 @@
 package addon
 
 import (
+	"context"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
+	"net/http"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
 const (
@@ -26,4 +32,64 @@ func GetName(installationType integreatlyv1alpha1.InstallationType) string {
 	}
 
 	return addonName
+}
+
+//adding a few things here to managed 3scale CR webhook handler
+type threescaleCRBlockCreateHandler struct {
+	decoder    *admission.Decoder
+	restConfig *rest.Config
+	scheme     *runtime.Scheme
+	client     k8sclient.Client
+}
+
+var _ admission.Handler = &threescaleCRBlockCreateHandler{}
+var _ admission.DecoderInjector = &threescaleCRBlockCreateHandler{}
+
+func New3scaleCRBlockCreateHandler(config *rest.Config, scheme *runtime.Scheme) admission.Handler {
+	return &threescaleCRBlockCreateHandler{
+		restConfig: config,
+		scheme:     scheme,
+	}
+}
+
+func (h *threescaleCRBlockCreateHandler) InjectDecoder(d *admission.Decoder) error {
+	h.decoder = d
+	return nil
+}
+
+func (h *threescaleCRBlockCreateHandler) Handle(ctx context.Context, request admission.Request) admission.Response {
+	rhmi := &integreatlyv1alpha1.RHMI{}
+	if err := h.decoder.DecodeRaw(request.Object, rhmi); err != nil {
+		return admission.Errored(http.StatusBadRequest, err)
+	}
+
+	//if err := h.decoder.DecodeRaw(request.OldObject, ns); err != nil {
+	//	return admission.Errored(http.StatusBadRequest, err)
+	//}
+
+	// I have access to the CR so I can access the type so can trigger on that
+	if (rhmi.Spec.Type) == "managed" || (rhmi.Spec.Type) == "managed-api" {
+		return admission.Allowed("Allow CR creation on managed-api and managed types")
+	}
+
+	//must be a better way to get this but will do for now
+	//if (ns.Name) == "sandbox-rhoam-3scale" {
+	//	return admission.Allowed("Allow CR creation in sandbox-rhoam-3scale ns")
+	//}
+    // if none of the other conditions are met block creation
+	return admission.Denied("Denied CR creation on multitenant-managed-api")
+}
+
+func (h *threescaleCRBlockCreateHandler) getClient() (k8sclient.Client, error) {
+	if h.client == nil {
+		c, err := k8sclient.New(h.restConfig, k8sclient.Options{
+			Scheme: h.scheme,
+		})
+		if err != nil {
+			return nil, err
+		}
+		h.client = c
+	}
+
+	return h.client, nil
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
MGDAPI-3377

# What
WIP PR investigate weather webhooks can be used to stop tenant CR creation and apimanger CR creation

They can

No need to review as not going to use this method to restrict CR creation in dev sandbox

