### PR TITLE
MGDAPI-2657 - Scripts STS support

### DIFF
--- a/test-cases/tests/backup-restore/j05b-verify-3scale-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j05b-verify-3scale-backup-and-restore.md
@@ -68,11 +68,18 @@ Once verified, delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 NS_PREFIX=redhat-rhoam ./j05-verify-3scale-postgres-backup-and-restore.sh | tee test-output.txt
+```
+
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j05-verify-3scale-postgres-backup-and-restore.sh | tee test-output.txt
 ```
 
 4. Wait for the script to finish without errors

--- a/test-cases/tests/backup-restore/j07b-verify-cluster-sso-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j07b-verify-cluster-sso-backup-and-restore.md
@@ -72,15 +72,22 @@ Once verified. Delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 NS_PREFIX=redhat-rhoam ./j07-verify-rhsso-backup-and-restore.sh | tee test-output.txt
 ```
 
-4. Wait for the script to finish without errors
-5. Verify in the `test-output.txt` log that the test finished successfully.
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j07-verify-rhsso-backup-and-restore.sh | tee test-output.txt
+```
+
+5. Wait for the script to finish without errors
+6. Verify in the `test-output.txt` log that the test finished successfully.
 
 **Note**
 Sometimes there could be a difference between the DB dump files, caused by a changed order of lines in these files. That is not considered to be an issue. More details: https://issues.redhat.com/browse/MGDAPI-2380

--- a/test-cases/tests/backup-restore/j08b-verify-user-sso-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j08b-verify-user-sso-backup-and-restore.md
@@ -72,15 +72,22 @@ Once verified. Delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 NS_PREFIX=redhat-rhoam ./j08-verify-user-sso-backup-and-restore.sh | tee test-output.txt
 ```
 
-4. Wait for the script to finish without errors
-5. Verify in the `test-output.txt` log that the test finished successfully.
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j08-verify-user-sso-backup-and-restore.sh | tee test-output.txt
+```
+
+5. Wait for the script to finish without errors
+6. Verify in the `test-output.txt` log that the test finished successfully.
 
 **Note**
 Sometimes there could be a difference between the DB dump files, caused by a changed order of lines in these files. That is not considered to be an issue. More details: https://issues.redhat.com/browse/MGDAPI-2380

--- a/test/scripts/backup-restore/j05-verify-3scale-postgres-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j05-verify-3scale-postgres-backup-and-restore.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+# USAGE
+# ./j05-verify-3scale-postgres-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests 3scale postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
@@ -15,9 +25,14 @@ else
 fi
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhmi}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)
 AWS_DB_ID=$(oc get secret/system-database -o go-template --template="{{.data.URL|base64decode}}" -n ${NS_PREFIX}-3scale | $grep_cmd -Po "(?<=@).*?(?=\.)")
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')

--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
+# USAGE
+# ./j07-verify-rhsso-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests RHSSO postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhmi}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_secret_access_key} | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_access_key_id} | base64 --decode)
 AWS_DB_ID=$(oc get secret/keycloak-db-secret -o go-template --template="{{.data.POSTGRES_EXTERNAL_ADDRESS|base64decode}}" -n ${NS_PREFIX}-rhsso | awk -F\. '{print $1}')
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')

--- a/test/scripts/backup-restore/j08-verify-user-sso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j08-verify-user-sso-backup-and-restore.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
+# USAGE
+# ./j08-verify-user-sso-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests User SSO postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhmi}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_secret_access_key} | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_access_key_id} | base64 --decode)
 AWS_DB_ID=$(oc get secret/keycloak-db-secret -o go-template --template="{{.data.POSTGRES_EXTERNAL_ADDRESS|base64decode}}" -n ${NS_PREFIX}-user-sso | awk -F\. '{print $1}')
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-2657

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
For an STS cluster, AWS credentials are not available on cluster for the backup and restore scripts to run. In order to support STS clusters, we should allow passing in AWS credenitals to these scripts as an option 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Provision ROSA STS cluster
* Ensure the prerequisite role is created
* Install RHOAM from https://github.com/integr8ly/integreatly-operator/pull/2535
* Once completed, following the test case changes, verify that the backup and restore scripts complete successfully by passing in the AWS credentials for the `osdCcsAdmin` user