### PR TITLE
[MGDAPI-4266] add coverpkg flag to the go test command

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -17,8 +17,8 @@ coverage:
       default:
         target: auto
         threshold: 0%
-    patch: false
-    changes: false
+    patch: off
+    changes: off
 
 parsers:
   gcov:

--- a/hack/codecov.sh
+++ b/hack/codecov.sh
@@ -19,7 +19,7 @@ COV_THREAD_COUNT=${COV_THREAD_COUNT:-4}
 
 echo Running tests:
 # tests with negated `unittests` build tag will not be run
-go test -tags=unittests -covermode=atomic -coverprofile="$COVER_PROFILE".tmp -p "$COV_THREAD_COUNT" ./apis/... ./controllers/... ./pkg/...
+go test -tags=unittests -covermode=atomic -coverprofile="$COVER_PROFILE".tmp -p "$COV_THREAD_COUNT" -coverpkg=./apis/...,./controllers/...,./pkg/... ./apis/... ./controllers/... ./pkg/...
 # Remove generated files from coverage profile
 grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"
 rm -f "${COVER_PROFILE}.tmp"

--- a/scripts/ci/unit_test.sh
+++ b/scripts/ci/unit_test.sh
@@ -28,7 +28,7 @@ report_coverage_travis() {
 
 echo Running tests:
 # tests with negated `unittests` build tag will not be run
-go test -tags=unittests -covermode=atomic -coverprofile="$COVER_PROFILE".tmp -p "$COV_THREAD_COUNT" ./apis/... ./controllers/... ./pkg/...
+go test -tags=unittests -covermode=atomic -coverprofile="$COVER_PROFILE".tmp -p "$COV_THREAD_COUNT" -coverpkg=./apis/...,./controllers/...,./pkg/... ./apis/... ./controllers/... ./pkg/...
 # Remove generated files from coverage profile
 grep -v "zz_generated" "${COVER_PROFILE}.tmp" > "${COVER_PROFILE}"
 rm -f "${COVER_PROFILE}.tmp"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4266

# What
The `coverpkg` flag was previously removed from the `go test ...` commands.
This caused the unit test coverage to drop significantly.

# Verification steps
- Make sure all prow checks pass and that the coverage % has been restored back to normal levels
