### PR TITLE
MGDAPI-4260 set image tag to master if preparing for next release

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -316,6 +316,11 @@ if [[ "${OLM_TYPE}" == "managed-api-service" ]]; then
  set_related_images
 fi
 
+if [[ "${PREPARE_FOR_NEXT_RELEASE}" = true ]]; then
+  yq e -i ".spec.install.spec.deployments.[0].spec.template.spec.containers[0].image=\"quay.io/$ORG/$OLM_TYPE:master\"" bundles/$OLM_TYPE/${VERSION}/manifests/$OLM_TYPE.clusterserviceversion.yaml
+  yq e -i ".metadata.annotations.containerImage=\"quay.io/$ORG/$OLM_TYPE:master\"" bundles/$OLM_TYPE/${VERSION}/manifests/$OLM_TYPE.clusterserviceversion.yaml
+fi
+
 # Move bundle.Dockerfile to the bundle folder
 mv bundle.Dockerfile bundles/$OLM_TYPE/$VERSION
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4260

# Verification steps
Run
`OLM_TYPE=managed-api-service SEMVER=1.30.0-rc1 make release prepare` and confirm that the bundle created for 1.30 refers to images with tag 1.30.0-rc1
Run
`OLM_TYPE=managed-api-service SEMVER=1.30.0-rc1 PREPARE_FOR_NEXT_RELEASE=false make release prepare` and confirm that the bundle created for 1.30 refers to images with tag 1.30.0-rc1
Run
`OLM_TYPE=managed-api-service SEMVER=1.30.0-rc1 PREPARE_FOR_NEXT_RELEASE=true make release prepare` and confirm that the bundle created for 1.30 refers to images with tag `master`