### PR TITLE
MGDAPI-3412 rollback 3scale operator to 0.8.2 for cpaas

### DIFF
--- a/products/installation-cpaas.yaml
+++ b/products/installation-cpaas.yaml
@@ -58,7 +58,7 @@
 products:
   3scale:
     channel: threescale-2.11
-    bundle: registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:a5bd262966f0c384e08559a07d2a12e0272e5778f2fce4e21af8fc2f6407b18d
+    bundle: registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:76da98c3570da4141658a39e272309785ec049d156322d6f1aeffab1daae24d7
     installFrom: implicit
     package: 3scale-operator
   amqonline:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
