### PR TITLE
[MGDAPI-4147] add installation_controller_reconcile_duration_seconds metric and InstallationControllerReconcileLoopDelayed alert

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,6 +71,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumReconciledTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumFailedTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NoActivated3ScaleTenantAccount)
+	customMetrics.Registry.MustRegister(integreatlymetrics.InstallationControllerReconcileDurationSeconds)
 
 	integreatlymetrics.OperatorVersion.Add(1)
 	utilruntime.Must(v1.Install(clientgoscheme.Scheme))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -172,6 +172,13 @@ var (
 			"username",
 		},
 	)
+
+	InstallationControllerReconcileDurationSeconds = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "installation_controller_reconcile_duration_seconds",
+			Help: "Duration in seconds for the last call to the rhmi_controller's Reconcile(). It equals to 0 if the function is in progress",
+		},
+	)
 )
 
 // SetRHMIInfo exposes rhmi info metrics with labels from the installation CR

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -333,9 +333,9 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 					Alert: fmt.Sprintf("%sInstallationControllerReconcileLoopDelayed", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-						"message": fmt.Sprintf("The reconcile loop for the installation controller in %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
+						"message": fmt.Sprintf("The reconcile loop for the installation controller in a completed installation of %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
 					},
-					Expr:   intstr.FromString("installation_controller_reconcile_duration_seconds == 0"),
+					Expr:   intstr.FromString(installationName + `_version{version=~".+", to_version=""} * on(pod) installation_controller_reconcile_duration_seconds == 0`),
 					For:    "12m",
 					Labels: map[string]string{"severity": "warning", "product": installationName},
 				},

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -329,6 +329,16 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 					For:    "10m",
 					Labels: map[string]string{"severity": "warning", "product": installationName},
 				},
+				{
+					Alert: fmt.Sprintf("%sInstallationControllerReconcileLoopDelayed", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+						"message": fmt.Sprintf("The reconcile loop for the installation controller in %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString("installation_controller_reconcile_duration_seconds == 0"),
+					For:    "12m",
+					Labels: map[string]string{"severity": "warning", "product": installationName},
+				},
 			},
 		},
 	}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -404,6 +404,7 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
+				"RHOAMInstallationControllerReconcileLoopDelayed",
 			},
 		},
 	}
@@ -476,6 +477,7 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
+				"RHOAMInstallationControllerReconcileLoopDelayed",
 			},
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4147

# What
Create a metric and warning alert for when `rhmi_controller` Reconcile() takes longer than 12 mins

# Verification steps
1. Create a fresh cluster and ocm log in to it
2. `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
3. Create a catalog source pointing to my index where I added the following:
    1. `time.Sleep(time.Minute * 3)` to this line to simulate an install delay https://github.com/integr8ly/integreatly-operator/blob/master/controllers/rhmi/rhmi_controller.go#L472
    2. Tweaked the `RHOAMInstallationControllerReconcileLoopDelayed` alert to fire after 2 minutes, instead of 12, to save time
    3. The rest of the code is the same as in the PR
```
cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/tdimov0/managed-api-service-index:1.24.0
EOF
```
4. Install RHOAM from the operator hub (source=rhmi-operators)
5. Deploy an RHMI CR `INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml`
6. Verify that:
    1. During the installation of RHOAM, the `RHOAMInstallationControllerReconcileLoopDelayed` alert didn't fire
    2. When the RHMI CR's status stage changes to `complete`, the `RHOAMInstallationControllerReconcileLoopDelayed` should be triggered and should keep firing indefinitely
7. Simulate an upgrade scenario by changing the catalog source image to `quay.io/tdimov0/managed-api-service-index:1.24.1` and upgrading the RHOAM operator through OCM
8. Verify that:
    1. During the upgrade of RHOAM, the `RHOAMInstallationControllerReconcileLoopDelayed` alert didn't fire
    2. When the RHOAM upgrade completes, the `RHOAMInstallationControllerReconcileLoopDelayed` should be triggered and should keep firing indefinitely
9. After this PR has been merged, the same logic will apply. However, the alert will only fire in the case that `rhmi_controller` single reconciliation is taking more than 12 minutes instead of 2 minutes

