### PR TITLE
MGDAPI-3786 - fix: test image installing chrome

### DIFF
--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -22,9 +22,8 @@ RUN make test/compile/functional
 
 FROM registry.access.redhat.com/ubi8/ubi:latest
 # Install chrome for tests
-ADD https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm /root/google-chrome-stable_current_x86_64.rpm
-
-RUN yum -y install /root/google-chrome-stable_current_x86_64.rpm; yum clean all
+COPY test-dependancy/*.repo /etc/yum.repos.d/
+RUN dnf -y install google-chrome-stable && dnf clean all
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
 

--- a/test-dependancy/centos.repo
+++ b/test-dependancy/centos.repo
@@ -1,13 +1,13 @@
 [appstream]
 name=CentOS-$releasever - AppStream
-baseurl=http://vault.centos.org/centos/8-stream/AppStream/x86_64/os/
+baseurl=http://mirror.centos.org/centos/8-stream/AppStream/x86_64/os
 gpgcheck=1
 enabled=1
 gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official
 
 [baseos]
 name=CentOS-$releasever - BaseOS
-baseurl=http://vault.centos.org/centos/8-stream/BaseOS/x86_64/os
+baseurl=http://mirror.centos.org/centos/8-stream/BaseOS/x86_64/os
 gpgcheck=1
 enabled=1
-gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official 
+gpgkey=https://www.centos.org/keys/RPM-GPG-KEY-CentOS-Official


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-3786

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Seems the image build errors might have been resolved by the mirror centos side, so reverting back to use the package repo for installing chrome

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Prow image build should pass and test image build log should contain no errorrs around installing chrome