### PR TITLE
[WIP] MGDAPI-3696 - Create Initial Fleet wide SRE Dashboard querying observatorium

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1385,7 +1385,7 @@ func (r *RHMIReconciler) createInstallationCR(ctx context.Context, serverClient 
 }
 
 func (r *RHMIReconciler) composeAndSetAlertMetric(installation *rhmiv1alpha1.RHMI, rc *rest.Config, configManager *config.Manager) error {
-	var alerts []metrics.AlertMetric
+	var alerts []resources.AlertMetric
 
 	alertingNamespaces, err := r.getAlertingNamespace(installation, configManager)
 	if err != nil {
@@ -1410,8 +1410,8 @@ func (r *RHMIReconciler) composeAndSetAlertMetric(installation *rhmiv1alpha1.RHM
 	return nil
 }
 
-func (r *RHMIReconciler) composeAlertMetric(route string, namespace string, rc *rest.Config) ([]metrics.AlertMetric, error) {
-	var alerts metrics.AlertMetrics
+func (r *RHMIReconciler) composeAlertMetric(route string, namespace string, rc *rest.Config) ([]resources.AlertMetric, error) {
+	var alerts resources.AlertMetrics
 	endpoint := "/api/v1/alerts"
 
 	url, err := r.getURLFromRoute(route, namespace, rc)
@@ -1622,8 +1622,8 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 func formatAlerts(alerts []struct {
 	Labels models.LabelSet `json:"labels"`
 	State  string          `json:"state"`
-}) metrics.AlertMetrics {
-	alertMetrics := metrics.AlertMetrics{}
+}) resources.AlertMetrics {
+	alertMetrics := resources.AlertMetrics{}
 
 	for _, alert := range alerts {
 		if alert.Labels["alertname"] == "DeadMansSwitch" {
@@ -1632,7 +1632,7 @@ func formatAlerts(alerts []struct {
 			continue
 		}
 		if !alertMetrics.Contains(alert) {
-			alertMetrics.Alerts = append(alertMetrics.Alerts, metrics.AlertMetric{
+			alertMetrics.Alerts = append(alertMetrics.Alerts, resources.AlertMetric{
 				Name:     alert.Labels["alertname"],
 				Severity: alert.Labels["severity"],
 				State:    alert.State,

--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
-	"github.com/integr8ly/integreatly-operator/pkg/metrics"
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	corev1 "k8s.io/api/core/v1"
@@ -144,7 +144,7 @@ func TestFormatAlerts(t *testing.T) {
 		},
 	}
 
-	expected := metrics.AlertMetrics{Alerts: []metrics.AlertMetric{
+	expected := resources.AlertMetrics{Alerts: []resources.AlertMetric{
 		{
 			Name:     "dummy",
 			Severity: "High",
@@ -179,7 +179,7 @@ func TestFormatAlerts(t *testing.T) {
 
 }
 
-func compare(actual []metrics.AlertMetric, expected []metrics.AlertMetric) bool {
+func compare(actual []resources.AlertMetric, expected []resources.AlertMetric) bool {
 
 	if len(actual) != len(expected) {
 		return false

--- a/main.go
+++ b/main.go
@@ -64,6 +64,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMAlert)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMCluster)
 	customMetrics.Registry.MustRegister(integreatlymetrics.ThreeScaleUserAction)
 	customMetrics.Registry.MustRegister(integreatlymetrics.Quota)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumTenants)

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHMIStatus)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMVersion)
 	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMStatus)
+	customMetrics.Registry.MustRegister(integreatlymetrics.RHOAMAlert)
 	customMetrics.Registry.MustRegister(integreatlymetrics.ThreeScaleUserAction)
 	customMetrics.Registry.MustRegister(integreatlymetrics.Quota)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumTenants)

--- a/pkg/config/monitoring.go
+++ b/pkg/config/monitoring.go
@@ -45,6 +45,7 @@ var managedAPITemplateList = []string{
 	"critical-slo-managed-api-alerts",
 	"cro-resources",
 	"rhoam-rhsso-availability-slo",
+	"rhoam-fleet-wide-view",
 }
 
 func NewMonitoring(config ProductConfig) *Monitoring {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -107,6 +107,16 @@ var (
 		},
 	)
 
+	RHOAMCluster = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhoam_cluster",
+			Help: "Gives Cluster type for the RHOAM installation",
+		},
+		[]string{
+			"type",
+		},
+	)
+
 	ThreeScaleUserAction = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "threescale_user_action",
@@ -215,6 +225,13 @@ func SetRHOAMAlerts(alerts []AlertMetric) {
 			"state":    alerts[index].State,
 		}).Set(float64(alerts[index].Value))
 	}
+}
+
+func SetRHOAMCluster(cluster string, value int64) {
+	RHOAMCluster.Reset()
+	RHOAMCluster.With(prometheus.Labels{
+		"type": cluster,
+	}).Set(float64(value))
 }
 
 func SetThreeScaleUserAction(httpStatus int, username, action string) {

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -3,11 +3,11 @@ package metrics
 import (
 	"context"
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
-
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/version"
+	"github.com/prometheus/alertmanager/api/v2/models"
 
 	"github.com/prometheus/client_golang/prometheus"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
@@ -95,6 +95,18 @@ var (
 		},
 	)
 
+	RHOAMAlert = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "rhoam_alerts",
+			Help: "RHOAM alerts summary, excludes DeadManSwitch",
+		},
+		[]string{
+			"alert",
+			"severity",
+			"state",
+		},
+	)
+
 	ThreeScaleUserAction = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "threescale_user_action",
@@ -148,6 +160,17 @@ var (
 	)
 )
 
+type AlertMetric struct {
+	Name     string
+	Severity string
+	State    string
+	Value    int64
+}
+
+type AlertMetrics struct {
+	Alerts []AlertMetric
+}
+
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR
 func SetRHMIInfo(installation *integreatlyv1alpha1.RHMI) {
 	RHMIInfo.WithLabelValues(installation.Spec.UseClusterStorage,
@@ -181,6 +204,17 @@ func SetRhmiVersions(stage string, version string, toVersion string, firstInstal
 
 	RHOAMVersion.Reset()
 	RHOAMVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
+}
+
+func SetRHOAMAlerts(alerts []AlertMetric) {
+	RHOAMAlert.Reset()
+	for index := range alerts {
+		RHOAMAlert.With(prometheus.Labels{
+			"alert":    alerts[index].Name,
+			"severity": alerts[index].Severity,
+			"state":    alerts[index].State,
+		}).Set(float64(alerts[index].Value))
+	}
 }
 
 func SetThreeScaleUserAction(httpStatus int, username, action string) {
@@ -228,4 +262,51 @@ func GetContainerCPUMetric(ctx context.Context, serverClient k8sclient.Client, l
 	} else {
 		return "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate", nil
 	}
+}
+
+func (a *AlertMetric) ContainsName(name string) bool {
+	if a.Name == name {
+		return true
+	}
+	return false
+}
+
+func (a *AlertMetric) ContainsSeverity(severity string) bool {
+	if a.Severity == severity {
+		return true
+	}
+	return false
+}
+
+func (a *AlertMetric) ContainsState(state string) bool {
+	if a.State == state {
+		return true
+	}
+	return false
+}
+
+func (a *AlertMetric) Contains(alert struct {
+	Labels models.LabelSet `json:"labels"`
+	State  string          `json:"state"`
+}) bool {
+
+	if a.ContainsName(alert.Labels["alertname"]) && a.ContainsSeverity(alert.Labels["severity"]) && a.ContainsState(alert.State) {
+		return true
+	}
+
+	return false
+}
+
+func (a *AlertMetrics) Contains(alert struct {
+	Labels models.LabelSet `json:"labels"`
+	State  string          `json:"state"`
+}) bool {
+
+	for _, current := range a.Alerts {
+		if current.Contains(alert) {
+			return true
+		}
+	}
+
+	return false
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -80,6 +80,7 @@ var (
 		},
 		[]string{
 			"stage",
+			"status",
 			"version",
 			"to_version",
 		},
@@ -213,7 +214,8 @@ func SetRhmiVersions(stage string, version string, toVersion string, firstInstal
 	RHMIVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
 
 	RHOAMVersion.Reset()
-	RHOAMVersion.WithLabelValues(stage, version, toVersion).Set(float64(firstInstallTimestamp))
+	status := resources.InstallationState(version, toVersion)
+	RHOAMVersion.WithLabelValues(stage, status, version, toVersion).Set(float64(firstInstallTimestamp))
 }
 
 func SetRHOAMAlerts(alerts []AlertMetric) {

--- a/pkg/products/monitoringcommon/dashboardHelper.go
+++ b/pkg/products/monitoringcommon/dashboardHelper.go
@@ -42,6 +42,9 @@ func GetSpecDetailsForDashboard(dashboard string, rhmi *v1alpha1.RHMI, container
 	case "rhoam-rhsso-availability-slo":
 		return monitoringcommon.GetMonitoringGrafanaDBRhssoAvailabilityErrorBudgetBurnJSON(rhmi.ObjectMeta.Name), "rhoam-rhsso-availability-slo.json", nil
 
+	case "rhoam-fleet-wide-view":
+		return monitoringcommon.ObservatoriumFleetWideJSON, "rhoam-fleet-wide-view.json", nil
+
 	default:
 		return "", "", fmt.Errorf("Invalid/Unsupported Grafana Dashboard")
 

--- a/pkg/products/monitoringcommon/dashboards/fleetWideView.go
+++ b/pkg/products/monitoringcommon/dashboards/fleetWideView.go
@@ -1,0 +1,2011 @@
+package monitoringcommon
+
+const ObservatoriumFleetWideJSON =  `{
+	  "annotations": {
+		"list": [
+		  {
+			"builtIn": 1,
+			"datasource": "-- Grafana --",
+			"enable": true,
+			"hide": true,
+			"iconColor": "rgba(0, 211, 255, 1)",
+			"name": "Annotations & Alerts",
+			"type": "dashboard"
+		  }
+		]
+	  },
+	  "editable": true,
+	  "gnetId": null,
+	  "graphTooltip": 0,
+	  "id": 12,
+	  "links": [],
+	  "panels": [
+		{
+		  "collapsed": true,
+		  "datasource": null,
+		  "gridPos": {
+			"h": 1,
+			"w": 24,
+			"x": 0,
+			"y": 0
+		  },
+		  "id": 20,
+		  "panels": [
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "description": "",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": null,
+					"filterable": false
+				  },
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "service 1"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 250
+					  }
+					]
+				  }
+				]
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 6,
+				"w": 18,
+				"x": 0,
+				"y": 1
+			  },
+			  "hiddenSeries": false,
+			  "id": 45,
+			  "interval": "10s",
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "maxDataPoints": 1150,
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": false,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "expr": "count(rhoam_cluster{type=\"osd\"})",
+				  "format": "time_series",
+				  "instant": false,
+				  "interval": "",
+				  "legendFormat": "Total # OSD Clusters",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "OSD  Cluster Count",
+			  "tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "transformations": [],
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "label": null,
+				  "logBase": 1,
+				  "max": null,
+				  "min": null,
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "label": null,
+				  "logBase": 1,
+				  "max": null,
+				  "min": null,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false,
+				"alignLevel": null
+			  }
+			},
+			{
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": []
+			  },
+			  "gridPos": {
+				"h": 6,
+				"w": 5,
+				"x": 18,
+				"y": 1
+			  },
+			  "id": 13,
+			  "options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+				  "calcs": [
+					"mean"
+				  ],
+				  "fields": "",
+				  "values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "count(rhoam_cluster{type=\"osd\"}) or vector(0)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "timeFrom": null,
+			  "timeShift": null,
+			  "title": "OSD Cluster Count",
+			  "type": "stat"
+			},
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "description": "",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": null,
+					"filterable": false
+				  },
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "service 1"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 250
+					  }
+					]
+				  }
+				]
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 6,
+				"w": 18,
+				"x": 0,
+				"y": 7
+			  },
+			  "hiddenSeries": false,
+			  "id": 49,
+			  "interval": "10s",
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "maxDataPoints": 1150,
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": false,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "expr": "count(rhoam_cluster{type=\"rosa\"})",
+				  "format": "time_series",
+				  "instant": false,
+				  "interval": "",
+				  "legendFormat": "Total # OSD Clusters",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "ROSA  Cluster Count",
+			  "tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "transformations": [],
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "label": null,
+				  "logBase": 1,
+				  "max": null,
+				  "min": null,
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "label": null,
+				  "logBase": 1,
+				  "max": null,
+				  "min": null,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false,
+				"alignLevel": null
+			  }
+			},
+			{
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": []
+			  },
+			  "gridPos": {
+				"h": 6,
+				"w": 5,
+				"x": 18,
+				"y": 7
+			  },
+			  "id": 51,
+			  "options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+				  "calcs": [
+					"mean"
+				  ],
+				  "fields": "",
+				  "values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "count(rhoam_cluster{type=\"rosa\"}) or vector(0)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "ROSA Cluster Count",
+			  "type": "stat"
+			},
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {}
+				},
+				"overrides": []
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 6,
+				"w": 18,
+				"x": 0,
+				"y": 13
+			  },
+			  "hiddenSeries": false,
+			  "id": 11,
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": false,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(kube_node_labels) by (cluster_id)",
+				  "interval": "",
+				  "legendFormat": "{{cluster_id}}",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "Cluster Node Count",
+			  "tooltip": {
+				"shared": true,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "$$hashKey": "object:2344",
+				  "decimals": 0,
+				  "format": "short",
+				  "logBase": 1,
+				  "min": "0",
+				  "show": true
+				},
+				{
+				  "$$hashKey": "object:2345",
+				  "format": "short",
+				  "logBase": 1,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false
+			  }
+			},
+			{
+			  "datasource": null,
+			  "description": "",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": "auto",
+					"displayMode": "auto",
+					"filterable": false
+				  },
+				  "links": [
+					{
+					  "targetBlank": true,
+					  "title": "OpenShift Console",
+					  "url": "${__data.fields.url}"
+					}
+				  ],
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "url"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 561
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Value"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 72
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "#Kafka CRs"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 111
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "# Node Count"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 104
+					  }
+					]
+				  }
+				]
+			  },
+			  "gridPos": {
+				"h": 6,
+				"w": 5,
+				"x": 18,
+				"y": 13
+			  },
+			  "id": 15,
+			  "links": [],
+			  "maxDataPoints": 1,
+			  "options": {
+				"showHeader": true
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(kube_node_labels * on(cluster_id) group_left(url) console_url) by(cluster_id, url)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "? OSD Cluster Node Count",
+			  "transformations": [
+				{
+				  "id": "labelsToFields",
+				  "options": {}
+				},
+				{
+				  "id": "merge",
+				  "options": {}
+				},
+				{
+				  "id": "organize",
+				  "options": {
+					"excludeByName": {
+					  "Time": true,
+					  "cluster_id": true,
+					  "url": false
+					},
+					"indexByName": {
+					  "Time": 0,
+					  "Value": 1,
+					  "cluster_id": 2,
+					  "url": 3
+					},
+					"renameByName": {
+					  "Value": "# Node Count",
+					  "cluster_id": "",
+					  "url": "OpenShift Cluster (link)"
+					}
+				  }
+				}
+			  ],
+			  "type": "table"
+			}
+		  ],
+		  "title": "OSD & ROSA Cluster Count",
+		  "type": "row"
+		},
+		{
+		  "collapsed": true,
+		  "datasource": null,
+		  "gridPos": {
+			"h": 1,
+			"w": 24,
+			"x": 0,
+			"y": 1
+		  },
+		  "id": 22,
+		  "panels": [
+			{
+			  "datasource": null,
+			  "description": "",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": null,
+					"filterable": false
+				  },
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "service 1"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 250
+					  }
+					]
+				  }
+				]
+			  },
+			  "gridPos": {
+				"h": 8,
+				"w": 24,
+				"x": 0,
+				"y": 2
+			  },
+			  "id": 9,
+			  "interval": "100000",
+			  "maxDataPoints": 1,
+			  "options": {
+				"showHeader": true,
+				"sortBy": [
+				  {
+					"desc": false,
+					"displayName": "Rhoam Status"
+				  }
+				]
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "rhoam_cluster",
+				  "format": "table",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				},
+				{
+				  "expr": "rhoam_version{}",
+				  "format": "table",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "B"
+				}
+			  ],
+			  "timeFrom": null,
+			  "timeShift": null,
+			  "title": "Rhoam  Versions Count & Install Status",
+			  "transformations": [
+				{
+				  "id": "seriesToColumns",
+				  "options": {
+					"byField": "instance"
+				  }
+				},
+				{
+				  "id": "organize",
+				  "options": {
+					"excludeByName": {
+					  "Time 1": true,
+					  "Time 2": true,
+					  "Value #A": true,
+					  "Value #B": true,
+					  "__name__ 1": true,
+					  "__name__ 2": true,
+					  "endpoint 1": true,
+					  "endpoint 2": true,
+					  "job 1": true,
+					  "job 2": true,
+					  "namespace 2": true,
+					  "pod 1": true,
+					  "pod 2": true,
+					  "service 1": false,
+					  "service 2": true,
+					  "version": false
+					},
+					"indexByName": {
+					  "Time 1": 5,
+					  "Time 2": 13,
+					  "Value #A": 12,
+					  "Value #B": 20,
+					  "__name__ 1": 6,
+					  "__name__ 2": 14,
+					  "endpoint 1": 7,
+					  "endpoint 2": 15,
+					  "instance": 2,
+					  "job 1": 8,
+					  "job 2": 16,
+					  "namespace 1": 9,
+					  "namespace 2": 17,
+					  "pod 1": 10,
+					  "pod 2": 18,
+					  "service 1": 11,
+					  "service 2": 19,
+					  "stage": 4,
+					  "status": 3,
+					  "type": 1,
+					  "version": 0
+					},
+					"renameByName": {
+					  "Time 1": "",
+					  "instance": "",
+					  "stage": "Rhoam Install Stage",
+					  "status": "Rhoam Status",
+					  "type": "Cluster type",
+					  "version": "Rhoam version"
+					}
+				  }
+				},
+				{
+				  "id": "seriesToColumns",
+				  "options": {
+					"byField": "version"
+				  }
+				}
+			  ],
+			  "type": "table"
+			}
+		  ],
+		  "title": "RHOAM  Version Count & Install Status",
+		  "type": "row"
+		},
+		{
+		  "collapsed": true,
+		  "datasource": null,
+		  "gridPos": {
+			"h": 1,
+			"w": 24,
+			"x": 0,
+			"y": 2
+		  },
+		  "id": 24,
+		  "panels": [
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "links": [
+					{
+					  "targetBlank": true,
+					  "title": "Observability Routes in OpenShift Console",
+					  "url": "${__field.labels.url}/k8s/ns/managed-application-services-observability/routes"
+					}
+				  ]
+				},
+				"overrides": []
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 6,
+				"w": 19,
+				"x": 0,
+				"y": 3
+			  },
+			  "hiddenSeries": false,
+			  "id": 26,
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "links": [],
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": true,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(rhoam_version{}) by (version, status, stage) ",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "AddOn Versions count -  OSD clusters",
+			  "tooltip": {
+				"shared": false,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "min": "0",
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false
+			  }
+			},
+			{
+			  "aliasColors": {},
+			  "breakPoint": "50%",
+			  "cacheTimeout": null,
+			  "combine": {
+				"label": "Others",
+				"threshold": 0
+			  },
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": []
+			  },
+			  "fontSize": "80%",
+			  "format": "short",
+			  "gridPos": {
+				"h": 6,
+				"w": 5,
+				"x": 19,
+				"y": 3
+			  },
+			  "id": 28,
+			  "interval": null,
+			  "legend": {
+				"show": true,
+				"values": true
+			  },
+			  "legendType": "Under graph",
+			  "links": [],
+			  "maxDataPoints": 1,
+			  "nullPointMode": "connected",
+			  "pieType": "pie",
+			  "pluginVersion": "7.3.10",
+			  "strokeWidth": 1,
+			  "targets": [
+				{
+				  "expr": "count(rhoam_version{}) by (version, status, stage) ",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "{{installed}}",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "AddOn Version count - OSD Clusters",
+			  "type": "grafana-piechart-panel",
+			  "valueName": "current"
+			},
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "links": [
+					{
+					  "targetBlank": true,
+					  "title": "Observability Routes in OpenShift Console",
+					  "url": "${__field.labels.url}/k8s/ns/managed-application-services-observability/routes"
+					}
+				  ]
+				},
+				"overrides": []
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 6,
+				"w": 19,
+				"x": 0,
+				"y": 9
+			  },
+			  "hiddenSeries": false,
+			  "id": 31,
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "links": [],
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": true,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(rhoam_version{}) by (version, status, stage) ",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "? AddOn Operator Versions count across ROSA clusters",
+			  "tooltip": {
+				"shared": false,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "min": "0",
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false
+			  }
+			},
+			{
+			  "aliasColors": {},
+			  "breakPoint": "50%",
+			  "cacheTimeout": null,
+			  "combine": {
+				"label": "Others",
+				"threshold": 0
+			  },
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {}
+				},
+				"overrides": []
+			  },
+			  "fontSize": "80%",
+			  "format": "short",
+			  "gridPos": {
+				"h": 6,
+				"w": 5,
+				"x": 19,
+				"y": 9
+			  },
+			  "id": 32,
+			  "interval": null,
+			  "legend": {
+				"show": true,
+				"values": true
+			  },
+			  "legendType": "Under graph",
+			  "links": [],
+			  "maxDataPoints": 1,
+			  "nullPointMode": "connected",
+			  "pieType": "pie",
+			  "pluginVersion": "7.3.10",
+			  "strokeWidth": 1,
+			  "targets": [
+				{
+				  "expr": "count(rhoam_version{}) by (version, status, stage)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "{{installed}}",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "AddOn Operator Versions count across ROSA clusters",
+			  "type": "grafana-piechart-panel",
+			  "valueName": "current"
+			}
+		  ],
+		  "title": "RHOAM AddOn Operator Versions count across clusters",
+		  "type": "row"
+		},
+		{
+		  "collapsed": true,
+		  "datasource": null,
+		  "gridPos": {
+			"h": 1,
+			"w": 24,
+			"x": 0,
+			"y": 3
+		  },
+		  "id": 5,
+		  "panels": [
+			{
+			  "datasource": "Prometheus",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": null,
+					"filterable": false
+				  },
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "alert"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 228
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "namespace"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 198
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Value"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 66
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "state"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 110
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "severity"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 116
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "value"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 53
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Alert"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 233
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "State"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 89
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Severity"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 109
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "service"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 217
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "job"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 181
+					  }
+					]
+				  }
+				]
+			  },
+			  "gridPos": {
+				"h": 7,
+				"w": 24,
+				"x": 0,
+				"y": 4
+			  },
+			  "id": 1,
+			  "links": [],
+			  "options": {
+				"showHeader": true,
+				"sortBy": [
+				  {
+					"desc": false,
+					"displayName": "value"
+				  }
+				]
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "rhoam_alerts{}",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "A",
+				  "step": 10
+				}
+			  ],
+			  "timeFrom": null,
+			  "timeShift": null,
+			  "title": "Rhoam Alerts across OSD and ROSA clusters",
+			  "transformations": [
+				{
+				  "id": "organize",
+				  "options": {
+					"excludeByName": {
+					  "Time": true,
+					  "__name__": true,
+					  "endpoint": false
+					},
+					"indexByName": {
+					  "Time": 0,
+					  "Value": 5,
+					  "__name__": 1,
+					  "alert": 2,
+					  "endpoint": 11,
+					  "instance": 8,
+					  "job": 10,
+					  "namespace": 6,
+					  "pod": 7,
+					  "service": 9,
+					  "severity": 3,
+					  "state": 4
+					},
+					"renameByName": {
+					  "Value": "value",
+					  "__name__": "",
+					  "alert": "Alert",
+					  "severity": "Severity",
+					  "state": "State"
+					}
+				  }
+				}
+			  ],
+			  "type": "table"
+			},
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "links": [
+					{
+					  "targetBlank": true,
+					  "title": "Observability Routes in OpenShift Console",
+					  "url": "${__field.labels.url}/k8s/ns/managed-application-services-observability/routes"
+					}
+				  ]
+				},
+				"overrides": []
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 5,
+				"w": 19,
+				"x": 0,
+				"y": 11
+			  },
+			  "hiddenSeries": false,
+			  "id": 34,
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "links": [],
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": true,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(ALERTS{alertstate=\"firing\", alertname!=\"DeadMansSwitch\", severity=\"critical\"}) by(severity, alertname) #count(ALERTS{alertstate=\"firing\", alertname!=\"DeadMansSwitch\", severity=\"critical\"} * on(cluster_id) group_left(url) console_url) by(severity, alertname, cluster_id, url)",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "Count of Critical alerts firing by severity and alertname",
+			  "tooltip": {
+				"shared": false,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "min": "0",
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false
+			  }
+			},
+			{
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 1
+					  }
+					]
+				  }
+				},
+				"overrides": []
+			  },
+			  "gridPos": {
+				"h": 5,
+				"w": 5,
+				"x": 19,
+				"y": 11
+			  },
+			  "id": 36,
+			  "options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+				  "calcs": [
+					"mean"
+				  ],
+				  "fields": "",
+				  "values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "count(ALERTS{alertstate=\"firing\",severity=\"critical\"}) or vector(0)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "Total Criticals Firing",
+			  "type": "stat"
+			},
+			{
+			  "aliasColors": {},
+			  "bars": false,
+			  "dashLength": 10,
+			  "dashes": false,
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "links": [
+					{
+					  "targetBlank": true,
+					  "title": "Observability Routes in OpenShift Console",
+					  "url": "${__field.labels.url}/k8s/ns/managed-application-services-observability/routes"
+					}
+				  ]
+				},
+				"overrides": []
+			  },
+			  "fill": 1,
+			  "fillGradient": 0,
+			  "gridPos": {
+				"h": 5,
+				"w": 19,
+				"x": 0,
+				"y": 16
+			  },
+			  "hiddenSeries": false,
+			  "id": 38,
+			  "legend": {
+				"avg": false,
+				"current": false,
+				"max": false,
+				"min": false,
+				"show": true,
+				"total": false,
+				"values": false
+			  },
+			  "lines": true,
+			  "linewidth": 1,
+			  "links": [],
+			  "nullPointMode": "null",
+			  "options": {
+				"alertThreshold": true
+			  },
+			  "percentage": false,
+			  "pluginVersion": "7.3.10",
+			  "pointradius": 2,
+			  "points": false,
+			  "renderer": "flot",
+			  "seriesOverrides": [],
+			  "spaceLength": 10,
+			  "stack": true,
+			  "steppedLine": false,
+			  "targets": [
+				{
+				  "exemplar": true,
+				  "expr": "count(ALERTS{alertstate=\"firing\", alertname!=\"DeadMansSwitch\", severity=\"warning\"}) by(severity, alertname) #count(ALERTS{alertstate=\"firing\", alertname!=\"DeadMansSwitch\", severity=\"warning\"} * on(cluster_id) group_left(url) console_url) by(severity, alertname, cluster_id, url)",
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "thresholds": [],
+			  "timeFrom": null,
+			  "timeRegions": [],
+			  "timeShift": null,
+			  "title": "Count of Warning alerts firing by severity and alertname",
+			  "tooltip": {
+				"shared": false,
+				"sort": 0,
+				"value_type": "individual"
+			  },
+			  "type": "graph",
+			  "xaxis": {
+				"buckets": null,
+				"mode": "time",
+				"name": null,
+				"show": true,
+				"values": []
+			  },
+			  "yaxes": [
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "min": "0",
+				  "show": true
+				},
+				{
+				  "format": "short",
+				  "logBase": 1,
+				  "show": true
+				}
+			  ],
+			  "yaxis": {
+				"align": false
+			  }
+			},
+			{
+			  "datasource": null,
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {},
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 1
+					  }
+					]
+				  }
+				},
+				"overrides": []
+			  },
+			  "gridPos": {
+				"h": 5,
+				"w": 5,
+				"x": 19,
+				"y": 16
+			  },
+			  "id": 40,
+			  "options": {
+				"colorMode": "value",
+				"graphMode": "area",
+				"justifyMode": "auto",
+				"orientation": "auto",
+				"reduceOptions": {
+				  "calcs": [
+					"mean"
+				  ],
+				  "fields": "",
+				  "values": false
+				},
+				"text": {},
+				"textMode": "auto"
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "count(ALERTS{alertstate=\"firing\",severity=\"warning\"}) or vector(0)",
+				  "instant": true,
+				  "interval": "",
+				  "legendFormat": "",
+				  "refId": "A"
+				}
+			  ],
+			  "title": "Total Warnings Firing",
+			  "type": "stat"
+			}
+		  ],
+		  "repeat": null,
+		  "title": "RHOAM ALERTS across clusters",
+		  "type": "row"
+		},
+		{
+		  "collapsed": true,
+		  "datasource": null,
+		  "gridPos": {
+			"h": 1,
+			"w": 24,
+			"x": 0,
+			"y": 4
+		  },
+		  "id": 42,
+		  "panels": [
+			{
+			  "datasource": "Prometheus",
+			  "description": "Summary of CPU, Memory, Disk and Network usage for each Rhoam cluster.",
+			  "fieldConfig": {
+				"defaults": {
+				  "custom": {
+					"align": "left",
+					"displayMode": "auto",
+					"filterable": false
+				  },
+				  "links": [],
+				  "mappings": [],
+				  "thresholds": {
+					"mode": "absolute",
+					"steps": [
+					  {
+						"color": "green",
+						"value": null
+					  },
+					  {
+						"color": "red",
+						"value": 80
+					  }
+					]
+				  }
+				},
+				"overrides": [
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "CPU Usage"
+					},
+					"properties": [
+					  {
+						"id": "unit"
+					  },
+					  {
+						"id": "custom.width",
+						"value": 118
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Memory Usage"
+					},
+					"properties": [
+					  {
+						"id": "unit",
+						"value": "decbytes"
+					  },
+					  {
+						"id": "custom.width",
+						"value": 131
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Available Disk Space"
+					},
+					"properties": [
+					  {
+						"id": "unit",
+						"value": "percent"
+					  },
+					  {
+						"id": "custom.width",
+						"value": 173
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Network Transmit Bytes"
+					},
+					"properties": [
+					  {
+						"id": "unit",
+						"value": "decbytes"
+					  },
+					  {
+						"id": "custom.width",
+						"value": 193
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Network Received Bytes"
+					},
+					"properties": [
+					  {
+						"id": "unit",
+						"value": "decbytes"
+					  },
+					  {
+						"id": "custom.width",
+						"value": 163
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "cluster_id"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 100
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "namespace"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 446
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "namespace"
+					},
+					"properties": [
+					  {
+						"id": "links",
+						"value": [
+						  {
+							"title": "Drill Down",
+							"url": "./d/c37212696a6c9b90acae3af21966521e06169e1c/strimzi-kafka-fleet-panel-compute-resources-namespace?&var-namespace=${__value.raw}"
+						  }
+						]
+					  }
+					]
+				  },
+				  {
+					"matcher": {
+					  "id": "byName",
+					  "options": "Time 2"
+					},
+					"properties": [
+					  {
+						"id": "custom.width",
+						"value": 311
+					  }
+					]
+				  }
+				]
+			  },
+			  "gridPos": {
+				"h": 8,
+				"w": 24,
+				"x": 0,
+				"y": 5
+			  },
+			  "id": 44,
+			  "options": {
+				"footer": {
+				  "fields": "",
+				  "reducer": [
+					"sum"
+				  ],
+				  "show": false
+				},
+				"frameIndex": 0,
+				"showHeader": true,
+				"sortBy": []
+			  },
+			  "pluginVersion": "7.3.10",
+			  "targets": [
+				{
+				  "expr": "sum(kube_pod_info{namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace,cluster_id)",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "A"
+				},
+				{
+				  "expr": "sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate{container!=\"\",namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\", namespace !~ \".*minio.*\"}) by (namespace)",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "B"
+				},
+				{
+				  "expr": "sum(container_memory_working_set_bytes{container != \"\", namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace)",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "C"
+				},
+				{
+				  "expr": "sum((sum(kubelet_volume_stats_available_bytes{ job=\"kubelet\", namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace) / sum(kubelet_volume_stats_capacity_bytes{ job=\"kubelet\", namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace) * 100)) by (namespace) ",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "D"
+				},
+				{
+				  "expr": "sum(container_network_transmit_bytes_total{ container!= \"\",namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace)",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "E"
+				},
+				{
+				  "expr": "sum(container_network_receive_bytes_total{ container!= \"\",namespace !~\"openshift.*\", namespace !~\".*monitor.*\", namespace !~\".*operator.*\",namespace !~\".*obser.*\",namespace !~ \".*logging.*\",namespace !~ \".*minio.*\"}) by (namespace)",
+				  "format": "table",
+				  "instant": true,
+				  "interval": "",
+				  "intervalFactor": 2,
+				  "legendFormat": "",
+				  "refId": "F"
+				}
+			  ],
+			  "title": "Cluster Compute Metrics ",
+			  "transformations": [
+				{
+				  "id": "seriesToColumns",
+				  "options": {
+					"byField": "namespace"
+				  }
+				},
+				{
+				  "id": "organize",
+				  "options": {
+					"excludeByName": {
+					  "Time": true,
+					  "Time 1": true,
+					  "Time 2": true,
+					  "Value #A": true,
+					  "Value #C": false,
+					  "cluster_id": true
+					},
+					"indexByName": {},
+					"renameByName": {
+					  "Value #B": "CPU Usage",
+					  "Value #C": "Memory Usage",
+					  "Value #D": "Available Disk Space",
+					  "Value #E": "Network Transmit Bytes",
+					  "Value #F": "Netowrk Received Bytes"
+					}
+				  }
+				}
+			  ],
+			  "type": "table"
+			}
+		  ],
+		  "title": "Compute Resources",
+		  "type": "row"
+		}
+	  ],
+	  "refresh": "10s",
+	  "schemaVersion": 26,
+	  "style": "dark",
+	  "tags": [],
+	  "templating": {
+		"list": []
+	  },
+	  "time": {
+		"from": "now-3h",
+		"to": "now"
+	  },
+	  "timepicker": {
+		"refresh_intervals": [
+		  "5s",
+		  "10s",
+		  "30s",
+		  "1m",
+		  "5m",
+		  "15m",
+		  "30m",
+		  "1h",
+		  "2h",
+		  "1d"
+		],
+		"time_options": [
+		  "5m",
+		  "15m",
+		  "1h",
+		  "6h",
+		  "12h",
+		  "24h",
+		  "2d",
+		  "7d",
+		  "30d"
+		]
+	  },
+	  "timezone": "",
+	  "title": "RHOAM - Fleet Wide View",
+	  "uid": "b06hC0U7z",
+	  "version": 40
+}`

--- a/pkg/resources/cluster_test.go
+++ b/pkg/resources/cluster_test.go
@@ -197,3 +197,115 @@ func TestVersions(t *testing.T) {
 		})
 	}
 }
+
+func TestGetClusterType(t *testing.T) {
+	type testScenario struct {
+		Name     string
+		Input    *configv1.Infrastructure
+		Expected string
+		Error    bool
+	}
+
+	scenarios := []testScenario{
+		{
+			Name: "Get AWS cluster type",
+			Input: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: "",
+					Platform:           "",
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.AWSPlatformType,
+						AWS: &configv1.AWSPlatformStatus{
+							Region:           "",
+							ServiceEndpoints: nil,
+							ResourceTags: []configv1.AWSResourceTag{
+								{
+									Key:   "red-hat-clustertype",
+									Value: "OSD",
+								},
+							},
+						},
+					},
+					EtcdDiscoveryDomain:    "",
+					APIServerURL:           "",
+					APIServerInternalURL:   "",
+					ControlPlaneTopology:   "",
+					InfrastructureTopology: "",
+				},
+			},
+			Expected: "OSD",
+			Error:    false,
+		},
+		{
+			Name: "Get AWS error on cluster type",
+			Input: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: "",
+					Platform:           "",
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: configv1.AWSPlatformType,
+						AWS: &configv1.AWSPlatformStatus{
+							Region:           "",
+							ServiceEndpoints: nil,
+							ResourceTags: []configv1.AWSResourceTag{
+								{
+									Key:   "Missing Key",
+									Value: "OSD",
+								},
+							},
+						},
+					},
+					EtcdDiscoveryDomain:    "",
+					APIServerURL:           "",
+					APIServerInternalURL:   "",
+					ControlPlaneTopology:   "",
+					InfrastructureTopology: "",
+				},
+			},
+			Expected: "",
+			Error:    true,
+		},
+		{
+			Name: "Get Unknown on cluster type and Error",
+			Input: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: "",
+					Platform:           "",
+					PlatformStatus: &configv1.PlatformStatus{
+						Type: "Unknown Type",
+						AWS: &configv1.AWSPlatformStatus{
+							Region:           "",
+							ServiceEndpoints: nil,
+							ResourceTags: []configv1.AWSResourceTag{
+								{
+									Key:   "Missing Key",
+									Value: "OSD",
+								},
+							},
+						},
+					},
+					EtcdDiscoveryDomain:    "",
+					APIServerURL:           "",
+					APIServerInternalURL:   "",
+					ControlPlaneTopology:   "",
+					InfrastructureTopology: "",
+				},
+			},
+			Expected: "Unknown",
+			Error:    true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual, err := GetClusterType(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Infrstructure does not contain the expected result; Actual: %s, Expected: %s", scenario.Name, actual, scenario.Expected)
+		}
+
+		if scenario.Error && err == nil {
+			t.Fatalf("Test: %s; Failed to raise error when error was expected", scenario.Name)
+		}
+
+	}
+}

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -862,3 +862,18 @@ func reconcilePrometheusRule(ctx context.Context, client k8sclient.Client, ruleN
 
 	return rule, nil
 }
