### PR TITLE
H22 bug fix

### DIFF
--- a/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
+++ b/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
@@ -129,12 +129,12 @@ func main() {
 			osExit1(err, ctx, client, namespace, namespacePrefix, cleanupAPI, api)
 		}
 
-		overallSuccess = overallSuccess && success && !allSkipped
+		overallSuccess = overallSuccess && success
 
 		time.Sleep(time.Second)
 	}
 
-	if !overallSuccess {
+	if !overallSuccess || allSkipped {
 		fmt.Println("Test failed, not all iterations succeeded")
 		fmt.Println("Note: Counter reset can cause false failures due to current count being higher than previous count")
 		osExit1(errors.New("cleaning up after a failure"), ctx, client, namespace, namespacePrefix, cleanupAPI, api)


### PR DESCRIPTION
# Issue link
N\A

# What
If the first run of the test is skipped it locks `overallSuccess` at `false` and the test fails. 

# Verification steps
You could modify the code to fail the first iteration and check that it is a success and then update the code to skip all and see it fail  :thinking: 
