### PR TITLE
MGDAPI-4241 bump Grafana oauth proxy image

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -375,7 +375,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 			BaseImage: fmt.Sprintf("%s:%s", constants.GrafanaImage, constants.GrafanaVersion),
 			Containers: []v1.Container{
 				{Name: "grafana-proxy",
-					Image: "quay.io/openshift/origin-oauth-proxy:4.8",
+					Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1",
 					VolumeMounts: []v1.VolumeMount{
 						{MountPath: "/etc/tls/private",
 							Name:     "secret-grafana-k8s-tls",

--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -835,8 +835,6 @@ func prepareEmailAddresses(list string) string {
 }
 
 func (r *Reconciler) updateGrafanaImage(operatorNamespace string, ctx context.Context, serverClient k8sclient.Client) error {
-	r.Log.Info("Updating grafana image to quay")
-
 	grafana := &grafanav1alpha1.Grafana{}
 
 	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: "grafana", Namespace: operatorNamespace}, grafana)
@@ -848,7 +846,7 @@ func (r *Reconciler) updateGrafanaImage(operatorNamespace string, ctx context.Co
 
 	// Hotfix to unblock 1.10. TODO: improve this solution by the next release
 	if len(grafana.Spec.Containers) > 0 {
-		grafana.Spec.Containers[0].Image = "quay.io/openshift/origin-oauth-proxy:4.8"
+		grafana.Spec.Containers[0].Image = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1"
 	}
 
 	err = serverClient.Update(ctx, grafana)

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -9,7 +9,7 @@ additionalImages:
   - name: observability-grafana-plugins-init
     url: "quay.io/grafana-operator/grafana_plugins_init:0.0.6"
   - name: observability-origin-oauth-proxy
-    url: "quay.io/openshift/origin-oauth-proxy:4.8"
+    url: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1"
   - name: observability-prometheus-operator
     url: "quay.io/prometheus-operator/prometheus-operator@sha256:066fce4a6b7392f07f7179b59ed4448bacc0767277637de99809449637be924b"
   - name: rhsso-sso-openshift


### PR DESCRIPTION
# Issue link
n/a

# What
Bump to Grafana proxy image

# Verification steps
## Pre-req
- osd cluster

## Initial install
- be oc logged in
- from this branch run
`INSTALLATION_TYPE=managed-api make cluster/prepare/local`
`INSTALLATION_TYPE=managed-api make code/run`
- wait for the installation to complete and verify that the Grafana pod under redhat-rhoam-customer-monitoring ns is using the `registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1` as proxy image.
- verify that no alerts apart from DMS fired
- verify that you can access the Grafana dashboard under redhat-rhoam-customer-monitoring ns by navigating to routes under that namespace and opening the grafana route. Once in, click on manage and review the ratelimiting dashboard.

## Verify upgrade scenario
Upgrade will be done from the current MTR version to version 1.24 made of this branch. For this purpose, I've generated the 1.23 (matching MTR) and 1.24 index however feel free to build it yourself if you prefer.
Run the following commands against a clean cluster:
- `INSTALLATION_TYPE=managed-api make cluster/prepare/local` to prep cluster for rhoam via olm
- Create a catalog source
``` 
cat << EOF | oc apply -f - 
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.23.0
EOF
```
- `INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml` - to create rhmi cr
- Navigate to Operators hub and search for RHOAM - click on install and install under redhat-rhoam-operator ns
- Wait for the installation to fully complete
- Once completed trigger upgrade by running
 ``` 
 cat << EOF | oc apply -f - 
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.24.0
EOF
```
- after 2mins go to Installed Operators and approve RHOAM upgrade to 1.24
- wait for upgrade to complete
- verify that no alerts apart from DMS fired
- verify that you can access the Grafana dashboard under redhat-rhoam-customer-monitoring ns by navigating to routes under that namespace and opening the grafana route. Once in, click on manage and review the ratelimiting dashboard.

Verify that the rhoam-e2e tests have passed successfully on this PR.
