### PR TITLE
MGDAPI-3627 - Performance test that simulates 200 tenants created at once

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -25,6 +25,7 @@ coverage:
     - "tmp"
     - "vendor"
     - "version"
+    - "test"
 
   status:
     project:

--- a/test/common/multitenancy.go
+++ b/test/common/multitenancy.go
@@ -17,7 +17,9 @@ import (
 	"net/url"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strconv"
 
+	"os"
 	"strings"
 	"time"
 )
@@ -66,7 +68,8 @@ func TestMultitenancy(t TestingTB, ctx *TestingContext) {
 
 func loginUsersTo3scale(t TestingTB, ctx *TestingContext, rhmi *integreatlyv1alpha1.RHMI) error {
 	postfix := 1
-	for postfix <= defaultNumberOfTestUsers {
+	numberOfTestUsers := getNumberOfTestUsersFromEnv()
+	for postfix <= numberOfTestUsers {
 		isClusterLoggedIn := false
 		isTenantCRCreated := false
 		routeFound := false
@@ -299,4 +302,17 @@ func createTestingUserApiManagementTenantCR(t TestingTB, testUserName string, te
 		t.Fatalf("error while creating APIManagementTenant CR for testing user %v", err)
 	}
 	return nil
+}
+
+func getNumberOfTestUsersFromEnv() int {
+	strNum := os.Getenv("TENANTS_NUMBER")
+	if strNum == "" {
+		return defaultNumberOfTestUsers
+	}
+	num, err := strconv.Atoi(strNum)
+	if err != nil {
+		fmt.Println("error converting env var TENANTS_NUMBER to integer, using default number of test users")
+		return defaultNumberOfTestUsers
+	}
+	return num
 }

--- a/test/common/multitenancy_performance.go
+++ b/test/common/multitenancy_performance.go
@@ -1,0 +1,139 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/test/resources"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"os"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"strconv"
+)
+
+const (
+	numberOfPerformanceTestUsers = 200
+)
+
+// M02 test
+// The test is required IDP to be already created with number of users as defined in const: numberOfPerformanceTestUsers
+// Test could be extended to add Products creation and Promotion as in script:
+// test/scripts/performance/m02_check_tenants_creation_performance.bash
+
+// To allow users login and creation: export PERF_TEST_USERS_LOGIN=true
+
+func TestMultitenancyPerformance(t TestingTB, ctx *TestingContext) {
+	numberOfTestUsers := getNumberOfPerformanceTestUsersFromEnv()
+	// Get master URL
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		t.Fatalf("error getting RHMI CR: %v", err)
+	}
+
+	// Login Users to Cluster to create OC users for test
+	if os.Getenv("PERF_TEST_USERS_LOGIN") == "true" {
+		err = loginUsersToCluster(t, ctx, rhmi, numberOfTestUsers)
+		if err != nil {
+			t.Errorf("User login to Cluster failed: %v", err)
+		}
+	}
+
+	err = createNamespaces(t, ctx, numberOfTestUsers)
+	if err != nil {
+		t.Errorf("error while createNamespaces for test users: %v", err)
+	}
+
+	err = createApiManagementTenantCRs(t, ctx, numberOfTestUsers)
+	if err != nil {
+		t.Errorf("error while createNamespaces for test users: %v", err)
+	}
+}
+
+func loginUsersToCluster(t TestingTB, ctx *TestingContext, rhmi *integreatlyv1alpha1.RHMI, numberOfTestUsers int) error {
+	postfix := 1
+	for postfix <= numberOfTestUsers {
+		isClusterLoggedIn := false
+		// Create client for current tenant
+		tenantClient, err := NewTestingHTTPClient(ctx.KubeConfig)
+		if err != nil {
+			return fmt.Errorf("error while creating client for tenant: %v", err)
+		}
+		testUser := fmt.Sprintf("%v%02v", DefaultTestUserName, postfix)
+		err = wait.Poll(pollingTime, tenantReadyTimeout, func() (done bool, err error) {
+			// login to cluster
+			if !isClusterLoggedIn {
+				err = resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", rhmi.Spec.MasterURL),
+					testUser, DefaultPassword, tenantClient, TestingIDPRealm, t)
+				if err != nil {
+					return false, nil
+				} else {
+					isClusterLoggedIn = true
+				}
+			}
+			return true, nil
+		})
+		if err != nil {
+			return fmt.Errorf("user %s login failed with: %v", testUser, err)
+		}
+		postfix++
+	}
+	return nil
+}
+
+func getNumberOfPerformanceTestUsersFromEnv() int {
+	strNum := os.Getenv("PERF_TEST_TENANTS_NUMBER")
+	if strNum == "" {
+		return numberOfPerformanceTestUsers
+	}
+	num, err := strconv.Atoi(strNum)
+	if err != nil {
+		fmt.Println("error converting env var TENANTS_NUMBER to integer, using default number of test users")
+		return numberOfPerformanceTestUsers
+	}
+	return num
+}
+
+func createNamespaces(t TestingTB, ctx *TestingContext, numberOfTestUsers int) error {
+	postfix := 1
+	for postfix <= numberOfTestUsers {
+		testUser := fmt.Sprintf("%v%02v", DefaultTestUserName, postfix)
+		testUserNamespaceName := testUser + "-dev"
+		testUserNamespace := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: testUserNamespaceName,
+			},
+		}
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), ctx.Client, testUserNamespace, func() error {
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("error while creating namespace for testing user %v", err)
+		}
+		postfix++
+	}
+	return nil
+}
+
+func createApiManagementTenantCRs(t TestingTB, ctx *TestingContext, numberOfTestUsers int) error {
+	postfix := 1
+	for postfix <= numberOfTestUsers {
+		testUser := fmt.Sprintf("%v%02v", DefaultTestUserName, postfix)
+		testUserNamespace := testUser + "-dev"
+		tenantCR := &integreatlyv1alpha1.APIManagementTenant{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example",
+				Namespace: testUserNamespace,
+			},
+		}
+		_, err := controllerutil.CreateOrUpdate(context.TODO(), ctx.Client, tenantCR, func() error {
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("error while creating APIManagementTenant CR for testing user %v", err)
+		}
+		postfix++
+	}
+	return nil
+}

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -78,6 +78,8 @@ var (
 		{
 			[]TestCase{
 				{"M01 - Verify multitenancy works as expected", TestMultitenancy},
+				//{"MT02 - Performance test simulate parallel Tenants creation", TestMultitenancyPerformance},
+				// MT02 test will be used for manual Performance verification Only. Not include in Test suite!
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeMultitenantManagedApi},
 		},

--- a/test/scripts/performance/mt02_verify_tenants_creation_performance.sh
+++ b/test/scripts/performance/mt02_verify_tenants_creation_performance.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# The script could be used for Multitenants Performance verification
+# script could be used together with multitenancy_performance.go, to provide flexibility for testing
+# Notes:
+#   IDP should be created before script execution.
+#       NUM_REGULAR_USER in scripts/setup-sso-idp.sh need to be changed before running IDP creation
+#   Promotions options in the script are not checked yet and could require updating. Use PROMOTE_STAGE=false and PROMOTE_PROD=false
+#   Recommended to use multitenancy_performance.go for Cluster users creation, as usersLogin function is not creating Cluster users_
+# Script require improvement, but could be used for performance investigation
+
+ACCESS_TOKEN="xxxxxxx"
+ADMIN_URL="https://3scale-admin.apps.xxxx.xx.s1.devshift.org"
+CLUSTER_WIDLCARD_URL="xxxxx.xxx.s1.devshift.org"
+INSTALL_TYPE_PREFIX="sandbox"
+USER_BASENAME="test-user"
+USER_PASSWD="Password1"
+ADMIN_API_TOKEN="sha256~#####"
+MIN=1
+MAX=200
+CREATE_CRS=true
+CREATE_PROD=true
+PROMOTE_STAGE=false
+PROMOTE_PROD=false
+DO_USERS_LOGIN=false
+
+createTenantCR() {
+  cat << EOF | oc create -f -
+apiVersion: integreatly.org/v1alpha1
+kind: APIManagementTenant
+metadata:
+  name: example
+  namespace: "$USER_BASENAME$i-dev"
+spec: {}
+EOF
+}
+
+createResourceUsageReport(){
+  oc adm top pods -n "$INSTALL_TYPE_PREFIX-rhoam-3scale" > ./ResourceUsageReport
+  oc adm top pods -n "$INSTALL_TYPE_PREFIX-rhoam-3scale-operator" >> ./ResourceUsageReport
+}
+
+usersLogin () {
+  echo "IDP Users login to create sso users"
+  for i in $(seq $MIN $MAX)
+  do
+    # login with user i
+    if [[ $i -lt 10 ]]
+    then
+      i="0$i"
+    fi
+    oc login -u "$USER_BASENAME$i" -p $USER_PASSWD >/dev/null
+    echo "user "$USER_BASENAME$i" logged in"
+    sleep 5
+  done
+}
+
+adminCreateTenantCRs () {
+  echo "Create projects and Tenant CRs"
+  #oc login --token=$ADMIN_API_TOKEN --server=$SERVER_URL >/dev/null
+  for i in $(seq $MIN $MAX)
+  do
+    if [[ $i -lt 10 ]]
+    then
+      i="0$i"
+    fi
+    echo "Create $USER_BASENAME$i-dev project and APIManagementTenant instance"
+    oc new-project "$USER_BASENAME$i-dev" >/dev/null
+    createTenantCR&
+    sleep 1
+  done
+}
+
+# Create products using 3scale-admin route and admin access token. It's simplified approach
+# To improve the test - need create tenant Products using access tokens and routes of specific tenant users
+createProducts () {
+  echo "### Create Products ###"
+  for i in $(seq $MIN $MAX)
+  do
+    #USER_URL="https://$USER_BASENAME$i.$CLUSTER_WIDLCARD_URL"
+    curl -v  -X POST "$ADMIN_URL/admin/api/services.xml" -d "access_token=$ACCESS_TOKEN&name=Product$i"
+  done
+}
+
+## to check
+promoteProductsToStaging () {
+  for i in $(seq $MIN $MAX)
+  do
+    prod_id=$(expr $i + 2)
+    backend_api_id=$(expr $i + 5)
+    curl -v -X POST "$ADMIN_URL/admin/api/services/$prod_id/backend_usages.json" -d "access_token=$ACCESS_TOKEN&backend_api_id=$backend_api_id&path=%2F"
+    curl -v -X POST "$ADMIN_URL/admin/api/services/$prod_id/proxy/deploy.xml" -d "access_token=$ACCESS_TOKEN"
+  done
+}
+
+## to check
+promoteProductsToProduction () {
+  for i in $(seq $MIN $MAX)
+  do
+    prod_id=$(expr $i + 2)
+    curl -v -X POST "{$ADMIN_URL}/admin/api/services/$prod_id/proxy/configs/sandbox/1/promote.json" -d "access_token={$ACCESS_TOKEN}&to=production"
+  done
+}
+
+## main:
+echo "Create $MAX tenants"
+if $DO_USERS_LOGIN
+then
+  usersLogin
+fi
+
+if $CREATE_CRS
+then
+  adminCreateTenantCRs
+fi
+
+#createResourceUsageReport
+
+if $CREATE_PROD
+then
+  createProducts
+fi
+
+if $PROMOTE_STAGE
+then
+  promoteProductsToStaging
+fi
+
+if $PROMOTE_PROD
+then
+  promoteProductsToProduction
+fi


### PR DESCRIPTION
Performance test that simulates 200 tenants created at once

# Issue link
https://issues.redhat.com/browse/MGDAPI-3627

# What
1. Exising M01 test - `TestMultitenancy` allows you to create 2 tenants, as defined in `defaultNumberOfTestUsers`.
M01 updated - added env variable: `TENANTS_NUMBER`.   If `TENANTS_NUMBER env var is not defined - the number of tenants = defaultNumberOfTestUsers`
2. New Test created MT02 (common/multitenancy_performance.go) and new test script test/scripts/performance/mt02_verify_tenants_creation_performance.bash. Both for manual verification of Multitenants Performance. Tests allow to create large number of Tenants. Checked for 200 and 400 Tenants.
3. Testing report: https://docs.google.com/document/d/12fDMyoIyIBJ5Cy8YEWDLPAse1_Ai0dAW7a5neF78GOw/edit

# Verification steps
1. Create cluster
2.  Install Rhoam (sandbox) 
INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local
INSTALLATION_TYPE=multitenant-managed-api make code/run
4. Install IDP: 
4.1. change NUM_REGULAR_USER in scripts/setup-sso-idp.sh - from 10 to 200
4.2. Create IDP: PASSWORD=Password1 DEDICATED_ADMIN_PASSWORD=Password1 scripts/setup-sso-idp.sh 
5. Run MT02 Test on first cluster.
6. Check that all Tenant CRs created
7. Check that all Tenant Routes created
8. Check that all Tenant CRs have  correct URLs
9. Check Resources usage - in OCM and Grafana
For reference - Please see Testing report: https://docs.google.com/document/d/12fDMyoIyIBJ5Cy8YEWDLPAse1_Ai0dAW7a5neF78GOw/edit

If you see any issue, and see that need more flexibility for investigation - you can use also the script: test/scripts/performance/mt02_verify_tenants_creation_performance.bash
