### PR TITLE
MGDAPI-4133 Refactored ApiManagementTenantCRFailed alert to be time based

### DIFF
--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -342,10 +342,11 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 				{
 					Alert: "ApiManagementTenantCRFailed",
 					Annotations: map[string]string{
-						"message": "One or more APIManagementTenant CRs has failed to reconcile",
+						"message": "One or more APIManagementTenant CRs are failing to reconcile",
 					},
-					Expr:   intstr.FromString("num_failed_tenants > 0"),
-					Labels: map[string]string{"severity": "warning", "product": installationName},
+					Expr:   intstr.FromString("num_reconciled_tenants / total_num_tenants < 1"),
+					For:    "10m",
+					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},
 			},
 		}


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4133

# What
This ticket's primary purpose was to fix Alertmanager on the DevSandbox stage and prod clusters so it would properly send emails when alerts were triggered. This required manually patching the credentials with proper values on each cluster and has since been completed and tested. However while investigating this, it was determined that the existing multitenant-specific alert that tracks failed APIManagementTenant CRs needed to be refactored.

Instead of firing whenever an APIManagementTenant CR reaches the `Won't Reconcile` `ProvisioningStatus`, the alert will now fire when a CR takes longer than 10 minutes to reach the `ThreeScaleAccountReady` `ProvisioningStatus`.

# Verification steps
1. [Provision](https://qaprodauth.cloud.redhat.com/openshift/create) a non-CCS cluster
2. Checkout this PR and run `INSTALLATION_TYPE=multitenant-managed-api make cluster/prepare/local` on the command line once the cluster is ready
3. Create a CatalogSource either using `oc` or the GUI:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/ckyrillo/managed-api-service-index:1.23.0
```
4. Once the CatalogSource's Status is `READY`, install the RHOAM operator through the OperatorHub (OLM installation). Make sure to change the Installed Namespace to `sandbox-rhoam-operator`
5. Once the operator is installed, create a RHMI CR by running `INSTALLATION_TYPE=multitenant-managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml` on the command line
6. Wait until the the RHMI CR's Status.Stage is `Complete` and then setup the testing IDP by running `DEDICATED_ADMIN_PASSWORD=Password1 PASSWORD=Password1 ./scripts/setup-sso-idp.sh` on the command line
7. Once the IDP is deployed on the cluster, login `test-user01` through the `testing-idp` so a user is created
8. Next create the following Project either using `oc` or the GUI: `test-user01-dev`
9. Login into the `sandbox-rhoam-observability` instance of Prometheus and confirm that the alert `ApiManagementTenantCRFailed` is **not** firing
10. Now create an APIManagementTenant CR in the `test-user01-dev` namespace:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: APIManagementTenant
metadata:
  name: example
  namespace: test-user01-dev
spec: {}
```
11. Wait until the CR has reconciled and confirm that the alert is still not firing.
12. Once the above CR has reconciled and the alert is confirmed to not be firing, create another CR:
```yaml
apiVersion: integreatly.org/v1alpha1
kind: APIManagementTenant
metadata:
  name: this-should-fail
  namespace: test-user01-dev
spec: {}
```
13. The second CR's `ProvisioningStatus` field should be `won't provision`
14. Wait 10 minutes and then go back to Prometheus and confirm that the alert **is** firing
15. Lastly, delete the ApiManagementTenant CR named `this-should-fail` and confirm that the alert stops firing