### PR TITLE
MGDAPI-3891 Added metric and alert to track failed APIManagementTenant CRs

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -293,9 +293,14 @@ func (r *Reconciler) setTenantMetrics(ctx context.Context, serverClient k8sclien
 	if err != nil {
 		return err
 	}
+	failed, err := userHelper.GetFailedAPIManagementTenantsCount(ctx, serverClient)
+	if err != nil {
+		return err
+	}
 	r.log.Info("Setting tenant metrics")
 	metrics.SetTotalNumTenants(total)
 	metrics.SetNumReconciledTenants(reconciled)
+	metrics.SetNumFailedTenants(failed)
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -67,6 +67,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.Quota)
 	customMetrics.Registry.MustRegister(integreatlymetrics.TotalNumTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumReconciledTenants)
+	customMetrics.Registry.MustRegister(integreatlymetrics.NumFailedTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NoActivated3ScaleTenantAccount)
 
 	integreatlymetrics.OperatorVersion.Add(1)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -131,6 +131,13 @@ var (
 		},
 	)
 
+	NumFailedTenants = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "num_failed_tenants",
+			Help: "Number of tenants (APIManagementTenant CRs) on the cluster that didn't reconcile",
+		},
+	)
+
 	NoActivated3ScaleTenantAccount = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Name: "no_activated_3scale_tenant_account",
