### PR TITLE
MGDAPI-4148 - bump: envoy side car image

### DIFF
--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.0-1"
+	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.2-2"
 	EnvoyAPIVersion = "v3"
 )
 

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -3,7 +3,7 @@
 # url - url to quay / redhat registry repo of the component
 additionalImages:
   - name: 3scale-openshift-servce-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.0-1"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.2-2"
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"
   - name: observability-grafana-plugins-init


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4148

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Bump side car container image

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Verifiy Fresh Install
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Verify install complete successfully
* Verify image in used in annotations 
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Run `./test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected

**NOTE: It might take a while before rate limiting starts working on fresh installs and upgrades due to https://issues.redhat.com/browse/THREESCALE-8385** 

Apicast gateway port should be `8443` for rate limiting to be correctly working (will need to wait for operator to reconcile to this value)
```
oc get service apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.ports'
```

## Verify Upgrade
* Unintall RHAOM
* Checkout master
* Install from master
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Once installation complete, stop the opertor
* Checkout this branch
* Run operator
```
make code/run
```
* Verify apicast / backend-listener pods are redeployed
```
 watch "oc get pods -n redhat-rhoam-3scale | grep -E 'apicast|backend-listener'; echo "RHMI CR Status:"; oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq '.status.stage'"
```
* Verify image in used in annotations
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Run `./test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected

**NOTE: It might take a while before rate limiting starts working on fresh installs and upgrades due to https://issues.redhat.com/browse/THREESCALE-8385** 

Apicast gateway port should be `8443` for rate limiting to be correctly working (will need to wait for operator to reconcile to this value)
```
oc get service apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.ports'
```
