### PR TITLE
MGDAPI-3979 - change install mode to use 3scale-index

### DIFF
--- a/products/installation.yaml
+++ b/products/installation.yaml
@@ -57,9 +57,10 @@
 #
 products:
   3scale:
-    channel: "rhmi"
-    installFrom: "local"
-    manifestsDir: "integreatly-3scale"
+    channel: "threescale-2.11"
+    installFrom: "index"
+    package: "3scale-operator"
+    index: "quay.io/integreatly/3scale-index:v0.8.3-0.1649688682"
   amqonline:
     channel: "rhmi"
     installFrom: "local"


### PR DESCRIPTION
# Issue link
[MGDAPI-3979](https://issues.redhat.com/browse/MGDAPI-3979)

# What
Update installation yaml to use 3scale-index instead of manifests.

# Verification steps
- Install RHOAM is successful
- Upgrade completes successfully (maybe upgrade pipeline could be used?)