@@ -191,6 +198,10 @@ func SetTotalNumTenants(numTenants int) {
 
 func SetNumReconciledTenants(numTenants int) {
 	NumReconciledTenants.Set(float64(numTenants))
+}
+
+func SetNumFailedTenants(numTenants int) {
+	NumFailedTenants.Set(float64(numTenants))
 }
 
 func ResetNoActivated3ScaleTenantAccount() {

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,67 @@
+package metrics
+
+import (
+	"context"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	configv1 "github.com/openshift/api/config/v1"
+	userv1 "github.com/openshift/api/user/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestGetContainerCPUMetric(t *testing.T) {
+	scheme := runtime.NewScheme()
+	err := userv1.AddToScheme(scheme)
+	err = configv1.AddToScheme(scheme)
+
+	if err != nil {
+		t.Fatalf("Error creating build scheme")
+	}
+
+	tests := []struct {
+		Name           string
+		FakeClient     k8sclient.Client
+		ExpectedMetric string
+		ExpectedError  bool
+	}{
+		{
+			Name: "Test GetContainerCPUMetric for OpenShift < 4.9",
+			FakeClient: fake.NewFakeClientWithScheme(scheme,
+				&configv1.ClusterVersionList{
+					Items: []configv1.ClusterVersion{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name: "version",
+							},
+							Status: configv1.ClusterVersionStatus{
+								History: []configv1.UpdateHistory{
+									{
+										Version: "4.8",
+									},
+								},
+							},
+						},
+					},
+				},
+			),
+			ExpectedMetric: "node_namespace_pod_container:container_cpu_usage_seconds_total:sum_rate",
+			ExpectedError:  false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			metric, err := GetContainerCPUMetric(context.TODO(), tt.FakeClient, l.NewLogger())
+
+			if err != nil {
+				t.Fatalf("Failed test with: %v", err)
+			}
+
+			if metric != tt.ExpectedMetric {
+				t.Fatalf("incorrect metric returned, expected %v, got %v", tt.ExpectedMetric, metric)
+			}
+		})
+	}
+}

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -2,6 +2,7 @@ package observability
 
 import (
 	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -14,328 +15,347 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 	nsPrefix := r.installation.Spec.NamespacePrefix
 	namespace := r.Config.GetNamespace()
 
+	alerts := []resources.AlertConfiguration{
+		{
+			AlertName: "backup-monitoring-alerts",
+			GroupName: "general.rules",
+			Namespace: namespace,
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "JobRunningTimeExceeded",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 300 seconds",
+					},
+					Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 300 "),
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "JobRunningTimeExceeded",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 600 seconds",
+					},
+					Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 600 "),
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "CronJobNotRunInThreshold",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": " CronJob {{ $labels.namespace }} / {{ $labels.label_cronjob_name }} has not started a Job in 25 hours",
+					},
+					Expr: intstr.FromString("(time() - (max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (job_name, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (label_cronjob_name))) > 60*60*25"),
+				},
+			},
+		},
+		{
+			AlertName: "ksm-alerts",
+			Namespace: namespace,
+			GroupName: "general.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "KubePodCrashLooping",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is restarting {{  $value  }} times every 10 minutes; for the last 15 minutes",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("rate(kube_pod_container_status_restarts_total{job='kube-state-metrics',namespace=~'%s.*'}[10m]) * 60 * 5 > 0", r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePodNotReady",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": "Pod {{ $labels.namespace }} / {{ $labels.pod }}  has been in a non-ready state for longer than 15 minutes.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("sum by(pod, namespace) (kube_pod_status_phase{phase=~'Pending|Unknown', namespace=~'%s.*'}) > 0", r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePodImagePullBackOff",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": "Pod {{ $labels.namespace }} / {{  $labels.pod  }} has been unable to pull its image for longer than 5 minutes.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ImagePullBackOff',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePodBadConfig",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": " Pod {{ $labels.namespace  }} / {{  $labels.pod  }} has been unable to start due to a bad configuration for longer than 5 minutes",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='CreateContainerConfigError',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePodStuckCreating",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": "Pod {{  $labels.namespace }} / {{  $labels.pod  }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ContainerCreating',namespace=~'%s.*'} > 0", r.Config.GetOperatorNamespace())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "ClusterSchedulableMemoryLow",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+						"message": "The cluster has {{  $value }} percent of memory requested and unavailable for scheduling for longer than 15 minutes.",
+					},
+					Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='memory'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'}  == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'}  == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='memory'})))))) * 100 > 85"),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "ClusterSchedulableCPULow",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+						"message": "The cluster has {{ $value }} percent of CPU cores requested and unavailable for scheduling for longer than 15 minutes.",
+					},
+					Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='cpu'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='cpu'})))))) * 100 > 85"),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "PVCStorageAvailable",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+						"message": "The {{  $labels.persistentvolumeclaim  }} PVC has has been {{ $value }} percent full for longer than 15 minutes.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes{namespace=~'%s.*'})) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~'%s.*'}))) * 100 > 85", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "PVCStorageMetricsAvailable",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
+						"message": "PVC storage metrics are not available",
+					},
+					Expr:   intstr.FromString("absent(kubelet_volume_stats_available_bytes) == 1 or absent(kubelet_volume_stats_capacity_bytes) == 1 or absent(kubelet_volume_stats_used_bytes) == 1 or absent(kube_persistentvolumeclaim_resource_requests_storage_bytes) == 1"),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePersistentVolumeFillingUp4h",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#pvcstoragewillfillin4hours",
+						"message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("(predict_linear(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} [6h], 4 * 24 * 3600) <= 0 and kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'}  / kubelet_volume_stats_capacity_bytes{job='kubelet'} < 0.15)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "KubePersistentVolumeFillingUp",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#kubepersistentvolumefillingup",
+						"message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} / kubelet_volume_stats_capacity_bytes{job='kubelet', namespace=~'%s.*'} < 0.03)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+
+				{
+					Alert: "PersistentVolumeErrors",
+					Annotations: map[string]string{
+						"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#persistentvolumeerrors",
+						"message": "The PVC {{  $labels.persistentvolumeclaim  }} is in status {{  $labels.phase  }} in namespace {{  $labels.namespace }} ",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("(sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~'Failed|Pending|Lost', namespace=~'%s.*'})) > 0", r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		},
+		{
+			AlertName: "ksm-endpoint-alerts",
+			Namespace: namespace,
+			GroupName: "middleware-monitoring-operator-endpoint.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerOperatedServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorApplicationMonitoringMetricsServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='application-monitoring-operator-metrics', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorGrafanaServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='grafana-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorPrometheusOperatedServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorPrometheusServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+				{
+					Alert: "RHMIMiddlewareMonitoringOperatorRhmiRegistryCsServiceEndpointDown",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlEndpointAvailableAlert,
+						"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		},
+		{
+			AlertName: "install-upgrade-alerts",
+			Namespace: namespace,
+			GroupName: "general.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "RHMICSVRequirementsNotMet",
+					Annotations: map[string]string{
+						"message": "RequirementsNotMet for CSV '{{$labels.name}}' in namespace '{{$labels.namespace}}'. Phase is {{$labels.phase}}",
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("csv_abnormal{phase=~'Pending|Failed',exported_namespace=~'%s.*'}", r.Config.GetNamespacePrefix())),
+					For:    "15m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		},
+		{
+			AlertName: "multi-az-pod-distribution",
+			Namespace: namespace,
+			GroupName: "general.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "MultiAZPodDistribution",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlPodDistributionIncorrect,
+						"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is incorretly distributed to the zone {{  $value  }} ; for the last 5 minutes",
+					},
+					Expr:   intstr.FromString(installationName + "_version{to_version=\"\"} and (count by(namespace, created_by_name, label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"} == on(node) group_left(label_topology_kubernetes_io_zone) kube_node_labels) == on (namespace, created_by_name)(count by(namespace, created_by_name) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"}) > 1) > scalar((count(count by (label_topology_kubernetes_io_zone) (kube_node_labels)) >= bool 2) == 1))"),
+					For:    "5m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		},
+		{
+			AlertName: "test-alerts",
+			Namespace: namespace,
+			GroupName: "test.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "TestFireCriticalAlert",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlTestFireAlerts,
+						"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+					},
+					Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='cj3cssrec'}) > 0"),
+					For:    "10s",
+					Labels: map[string]string{"severity": "critical", "product": "secret"},
+				},
+				{
+					Alert: "TestFireWarningAlert",
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlTestFireAlerts,
+						"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+					},
+					Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='wj3cssrew'}) > 0"),
+					For:    "10s",
+					Labels: map[string]string{"severity": "warning", "product": "secret"},
+				},
+			},
+		},
+		{
+			AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
+			Namespace: namespace,
+			GroupName: fmt.Sprintf("%s-installation.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
+					For:    "10m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		},
+	}
+
+	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {
+		multitenantAlert := resources.AlertConfiguration{
+			AlertName: "multitenancy-api-management-tenant-alerts",
+			Namespace: namespace,
+			GroupName: "multitenancy-api-management-tenant.rules",
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: "ApiManagementTenantCRFailed",
+					Annotations: map[string]string{
+						"message": "One or more APIManagementTenant CRs has failed to reconcile",
+					},
+					Expr:   intstr.FromString("num_failed_tenants > 0"),
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
+			},
+		}
+		alerts = append(alerts, multitenantAlert)
+	}
+
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "monitoring",
 		Installation: r.installation,
 		Log:          logger,
