### PR TITLE
MGDAPI-3635 Fixed RBAC issue for multitenant installs

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -55,6 +55,7 @@ rules:
   resources:
   - configmaps
   - secrets
+  - services
   - subscriptions
   verbs:
   - get

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -205,7 +205,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups=observability.redhat.com,resources=observabilities,verbs=*
 
 // Required for multitenant installations of RHOAM because the RHOAM operator is cluster scoped in these installations
-// +kubebuilder:rbac:groups="*",resources=configmaps;secrets;subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="*",resources=configmaps;secrets;services;subscriptions,verbs=get;list;watch
 
 // Role permissions
 

--- a/controllers/tenant/apimanagementtenant_controller.go
+++ b/controllers/tenant/apimanagementtenant_controller.go
@@ -247,7 +247,7 @@ func (r *TenantReconciler) reconcileTenantUrl(tenant *v1alpha1.APIManagementTena
 				return tenantUrlReconciled, err
 			}
 			// Update the value of lastError to reflect the user's SSO not being ready
-			err = r.updateLastError(tenant, fmt.Sprintf("waiting for matching route in namespace %s for tenant %s", opts.Namespace, tenant.Name))
+			err = r.updateLastError(tenant, fmt.Sprintf("waiting for route creation for tenant %s", tenant.Name))
 			return tenantUrlReconciled, nil
 		}
 

--- a/test/common/verify_prometheus_metrics.go
+++ b/test/common/verify_prometheus_metrics.go
@@ -135,8 +135,13 @@ func TestRhoamVersionMetricExposed(t TestingTB, ctx *TestingContext) {
 }
 
 func TestAdditionalBlackboxTargets(t TestingTB, ctx *TestingContext) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
 	// get all active targets in prometheus
-	expectedBlackboxTargets := getBlackboxTargets()
+	expectedBlackboxTargets := getBlackboxTargets(rhmi.Spec.Type)
 	targetsResult, err := getPrometheusTargets(ctx)
 	if err != nil {
 		t.Fatalf("%v", err)
@@ -157,13 +162,26 @@ func TestAdditionalBlackboxTargets(t TestingTB, ctx *TestingContext) {
 	}
 }
 
-func getBlackboxTargets() []string {
-	return []string{
-		"3scale-admin-ui",
-		"3scale-developer-console-ui",
-		"3scale-system-admin-ui",
-		"grafana-ui",
-		"rhsso-ui",
-		"rhssouser-ui",
+func getBlackboxTargets(installType string) []string {
+	var blackboxTargets []string
+	if integreatlyv1alpha1.IsRHOAMSingletenant(integreatlyv1alpha1.InstallationType(installType)) {
+		blackboxTargets = []string{
+			"3scale-admin-ui",
+			"3scale-developer-console-ui",
+			"3scale-system-admin-ui",
+			"grafana-ui",
+			"rhsso-ui",
+			"rhssouser-ui",
+		}
+	} else if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {
+		blackboxTargets = []string{
+			"3scale-admin-ui",
+			"3scale-developer-console-ui",
+			"3scale-system-admin-ui",
+			"grafana-ui",
+			"rhsso-ui",
+		}
 	}
+
+	return blackboxTargets
 }


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3635

# What
This change addresses an RBAC issue that was preventing multitenant installations of RHOAM from completing because the rhmi-operator ServiceAccount was unable to list Services at the cluster scope.

# Verification steps
Passing the automated PROW tests should be enough for a verification. However this change can also be verified by checking out this PR, building the operator, bundle, and index images, and then installing RHOAM using OLM.