### PR TITLE
MGDAPI-1728 - Consume addon parameter for the STS role in RHOAM 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ IN_PROW ?= "false"
 # if 500 then 50M
 # if 1 then 100k
 DEV_QUOTA ?= "1"
-ROLE_ARN = "arn:aws:iam::485026278258:role/12345"
+ROLE_ARN ?= "arn:aws:iam::485026278258:role/12345"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ IN_PROW ?= "false"
 # if 500 then 50M
 # if 1 then 100k
 DEV_QUOTA ?= "1"
+ROLE_ARN = "arn:aws:iam::485026278258:role/12345"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker
@@ -310,7 +311,7 @@ ifeq ($(INSTALLATION_TYPE), managed)
 endif
 
 .PHONY: cluster/prepare
-cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/quota
+cluster/prepare: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/pagerduty cluster/prepare/delorean cluster/prepare/addon-params
 
 .PHONY: cluster/prepare/bundle
 cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/delorean
@@ -339,7 +340,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd-sandbox | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/quota cluster/prepare/delorean cluster/prepare/croaws cluster/prepare/rbac/dedicated-admins
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/addon-params cluster/prepare/delorean cluster/prepare/croaws cluster/prepare/rbac/dedicated-admins
 	@ - oc create -f config/rbac/service_account.yaml -n $(NAMESPACE)
 	@ - $(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc create -f -
 
@@ -371,9 +372,10 @@ cluster/prepare/dms:
 	@-oc create secret generic $(NAMESPACE_PREFIX)deadmanssnitch -n $(NAMESPACE) \
 		--from-literal=url=https://dms.example.com
 
-.PHONY: cluster/prepare/quota
-cluster/prepare/quota:
-	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) -f config/secrets/quota-secret.yaml | oc apply -f -
+.PHONY: cluster/prepare/addon-params
+cluster/prepare/addon-params:
+	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) StsRoleARN=$(ROLE_ARN) -f config/secrets/addon-params-secret.yaml | oc apply -f -
+
 
 .PHONY: cluster/prepare/quota/trial
 cluster/prepare/quota/trial:
@@ -549,7 +551,7 @@ bundle-rhmi: manifests kustomize
 .PHONY: bundle-rhoam
 bundle-rhoam: manifests kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=$(OPERATOR_IMAGE)
-	$(KUSTOMIZE) build config/manifests-rhoam | operator-sdk generate bundle -q --output-dir ./bundles/managed-api-service/$(TAG) --kustomize-dir config/manifests-rhoam --version $(TAG) $(BUNDLE_METADATA_OPTS) 
+	$(KUSTOMIZE) build config/manifests-rhoam | operator-sdk generate bundle -q --output-dir ./bundles/managed-api-service/$(TAG) --kustomize-dir config/manifests-rhoam --version $(TAG) $(BUNDLE_METADATA_OPTS)
 
 .PHONY: packagemanifests
 packagemanifests: manifests kustomize
@@ -562,7 +564,7 @@ bundle-build:
 	docker build -f bundle.Dockerfile -t $(BUNDLE_IMG) .
 
 # USAGE: make olm/bundle BUNDLE_TAG="quay.io/mstoklus/integreatly-index:1.15.2" VERSION=1.15.2 OLM_TYPE=managed-api-service will build a bundle from 1.15.2 bundles/managed-api-service directory.
-.PHONY: olm/bundle 
+.PHONY: olm/bundle
 olm/bundle:
 	docker build -f bundles/$(OLM_TYPE)/bundle.Dockerfile -t $(BUNDLE_TAG) --build-arg version=$(VERSION) .
 

--- a/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
+++ b/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
@@ -49,6 +49,8 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	"k8s.io/apimachinery/pkg/runtime"
+
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
@@ -94,5 +96,6 @@ func init() {
 		apiextensionv1beta1.SchemeBuilder.AddToScheme,
 		apiextensionv1.SchemeBuilder.AddToScheme,
 		observabilityoperator.SchemeBuilder.AddToScheme,
+		cloudcredentialv1.AddToScheme,
 	)
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -237,6 +237,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - cloudcredentials
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operators.coreos.com
   resourceNames:
   - rhmi-registry-cs

--- a/config/secrets/addon-params-secret.yaml
+++ b/config/secrets/addon-params-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: quota-secret
+  name: addon-params-secret
 objects:
   - apiVersion: v1
     kind: Secret
@@ -9,7 +9,10 @@ objects:
       name: addon-managed-api-service-parameters
     stringData:
       addon-managed-api-service: ${QUOTA}
+      sts-role-arn: ${StsRoleARN}
 parameters:
   - name: QUOTA
     # QUOTA value is per 100,000
     value: "1"
