### PR TITLE
MGDAPI-3517 Refactor code to use new product

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ Prerequisites:
 - `ocm` command available ( the newest CLI can be downloaded [here](https://github.com/openshift-online/ocm-cli/releases) and you install it with `mv (your downloaded file) /usr/local/bin/ocm`) (necessary only if using OSD cluster)
 - OC session with cluster admin permissions in a target cluster
 - OCM session (necessary only if using OSD cluster)
+- `openssl` command available on your machine 
 
 | Variable                  | Format  | Type     | Default        | Details                                                                     |
 |---------------------------|---------|:--------:|----------------|-----------------------------------------------------------------------------|


### PR DESCRIPTION
# Issue link
[MGDAPI-3517](https://issues.redhat.com/browse/MGDAPI-3517)
# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
If the A08 test was run after H24 then it failed due to missing APIcast routes. Changed code to create a new product with the application for the H24 test and cleans both of them up at the end of the run.

# Verification steps

1. Install RHOAM on a cluster 

2. Create IDP 
`PASSWORD=Password1 DEDICATED_ADMIN_PASSWORD=Password1 scripts/setup-sso-idp.sh`

3. Run H24 test  -  `Expected result : PASS` 
`INSTALLATION_TYPE=managed-api TEST=H24 make test/e2e/single`

4. Run A08 test  - `Expected result : PASS`
`INSTALLATION_TYPE=managed-api TEST=A08 make test/e2e/single`


<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
