### PR TITLE
MGDAPI-3979 - add 3scale index build script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -319,6 +319,10 @@ cluster/prepare/bundle: cluster/prepare/project cluster/prepare/configmaps clust
 create/olm/bundle:
 	./scripts/bundle-rhmi-operators.sh
 
+.PHONY: create/3scale/index
+create/3scale/index:
+	./scripts/create-3scale-index.sh
+
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
 	@ - oc new-project $(NAMESPACE)

--- a/bundles/3scale-operator/bundles.yaml
+++ b/bundles/3scale-operator/bundles.yaml
@@ -1,0 +1,19 @@
+bundles:
+  - name: 3scale-operator.v0.8.0
+    image: quay.io/integreatly/3scale-bundle:v0.8.0
+  - name: 3scale-operator.v0.8.0+0.1634606167.p
+    image: quay.io/integreatly/3scale-bundle:v0.8.0-0.1634606167
+  - name: 3scale-operator.v0.8.1
+    image: quay.io/integreatly/3scale-bundle:v0.8.1
+  - name: 3scale-operator.v0.8.2
+    image: quay.io/integreatly/3scale-bundle:v0.8.2
+  - name: 3scale-operator.v0.8.3
+    image: quay.io/integreatly/3scale-bundle:v0.8.3
+  - name: 3scale-operator.v0.8.3+0.1645735250.p
+    image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1645735250
+  - name: 3scale-operator.v0.8.3+0.1646619125.p
+    image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1646619125
+  - name: 3scale-operator.v0.8.3+0.1646742992.p
+    image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1646742992
+  - name: 3scale-operator.v0.8.3+0.1649688682.p
+    image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1649688682

--- a/scripts/create-3scale-index.sh
+++ b/scripts/create-3scale-index.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Prereq:
+# - opm
+# - yq (4.24.2+)
+#
+# Function:
+# Script creates 3scale index/indices for RHOAM 
+#
+# Usage:
+# REG=<REGISTRY> ORG=<QUAY ORG> IMAGE=<IMAGE NAME> BUILD_TOOL=<docker|podman>  VERSION=<VERSION TAG> make create/3scale/index
+# REG - registry of where to push the bundles and indices, defaults to quay.io
+# ORG - organization of where to push the bundles and indices
+# IMAGE - image name of the image to push
+# BUILD_TOOL - tool used for building the bundle and index, defaults to docker
+# VERSION - index version to build; this defines the max version and includes all bundles beneath it
+# TAG - version tag to be used for the image
+#
+# Example:
+# VERSION=0.8.3+0.1645735250.p ORG=acatterm make create/3scale/index
+
+
+REG="${REG:-quay.io}"
+ORG="${ORG:-integreatly}"
+IMAGE="${IMAGE:-3scale-index}"
+BUILD_TOOL="${BUILD_TOOL:-docker}"
+VERSION="${VERSION}"
+
+
+generate_index() {
+
+    if [[ $VERSION =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*)?(\+[0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*)?$ ]]; then
+        echo "Valid version string: ${VERSION}"
+    else
+        echo "Error: Invalid version string: ${VERSION}"
+        exit 1
+    fi
+
+    echo "Building index for v$VERSION"
+
+    bundles=$(yq e ".bundles[] | .name |= sub(\"3scale-operator.\",\"\") \
+        | select(.name <= \"v$VERSION\") | .image" \
+        bundles/3scale-operator/bundles.yaml)
+
+
+    if [[ -z $bundles ]]; then
+        echo "No matching bundles, exiting"
+        exit 1
+    fi
+
+    printf "Including bundles:\n$bundles\n"
+
+    delim=""
+    bundle_csv=""
+    for item in $bundles; do
+        bundle_csv="$bundle_csv$delim$item"
+        delim=","
+    done
+
+    tag=$(echo $VERSION | sed 's/.p$//g' | sed 's/+/-/g')
+    image="$REG/$ORG/$IMAGE:v$tag"
+
+    echo "Building index $image"
+    opm index add \
+      --enable-alpha \
+      --bundles $bundle_csv \
+      --container-tool $BUILD_TOOL \
+      --tag $image
+}
+
+generate_index


### PR DESCRIPTION
# Issue link
[MGDAPI-3979](https://issues.redhat.com/browse/MGDAPI-3979)

# What
- Added new bundles.yaml containing a list of all the 3scale bundle images used to build an index
- New script create-3scale-index which uses the bundle file and parameters to create an index

# Verification steps
- Verify indexes can be successfully created by the script

note: I think it is best to verify the install / upgrade of these indices in the separate PR that changes the installation mode to use these indices.

~~[WIP] until referenced bundles exist.~~