+  - name: StsRoleARN
+    value: "arn:aws:iam::485026278258:role/12345"

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -74,8 +75,6 @@ import (
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	"github.com/integr8ly/integreatly-operator/version"
-
-	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 const (
@@ -91,7 +90,6 @@ const (
 	priorityClassNameEnvName         = "PRIORITY_CLASS_NAME"
 	managedServicePriorityClassName  = "rhoam-pod-priority"
 	routeRequestUrl                  = "/apis/route.openshift.io/v1"
-	addonStsArnParameterName         = "sts-role-arn"
 )
 
 var (
@@ -1040,14 +1038,14 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 	}
 
 	log.Info("preflightChecks: checking if STS mode")
-	sts, err := checkIfStsClusterByCredentialsMode(context.TODO(), r.Client, installation.Namespace)
+	isSTS, err := sts.IsClusterSTS(context.TODO(), r.Client, log)
 	if err != nil {
 		log.Error("Error checking STS mode", err)
 		return result, err
 	}
-	if sts {
+	if isSTS {
 		log.Info("validation of STS role ARN parameter ")
-		validArn, err := validateAddOnStsRoleArnParamaterPattern(r.Client, installation.Namespace)
+		validArn, err := validateAddOnStsRoleArnParameterPattern(r.Client, installation.Namespace)
 		if err != nil || !validArn {
 			log.Error("STS role ARN parameter pattern validation failed", err)
 			return result, err
@@ -1521,62 +1519,29 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 	}, nil
 }
 
-func validateAddOnStsRoleArnParamaterPattern(client k8sclient.Client, namespace string) (bool, error) {
-	// function is checking if STS addon parameter Pattern is valid
-	// Parameter is Valid only in case:
-	// 1.	Parameter exists and value matching AWS Role ARN pattern
-	// Parameter is Not valid  in other cases:
-	// 2.	parameter exists and value is NOT matching AWS Role ARN pattern
-	// 3.	parameter exists and value is empty
-	// 4.	parameter does not exists
+// function is checking if STS addon parameter Pattern is valid
+// Parameter is Valid only in case:
+// 1.	Parameter exists and value matching AWS Role ARN pattern
+// Parameter is Not valid  in other cases:
+// 2.	parameter exists and value is NOT matching AWS Role ARN pattern
+// 3.	parameter exists and value is empty
+// 4.	parameter does not exists
+func validateAddOnStsRoleArnParameterPattern(client k8sclient.Client, namespace string) (bool, error) {
+	stsRoleArn, err := sts.GetStsRoleArn(context.TODO(), client, namespace)
+	if err != nil {
+		return false, fmt.Errorf("failed while retrieving addon parameter: %v", err)
+	}
 
 	awsArnPattern := "arn:aws(?:-us-gov)?:iam:\\S*:\\d+:role\\/\\S+"
 	r, err := regexp.Compile(awsArnPattern)
 	if err != nil {
-		log.Error("regexp Compile error: ", err)
-		return false, err
+		return false, fmt.Errorf("regexp Compile error: %v", err)
 	}
 
-	stsRoleArn, stsFound, err := addon.GetStringParameterByInstallType(
-		context.TODO(),
-		client,
-		rhmiv1alpha1.InstallationTypeManagedApi,
-		namespace,
-		addonStsArnParameterName,
-	)
-	if err != nil {
-		log.Error("failed while retrieving addon parameter", err)
-		return false, err
-	} else if stsFound && r.MatchString(stsRoleArn) { //case 1 - VALID
-		log.Info("ARN pattern is valid")
-		return true, nil
-	} else if stsFound && len(stsRoleArn) == 0 { //case 2 - NOT valid
-		log.Info("AWS STS role ARN parameter validation failed - parameter value is empty")
-		return false, nil
-	} else if !stsFound { //case 3 - NOT valid
-		log.Info("AWS STS role ARN parameter validation failed - parameter not found")
-		return false, nil
-	} else if stsFound && !r.MatchString(stsRoleArn) { //case 4 - NOT valid
-		log.Info("AWS STS role ARN parameter validation failed - parameter pattern is not matching to AWS ARN standard")
-		return false, nil
+	// Not a regex match
+	if !r.MatchString(stsRoleArn) {
+		return false, fmt.Errorf("AWS STS role ARN parameter validation failed - parameter pattern is not matching to AWS ARN standard")
+	}
 
-	} else {
-		log.Info("AWS STS role ARN parameter validation failed")
-		return false, nil
-	}
-}
-
-func checkIfStsClusterByCredentialsMode(ctx context.Context, client k8sclient.Client, operatorNamespace string) (bool, error) {
-	cloudCredential := &cloudcredentialv1.CloudCredential{}
-	err := client.Get(ctx, k8sclient.ObjectKey{Name: "cluster"}, cloudCredential)
-	if err != nil {
-		log.Error("failed to get cloudCredential whle checking if STS mode", err)
-		return false, err
-	}
-	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
-		log.Info("STS mode")
-		return true, nil
-	}
-	log.Info("non STS mode")
-	return false, nil
+	return true, nil
 }

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -73,6 +74,8 @@ import (
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	"github.com/integr8ly/integreatly-operator/version"
+
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 const (
@@ -88,6 +91,7 @@ const (
 	priorityClassNameEnvName         = "PRIORITY_CLASS_NAME"
 	managedServicePriorityClassName  = "rhoam-pod-priority"
 	routeRequestUrl                  = "/apis/route.openshift.io/v1"
+	addonStsArnParameterName         = "sts-role-arn"
 )
 
 var (
@@ -228,6 +232,8 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups=operator.marin3r.3scale.net,resources=discoveryservices,verbs=get;list;watch;create;update;delete,namespace=integreatly-operator
 
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list;update
+
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials,verbs=get;list;watch
 
 func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
@@ -1033,6 +1039,21 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 		}
 	}
 
+	log.Info("preflightChecks: checking if STS mode")
+	sts, err := checkIfStsClusterByCredentialsMode(context.TODO(), r.Client, installation.Namespace)
+	if err != nil {
+		log.Error("Error checking STS mode", err)
+		return result, err
+	}
+	if sts {
+		log.Info("validation of STS role ARN parameter ")
+		validArn, err := validateAddOnStsRoleArnParamaterPattern(r.Client, installation.Namespace)
+		if err != nil || !validArn {
+			log.Error("STS role ARN parameter pattern validation failed", err)
+			return result, err
+		}
+	}
+
 	installation.Status.PreflightStatus = rhmiv1alpha1.PreflightSuccess
 	installation.Status.PreflightMessage = "preflight checks passed"
 	err = r.Status().Update(context.TODO(), installation)
@@ -1498,4 +1519,64 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 			Type: installType,
 		},
 	}, nil
+}
+
+func validateAddOnStsRoleArnParamaterPattern(client k8sclient.Client, namespace string) (bool, error) {
+	// function is checking if STS addon parameter Pattern is valid
+	// Parameter is Valid only in case:
+	// 1.	Parameter exists and value matching AWS Role ARN pattern
+	// Parameter is Not valid  in other cases:
+	// 2.	parameter exists and value is NOT matching AWS Role ARN pattern
+	// 3.	parameter exists and value is empty
+	// 4.	parameter does not exists
+
+	awsArnPattern := "arn:aws(?:-us-gov)?:iam:\\S*:\\d+:role\\/\\S+"
+	r, err := regexp.Compile(awsArnPattern)
+	if err != nil {
+		log.Error("regexp Compile error: ", err)
+		return false, err
+	}
+
+	stsRoleArn, stsFound, err := addon.GetStringParameterByInstallType(
+		context.TODO(),
+		client,
+		rhmiv1alpha1.InstallationTypeManagedApi,
+		namespace,
+		addonStsArnParameterName,
+	)
+	if err != nil {
+		log.Error("failed while retrieving addon parameter", err)
+		return false, err
+	} else if stsFound && r.MatchString(stsRoleArn) { //case 1 - VALID
+		log.Info("ARN pattern is valid")
+		return true, nil
+	} else if stsFound && len(stsRoleArn) == 0 { //case 2 - NOT valid
+		log.Info("AWS STS role ARN parameter validation failed - parameter value is empty")
+		return false, nil
+	} else if !stsFound { //case 3 - NOT valid
+		log.Info("AWS STS role ARN parameter validation failed - parameter not found")
+		return false, nil
+	} else if stsFound && !r.MatchString(stsRoleArn) { //case 4 - NOT valid
+		log.Info("AWS STS role ARN parameter validation failed - parameter pattern is not matching to AWS ARN standard")
+		return false, nil
+
+	} else {
+		log.Info("AWS STS role ARN parameter validation failed")
+		return false, nil
+	}
+}
+
+func checkIfStsClusterByCredentialsMode(ctx context.Context, client k8sclient.Client, operatorNamespace string) (bool, error) {
+	cloudCredential := &cloudcredentialv1.CloudCredential{}
+	err := client.Get(ctx, k8sclient.ObjectKey{Name: "cluster"}, cloudCredential)
+	if err != nil {
+		log.Error("failed to get cloudCredential whle checking if STS mode", err)
+		return false, err
+	}
+	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
+		log.Info("STS mode")
+		return true, nil
+	}
+	log.Info("non STS mode")
+	return false, nil
 }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"regexp"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	"strings"
 	"time"
 