+
+func InstallationState(version string, toVersion string) string {
+
+	if len(version) == 0 && len(toVersion) == 0 {
+		return "Unknown State"
+	} else if len(version) == 0 && len(toVersion) > 0 {
+		return "Installation"
+	} else if len(version) > 0 && len(toVersion) > 0 {
+		return "Upgrade"
+	} else if len(version) > 0 && len(toVersion) == 0 {
+		return "Installed"
+	}
+
+	return ""
+}

--- a/pkg/resources/metrics_test.go
+++ b/pkg/resources/metrics_test.go
@@ -1,6 +1,7 @@
 package resources
 
 import (
+	"github.com/prometheus/alertmanager/api/v2/models"
 	"testing"
 )
 
@@ -53,7 +54,291 @@ func TestInstallationState(t *testing.T) {
 		actual := InstallationState(scenario.Input.Version, scenario.Input.ToVersion)
 
 		if actual != scenario.Expected {
-			t.Fatalf("Status not equal to expected result, Expected: %s, Actual: %s", scenario.Expected, actual)
+			t.Fatalf("Test: %s; Status not equal to expected result, Expected: %s, Actual: %s", scenario.Name, scenario.Expected, actual)
 		}
+	}
+}
+
+func TestAlertMetric_ContainsName(t *testing.T) {
+	type testScenario struct {
+		Name     string
+		Metric   AlertMetric
+		Input    string
+		Expected bool
+	}
+	scenarios := []testScenario{
+		{
+			Name:     "Has name",
+			Metric:   AlertMetric{Name: "Contains Name"},
+			Input:    "Contains Name",
+			Expected: true,
+		},
+		{
+			Name:     "Not got name",
+			Metric:   AlertMetric{Name: "Contains Name"},
+			Input:    "Does Not Contain Name",
+			Expected: false,
+		},
+		{
+			Name:     "No name is set",
+			Metric:   AlertMetric{State: "Firing"},
+			Input:    "Contains Name",
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := scenario.Metric.ContainsName(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Alert Metric did not match the name; Expected: %t, Actual: %t", scenario.Name, scenario.Expected, actual)
+		}
+
+	}
+}
+
+func TestAlertMetric_ContainsSeverity(t *testing.T) {
+	type testScenario struct {
+		Name     string
+		Metric   AlertMetric
+		Input    string
+		Expected bool
+	}
+	scenarios := []testScenario{
+		{
+			Name:     "Has severity",
+			Metric:   AlertMetric{Severity: "High"},
+			Input:    "High",
+			Expected: true,
+		},
+		{
+			Name:     "Not got severity",
+			Metric:   AlertMetric{Severity: "High"},
+			Input:    "Low",
+			Expected: false,
+		},
+		{
+			Name:     "No severity is set",
+			Metric:   AlertMetric{State: "Firing"},
+			Input:    "High",
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := scenario.Metric.ContainsSeverity(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Alert Metric did not match the severity; Expected: %t, Actual: %t", scenario.Name, scenario.Expected, actual)
+		}
+
+	}
+}
+
+func TestAlertMetric_ContainsState(t *testing.T) {
+	type testScenario struct {
+		Name     string
+		Metric   AlertMetric
+		Input    string
+		Expected bool
+	}
+	scenarios := []testScenario{
+		{
+			Name:     "Has State",
+			Metric:   AlertMetric{State: "Firing"},
+			Input:    "Firing",
+			Expected: true,
+		},
+		{
+			Name:     "Not got state",
+			Metric:   AlertMetric{State: "Firing"},
+			Input:    "Pending",
+			Expected: false,
+		},
+		{
+			Name:     "No state is set",
+			Metric:   AlertMetric{Name: "No State"},
+			Input:    "Firing",
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := scenario.Metric.ContainsState(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Alert Metric did not match the state; Expected: %t, Actual: %t", scenario.Name, scenario.Expected, actual)
+		}
+
+	}
+}
+
+func TestAlertMetric_Contains(t *testing.T) {
+	type input struct {
+		Labels models.LabelSet `json:"labels"`
+		State  string          `json:"state"`
+	}
+
+	type testScenario struct {
+		Name     string
+		Metric   AlertMetric
+		Input    input
+		Expected bool
+	}
+
+	scenarios := []testScenario{
+		{
+			Name: "has metric",
+			Metric: AlertMetric{
+				Name:     "Metric Exists",
+				Severity: "High",
+				State:    "Firing",
+				Value:    0,
+			},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Exists",
+					"severity":  "High",
+				},
+				State: "Firing",
+			},
+			Expected: true,
+		},
+		{
+			Name: "Does not contain metric, missing name",
+			Metric: AlertMetric{
+				Name:     "Metric Exists",
+				Severity: "High",
+				State:    "Firing",
+				Value:    0,
+			},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Missing",
+					"severity":  "High",
+				},
+				State: "Firing",
+			},
+			Expected: false,
+		},
+		{
+			Name: "Does not contain metric, missing severity",
+			Metric: AlertMetric{
+				Name:     "Metric Exists",
+				Severity: "High",
+				State:    "Firing",
+				Value:    0,
+			},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Exists",
+					"severity":  "Missing",
+				},
+				State: "Firing",
+			},
+			Expected: false,
+		},
+		{
+			Name: "Does not contain metric, missing state",
+			Metric: AlertMetric{
+				Name:     "Metric Exists",
+				Severity: "High",
+				State:    "Firing",
+				Value:    0,
+			},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Exists",
+					"severity":  "High",
+				},
+				State: "Missing",
+			},
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := scenario.Metric.Contains(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Alert Metric did not match Metric; Expected: %t, Actual: %t", scenario.Name, scenario.Expected, actual)
+		}
+
+	}
+}
+
+func TestAlertMetrics_Contains(t *testing.T) {
+	type input struct {
+		Labels models.LabelSet `json:"labels"`
+		State  string          `json:"state"`
+	}
+
+	type testScenario struct {
+		Name     string
+		Metrics  AlertMetrics
+		Input    input
+		Expected bool
+	}
+
+	scenarios := []testScenario{
+		{
+			Name: "Metric list has input",
+			Metrics: AlertMetrics{Alerts: []AlertMetric{
+				{
+					Name:     "Metric Exists",
+					Severity: "High",
+					State:    "Firing",
+					Value:    0,
+				},
+			}},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Exists",
+					"severity":  "High",
+				},
+				State: "Firing",
+			},
+			Expected: true,
+		},
+		{
+			Name: "Metric list not got input",
+			Metrics: AlertMetrics{Alerts: []AlertMetric{
+				{
+					Name:     "Metric Exists",
+					Severity: "High",
+					State:    "Firing",
+					Value:    0,
+				},
+			}},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Missing",
+					"severity":  "High",
+				},
+				State: "Firing",
+			},
+			Expected: false,
+		},
+		{
+			Name:    "Metric list is empty",
+			Metrics: AlertMetrics{Alerts: []AlertMetric{}},
+			Input: input{
+				Labels: models.LabelSet{
+					"alertname": "Metric Missing",
+					"severity":  "High",
+				},
+				State: "Firing",
+			},
+			Expected: false,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := scenario.Metrics.Contains(scenario.Input)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Test: %s; Alert Metrics do not contain Metric Input; Expected: %t, Actual: %t", scenario.Name, scenario.Expected, actual)
+		}
+
 	}
 }