-		Alerts: []resources.AlertConfiguration{
-			{
-				AlertName: "backup-monitoring-alerts",
-				GroupName: "general.rules",
-				Namespace: namespace,
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "JobRunningTimeExceeded",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 300 seconds",
-						},
-						Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 300 "),
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "JobRunningTimeExceeded",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": " Job {{ $labels.namespace }} / {{ $labels.job  }} has been running for longer than 600 seconds",
-						},
-						Expr:   intstr.FromString("time() - (max(kube_job_status_active * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name) * ON(job_name) GROUP_RIGHT() max(kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'}) BY (job_name, namespace, label_cronjob_name) > 0) > 600 "),
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "CronJobNotRunInThreshold",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": " CronJob {{ $labels.namespace }} / {{ $labels.label_cronjob_name }} has not started a Job in 25 hours",
-						},
-						Expr: intstr.FromString("(time() - (max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (job_name, label_cronjob_name) == ON(label_cronjob_name) GROUP_LEFT() max( kube_job_status_start_time * ON(job_name) GROUP_RIGHT() kube_job_labels{label_monitoring_key='middleware'} ) BY (label_cronjob_name))) > 60*60*25"),
-					},
-				},
-			},
-
-			{
-				AlertName: "ksm-alerts",
-				Namespace: namespace,
-				GroupName: "general.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "KubePodCrashLooping",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is restarting {{  $value  }} times every 10 minutes; for the last 15 minutes",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("rate(kube_pod_container_status_restarts_total{job='kube-state-metrics',namespace=~'%s.*'}[10m]) * 60 * 5 > 0", r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePodNotReady",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "Pod {{ $labels.namespace }} / {{ $labels.pod }}  has been in a non-ready state for longer than 15 minutes.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("sum by(pod, namespace) (kube_pod_status_phase{phase=~'Pending|Unknown', namespace=~'%s.*'}) > 0", r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePodImagePullBackOff",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "Pod {{ $labels.namespace }} / {{  $labels.pod  }} has been unable to pull its image for longer than 5 minutes.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ImagePullBackOff',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePodBadConfig",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": " Pod {{ $labels.namespace  }} / {{  $labels.pod  }} has been unable to start due to a bad configuration for longer than 5 minutes",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='CreateContainerConfigError',namespace=~'%s.*'} > 0", r.Config.GetNamespacePrefix())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePodStuckCreating",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": "Pod {{  $labels.namespace }} / {{  $labels.pod  }} has been trying to start for longer than 15 minutes - this could indicate a configuration error.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_pod_container_status_waiting_reason{reason='ContainerCreating',namespace=~'%s.*'} > 0", r.Config.GetOperatorNamespace())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "ClusterSchedulableMemoryLow",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
-							"message": "The cluster has {{  $value }} percent of memory requested and unavailable for scheduling for longer than 15 minutes.",
-						},
-						Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='memory'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'}  == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'}  == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='memory'})))))) * 100 > 85"),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "ClusterSchedulableCPULow",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
-							"message": "The cluster has {{ $value }} percent of CPU cores requested and unavailable for scheduling for longer than 15 minutes.",
-						},
-						Expr:   intstr.FromString("((sum(sum by(node) (sum by(pod, node) (kube_pod_container_resource_requests{resource='cpu'} * on(node) group_left() (sum by(node) (kube_node_role{role='worker'} == 1))) * on(pod) group_left() (sum by(pod) (kube_pod_status_phase{phase='Running'}) == 1)))) / ((sum((kube_node_role{role='worker'} == 1) * on(node) group_left() (sum by(node) (kube_node_status_allocatable{resource='cpu'})))))) * 100 > 85"),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "PVCStorageAvailable",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
-							"message": "The {{  $labels.persistentvolumeclaim  }} PVC has has been {{ $value }} percent full for longer than 15 minutes.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("((sum by(persistentvolumeclaim, namespace) (kubelet_volume_stats_used_bytes{namespace=~'%s.*'})) / (sum by(persistentvolumeclaim, namespace) (kube_persistentvolumeclaim_resource_requests_storage_bytes{namespace=~'%s.*'}))) * 100 > 85", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "PVCStorageMetricsAvailable",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/alerts/Cluster_Schedulable_Resources_Low.asciidoc",
-							"message": "PVC storage metrics are not available",
-						},
-						Expr:   intstr.FromString("absent(kubelet_volume_stats_available_bytes) == 1 or absent(kubelet_volume_stats_capacity_bytes) == 1 or absent(kubelet_volume_stats_used_bytes) == 1 or absent(kube_persistentvolumeclaim_resource_requests_storage_bytes) == 1"),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePersistentVolumeFillingUp4h",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#pvcstoragewillfillin4hours",
-							"message": "Based on recent sampling, the PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is expected to fill up within four days. Currently {{ $value | humanizePercentage }} is available.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("(predict_linear(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} [6h], 4 * 24 * 3600) <= 0 and kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'}  / kubelet_volume_stats_capacity_bytes{job='kubelet'} < 0.15)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "KubePersistentVolumeFillingUp",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#kubepersistentvolumefillingup",
-							"message": "The PersistentVolume claimed by {{ $labels.persistentvolumeclaim }} in Namespace {{ $labels.namespace }} is only {{ $value | humanizePercentage }} free.",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("(kubelet_volume_stats_available_bytes{job='kubelet', namespace=~'%s.*'} / kubelet_volume_stats_capacity_bytes{job='kubelet', namespace=~'%s.*'} < 0.03)", r.Config.GetNamespacePrefix(), r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-
-					{
-						Alert: "PersistentVolumeErrors",
-						Annotations: map[string]string{
-							"sop_url": "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/2.x/alerts/pvc_storage.asciidoc#persistentvolumeerrors",
-							"message": "The PVC {{  $labels.persistentvolumeclaim  }} is in status {{  $labels.phase  }} in namespace {{  $labels.namespace }} ",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("(sum by(persistentvolumeclaim, namespace, phase) (kube_persistentvolumeclaim_status_phase{phase=~'Failed|Pending|Lost', namespace=~'%s.*'})) > 0", r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-
-			{
-				AlertName: "ksm-endpoint-alerts",
-				Namespace: namespace,
-				GroupName: "middleware-monitoring-operator-endpoint.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerOperatedServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorAlertmanagerServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='alertmanager-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorApplicationMonitoringMetricsServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='application-monitoring-operator-metrics', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorGrafanaServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='grafana-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorPrometheusOperatedServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-operated', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorPrometheusServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='prometheus-service', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-					{
-						Alert: "RHMIMiddlewareMonitoringOperatorRhmiRegistryCsServiceEndpointDown",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlEndpointAvailableAlert,
-							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace='%s'} < 1", r.Config.GetOperatorNamespace())),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-			{
-				AlertName: "install-upgrade-alerts",
-				Namespace: namespace,
-				GroupName: "general.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "RHMICSVRequirementsNotMet",
-						Annotations: map[string]string{
-							"message": "RequirementsNotMet for CSV '{{$labels.name}}' in namespace '{{$labels.namespace}}'. Phase is {{$labels.phase}}",
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("csv_abnormal{phase=~'Pending|Failed',exported_namespace=~'%s.*'}", r.Config.GetNamespacePrefix())),
-						For:    "15m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-			{
-				AlertName: "multi-az-pod-distribution",
-				Namespace: namespace,
-				GroupName: "general.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "MultiAZPodDistribution",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlPodDistributionIncorrect,
-							"message": "Pod {{  $labels.namespace  }} / {{  $labels.pod  }} ({{  $labels.container  }}) is incorretly distributed to the zone {{  $value  }} ; for the last 5 minutes",
-						},
-						Expr:   intstr.FromString(installationName + "_version{to_version=\"\"} and (count by(namespace, created_by_name, label_topology_kubernetes_io_zone) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"} == on(node) group_left(label_topology_kubernetes_io_zone) kube_node_labels) == on (namespace, created_by_name)(count by(namespace, created_by_name) (kube_pod_info{namespace=~'" + nsPrefix + ".*', created_by_kind!=\"<none>\"}) > 1) > scalar((count(count by (label_topology_kubernetes_io_zone) (kube_node_labels)) >= bool 2) == 1))"),
-						For:    "5m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-			{
-				AlertName: "test-alerts",
-				Namespace: namespace,
-				GroupName: "test.rules",
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: "TestFireCriticalAlert",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlTestFireAlerts,
-							"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
-						},
-						Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='cj3cssrec'}) > 0"),
-						For:    "10s",
-						Labels: map[string]string{"severity": "critical", "product": "secret"},
-					},
-					{
-						Alert: "TestFireWarningAlert",
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlTestFireAlerts,
-							"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
-						},
-						Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetOperatorNamespace() + "', secret='wj3cssrew'}) > 0"),
-						For:    "10s",
-						Labels: map[string]string{"severity": "warning", "product": "secret"},
-					},
-				},
-			},
-			{
-				AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
-				Namespace: namespace,
-				GroupName: fmt.Sprintf("%s-installation.rules", installationName),
-				Rules: []monitoringv1.Rule{
-					{
-						Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
-						Annotations: map[string]string{
-							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
-						},
-						Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
-						For:    "10m",
-						Labels: map[string]string{"severity": "warning", "product": installationName},
-					},
-				},
-			},
-		},
+		Alerts:       alerts,
 	}
 }

