### PR TITLE
MGDAPI-3097 - add commit check function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -538,6 +538,10 @@ olm/bundle:
 coverage:
 	hack/codecov.sh
 
+.PHONY: commits/check
+commits/check:
+	@./scripts/commits-check.sh
+
 .PHONY: gosec/exclude
 gosec/exclude:
 	gosec -exclude=G104,G107,G404,G601 ./...

--- a/scripts/commits-check.sh
+++ b/scripts/commits-check.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# This script retrieves the list of commits difference from master
+# and ensures that each commit starts with a MGDAPI- numbered ticket
+# See https://issues.redhat.com/browse/MGDAPI-3097
+
+merge_base=$(git merge-base master HEAD)
+commits=$(git rev-list --no-merges $merge_base..HEAD)
+invalidCommits=()
+
+if [ -z "$commits" ]; then
+    echo "No commits to scan"
+    exit 0
+fi
+
+for sha in $commits; do
+    msg=$(git log --format=%B -n 1 $sha)
+    if [[ ! $msg =~ ^(MGDAPI-[0-9]+)[[:blank:]].*$ ]]; then
+        invalidCommits+=( "Commit $sha:\n$msg\n" )
+    fi
+done
+
+if [ ${#invalidCommits[@]} -gt 0 ]; then
+    printf "Not all commits start with a \"MGDAPI-\" ticket\n\n"
+    for i in "${invalidCommits[@]}"; do
+        printf "$i"
+    done
+    exit 1
+fi
+
+echo "All commits valid"


### PR DESCRIPTION
# Issue link
[MGDAPI-3097](https://issues.redhat.com/browse/MGDAPI-3097)

# What
- Added a script and associated make target to check that all commits begin with a MGDAPI- ticket.

# Verification steps
- Checkout PR
- Add some commits that fit or break the name structure
- `make commits/check`