### PR TITLE
MGDAPI-3377 change deprecated flag --tojson

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -190,7 +190,7 @@ set_related_images() {
   echo "Adding related images to the CSV"
   containerImageField="""[
   """
-  length=$(yq e -j ./products/products.yaml| jq -r '.products' | jq length)
+  length=$(yq e -o=j ./products/products.yaml| jq -r '.products' | jq length)
   # Get supported components
   for (( i=0; i<${length}; i++))
   do
@@ -203,14 +203,14 @@ set_related_images() {
       component_version=$(grep currentCSV manifests/$product_dir/*.package.yaml | awk -F v '{print $2}')
       fi
       # Read component name
-      component_name=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq '.metadata.name' | tr -d '"')
+      component_name=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq '.metadata.name' | tr -d '"')
 
       # Read containers section length
-      containerLength=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq '.spec.install.spec.deployments[0].spec.template.spec.containers' | jq length)
+      containerLength=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq '.spec.install.spec.deployments[0].spec.template.spec.containers' | jq length)
       for (( y=0; y<$containerLength; y++))
       do
         # Read image from the component version but only select quay.io or redhat.registry
-        component_image=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq ".spec.install.spec.deployments[0].spec.template.spec.containers[$y].image" | jq -r 'select((test("quay.")) or (test("registry.redhat")))' | tr -d '"')
+        component_image=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq ".spec.install.spec.deployments[0].spec.template.spec.containers[$y].image" | jq -r 'select((test("quay.")) or (test("registry.redhat")))' | tr -d '"')
 
         # If component image is found, check if the list already contains image pointing to that URL, if not, add it to the list
         if [[ ! -z "$component_image" ]]; then
@@ -221,15 +221,15 @@ set_related_images() {
       done
 
       # Check if the CSV of the component has the relatedImages set, if it does, populate RHOAM CSV with it.
-      relatedImagesLength=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r '.spec.relatedImages' | jq length)
+      relatedImagesLength=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r '.spec.relatedImages' | jq length)
       
       # Adding generic related images but only if such image does not already exists in the list
       if [[ $relatedImagesLength != 0 ]]; then
         for (( y=0; y<$relatedImagesLength; y++))
         do
           excluded=false
-          relatedImageName=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r ".spec.relatedImages[$y].name")
-          relatedImageURL=$(yq e -j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r ".spec.relatedImages[$y].image")
+          relatedImageName=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r ".spec.relatedImages[$y].name")
+          relatedImageURL=$(yq e -o=j ./manifests/$product_dir/${component_version}/*.clusterserviceversion.yaml | jq -r ".spec.relatedImages[$y].image")
     
           for excludedItem in ${exclusionList[*]}
             do


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
MGDAPI-3377


# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
make prepare/release is throwing an deprecation warning when run. Update the flag
```bash
OLM_TYPE=managed-api-service SEMVER=1.18.2 make release/prepare
Valid version string: 1.18.2
Generating bundle version 1.18.2
Generating bundle manifests
Bundle manifests generated successfully in bundles/managed-api-service/1.18.2
Generating bundle metadata
INFO[0000] Creating bundle.Dockerfile                   
INFO[0000] Creating bundles/managed-api-service/1.18.2/metadata/annotations.yaml 
INFO[0000] Bundle metadata generated suceessfully       
Updating descriptions
Updating permissions
Adding related images to the CSV
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
Flag --tojson has been deprecated, please use -o=json instead
```
In `scripts/prepare-release.sh` there is no --tojson flag we use -j changing to `-o=j`


# Verification steps
- yq --version 4.22 >
- checkout this branch 
- run the make command and the output should be as follows
```bash
OLM_TYPE=managed-api-service SEMVER=1.18.2 make release/prepare
Valid version string: 1.18.2
Generating bundle version 1.18.2
Generating bundle manifests
Bundle manifests generated successfully in bundles/managed-api-service/1.18.2
Generating bundle metadata
INFO[0000] Creating bundle.Dockerfile                   
INFO[0000] Creating bundles/managed-api-service/1.18.2/metadata/annotations.yaml 
INFO[0000] Bundle metadata generated suceessfully       
Updating descriptions
Updating permissions
Adding related images to the CSV
```


<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