@@ -42,15 +42,12 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
-
-	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 const (
 	defaultInstallationNamespace = "cloud-resources"
 	serviceUpdatesKey            = "serviceUpdates"
-	croSecretName                = "sts-credentials"
-	addonStsArnParameterName     = "sts-role-arn"
+	stsCROSecretName             = "sts-credentials"
 )
 
 var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002"}
@@ -170,24 +167,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	// Check if STS Cluster, get STS role ARN addon parameter and pass ARN to Secret in CRO namespace
 	r.log.Info("checking if STS mode")
-	sts, err := checkIfStsClusterByCredentialsMode(ctx, client, operatorNamespace)
+	isSTS, err := sts.IsClusterSTS(ctx, client, r.log)
 	if err != nil {
 		r.log.Error("Error checking STS mode", err)
-		phase := integreatlyv1alpha1.PhaseFailed
-		return phase, err
+		return integreatlyv1alpha1.PhaseFailed, err
 	}
-	if sts {
-		r.log.Info("validation of STS role ARN parameter ")
-		stsRoleArn, err := getStsRoleArn(installation, client)
-		if err != nil {
-			r.log.Error("STS role ARN parameter pattern validation failed", err)
-			phase := integreatlyv1alpha1.PhaseFailed
-			return phase, err
-		}
-		r.log.Info("pass ARN into secret in cro namespace")
-		if err := passArnIntoSecretInCroNamespace(ctx, client, operatorNamespace, stsRoleArn); err != nil {
-			r.log.Error("error passing ARN into secret in cro namespace", err)
-			phase := integreatlyv1alpha1.PhaseFailed
+	if isSTS {
+		phase, err = r.createSTSArnSecret(ctx, client, operatorNamespace)
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, "Failed to create STS secret", err)
 			return phase, err
 		}
 	}
