### PR TITLE
fix: scorecard - update scorecard base image

### DIFF
--- a/Dockerfile.scorecard
+++ b/Dockerfile.scorecard
@@ -17,7 +17,13 @@ COPY test/scorecard ./test/scorecard
 # Build
 RUN GOOS=linux GOARCH=amd64 make scorecard/compile
 
-FROM kudobuilder/kuttl:v0.11.1
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+
+#  kubectl 1.18
+RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl
+# kuttl v0.11.1
+RUN curl -Lso /usr/local/bin/kubectl-kuttl https://github.com/kudobuilder/kuttl/releases/download/v0.11.1/kubectl-kuttl_0.11.1_linux_x86_64
+RUN chmod +x /usr/local/bin/*
 
 ENV HOME=/opt/scorecard-test-kuttl \
     USER_NAME=scorecard-test-kuttl \

--- a/make/scorecard.mk
+++ b/make/scorecard.mk
@@ -6,6 +6,8 @@ SCORECARD_SA_NAME ?= rhoam-test-runner
 
 SCORECARD_TEST_NAME ?= ""
 SCORECARD_SKIP_CLEANUP ?= true
+ARTIFACTS_DIR ?= "logs/artifacts"
+TEST_TIMEOUT ?= "3000s"
 
 .PHONY: scorecard/bundle/prepare
 scorecard/bundle/prepare:
@@ -24,7 +26,7 @@ scorecard/service_account/cleanup:
 
 .PHONY: scorecard/test/run
 scorecard/test/run:
-	operator-sdk scorecard ./bundle --namespace=${SCORECARD_NAMESPACE} --output json --selector=test=${SCORECARD_TEST_NAME} --skip-cleanup=${SCORECARD_SKIP_CLEANUP}
+	operator-sdk scorecard ./bundle --namespace=${SCORECARD_NAMESPACE} --output json --service-account ${SCORECARD_SA_NAME}  --wait-time ${TEST_TIMEOUT} --test-output ${ARTIFACTS_DIR} --selector=test=${SCORECARD_TEST_NAME} --skip-cleanup=${SCORECARD_SKIP_CLEANUP}
 
 .PHONY: scorecard/build/push
 scorecard/build/push: scorecard/build


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3595

# What
* resolves an issue with scorecard image that doesn't contain kubectl and kubectl-kuttl binaries after it's built by openshift-ci (reason is that openshift-ci replaces `kudobuilder/kuttl:v0.11.1` base image with `registry.access.redhat.com/ubi8/ubi-minimal:latest`)

# Verification steps
1. Create OCP/OSD cluster and deploy RHOAM from master branch
```bash
export INSTALLATION_TYPE=managed-api
make cluster/deploy
```
2. Build the test scorecard test image and push it to your quay.io account
```bash
export IMAGE=quay.io/<YOUR-ACCOUNT-ID>/scorecard-test-kuttl:MGDAPI-3595
make scorecard/build/push IMAGE=$IMAGE
```
3. Prepare scorecard tests and update the happy path test image in scorecard test config (to point to your image in quay.io)
```bash
make scorecard/bundle/prepare
make scorecard/service_account/prepare
# Update the image in config.yaml - make sure you've got yq v4.x
yq e -i "select(.stages[0].tests[].labels.test == \"happy-path\").image |= \"$IMAGE\"" bundle/tests/scorecard/config.yaml
```
4. Run happy-path test
```bash
SCORECARD_TEST_NAME=happy-path make scorecard/test/run
```
5. Make sure the test finished successfully and there are test artifacts saved in `logs/artifacts` dir