### PR TITLE
MGDAPI-3903 Autoscaling RHMI CR Flag

### DIFF
--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -198,6 +198,7 @@ type RHMISpec struct {
 	//
 	// url
 	DeadMansSnitchSecret string `json:"deadMansSnitchSecret,omitempty"`
+	AutoscalingEnabled   bool   `json:"autoscalingEnabled,omitempty"`
 }
 
 type PullSecretSpec struct {

--- a/config/crd/bases/integreatly.org_rhmis.yaml
+++ b/config/crd/bases/integreatly.org_rhmis.yaml
@@ -50,6 +50,8 @@ spec:
                 - businessUnit
                 - cssre
                 type: object
+              autoscalingEnabled:
+                type: boolean
               deadMansSnitchSecret:
                 description: "DeadMansSnitchSecret is the name of a secret in the
                   installation namespace containing connection details for Dead Mans


### PR DESCRIPTION
# Issue link
[MGDAPI-3903](https://issues.redhat.com/browse/MGDAPI-3903)

# What
- Added flag to the RHMI cr `AutoscalingEnabled`.
- Added logic to `bootstrapReconciler.go` to reconcile quota accordingly
- Added config map creation with HPA resource limits.

# Verification steps
1. Provision a cluster large enough for a 50 Million quota install
2. Quota can be set to 20 mil or 50 mil for testing but ensure the cluster is large enough to handle a 50 mil install
3. Prepare your cluster as normal and then set quota with `INSTALLATION_TYPE=managed-api DEV_QUOTA="500" make cluster/prepare/quota`
4. Run the rhoam install and wait for the stage `complete`
5. Add the flag to the RHMI CR `autoscalingEnabled: true`, wait for bootstrap to reconcile and wait for quota to change to `50 Million` and stage `complete`. Set the flag to `false` or remove it entirely and wait for the quote to be reverted.
6. Run the test with ` INSTALLATION_TYPE=managed-api TEST="F10" make test/e2e/single` and make sure it passes
7. Set the flag `autoscalingEnabled` to `true` and rerun the test ensuring it passes 
>The flag may not be present at all so you may have to manually enter it into the spec