@@ -627,75 +615,31 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 	return client.Patch(ctx, cfgMap, k8sclient.Merge)
 }
 
-// passArnIntoSecretInCroNamespace pass the ARN value into a Secret in CRO namespace
-func passArnIntoSecretInCroNamespace(ctx context.Context, client k8sclient.Client, operatorNamespace string, stsRoleArn string) error {
+// createSTSArnSecret create the STS arn secret - should be already validated in preflight checks
+func (r *Reconciler) createSTSArnSecret(ctx context.Context, client k8sclient.Client, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+	stsRoleArn, err := sts.GetStsRoleArn(ctx, client, r.installation.Namespace)
+	if err != nil {
+		r.log.Error("STS role ARN parameter pattern validation failed", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
 	// create CRO credentials secret
 	credSec := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      croSecretName,
+			Name:      stsCROSecretName,
 			Namespace: operatorNamespace,
 		},
 		Data: map[string][]byte{},
 	}
 
-	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, credSec, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, client, credSec, func() error {
 		credSec.Data["role_arn"] = []byte(stsRoleArn)
 		credSec.Data["web_identity_token_file"] = []byte("/var/run/secrets/openshift/serviceaccount/token")
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to update CRO credentials Secret. Failed to pass ARN into secret: %w", err)
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update CRO credentials Secret. Failed to pass ARN into secret: %w", err)
 	}
 
-	return nil
-}
-
-func getStsRoleArn(installation *integreatlyv1alpha1.RHMI, client k8sclient.Client) (string, error) {
-	stsRoleArn, stsFound, err := addon.GetStringParameterByInstallType(
-		context.TODO(),
-		client,
-		integreatlyv1alpha1.InstallationTypeManagedApi,
-		installation.Namespace,
-		addonStsArnParameterName,
-	)
-	if err != nil {
-		return "", fmt.Errorf("failed while retrieving addon parameter %w", err)
-	} else if !stsFound || stsRoleArn == "" {
-		fmt.Printf("Non STS configuration")
-		return "", nil
-	}
-
-	validArn, err := validateStsRoleArnPattern(stsRoleArn)
-	if err != nil {
-		return "", fmt.Errorf("failed to validate STS role ARN parameter: %w", err)
-	} else if !validArn {
-		return "", fmt.Errorf("STS role ARN parameter is not valid, not matching to AWS ARN standard")
-	}
-
-	return stsRoleArn, nil
-}
-
-func checkIfStsClusterByCredentialsMode(ctx context.Context, client k8sclient.Client, operatorNamespace string) (bool, error) {
-	//Check if Cluster uses STS authentication
-	cloudCredential := &cloudcredentialv1.CloudCredential{}
-	err := client.Get(ctx, k8sclient.ObjectKey{Name: "cluster"}, cloudCredential)
-	if err != nil {
-		return false, fmt.Errorf("failed to get cloudCredential: %w", err)
-	}
-	//If CloudCredentialsModeManual - so cluster uses STS
-	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
-		return true, nil
-	}
-	return false, nil
-}
-
-func validateStsRoleArnPattern(stsRoleArn string) (bool, error) {
-	//Check ARN pattern
-	awsArnPattern := "arn:aws(?:-us-gov)?:iam:\\S*:\\d+:role\\/\\S+"
-	r, err := regexp.Compile(awsArnPattern)
-	if err != nil {
-		return false, fmt.Errorf("regexp Compile error %w", err)
-	}
-
-	return r.MatchString(stsRoleArn), nil
+	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -41,11 +42,15 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 const (
 	defaultInstallationNamespace = "cloud-resources"
 	serviceUpdatesKey            = "serviceUpdates"
+	croSecretName                = "sts-credentials"
+	addonStsArnParameterName     = "sts-role-arn"
 )
 
 var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002"}
@@ -161,6 +166,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", operatorNamespace), err)
 		return phase, err
+	}
+
+	// Check if STS Cluster, get STS role ARN addon parameter and pass ARN to Secret in CRO namespace
+	r.log.Info("checking if STS mode")
+	sts, err := checkIfStsClusterByCredentialsMode(ctx, client, operatorNamespace)
+	if err != nil {
+		r.log.Error("Error checking STS mode", err)
+		phase := integreatlyv1alpha1.PhaseFailed
+		return phase, err
+	}
+	if sts {
+		r.log.Info("validation of STS role ARN parameter ")
+		stsRoleArn, err := getStsRoleArn(installation, client)
+		if err != nil {
+			r.log.Error("STS role ARN parameter pattern validation failed", err)
+			phase := integreatlyv1alpha1.PhaseFailed
+			return phase, err
+		}
+		r.log.Info("pass ARN into secret in cro namespace")
+		if err := passArnIntoSecretInCroNamespace(ctx, client, operatorNamespace, stsRoleArn); err != nil {
+			r.log.Error("error passing ARN into secret in cro namespace", err)
+			phase := integreatlyv1alpha1.PhaseFailed
+			return phase, err
+		}
 	}
 
 	if err := r.reconcileCIDRValue(ctx, client); err != nil {
@@ -596,4 +625,77 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 	cfgMap.Data["_network"] = string(networkJSON)
 
 	return client.Patch(ctx, cfgMap, k8sclient.Merge)
+}
+
+// passArnIntoSecretInCroNamespace pass the ARN value into a Secret in CRO namespace
+func passArnIntoSecretInCroNamespace(ctx context.Context, client k8sclient.Client, operatorNamespace string, stsRoleArn string) error {
+	// create CRO credentials secret
+	credSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      croSecretName,
+			Namespace: operatorNamespace,
+		},
+		Data: map[string][]byte{},
+	}
+
+	_, err := controllerutil.CreateOrUpdate(context.TODO(), client, credSec, func() error {
+		credSec.Data["role_arn"] = []byte(stsRoleArn)
+		credSec.Data["web_identity_token_file"] = []byte("/var/run/secrets/openshift/serviceaccount/token")
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to update CRO credentials Secret. Failed to pass ARN into secret: %w", err)
+	}
+
+	return nil
+}
+
+func getStsRoleArn(installation *integreatlyv1alpha1.RHMI, client k8sclient.Client) (string, error) {
+	stsRoleArn, stsFound, err := addon.GetStringParameterByInstallType(
+		context.TODO(),
+		client,
+		integreatlyv1alpha1.InstallationTypeManagedApi,
+		installation.Namespace,
+		addonStsArnParameterName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed while retrieving addon parameter %w", err)
+	} else if !stsFound || stsRoleArn == "" {
+		fmt.Printf("Non STS configuration")
+		return "", nil
+	}
+
+	validArn, err := validateStsRoleArnPattern(stsRoleArn)
+	if err != nil {
+		return "", fmt.Errorf("failed to validate STS role ARN parameter: %w", err)
+	} else if !validArn {
+		return "", fmt.Errorf("STS role ARN parameter is not valid, not matching to AWS ARN standard")
+	}
+
+	return stsRoleArn, nil
+}
+
+func checkIfStsClusterByCredentialsMode(ctx context.Context, client k8sclient.Client, operatorNamespace string) (bool, error) {
+	//Check if Cluster uses STS authentication
+	cloudCredential := &cloudcredentialv1.CloudCredential{}
+	err := client.Get(ctx, k8sclient.ObjectKey{Name: "cluster"}, cloudCredential)
+	if err != nil {
+		return false, fmt.Errorf("failed to get cloudCredential: %w", err)
+	}
+	//If CloudCredentialsModeManual - so cluster uses STS
+	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
+		return true, nil
+	}
+	return false, nil
+}
+
+func validateStsRoleArnPattern(stsRoleArn string) (bool, error) {
+	//Check ARN pattern
+	awsArnPattern := "arn:aws(?:-us-gov)?:iam:\\S*:\\d+:role\\/\\S+"
+	r, err := regexp.Compile(awsArnPattern)
+	if err != nil {
+		return false, fmt.Errorf("regexp Compile error %w", err)
+	}
+
+	return r.MatchString(stsRoleArn), nil
 }

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -1,7 +1,10 @@
 package cloudresources
 
 import (
+	"bytes"
 	"context"
+	"testing"
+
 	threescalev1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
 	monitoringv1 "github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
@@ -15,6 +18,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"
@@ -22,10 +26,16 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"testing"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+const (
+	operatorNamespace = "openshift-operators"
 )
 
 func TestReconciler_cleanupResources(t *testing.T) {
@@ -240,5 +250,163 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	if err != nil {
 		return nil, err
 	}
+	err = cloudcredentialv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+
 	return scheme, err
+}
+
+func TestReconciler_validateStsRoleArnPattern(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		awsArnPattern string
+		want          bool
+	}{
+		{
+			name:          "ARN string Pattern is matching for AWS GovCloud (US) Regions",
+			awsArnPattern: "arn:aws-us-gov:iam::485026278258:role/12345",
+			want:          true,
+		},
+		{
+			name:          "ARN string Pattern is matching",
+			awsArnPattern: "arn:aws:iam::485026278258:role/12345",
+			want:          true,
+		},
+		{
+			name:          "ARN string Pattern is not matching #1",
+			awsArnPattern: "arn:aws:iam::485026278258:user/12345",
+			want:          false,
+		},
+		{
+			name:          "ARN string Pattern is not matching #2",
+			awsArnPattern: "12345",
+			want:          false,
+		},
+		{
+			name:          "ARN string Pattern is not matching #3",
+			awsArnPattern: "",
+			want:          false,
+		},
+	}
+	for _, tt := range tests {
+		got, err := validateStsRoleArnPattern(tt.awsArnPattern)
+		if err != nil {
+			t.Errorf("failed to validate STS role ARN parameter: %w", err)
+			return
+		}
+		if got != tt.want {
+			t.Errorf("validateStsRoleArnPattern() got = %v, want %v", got, tt.want)
+		}
+	}
+
+}
+
+func TestReconciler_passArnIntoSecretInCroNamespace(t *testing.T) {
+	sourceSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      operatorNamespace,
+			Namespace: operatorNamespace,
+		},
+		Data: map[string][]byte{
+			"role_arn": {'t', 'e', 's', 't'},
+		},
+	}
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("Error obtaining scheme")
+	}
+	type args struct {
+		ctx    context.Context
+		client client.Client
+	}
+	tests := []struct {
+		name    string
+		ARN     string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "ARN Secret passed to Cro Namespace",
+			ARN:  "test", //Note that any ARN will be passed, there is no checking of ARN pattern here.
+			args: args{
+				ctx: context.TODO(),
+				client: moqclient.NewSigsClientMoqWithScheme(scheme, sourceSecret, &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: operatorNamespace,
+						Name:      operatorNamespace,
+					},
+				}),
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		err := passArnIntoSecretInCroNamespace(tt.args.ctx, tt.args.client, operatorNamespace, tt.ARN)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("passArnIntoSecretInCroNamespace() error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+		destinationSecret := &corev1.Secret{}
+		err = tt.args.client.Get(context.TODO(), k8sclient.ObjectKey{Name: croSecretName, Namespace: operatorNamespace}, destinationSecret)
+		if err != nil {
+			return
+		}
+		if !bytes.Equal(destinationSecret.Data["role_arn"], sourceSecret.Data["role_arn"]) {
+			t.Fatalf("expected data %v, but got %v", sourceSecret.Data["role_arn"], destinationSecret.Data["role_arn"])
+		}
+	}
+}
+
+func TestReconciler_checkIfStsClusterByCredentialsMode(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("Error obtaining scheme")
+	}
+	tests := []struct {
+		name       string
+		ARN        string
+		fakeClient k8sclient.Client
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name: "STS cluster",
+			fakeClient: fake.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: cloudcredentialv1.CloudCredentialSpec{
+					CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+				},
+			}),
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Non STS cluster",
+			fakeClient: fake.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: cloudcredentialv1.CloudCredentialSpec{
+					CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+				},
+			}),
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		got, err := checkIfStsClusterByCredentialsMode(context.TODO(), tt.fakeClient, operatorNamespace)
+		if (err != nil) != tt.wantErr {
+			t.Errorf("checkIfStsClusterByCredentialsMode() error = %v, wantErr %v", err, tt.wantErr)
+			return
+		}
+		if got != tt.want {
+			t.Errorf("checkIfStsClusterByCredentialsMode() got = %v, want %v", got, tt.want)
+		}
+	}
 }

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -1,8 +1,8 @@
 package cloudresources
 
 import (
-	"bytes"
 	"context"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	"testing"
 
 	threescalev1 "github.com/3scale/3scale-operator/pkg/apis/apps/v1alpha1"
@@ -18,7 +18,6 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
-	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 	projectv1 "github.com/openshift/api/project/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	usersv1 "github.com/openshift/api/user/v1"
@@ -30,12 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-)
-
-const (
-	operatorNamespace = "openshift-operators"
 )
 
 func TestReconciler_cleanupResources(t *testing.T) {
@@ -250,163 +243,92 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = cloudcredentialv1.AddToScheme(scheme)
-	if err != nil {
-		return nil, err
-	}
 
 	return scheme, err
 }
 
