### PR TITLE
[MGDAPI-3882] use observability namespace and add unit tests

### DIFF
--- a/pkg/products/monitoringcommon/alertmanagerConfig_test.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig_test.go
@@ -156,7 +156,9 @@ func TestReconciler_reconcileAlertManagerSecrets(t *testing.T) {
 			Name:      config.AlertManagerConfigSecretName,
 			Namespace: defaultInstallationNamespace,
 		},
-		Data: map[string][]byte{},
+		Data: map[string][]byte{
+			"alertmanager.yaml": []byte("global:\n  smtp_from: noreply-alert@devshift.org"),
+		},
 		Type: corev1.SecretTypeOpaque,
 	}
 	alertmanagerRoute := &v1.Route{

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1092,7 +1092,7 @@ func (r *Reconciler) reconcileOutgoingEmailAddress(ctx context.Context, serverCl
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
-	existingSMTPFromAddress, err := resources.GetExistingSMTPFromAddress(ctx, serverClient, observabilityConfig.GetOperatorNamespace())
+	existingSMTPFromAddress, err := resources.GetExistingSMTPFromAddress(ctx, serverClient, observabilityConfig.GetNamespace())
 
 	if err != nil {
 		if !k8serr.IsNotFound(err) {

--- a/pkg/resources/smtp.go
+++ b/pkg/resources/smtp.go
@@ -28,12 +28,18 @@ func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client, ns
 	if err != nil {
 		return "", err
 	}
-	monitoring := amSecret.Data[alertManagerConfigSecretFileName]
+	monitoring, ok := amSecret.Data[alertManagerConfigSecretFileName]
+	if !ok {
+		return "", fmt.Errorf("failed to find %s in %s secret data", alertManagerConfigSecretFileName, alertManagerConfigSecretName)
+	}
 	var config alertManagerConfig
 	err = yaml.Unmarshal(monitoring, &config)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse alert monitoring yaml: %w", err)
 	}
-
-	return config.Global["smtp_from"], nil
+	smtpFrom, ok := config.Global["smtp_from"]
+	if !ok {
+		return "", fmt.Errorf("failed to find smtp_from in alert manager config map")
+	}
+	return smtpFrom, nil
 }

--- a/pkg/resources/smtp.go
+++ b/pkg/resources/smtp.go
@@ -19,17 +19,16 @@ type alertManagerConfig struct {
 	Global map[string]string `yaml:"global"`
 }
 
-func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client, operatorNs string) (string, error) {
+func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client, ns string) (string, error) {
 	amSecret := &corev1.Secret{}
-	err := client.Get(ctx, types.NamespacedName{Name: alertManagerConfigSecretName,
-		Namespace: operatorNs}, amSecret)
-
+	err := client.Get(ctx, types.NamespacedName{
+		Name:      alertManagerConfigSecretName,
+		Namespace: ns,
+	}, amSecret)
 	if err != nil {
 		return "", err
 	}
-
 	monitoring := amSecret.Data[alertManagerConfigSecretFileName]
-
 	var config alertManagerConfig
 	err = yaml.Unmarshal(monitoring, &config)
 	if err != nil {

--- a/pkg/resources/smtp_test.go
+++ b/pkg/resources/smtp_test.go
@@ -1,0 +1,76 @@
+package resources
+
+import (
+	"context"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestGetExistingSMTPFromAddress(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("failed to build scheme: %s", err.Error())
+	}
+
+	scenarios := []struct {
+		Name       string
+		FakeClient k8sclient.Client
+		WantErr    bool
+	}{
+		{
+			Name: "successfully retrieve existing smtp from address",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      alertManagerConfigSecretName,
+					Namespace: "test",
+				},
+				Data: map[string][]byte{
+					"alertmanager.yaml": []byte(`
+global:
+  smtp_from: test
+`),
+				},
+			}, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+			}),
+		},
+		{
+			Name:       "failed to retrieve alert manager config secret",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme),
+			WantErr:    true,
+		},
+		{
+			Name: "failed to unmarshal yaml from secret data",
+			FakeClient: fakeclient.NewFakeClientWithScheme(scheme, &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      alertManagerConfigSecretName,
+					Namespace: "test",
+				},
+				Data: map[string][]byte{
+					"alertmanager.yaml": []byte(`invalid yaml`),
+				},
+			}, &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "test",
+				},
+			}),
+			WantErr: true,
+		},
+	}
+
+	for _, scenario := range scenarios {
+		t.Run(scenario.Name, func(t *testing.T) {
+			_, err := GetExistingSMTPFromAddress(context.TODO(), scenario.FakeClient, "test")
+			if !scenario.WantErr && err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}

--- a/pkg/resources/smtp_test.go
+++ b/pkg/resources/smtp_test.go
@@ -29,10 +29,10 @@ func TestGetExistingSMTPFromAddress(t *testing.T) {
 					Namespace: "test",
 				},
 				Data: map[string][]byte{
-					"alertmanager.yaml": []byte("global:\n  smtp_from: noreply-alert@devshift.net"),
+					"alertmanager.yaml": []byte("global:\n  smtp_from: noreply-alert@devshift.org"),
 				},
 			}),
-			WantRes: "noreply-alert@devshift.net",
+			WantRes: "noreply-alert@devshift.org",
 			WantErr: false,
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3882

# What
This function - https://github.com/integr8ly/integreatly-operator/blob/master/pkg/products/threescale/reconciler.go#L1095 looks for the secret in the observability operator ns while it should look for it under observability ns.

# Verification steps
Check unit tests are passing and the coverage of `GetExistingSMTPFromAddress` is sufficient 
