### PR TITLE
MGDAPI-3704 add openshift.io/cluster-monitoring="true" label to makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ install/sandboxrhoam/operator:
 .PHONY: install/sandboxrhoam/config
 install/sandboxrhoam/config:
 	@-oc process -p RHOAM_OPERATOR_NAMESPACE=$(SANDBOX_NAMESPACE) -f config/developer-sandbox/sandbox-config-template.yml | oc create -f - -n $(SANDBOX_NAMESPACE)
-	@oc label namespace $(SANDBOX_NAMESPACE) monitoring-key=middleware --overwrite
+	@oc label namespace $(SANDBOX_NAMESPACE) monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 	@-oc process -f config/developer-sandbox/sandbox-rhoam-quickstart.yml | oc create -f -
 
 .PHONY: code/run


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
MGDAPI-3704

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Update the `make cluster/prepare/local` to add `openshift.io/cluster-monitoring="true"` label to the rhoam operator namespace for local development


# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Run 
```
INSTALLATION_TYPE=managed-api make cluster/prepare/local
```
- confirm that the `openshift.io/cluster-monitoring="true"` label has been added to the redhat-rhoam-operator namespace either in the ui
![image](https://user-images.githubusercontent.com/16667688/160774909-8cb19c12-75ac-42ee-9ae8-f5950caae0a9.png)
or via the command line
```
oc describe ns redhat-rhoam-operator | grep openshift.io/cluster-monitoring=
```