--- a/pkg/resources/metrics_test.go
+++ b/pkg/resources/metrics_test.go
@@ -1,0 +1,59 @@
+package resources
+
+import (
+	"testing"
+)
+
+func TestInstallationState(t *testing.T) {
+	type testScenario struct {
+		Name  string
+		Input struct {
+			Version   string
+			ToVersion string
+		}
+		Expected string
+	}
+
+	scenarios := []testScenario{
+		{
+			Name: "No version information is set",
+			Input: struct {
+				Version   string
+				ToVersion string
+			}{Version: "", ToVersion: ""},
+			Expected: "Unknown State",
+		},
+		{
+			Name: "Initial installation",
+			Input: struct {
+				Version   string
+				ToVersion string
+			}{Version: "", ToVersion: "1.1.0"},
+			Expected: "Installation",
+		},
+		{
+			Name: "Upgrade installation",
+			Input: struct {
+				Version   string
+				ToVersion string
+			}{Version: "1.1.0", ToVersion: "1.2.0"},
+			Expected: "Upgrade",
+		},
+		{
+			Name: "Installed state",
+			Input: struct {
+				Version   string
+				ToVersion string
+			}{Version: "1.1.0", ToVersion: ""},
+			Expected: "Installed",
+		},
+	}
+
+	for _, scenario := range scenarios {
+		actual := InstallationState(scenario.Input.Version, scenario.Input.ToVersion)
+
+		if actual != scenario.Expected {
+			t.Fatalf("Status not equal to expected result, Expected: %s, Actual: %s", scenario.Expected, actual)
+		}
+	}
+}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3696
This branch contains merge from MGDAPI-3695 (metrics for Fleet-wide), PR https://github.com/integr8ly/integreatly-operator/pull/2574
Do not merge to master, as MGDAPI-3695 is still in development.

# What
Create Initial Fleet wide SRE Dashboard querying observatorium
Grafana dashboard displaying data that is captured in [this JIRA](https://issues.redhat.com/browse/MGDAPI-3695), and more
Kafka Fleet dashboard was used as example.
The Grafana used will be managed by AppSRE and will query Observatorium.

# Verification steps
Be sure rhoam image includes changes from MGDAPI-3695
Install Rhoam as addon
Review Grafana Dashboard: "Fleet Wide View - initial Draft"
