### PR TITLE
MGDAPI-4031 Reconciler Error Alert

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -81,28 +81,6 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 		},
 	}
 
-	if !integreatlyv1alpha1.IsRHOAM(integreatlyv1alpha1.InstallationType(installation.Spec.Type)) {
-		installationAlert := resources.AlertConfiguration{
-			AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
-			Namespace: installation.Namespace,
-			GroupName: fmt.Sprintf("%s-installation.rules", installationName),
-			Rules: []monitoringv1.Rule{
-				{
-					Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
-					Annotations: map[string]string{
-						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
-					},
-					Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
-					For:    "10m",
-					Labels: map[string]string{"severity": "warning", "product": installationName},
-				},
-			},
-		}
-
-		alerts = append(alerts, installationAlert)
-	}
-
 	return &resources.AlertReconcilerImpl{
 		ProductName:  "installation",
 		Installation: installation,

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -315,19 +315,19 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 			},
 		},
 		{
-			AlertName: fmt.Sprintf("%s-installation-controller-alerts", installationName),
+			AlertName: fmt.Sprintf("%s-rhmi-controller-alerts", installationName),
 			Namespace: namespace,
 			GroupName: fmt.Sprintf("%s-installation.rules", installationName),
 			Rules: []monitoringv1.Rule{
 				{
-					Alert: fmt.Sprintf("%sInstallationControllerIsInReconcilingErrorState", strings.ToUpper(installationName)),
+					Alert: fmt.Sprintf("%sIsInReconcilingErrorState", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
-						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for 5 of the last 10 minutes", strings.ToUpper(installationName)),
+						"sop_url": resources.SopUrlRHOAMIsInReconcilingErrorState,
+						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for last 10 minutes", strings.ToUpper(installationName)),
 					},
-					Expr:   intstr.FromString(fmt.Sprintf("%s_status{stage='complete'} AND on(namespace) rate(controller_runtime_reconcile_total{controller='installation-controller', result='error'}[5m]) > 0", installationName)),
+					Expr:   intstr.FromString(fmt.Sprintf(`(%s_status{stage!="complete"} > 0) * on(pod) group_left(to_version, version) %[1]s_version{to_version="", version=~".+"} > 0`, installationName)),
 					For:    "10m",
-					Labels: map[string]string{"severity": "warning", "product": installationName},
+					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},
 			},
 		},

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -325,7 +325,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 						"sop_url": resources.SopUrlRHOAMIsInReconcilingErrorState,
 						"message": fmt.Sprintf("%s operator has finished installing, but has been in a error state while reconciling for last 10 minutes", strings.ToUpper(installationName)),
 					},
-					Expr:   intstr.FromString(fmt.Sprintf(`(%s_status{stage!="complete"} > 0) * on(pod) group_left(to_version, version) %[1]s_version{to_version="", version=~".+"} > 0`, installationName)),
+					Expr:   intstr.FromString(fmt.Sprintf(`(%s_status{stage!="complete"} > 0) * on(pod) group_left(to_version, version) (%[1]s_version{to_version="",version=~".+"} > 0) OR absent(%[1]s_status) OR absent(%[1]s_version)`, installationName)),
 					For:    "10m",
 					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -26,6 +26,7 @@ const (
 	SopUrlMarin3rEnvoyApicastStagingContainerDown              = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/Marin3rEnvoyApicastStagingContainerDown.asciidoc"
 	SopUrlOperatorInstallDelayed                               = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/OperatorInstallDelayed.asciidoc"
 	SopUrlUpgradeExpectedDurationExceeded                      = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/UpgradeExpectedDurationExceeded.asciidoc"
+	SopUrlRHOAMIsInReconcilingErrorState                       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHOAMIsInReconcilingErrorState.asciidoc"
 	SopUrlRHOAMCloudResourceOperatorMetricsServiceEndpointDown = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHOAMCloudResourceOperatorMetricsServiceEndpointDown.asciidoc"
 	SopUrlRHOAMCloudResourceOperatorVPCActionFailed            = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHOAMCloudResourceOperatorVPCActionFailed.asciidoc"
 	SopUrlRHOAMThreeScaleApicastProductionServiceEndpointDown  = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/RHOAMThreeScaleApicastProductionServiceEndpointDown.asciidoc"

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -278,12 +278,6 @@ func rhmi2ExpectedRules(installationName string) []alertsTestRule {
 				"RHOAMUPSUnifiedpushProxyServiceEndpointDown",
 			},
 		},