-func TestReconciler_validateStsRoleArnPattern(t *testing.T) {
-
-	tests := []struct {
-		name          string
-		awsArnPattern string
-		want          bool
-	}{
-		{
-			name:          "ARN string Pattern is matching for AWS GovCloud (US) Regions",
-			awsArnPattern: "arn:aws-us-gov:iam::485026278258:role/12345",
-			want:          true,
-		},
-		{
-			name:          "ARN string Pattern is matching",
-			awsArnPattern: "arn:aws:iam::485026278258:role/12345",
-			want:          true,
-		},
-		{
-			name:          "ARN string Pattern is not matching #1",
-			awsArnPattern: "arn:aws:iam::485026278258:user/12345",
-			want:          false,
-		},
-		{
-			name:          "ARN string Pattern is not matching #2",
-			awsArnPattern: "12345",
-			want:          false,
-		},
-		{
-			name:          "ARN string Pattern is not matching #3",
-			awsArnPattern: "",
-			want:          false,
-		},
-	}
-	for _, tt := range tests {
-		got, err := validateStsRoleArnPattern(tt.awsArnPattern)
-		if err != nil {
-			t.Errorf("failed to validate STS role ARN parameter: %w", err)
-			return
-		}
-		if got != tt.want {
-			t.Errorf("validateStsRoleArnPattern() got = %v, want %v", got, tt.want)
-		}
-	}
-
-}
-
-func TestReconciler_passArnIntoSecretInCroNamespace(t *testing.T) {
-	sourceSecret := &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      operatorNamespace,
-			Namespace: operatorNamespace,
-		},
-		Data: map[string][]byte{
-			"role_arn": {'t', 'e', 's', 't'},
-		},
-	}
+func TestReconciler_createSTSArnSecret(t *testing.T) {
 	scheme, err := getBuildScheme()
 	if err != nil {
 		t.Fatalf("Error obtaining scheme")
 	}
+
+	type fields struct {
+		Config        *config.CloudResources
+		ConfigManager config.ConfigReadWriter
+		installation  *integreatlyv1alpha1.RHMI
+		mpm           marketplace.MarketplaceInterface
+		log           logger.Logger
+		Reconciler    *resources.Reconciler
+		recorder      record.EventRecorder
+	}
 	type args struct {
-		ctx    context.Context
-		client client.Client
+		ctx               context.Context
+		client            client.Client
+		operatorNamespace string
 	}
 	tests := []struct {
 		name    string
-		ARN     string
+		fields  fields
 		args    args
+		want    integreatlyv1alpha1.StatusPhase
 		wantErr bool
 	}{
 		{
-			name: "ARN Secret passed to Cro Namespace",
-			ARN:  "test", //Note that any ARN will be passed, there is no checking of ARN pattern here.
+			name: "test: phase failed on error getting role arn",
+			fields: fields{
+				log: getLogger(),
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{Namespace: defaultInstallationNamespace},
+				},
+			},
 			args: args{
-				ctx: context.TODO(),
-				client: moqclient.NewSigsClientMoqWithScheme(scheme, sourceSecret, &corev1.Namespace{
+				client: moqclient.NewSigsClientMoqWithScheme(scheme),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "test: phase complete on creating secret",
+			fields: fields{
+				log: getLogger(),
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{Namespace: defaultInstallationNamespace},
+				},
+			},
+			args: args{
+				client: moqclient.NewSigsClientMoqWithScheme(scheme, &corev1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: operatorNamespace,
-						Name:      operatorNamespace,
+						Name:      "addon-managed-api-service-parameters",
+						Namespace: defaultInstallationNamespace,
+					},
+					Data: map[string][]byte{
+						sts.AddonStsArnParameterName: []byte("arn:aws:iam::123456789012:role/12345"),
 					},
 				}),
 			},
-			wantErr: false,
+			want: integreatlyv1alpha1.PhaseCompleted,
 		},
 	}
 	for _, tt := range tests {
-		err := passArnIntoSecretInCroNamespace(tt.args.ctx, tt.args.client, operatorNamespace, tt.ARN)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("passArnIntoSecretInCroNamespace() error = %v, wantErr %v", err, tt.wantErr)
-			return
-		}
-		destinationSecret := &corev1.Secret{}
-		err = tt.args.client.Get(context.TODO(), k8sclient.ObjectKey{Name: croSecretName, Namespace: operatorNamespace}, destinationSecret)
-		if err != nil {
-			return
-		}
-		if !bytes.Equal(destinationSecret.Data["role_arn"], sourceSecret.Data["role_arn"]) {
-			t.Fatalf("expected data %v, but got %v", sourceSecret.Data["role_arn"], destinationSecret.Data["role_arn"])
-		}
-	}
-}
-
-func TestReconciler_checkIfStsClusterByCredentialsMode(t *testing.T) {
-	scheme, err := getBuildScheme()
-	if err != nil {
-		t.Fatalf("Error obtaining scheme")
-	}
-	tests := []struct {
-		name       string
-		ARN        string
-		fakeClient k8sclient.Client
-		want       bool
-		wantErr    bool
-	}{
-		{
-			name: "STS cluster",
-			fakeClient: fake.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: cloudcredentialv1.CloudCredentialSpec{
-					CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
-				},
-			}),
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "Non STS cluster",
-			fakeClient: fake.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "cluster",
-				},
-				Spec: cloudcredentialv1.CloudCredentialSpec{
-					CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
-				},
-			}),
-			want:    false,
-			wantErr: false,
-		},
-	}
-	for _, tt := range tests {
-		got, err := checkIfStsClusterByCredentialsMode(context.TODO(), tt.fakeClient, operatorNamespace)
-		if (err != nil) != tt.wantErr {
-			t.Errorf("checkIfStsClusterByCredentialsMode() error = %v, wantErr %v", err, tt.wantErr)
-			return
-		}
-		if got != tt.want {
-			t.Errorf("checkIfStsClusterByCredentialsMode() got = %v, want %v", got, tt.want)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				Config:        tt.fields.Config,
+				ConfigManager: tt.fields.ConfigManager,
+				installation:  tt.fields.installation,
+				mpm:           tt.fields.mpm,
+				log:           tt.fields.log,
+				Reconciler:    tt.fields.Reconciler,
+				recorder:      tt.fields.recorder,
+			}
+			got, err := r.createSTSArnSecret(tt.args.ctx, tt.args.client, tt.args.operatorNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createSTSArnSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("createSTSArnSecret() got = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/pkg/resources/sts/sts.go
+++ b/pkg/resources/sts/sts.go
@@ -1,0 +1,49 @@
+package sts
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	clusterCloudCredentialName = "cluster"
+	AddonStsArnParameterName   = "sts-role-arn"
+)
+
+func IsClusterSTS(ctx context.Context, client k8sclient.Client, log logger.Logger) (bool, error) {
+	cloudCredential := &cloudcredentialv1.CloudCredential{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{Name: clusterCloudCredentialName}, cloudCredential); err != nil {
+		log.Error("failed to get cloudCredential whle checking if STS mode", err)
+		return false, err
+	}
+
+	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
+		log.Info("STS mode")
+		return true, nil
+	}
+	log.Info("non STS mode")
+	return false, nil
+}
+
+func GetStsRoleArn(ctx context.Context, client k8sclient.Client, namespace string) (string, error) {
+	stsRoleArn, stsFound, err := addon.GetStringParameterByInstallType(
+		ctx,
+		client,
+		integreatlyv1alpha1.InstallationTypeManagedApi,
+		namespace,
+		AddonStsArnParameterName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed while retrieving addon parameter %w", err)
+	}
+	if !stsFound || stsRoleArn == "" {
+		return "", fmt.Errorf("no STS configuration found")
+	}
+
+	return stsRoleArn, nil
+}

--- a/pkg/resources/sts/sts_test.go
+++ b/pkg/resources/sts/sts_test.go
@@ -1,0 +1,108 @@
+package sts
+
+import (
+	"context"
+	"fmt"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := cloudcredentialv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return scheme, err
+}
+
+func TestIsClusterSTS(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("Error obtaining scheme")
+	}
+
+	type args struct {
+		ctx    context.Context
+		client client.Client
+		log    logger.Logger
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "failed to get cluster cloud credential",
+			args: args{
+				ctx: context.TODO(),
+				client: &moqclient.SigsClientInterfaceMock{GetFunc: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return fmt.Errorf("get error")
+				}},
+				log: logger.NewLogger(),
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "STS cluster",
+			args: args{
+				ctx: context.TODO(),
+				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterCloudCredentialName,
+					},
+					Spec: cloudcredentialv1.CloudCredentialSpec{
+						CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+					},
+				}),
+				log: logger.NewLogger(),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Non STS cluster",
+			args: args{
+				ctx: context.TODO(),
+				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: clusterCloudCredentialName,
+					},
+					Spec: cloudcredentialv1.CloudCredentialSpec{
+						CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+					},
+				}),
+				log: logger.NewLogger(),
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsClusterSTS(tt.args.ctx, tt.args.client, tt.args.log)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsClusterSTS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsClusterSTS() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/products/installation.yaml
+++ b/products/installation.yaml
@@ -80,7 +80,7 @@ products:
     channel: "rhmi"
     installFrom: "index"
     package: "rhmi-cloud-resources"
