### PR TITLE
MGDAPI-1782 / Updated UpgradeDuration alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,9 +322,8 @@ create/olm/bundle:
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
 	@ - oc new-project $(NAMESPACE)
-	@oc label namespace $(NAMESPACE) monitoring-key=middleware --overwrite
+	@oc label namespace $(NAMESPACE) monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 	@oc project $(NAMESPACE)
-	@ - oc label namespace $(NAMESPACE) monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 
 .PHONY: kustomize cluster/prepare/configmaps
 cluster/prepare/configmaps: kustomize

--- a/Makefile
+++ b/Makefile
@@ -324,6 +324,7 @@ cluster/prepare/project:
 	@ - oc new-project $(NAMESPACE)
 	@oc label namespace $(NAMESPACE) monitoring-key=middleware --overwrite
 	@oc project $(NAMESPACE)
+	@ - oc label namespace $(NAMESPACE) monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 
 .PHONY: kustomize cluster/prepare/configmaps
 cluster/prepare/configmaps: kustomize

--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -58,13 +58,23 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 			GroupName: fmt.Sprintf("%s-upgrade.rules", installationName),
 			Rules: []monitoringv1.Rule{
 				{
-					Alert: fmt.Sprintf("%sUpgradeExpectedDurationExceeded", strings.ToUpper(installationName)),
+					Alert: fmt.Sprintf("%sUpgradeExpectedDuration10minExceeded", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
-						"message": fmt.Sprintf("%s operator upgrade is taking more than 60 minutes", strings.ToUpper(installationName)),
+						"message": fmt.Sprintf("%s operator upgrade is taking more than 10 minutes", strings.ToUpper(installationName)),
 					},
 					Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
-					For:    "60m",
+					For:    "10m",
+					Labels: map[string]string{"severity": "warning", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
+				},
+				{
+					Alert: fmt.Sprintf("%sUpgradeExpectedDuration30minExceeded", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
+						"message": fmt.Sprintf("%s operator upgrade is taking more than 30 minutes", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
+					For:    "30m",
 					Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 				},
 			},

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -35,7 +35,7 @@ fi
 if [[ -z $KUSTOMIZE_PATH ]]; then
   KUSTOMIZE="/usr/local/bin/kustomize"
 else
-  KUSTOMIZE="/usr/local/bin/kustomize"
+  KUSTOMIZE=$(which kustomize)
 fi
 
 # Path to gofmt


### PR DESCRIPTION
# Issue link
[MGDAPI-1782](https://issues.redhat.com/browse/MGDAPI-1782)

# What 
Added a 10min warning alert as well as a 30min critical alert for when a rhoam version upgrade exceeds that time limit.

# Test with own images
1. Get a cluster
2. Once ready > run 
```
INSTALLATION_TYPE=managed-api make cluster/prepare/local
```
So that redhat-rhoam ns is ready
3. have docker running and be quay.io logged in
5. When making an upgrade test, the first version of rhoam installed, should be the current master version - which now, is 1.18.2
6. WHEN installing the initial version, make sure to manually remove "replaces" field from the target version CSV, for example, for 1.18.2 - remove this field https://github.com/integr8ly/integreatly-operator/blob/master/bundles/managed-api-service/1.18.2/manifests/managed-api-service.clusterserviceversion.yaml#L719
7. Build a bundle of 1.18.2 by using the following command:
```
make olm/bundle BUNDLE_TAG="quay.io/<YOUR_QUAY.IO_ORG>/integreatly-bundle:<VERSION_FOR_EXAMPLE: 1.18.2>" VERSION=<VERSION_FOR_EXAMPLE: 1.18.2> OLM_TYPE=managed-api-service
```
8. Push the build bundle with `docker push <TAG>`
9. Build an index by using the command:
```
opm index add \
    --bundles <YOUR BUNDLE TAG FROM ABOVE> \
    --build-tool docker \
    --tag quay.io/<your org>/integreatly-index:<VERSION_FOR_EXAMPLE: 1.18.2>
```
10. Push the index by using `docker push <INDEX TAG>`
11. Navigate to your quay.io repo, confirm that the new folders are created/or if they already exists, that the images are in them.
12. Make sure your quay.io repos are PUBLIC. Otherwise images won't be pulled on to the cluster
13. Next, ensure you are oc logged in to your cluster
14. Create a yaml file with:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/<your org>/integreatly-index:<VERSION_FOR_EXAMPLE: 1.18.2>
```
And run: `oc apply -f rhmi-operators.yaml`
15. Navigate to your cluster, seletc `market place` namespace
16. Go to operator hub > type RHOAM - it might take few seconds before you can see it, reason for it is because newly created CatalogSource
needs to be reconciled by OLM
17. Select RHOAM, click Install under redhat-rhoam-operator ns
18. Because the installation is via OLM - we need to create RHMI CR by running the following command:
`INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml`
19. Wait for installation to complete.

Simulating upgrade:
1. On your own branch run:
`OLM_TYPE=managed-api-service SEMVER=<NEXT VERSION OF THE OPERATOR - for example, if you are bumping from 1.18.2, next version is going to be 1.19.0> make release/prepare`

This will generate new bundle in bundles folder, but also, most importantly, it will update version in version.go and makefile rhoam version

2. Build rhoam operator IMAGE:
a) change the org name in makefile: https://github.com/integr8ly/integreatly-operator/blob/master/Makefile#L3 to your QUAY org name
- Comment out [412](https://github.com/integr8ly/integreatly-operator/blob/master/controllers/rhmi/rhmi_controller.go#L412) to [414](https://github.com/integr8ly/integreatly-operator/blob/master/controllers/rhmi/rhmi_controller.go#L414)
- Change [PhaseComplete](https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/threescale/reconciler.go#L442) to PhaseInProgress. This will stall the upgrade and not let it complete allowing you to see the alerts firing.
b) run `INSTALLATION_TYPE=managed-api make image/build`
c) push the image to your quay repo with `docker push <OUTPUT of the MAKE IMAGE/BUILD above`

3. Replace the newly pushed RHOAM image in the CSV of the version you are about to release, for example, if the version you are releasing is 1.19.0 - replace these values with the image that you have just pushed: 
a) https://github.com/integr8ly/integreatly-operator/blob/master/bundles/managed-api-service/1.19.0/manifests/managed-api-service.clusterserviceversion.yaml#L54
b) https://github.com/integr8ly/integreatly-operator/blob/master/bundles/managed-api-service/1.19.0/manifests/managed-api-service.clusterserviceversion.yaml#L523
c) Make sure that the `replaces` field in the new CSV is replacing the currently installed on your cluster RHOAM version

4. Build bundle for your new version:
```
make olm/bundle 
BUNDLE_TAG="quay.io/<YOUR_QUAY.IO_ORG>/integreatly-bundle:<VERSION_FOR_EXAMPLE:
 1.19.0>" VERSION=<VERSION_FOR_EXAMPLE: 1.19.0> 
OLM_TYPE=managed-api-service
```
5. Push the build bundle with `docker push <TAG>`
6. Build an index by using the command:
```
opm index add \
   -- bundles <CURRENTLY INSTALLED RHOAM BUNDLE TAG> \
    --bundles <YOUR BUNDLE TAG FROM ABOVE> \
    --build-tool docker \
    --tag quay.io/<your org>/integreatly-index:<VERSION_FOR_EXAMPLE: 1.19.0>
```
7. Push the index by using `docker push <INDEX TAG>` 
8. Navigate to your cluster `marketplace` ns and search for CatalogSource
9. Find RHMI-OPERATORS catalog source
10. Change the index image version to the version you want to upgrade to
11. Go to INSTALLED OPERATORS under redhat-rhoam-operator NS
12. After few seconds (possibly a minute) you will see that an upgrade is available
13. Click on upgrade requires approval and approve.
14. This will trigger upgrade from 1.18.2 to your version

#Checking Alerts

1. Go to Networking -> routes and search for Prometheus, click *Prometheus k8s* and log in using kubeadmin login details.
2. Go to alerts tab and search for (UpgradeExpectedDuration10minExceeded) 
3. Wait for alerts to fire.
