### PR TITLE
MGDAPI-3923

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,16 +80,6 @@ ifeq ($(shell test -e envs/$(INSTALLATION_TYPE).env && echo -n yes),yes)
 	include envs/$(INSTALLATION_TYPE).env
 endif
 
-ifeq ($(INSTALLATION_TYPE),multitenant-managed-api)
-	export CLUSTER_CONFIG:=redhat-sandbox
-endif
-
-ifeq ($(LOCAL), true)
-	export INSTALLATION_SHORTHAND:=local-rhoam
-	export NAMESPACE_PREFIX:=local-rhoam-
-	export NAMESPACE:=$(NAMESPACE_PREFIX)operator
-endif
-
 define wait_command
 	@echo Waiting for $(2) for $(3)...
 	@time timeout --foreground $(3) bash -c "until $(1); do echo $(2) not ready yet, trying again in $(4)s...; sleep $(4); done"
@@ -363,7 +353,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd-sandbox | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize  cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/quota cluster/prepare/delorean cluster/prepare/croaws cluster/prepare/rbac/dedicated-admins
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/quota cluster/prepare/delorean cluster/prepare/croaws cluster/prepare/rbac/dedicated-admins
 	@ - oc create -f config/rbac/service_account.yaml -n $(NAMESPACE)
 	@ - $(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc create -f -
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Ensure that the cluster satisfies minimal requirements:
 - RHMI (managed): 26 vCPU 
 - RHOAM (managed-api and multitenant-managed-api): 18 vCPU. More details can be found in the [service definition](https://access.redhat.com/articles/5534341) 
   under the "Resource Requirements" section
+*Note:* The LOCAL flag is set to true by default, this means the namespace used to install RHOAM will be set to `local-rhoam-operator` and other RHOAM related namespaces will be prefixed with `local-rhoam`. If you wish to use non-local namespaces then  set LOCAL to false by running the following command `export LOCAL=false`.
 
 ### 1. Clone the integreatly-operator
 Only if you haven't already cloned. Otherwise, navigate to an existing copy. 
@@ -87,7 +88,7 @@ If you are working against a fresh cluster it will need to be prepared using the
 Ensure you are logged into a cluster by `oc whoami`.
 Include the `INSTALLATION_TYPE`. See [here](#3-configuration-optional) about this and other optional configuration variables.
 ```shell
-make cluster/prepare/local
+INSTALLATION_TYPE=<managed-api/multitenant-managed-api> make cluster/prepare/local
 ```
 
 
@@ -114,7 +115,7 @@ INSTALLATION_TYPE=managed-api IN_PROW=true USE_CLUSTER_STORAGE=<true/false> make
 Include the `INSTALLATION_TYPE` if you haven't already exported it. 
 The operator can now be run locally:
 ```shell
-make code/run
+INSTALLATION_TYPE=<managed-api/multitenant-managed-api> make code/run
 ```
 If you want to run the operator from a specific image, you can specify the image and run `make cluster/deploy`
 ```shell
@@ -144,54 +145,39 @@ Once the installation completed the command wil result in following output:
 
 ## Uninstalling RHOAM
 ### Local and OLM installation type
-If you installed RHOAM locally then you can uninstall one of two ways:
+If you installed RHOAM locally or via OLM then you can uninstall one of two ways:
+
+- for local installation use the `local-rhaom-operator Namespace`
+- for OLM installation use the `redhat-rhoam-operator Namespace`
 
 
 A) Create a configmap and add a deletion label (Prefered way of uninstallation).
 ```sh 
-oc create configmap managed-api-service -n local-rhoam-operator
-oc label configmap managed-api-service api.openshift.com/addon-managed-api-service-delete=true -n local-rhoam-operator
+oc create configmap managed-api-service -n <NAMESPACE>
+oc label configmap managed-api-service api.openshift.com/addon-managed-api-service-delete=true -n <NAMESPACE>
 ```
 
 B) Delete the RHOAM cr.
 ```sh 
-oc delete rhmi rhoam -n local-rhoam-operator
+oc delete rhmi rhoam -n <NAMESPACE>
 ```
 
 In both scenarios wait until the RHOAM cr is removed and then run the following command to delete the namespace.
 ```sh 
-oc delete namespace local-rhoam-operator
+oc delete namespace <NAMESPACE>
 ```
 
 #### Note: After uninstalling RHOAM you should clean up the cluster by running the following command.
+##### Local installation
 ```sh
 make cluster/cleanup && make cluster/cleanup/crds
 ```
 
-### OLM installation type
-If you installed RHOAM through a catalog source then you can uninstall one of two ways:
-
-
-A) Create a configmap and add a deletion label (Prefered way of uninstallation).
-```sh 
-oc create configmap managed-api-service -n redhat-rhoam-operator
-oc label configmap managed-api-service api.openshift.com/addon-managed-api-service-delete=true -n redhat-rhoam-operator
-```
-
-B) Delete the RHOAM cr.
-```sh 
-oc delete rhmi rhoam -n redhat-rhoam-operator
-```
-
-In both scenarios wait until the RHOAM cr is removed and then run the following command to delete the namespace.
-```sh 
-oc delete namespace redhat-rhoam-operator
-```
-
-#### Note: After uninstalling RHOAM you should clean up the cluster by running the following command.
+##### OLM installation
 ```sh
 LOCAL=false make cluster/cleanup && make cluster/cleanup/crds
 ```
+
 
 ## More Info
 More info can be found in the docs folder and at the [Integreatly Read the Docs site](https://integreatly-operator.readthedocs.io/en/latest/).

--- a/config/rbac-local-rhoam/kustomization.yaml
+++ b/config/rbac-local-rhoam/kustomization.yaml
@@ -1,0 +1,10 @@
+bases:
+  - ../rbac
+
+namespace: local-rhoam-operator
+namePrefix: rhmi-
+
+patchesStrategicMerge:
+  - patches/leader_election_role_binding.yaml
+  # - patches/auth_proxy_role_binding.yaml
+  - patches/role_binding.yaml

--- a/config/rbac-local-rhoam/patches/auth_proxy_role_binding.yaml
+++ b/config/rbac-local-rhoam/patches/auth_proxy_role_binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: proxy-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: rhmi-operator
+  namespace: local-rhoam-operator

--- a/config/rbac-local-rhoam/patches/leader_election_role_binding.yaml
+++ b/config/rbac-local-rhoam/patches/leader_election_role_binding.yaml
@@ -1,0 +1,8 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: leader-election-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: rhmi-operator
+  namespace: local-rhoam-operator

--- a/config/rbac-local-rhoam/patches/role_binding.yaml
+++ b/config/rbac-local-rhoam/patches/role_binding.yaml
@@ -1,0 +1,17 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: rhmi-operator
+  namespace: local-rhoam-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: manager-rolebinding
+subjects:
+- kind: ServiceAccount
+  name: rhmi-operator
+  namespace: local-rhoam-operator

--- a/envs/managed-api.env
+++ b/envs/managed-api.env
@@ -8,3 +8,8 @@ export OLM_TYPE ?= managed-api-service
 INSTALLATION_NAME ?= rhoam
 INSTALLATION_SHORTHAND ?= rhoam
 NAMESPACE=$(NAMESPACE_PREFIX)operator
+ifeq ($(LOCAL), true)
+	export INSTALLATION_SHORTHAND:=local-rhoam
+	export NAMESPACE_PREFIX:=local-rhoam-
+	export NAMESPACE:=$(NAMESPACE_PREFIX)operator
+endif

--- a/envs/multitenant-managed-api.env
+++ b/envs/multitenant-managed-api.env
@@ -8,3 +8,9 @@ export OLM_TYPE ?= multitenant-managed-api-service
 INSTALLATION_NAME ?= rhoam
 INSTALLATION_SHORTHAND ?= sandbox
 NAMESPACE=$(NAMESPACE_PREFIX)operator
+export CLUSTER_CONFIG:=redhat-sandbox
+ifeq ($(LOCAL), true)
+	export INSTALLATION_SHORTHAND:=local-rhoam
+	export NAMESPACE_PREFIX:=local-rhoam-
+	export NAMESPACE:=$(NAMESPACE_PREFIX)operator
+endif


### PR DESCRIPTION
# Issue link
[MGDAPI-3923](https://issues.redhat.com/browse/MGDAPI-3923)

# What
Addition of a new `LOCAL` variable. If set to true will change the namespace name to local-rhoam-operator
Changed default  `INSTALLATION_TYPE` value to managed-api 
 
# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Verify that you can install RHOAM locally and via OLM and that it works as expected (All products install successfully)

1. Local install 
     1.1 Checkout this branch 
     1.2 run `make cluster/prepare/local`
     1.3 run `make code/run`
     1.4 make sure that RHOAM installs as expected

2. OLM install guide
       2.1 install RHOAM via OLM - [guide](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md#installing-rhmi-through-olm-with-bundle-format)
       2.2 make sure that RHOAM installs as expected 
       