-    index: "quay.io/integreatly/cloud-resource-operator:index-v0.38.0"
+    index: "quay.io/kevfan/cloud-resource-operator:index-v0.38.0"
   codeready-workspaces:
     channel: "rhmi"
     installFrom: "local"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-1728

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Consume sts role addon parameter and create the secret required by CRO for sts enabled clusters

**Note**: 
- this currently uses own custom index to install CRO from the STS feature branch
- while 3scale installation will complete, 3scale could not provide access the S3 bucket provisioned by CRO as the STS implemenation does not provide any access keys to the provisioned buckets so some functionality that uses the S3 bucket is not expected to work at this stage. We're expecting this to be provided via an ARN by the user as part of the RHOAM installation and 3scale will support sts and can be configured to use this (https://issues.redhat.com/browse/THREESCALE-7132)

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Provision or borrow an STS Rosa cluster
* Create the RHOAM role on this account if needed
  * https://github.com/integr8ly/delorean/blob/master/make/ocm.mk#L78-L88 
* oc login to the rosa cluster
* Prepare the cluster with addon secret with the `ROLE_ARN` to install locally 
```
export INSTALLATION_TYPE=managed-api
# ROLE_ARN could be different if using a different account or role name
ROLE_ARN="arn:aws:iam::408612754352:role/rhoam_role" make cluster/prepare/local
# Use aws resources for installation
USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
```
* Run the operator
```
make code/run
```
* Verify installation of RHOAM completes successfully
* Delete the RHMI CR
* Verifiy RHOAM can be uninstalled successfully