-		{
-			File: NamespacePrefix + "operator-rhmi-installation-controller-alerts.yaml",
-			Rules: []string{
-				"RHOAMInstallationControllerIsInReconcilingErrorState",
-			},
-		},
 	}
 }
 
@@ -407,9 +401,9 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			},
 		},
 		{
-			File: ObservabilityNamespacePrefix + "rhoam-installation-controller-alerts.yaml",
+			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
-				"RHOAMInstallationControllerIsInReconcilingErrorState",
+				"RHOAMIsInReconcilingErrorState",
 			},
 		},
 	}
@@ -479,9 +473,9 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			},
 		},
 		{
-			File: ObservabilityNamespacePrefix + "rhoam-installation-controller-alerts.yaml",
+			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
-				"RHOAMInstallationControllerIsInReconcilingErrorState",
+				"RHOAMIsInReconcilingErrorState",
 			},
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4031

# What
RHOAMIsInReconcilingErrorState is not working as expected.
Fixing the alert and bumping the severity of it to a critical level.

# Verification steps
For the purpose of making the verification easier, I've built all the required bundles and indices, if you feel however that you would to build them yourself please don't hesitate to.

## Initial installation and confirmation that no unexpected behavior with alerts is happening
- Provision OSD cluster and be oc logged in into the cluster
- Run `INSTALLATION_TYPE=managed-api make cluster/prepare/local` from this branch against the cluster
- Create a catalog source for RHOAM built of this branch:
```
cat << EOF | oc apply -f - 
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.23.0
EOF
```
- On cluster navigate to the Operators > Operators Hub section and search for RHOAM
- Click Install under redhat-rhoam-operator namespace
- Create RHMI CR:
```
INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml
```
- Wait for the installation to install Observability Operator successfully 
- Navigate to the `redhat-rhoam-observability` namespace > routes section
- Open the Prometheus route
- Confirm that the RHOAMIsInReconcilingErrorState is NOT firing and that no unexpected alerts are firing (it is expected that some alerts will be flipping between pending & green state)
- Once installation is fully completed, confirm that no alerts apart from Deadmansnitch are firing

## Triggering the RHOAMIsInReconcilingErrorState alert (only do this when installation is fully completed)
- Navigate to redhat-rhoam-3scale-operator namespace > Deployments and scale down 3scale operator to 0
- Navigate to the redhat-rhoam-3scale namespace > DeploymentConfigs and scale down backend-cron deployment to 0
- Doing so will put rhmi CR into a products stage with 3scale "awaiting components"
- After a little while the RHOAMIsInReconcilingErrorState should trigger into pending > after 10 minutes into firing mode
- Once confirmed that the alert fires, scale the 3scale operator back up to 1, backend-cron will be scaled up by the 3scale operator so you don't have to be scaling it back up
- Once RHMI CR recovers, confirm that the RHOAMIsInReconcilingErrorState is back to normal (non-firing/pending mode)

## Verifying alerts are working as expected during an upgrade
- Trigger an update to RHOAM version (only to this when RHMI CR reports fully completed and only DMS alert is firing) by updating the Catalog Source with:
```
cat << EOF | oc apply -f - 
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.24.0
EOF
```
- Scale down 3scale operator and backend-cron again (this is in order to "freeze" rhoam in an upgrade scenario)
- Navigate to the Operators > Installed Operators section under redhat-rhoam-operator namespace, after a while you should see that there's an upgrade available.
- Click on the `Upgrade available` and then on `Preview Install Plan` and approve - this will trigger RHOAM upgrade
- Confirm that the `RHOAMIsInReconcilingErrorState` is NOT firing during upgrade
- Once you have confirmed that the alert isn't firing during upgrade, scale back the 3scale operator
- Once RHOAM has been successfully upgraded to version 1.24.0 the verification is completed. 

## Verifying missing metrics triggers the alert
Scale RHOAM down via deployment under redhat-rhoam-operator namespace
After a minute, the alert should fire based on missing metrics.

## Verifying e2e and mt e2e tests have passed
I've triggered tests on the PR, please double-check that they have passed.

## SOP
As this is a critical severity level alert the SOP will be reviewed by the SRE team however, I would appreciate any feedback on:
[SOP PR](https://github.com/RHCloudServices/integreatly-help/blob/388783424bda1ba7833111609a8770d33b7e2be8/sops/rhoam/alerts/RHOAMIsInReconcilingErrorState.asciidoc#make-changes-to-solve-alert)


