### PR TITLE
MGDAPI-3793 - Implemented gosec install in Dockerfile.tools and added new make command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -569,3 +569,7 @@ olm/bundle:
 .PHONY: coverage
 coverage:
 	hack/codecov.sh
+
+.PHONY: gosec/exclude
+gosec/exclude:
+	gosec -exclude=G101,G104,G107,G204,G304,G306,G307,G401,G402,G404,G501,G601 ./...

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -47,3 +47,6 @@ RUN curl -fsSLO --compressed "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE
 # install chrome
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
     && yum install -y --setopt=tsflags=nodocs ./google-chrome-stable_current_*.rpm
+
+# install gosec
+RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin v2.11.0

--- a/openshift-ci/test/run
+++ b/openshift-ci/test/run
@@ -7,6 +7,7 @@
 #
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'gosec --version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'operator-sdk version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'go version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'jq --version'


### PR DESCRIPTION
# Issue link
[MGDAPI-3793](https://issues.redhat.com/browse/MGDAPI-3793)

# What
- Added installation command for `gosec` in `Dockerfile.tools
- Added `gosec/exclude` command in Makefile to exclude unfinished rules
# Verification steps
- Have RHOAM installed on a cluster
- Checkout changes from this PR and follow steps in the [Openshift CI README](https://github.com/integr8ly/integreatly-operator/tree/master/openshift-ci#build-and-test) from the `openshift-ci` folder
- Check that the gosec version is printed and you see `SUCCESS!` from the output of the second command. 
- gosec version should look something like this:
```
Version: 2.11.0
Git tag: v2.11.0
Build date: 2022-03-21T15:55:53Z
```

