### PR TITLE
MGDAPI-4145 - add new 3scale v0.8.4 bundle

### DIFF
--- a/bundles/3scale-operator/bundles.yaml
+++ b/bundles/3scale-operator/bundles.yaml
@@ -17,3 +17,5 @@ bundles:
     image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1646742992
   - name: 3scale-operator.v0.8.3+0.1649688682.p
     image: quay.io/integreatly/3scale-bundle:v0.8.3-0.1649688682
+  - name: 3scale-operator.v0.8.4
+    image: quay.io/integreatly/3scale-bundle:v0.8.4


### PR DESCRIPTION
# Issue link
[MGDAPI-4145](https://issues.redhat.com/browse/MGDAPI-4145)

# What
Add new bundle to bundles file. This permits running the pipeline to build the index.

# Verification steps
Verified as part of #2721