--- a/pkg/resources/user/userHelper.go
+++ b/pkg/resources/user/userHelper.go
@@ -342,6 +342,24 @@ func GetReconciledAPIManagementTenantsCount(ctx context.Context, serverClient k8
 	return numReconciledTenants, nil
 }
 
+func GetFailedAPIManagementTenantsCount(ctx context.Context, serverClient k8sclient.Client) (int, error) {
+	tenants := &integreatlyv1alpha1.APIManagementTenantList{}
+
+	err := serverClient.List(ctx, tenants)
+	if err != nil {
+		return 0, err
+	}
+
+	numFailedTenants := 0
+	for _, tenant := range tenants.Items {
+		if tenant.Status.ProvisioningStatus == integreatlyv1alpha1.WontProvisionTenant {
+			numFailedTenants += 1
+		}
+	}
+
+	return numFailedTenants, nil
+}
+
 func SanitiseTenantUserName(username string) string {
 	// Regex for only alphanumeric values
 	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -420,6 +420,12 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 
 	return []alertsTestRule{
 		{
+			File: ObservabilityNamespacePrefix + "multitenancy-api-management-tenant-alerts.yaml",
+			Rules: []string{
+				"ApiManagementTenantCRFailed",
+			},
+		},
+		{
 			File: ObservabilityNamespacePrefix + "marin3r-ksm-endpoint-alerts.yaml",
 			Rules: []string{
 				"Marin3rDiscoveryServiceEndpointDown",

--- a/test/common/multitenancy.go
+++ b/test/common/multitenancy.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	goctx "context"
 	"fmt"
 	"github.com/headzoo/surf"
 	brow "github.com/headzoo/surf/browser"
@@ -42,7 +41,7 @@ func TestMultitenancy(t TestingTB, ctx *TestingContext) {
 	}
 
 	// Testing IDP with 2 regular users and 2 admins gets created
-	err = createTestingIDP(t, goctx.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts)
+	err = createTestingIDP(t, context.TODO(), ctx.Client, ctx.KubeConfig, ctx.SelfSignedCerts)
 	if err != nil {
 		t.Errorf("error while creating testing IDP: %s", err)
 	}
@@ -150,7 +149,7 @@ func getTenant3scaleRoute(t TestingTB, ctx *TestingContext, testUser string) err
 	routeFound := false
 	routes := &routev1.RouteList{}
 
-	err := ctx.Client.List(goctx.TODO(), routes, &k8sclient.ListOptions{
+	err := ctx.Client.List(context.TODO(), routes, &k8sclient.ListOptions{
 		Namespace: ThreeScaleProductNamespace,
 	})
 


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-3891

# What
We need an alert that fires whenever a APIManagementTenant CR fails to reconcile. This PR creates a new metric `num_failed_tenants` and a new alert `ApiManagementTenantCRFailed`. The alert is only created for multitenant installations of RHOAM.

# Verification steps
1. [Provision](https://qaprodauth.cloud.redhat.com/openshift/create) a non-CCS cluster
2. Checkout this PR and run `INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local` on the command line once the cluster is ready
3. Create a CatalogSource either using `oc` or the GUI:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/ckyrillo/managed-api-service-index:1.22.0
```
4. Once the CatalogSource's Status is `READY`, install the RHOAM operator through the OperatorHub (OLM installation). Make sure to change the Installed Namespace to `sandbox-rhoam-operator`
5. Once the operator is installed, create a RHMI CR by running `INSTALLATION_TYPE=multitenant-managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml` on the command line
6. Wait until the the RHMI CR's Status.Stage is `Complete` and then setup the testing IDP by running `DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 ./scripts/setup-sso-idp.sh` on the command line
7. Once the IDP is deployed on the cluster, login `test-user01` through the `testing-idp` so a user is created
8. Next create the following Project either using `oc` or the GUI: `test-user01-dev`
9. Login into the `sandbox-rhoam-observability` instance of Prometheus and confirm that the alert `ApiManagementTenantCRFailed` **is not** firing
10. Now create an APIManagementTenant CR in the `test-user01-dev` namespace:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: APIManagementTenant
metadata:
  name: example
  namespace: test-user01-dev
spec: {}
```
11. Wait until the CR has reconciled and confirm that the alert is still not firing.
12. Once the above CR has reconciled and the alert is confirmed to not be firing, create another CR:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: APIManagementTenant
metadata:
  name: this-should-fail
  namespace: test-user01-dev
spec: {}
```
13. The second CR's `ProvisioningStatus` field should be `won't provision`
14. Lastly, go back to Prometheus and confirm that the alert **is** firing (it might take a minute)