### PR TITLE
MGDAPI-4280 - fix errorf usage

### DIFF
--- a/pkg/resources/backup/aws_test.go
+++ b/pkg/resources/backup/aws_test.go
@@ -20,7 +20,7 @@ import (
 func TestAWSSnapshotPostgres(t *testing.T) {
 	scheme, err := buildSchemeForAWSBackup()
 	if err != nil {
-		t.Errorf("Error building scheme: %w", err)
+		t.Errorf("Error building scheme: %v", err)
 		return
 	}
 
@@ -59,7 +59,7 @@ func TestAWSSnapshotPostgres(t *testing.T) {
 
 	err = executor.PerformBackup(client, time.Second*10)
 	if err != nil {
-		t.Errorf("Unexpected error performing postgres backup: %w", err)
+		t.Errorf("Unexpected error performing postgres backup: %v", err)
 	}
 }
 
@@ -68,7 +68,7 @@ func TestAWSSnapshotPostgres(t *testing.T) {
 func TestAWSSnapshotRedis(t *testing.T) {
 	scheme, err := buildSchemeForAWSBackup()
 	if err != nil {
-		t.Errorf("Error building scheme: %w", err)
+		t.Errorf("Error building scheme: %v", err)
 		return
 	}
 
@@ -107,7 +107,7 @@ func TestAWSSnapshotRedis(t *testing.T) {
 
 	err = executor.PerformBackup(client, time.Second*10)
 	if err != nil {
-		t.Errorf("Unexpected error performing postgres backup: %w", err)
+		t.Errorf("Unexpected error performing postgres backup: %v", err)
 	}
 }
 

--- a/pkg/resources/backup/backup_executor_test.go
+++ b/pkg/resources/backup/backup_executor_test.go
@@ -31,7 +31,7 @@ func TestConcurrentBackup(t *testing.T) {
 	timeFinished := time.Now()
 
 	if err != nil {
-		t.Errorf("Unexpected error performing concurrent backups: %w", err)
+		t.Errorf("Unexpected error performing concurrent backups: %v", err)
 	}
 
 	elapsed := timeFinished.Sub(timeStarted)

--- a/pkg/resources/backup/cronjob_test.go
+++ b/pkg/resources/backup/cronjob_test.go
@@ -76,7 +76,7 @@ func TestCronJob(t *testing.T) {
 	// Call `PerformBackup` and assert that no error is returned
 	err := executor.PerformBackup(client, time.Second*10)
 	if err != nil {
-		t.Errorf("Unexpected error running backup from CronJob: %w", err)
+		t.Errorf("Unexpected error running backup from CronJob: %v", err)
 	}
 }
 
@@ -182,7 +182,7 @@ func buildSchemeForCronJob() (*runtime.Scheme, error) {
 func createMockClientForCronJob(t *testing.T, initObjects ...runtime.Object) k8sclient.Client {
 	scheme, err := buildSchemeForCronJob()
 	if err != nil {
-		t.Errorf("Error creating testing scheme: %w", err)
+		t.Errorf("Error creating testing scheme: %v", err)
 	}
 
 	return fake.NewFakeClientWithScheme(scheme, initObjects...)


### PR DESCRIPTION
# Issue link
[MGDAPI-4280](https://issues.redhat.com/browse/MGDAPI-4280)

# What
Updated the `%w` with `%v`

# Verification steps
Passing unit tests should be sufficient
