### PR TITLE
MGDAPI-4265 removing message bus fields from redisSecret

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1042,12 +1042,20 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 		},
 		Data: map[string][]byte{},
 	}
+
+	messageBusKeys := []string{"MESSAGE_BUS_URL", "MESSAGE_BUS_NAMESPACE", "MESSAGE_BUS_SENTINEL_HOSTS", "MESSAGE_BUS_SENTINEL_ROLE"}
+
 	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, redisSecret, func() error {
 		uri := systemCredSec.Data["uri"]
 		port := systemCredSec.Data["port"]
 		conn := fmt.Sprintf("redis://%s:%s/1", uri, port)
 		redisSecret.Data["URL"] = []byte(conn)
-		redisSecret.Data["MESSAGE_BUS_URL"] = []byte(conn)
+		for _, key := range messageBusKeys {
+			if redisSecret.Data[key] != nil {
+				delete(redisSecret.Data, key)
+			}
+		}
+
 		return nil
 	})
 	if err != nil {

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -1376,3 +1376,195 @@ func TestReconciler_getUserDiff(t *testing.T) {
 		})
 	}
 }
+
+func TestReconciler_reconcileExternalDatasources(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	postgres := &crov1.Postgres{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "threescale-postgres-rhmi",
+			Namespace: "test",
+		},
+		Status: types.ResourceTypeStatus{
+			Phase: types.PhaseComplete,
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		Spec: types.ResourceTypeSpec{
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+	}
+	backendRedis := &crov1.Redis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "threescale-backend-redis-rhmi",
+			Namespace: "test",
+		},
+		Status: types.ResourceTypeStatus{
+			Phase: types.PhaseComplete,
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		Spec: types.ResourceTypeSpec{
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+	}
+	systemRedis := &crov1.Redis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "threescale-redis-rhmi",
+			Namespace: "test",
+		},
+		Status: types.ResourceTypeStatus{
+			Phase: types.PhaseComplete,
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+		Spec: types.ResourceTypeSpec{
+			SecretRef: &types.SecretRef{
+				Name:      "test",
+				Namespace: "test",
+			},
+		},
+	}
+	credSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "test",
+		},
+	}
+	redisSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "system-redis",
+			Namespace: "test",
+		},
+		Data: map[string][]byte{
+			"MESSAGE_BUS_URL":            []byte("Hello"),
+			"MESSAGE_BUS_NAMESPACE":      []byte("Hello"),
+			"MESSAGE_BUS_SENTINEL_HOSTS": []byte("Hello"),
+			"MESSAGE_BUS_SENTINEL_ROLE":  []byte("Hello"),
+		},
+	}
+
+	type fields struct {
+		ConfigManager config.ConfigReadWriter
+		Config        *config.ThreeScale
+		mpm           marketplace.MarketplaceInterface
+		installation  *integreatlyv1alpha1.RHMI
+		tsClient      ThreeScaleInterface
+		appsv1Client  appsv1Client.AppsV1Interface
+		oauthv1Client oauthClient.OauthV1Interface
+		Reconciler    *resources.Reconciler
+	}
+	type args struct {
+		ctx          context.Context
+		serverClient k8sclient.Client
+	}
+	tests := []struct {
+		name                 string
+		fields               fields
+		args                 args
+		want                 integreatlyv1alpha1.StatusPhase
+		wantErr              bool
+		verificationFunction func(k8sclient.Client) bool
+	}{
+		{
+			name: "test initial install no MESSAGE_BUS keys",
+			fields: fields{
+				ConfigManager: nil,
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx:          context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, postgres, backendRedis, systemRedis, credSec),
+			},
+			want:                 integreatlyv1alpha1.PhaseCompleted,
+			wantErr:              false,
+			verificationFunction: verifyMessageBusDoesNotExist,
+		},
+		{
+			name: "test existing install no MESSAGE_BUS keys",
+			fields: fields{
+				ConfigManager: nil,
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx:          context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, postgres, backendRedis, systemRedis, credSec, redisSecret),
+			},
+			want:                 integreatlyv1alpha1.PhaseCompleted,
+			wantErr:              false,
+			verificationFunction: verifyMessageBusDoesNotExist,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				ConfigManager: tt.fields.ConfigManager,
+				Config:        tt.fields.Config,
+				log:           getLogger(),
+				mpm:           tt.fields.mpm,
+				installation:  tt.fields.installation,
+				tsClient:      tt.fields.tsClient,
+				appsv1Client:  tt.fields.appsv1Client,
+				oauthv1Client: tt.fields.oauthv1Client,
+				Reconciler:    tt.fields.Reconciler,
+			}
+			got, err := r.reconcileExternalDatasources(tt.args.ctx, tt.args.serverClient)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileExternalDatasources() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileExternalDatasources() got = %v, want %v", got, tt.want)
+			}
+			if !verifyMessageBusDoesNotExist(tt.args.serverClient) {
+				t.Fatal("found message bus values in secret")
+			}
+		})
+	}
+}
+
+func verifyMessageBusDoesNotExist(serverClient k8sclient.Client) bool {
+	redisSecret := &corev1.Secret{}
+	err := serverClient.Get(context.TODO(), k8sclient.ObjectKey{Name: "system-redis", Namespace: "test"}, redisSecret)
+	if err != nil {
+		return false
+	}
+	messageBusKeys := []string{"MESSAGE_BUS_URL", "MESSAGE_BUS_NAMESPACE", "MESSAGE_BUS_SENTINEL_HOSTS", "MESSAGE_BUS_SENTINEL_ROLE"}
+	for _, key := range messageBusKeys {
+		if redisSecret.Data[key] != nil {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
# Issue link
[MGDAPI-4265](https://issues.redhat.com/browse/MGDAPI-4265)

# What
Removing MESSAGE_BUS fields from system-redis secret.
This change is coming from a change in 3scale Operator ([Related Ticket](https://issues.redhat.com/browse/THREESCALE-7822))

# Verification steps
1. Provision a cluster.
2. Install RHOAM locally from the master branch by running the following commands:
     - `INSTALLATION_TYPE=managed-api make cluster/prepare/local`
     - `INSTALLATION_TYPE=managed-api make code/run`

3. Once installation is completed, verify that the redis-secret contains the MESSAGE_BUS fields. 
    - Log in to the OpenShift console. 
    - In the left menu choose Workloads and then Secrets.  
    - From the Project tab choose redhat-rhoam-3scale and find the secret with the name: system-redis. 
    - Check that the The MESSAGE_BUS fields are present in the Data section. There are 4 of them.
4. Back in the terminal stop the operator with `CTRL + C`.
5. Re-run RHOAM from this [PR](https://github.com/integr8ly/integreatly-operator/pull/2777) using this command : `INSTALLATION_TYPE=managed-api make code/run`
6. Verify that the secret has been updated with the removal of MESSAGE_BUS fields in the OpenShift console as at 3 above.
7. Confirm that 3scale is still accessible by running workload-web-app against the cluster.
    - Clone this [repo](https://github.com/integr8ly/workload-web-app) if you do not already have a copy.
    - Navigate to the folder and run the following commands from the master branch.
    - `export RHOAM=true`
    - `export GRAFANA_DASHBOARD=true`
    - `make local/deploy`
    - Once this is completed navigate to the cluster on the [OpenShift console](https://qaprodauth.cloud.redhat.com/openshift/) 
    - Choose the Networking option from the left menu, and choose Routes. 
    - From the Project tab choose redhat-rhoam-observability. 
    - Locate grafana-route and click on the Location url. This will bring you to Grafana.
    - In Grafana click on the 4 squares in the menu on the left, choose manage, redhat-rhoam-observability and the Workload App. Here you can see if 3scale is accessible and operational.

