### PR TITLE
MGDAPI-2589 / Increased alert threshold to 8min

### DIFF
--- a/pkg/products/marin3r/prometheusRules.go
+++ b/pkg/products/marin3r/prometheusRules.go
@@ -75,7 +75,7 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) res
 							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
 						},
 						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
+						For:    "8m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
 					},
 				},


### PR DESCRIPTION
# Issue link
[MGDAPI-2589](https://issues.redhat.com/browse/MGDAPI-2589)

# What 
Changed alert threshold to 8 min from 5 min.

# Verification 
Install rhoam on cluster from this branch, make sure alert has changed to 8min.
