### PR TITLE
MGDAPI-3637 Fixes test E03 for multitenant installations

### DIFF
--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -98,6 +98,12 @@ var customerRHOAMDashboards = []dashboardsTestRule{
 	},
 }
 
+var multitenantRHOAMDashboards = []dashboardsTestRule{
+	{
+		Title: "Multitenancy Detailed",
+	},
+}
+
 func TestIntegreatlyCustomerDashboardsExist(t TestingTB, ctx *TestingContext) {
 	// get console master url
 	rhmi, err := GetRHMI(ctx.Client, true)
@@ -230,6 +236,9 @@ func getExpectedCustomerDashboard(installType string) []dashboardsTestRule {
 
 func getExpectedMiddlewareDashboard(installType string) []dashboardsTestRule {
 	if integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installType)) {
+		if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {
+			return append(commonExpectedDashboards, multitenantRHOAMDashboards...)
+		}
 		return commonExpectedDashboards
 	} else {
 		return append(commonExpectedDashboards, rhmi2ExpectedDashboards...)


### PR DESCRIPTION
# Issue link
N/A

# What
The `Verify middleware dashboards exist` test (E03) was broken for multitenant installs of RHOAM when a new dashboard was added for [MGDAPI-3637](https://issues.redhat.com/browse/MGDAPI-3637). This PR fixes E03 by checking if the install type is multitenant when comparing expected grafana dashboards.

# Verification steps
Passing the automated tests should be sufficient. Alternatively, checkout this PR and install multitenant RHOAM then run the E03 test: `INSTALLATION_TYPE=multitenant-managed-api BYPASS_STORAGE_TYPE_CHECK=true TEST="E03" make test/e2e/single`
