### PR TITLE
MGDAPI-3661 / Added Additional images

### DIFF
--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -1,0 +1,16 @@
+# This file represents informations around components used within RHOAM and RHMI
+# name - the name of the components
+# url - url to quay / redhat registry repo of the component
+additionalImages:
+  - name: 3scale-openshift-servce-mesh
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.0-1"
+  - name: marin3r-limitador
+    url: "quay.io/3scale/limitador:0.5.0"
+  - name: observability-grafana-plugins-init
+    url: "quay.io/integreatly/grafana_plugins_init:0.0.3"
+  - name: observability-origin-oauth-proxy
+    url: "quay.io/openshift/origin-oauth-proxy:4.8"
+  - name: observability-prometheus-operator
+    url: "quay.io/prometheus-operator/prometheus-operator@sha256:066fce4a6b7392f07f7179b59ed4448bacc0767277637de99809449637be924b"
+  - name: rhsso-sso-openshift
+    url: "registry.redhat.io/rh-sso-7/sso75-openshift-rhel8:7.5-17"

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -237,7 +237,7 @@ set_related_images() {
               if [[ "$excludedItem" == "$relatedImageName" ]]; then
                 excluded=true
               fi
-          done
+            done
           # if item is not on exclusion list and is not already in the images list, add it in.
           if [ "$excluded" != true ]; then
             if [[ "$containerImageField" != *"$relatedImageURL"* ]]; then
@@ -248,6 +248,16 @@ set_related_images() {
       fi
     fi
   done
+
+  length=$(yq e -o=j ./products/additional-images.yaml| jq -r '.additionalImages' | jq length)
+  # Get supported components
+  for (( i=0; i<${length}; i++))
+    do
+      img_name=$(yq e ".additionalImages[$i]".name ./products/additional-images.yaml)
+      img_url=$(yq e ".additionalImages[$i].url" ./products/additional-images.yaml)
+
+      containerImageField="$containerImageField{\"component_name\":\"${img_name}\",\"component_url\":\"${img_url}\"},"
+    done
 
   containerImageRemovedLastCharacter=${containerImageField%?}
   containerImageField="$containerImageRemovedLastCharacter]"


### PR DESCRIPTION
# Issue link
[MGDAPI-3661](https://issues.redhat.com/browse/MGDAPI-3661)

# What
Included extra images into the CSV.

# Verification steps
1. Create cluster
2. In addons, install  Red Hat Openshift API Management.
3. Leave all the default values as they are.
4. In the rhoam yaml, add spec.useClusterStorage: 'true'
5. Run ```OLM_TYPE=managed-api-service SEMVER=1.21.0 make release/prepare``` 
6. Make sure the managed-api-service.clusterserviceversion.yaml contains the new images.
