### PR TITLE
MGDAPI-3854 add test cases for 3scale invitation mail

### DIFF
--- a/test-cases/tests/products/h32-verify-that-3scale-invitation-mail-is-set-correctly.md
+++ b/test-cases/tests/products/h32-verify-that-3scale-invitation-mail-is-set-correctly.md
@@ -1,0 +1,29 @@
+---
+products:
+  - name: rhoam
+    environments:
+      - osd-fresh-install
+      - osd-post-upgrade
+tags:
+  - manual-selection
+---
+
+# H32 - Verify that 3scale invitation mail is set correctly
+
+## Description
+
+3scale invitation mail is valid and present
+
+## Steps
+
+1. log in as `customer-admin01`
+
+2. Navigate to API management in the quick access menu at the top of the console page.
+
+3. From the drop-down menu at the top navigate to Audience > Developer Portal > Domain & Access
+
+4. Verify that the outgoing email is `noreply-alert@rhmw.io`
+
+5. Change the outgoing email and update the account.
+
+6. Verify that the outgoing email is reverted to `noreply-alert@rhmw.io`

--- a/test-cases/tests/products/h33-verify-that-3scale-invitation-mail-works-as-expected.md
+++ b/test-cases/tests/products/h33-verify-that-3scale-invitation-mail-works-as-expected.md
@@ -1,0 +1,27 @@
+---
+products:
+  - name: rhoam
+    environments:
+      - osd-fresh-install
+      - osd-post-upgrade
+tags:
+  - manual-selection
+---
+
+# H33 - Verify that 3scale invitation mail works as expected
+
+## Description
+
+Verify that 3scale invitation mail is sent out
+
+## Steps
+
+1. Log in as `customer-admin01`
+
+2. Navigate to API management in the quick access menu at the top of the console page.
+
+3. From the drop-down menu at the top navigate to Dashboard > Accounts > Developer (John Doe) > Invitations
+
+4. Click the invite user icon and input your email.
+
+5. You should receive an email with an invitation (This may take a few minutes).


### PR DESCRIPTION
# Issue link
[MGDAPI-3854](https://issues.redhat.com/browse/MGDAPI-3854)

# What
The addition of 2 new test cases to verify outgoing email in 3scale is set correctly and that sending out an invitation email works.

# Verification steps
Read through steps and make sure it makes sense.
