### PR TITLE
MGDAPI-4134 Changing OCM ui steps to OCM cli

### DIFF
--- a/test-cases/tests/installation/a31-verify-installation-on-all-osd-versions.md
+++ b/test-cases/tests/installation/a31-verify-installation-on-all-osd-versions.md
@@ -41,7 +41,8 @@ We want to validate that RHOAM can be installed via Addon Flow on all currently 
 2. Look for AWS account ID that is free (it doesn't have anything specified in 'Note'). If no account is free, you can use account that is used by nightly pipelines (but don't forget to clean it up for night)
 3. Open the [AWS secrets file from 'vault' repository](https://gitlab.cee.redhat.com/integreatly-qe/vault/-/blob/master/SECRETS.md) locally and look for the AWS credentials for the selected AWS account (aws account id, access key ID and secret access key)
 4. Make sure to fill in `openshiftVersion` properly
-5. Most of the parameters are self-explanatory, many can be left as they are or blank
+5. Make sure to use your own ocmAccessToken so you have access to the cluster provisioned by the pipeline.
+6. Most of the parameters are self-explanatory, many can be left as they are or blank
 
 ```
 clusterComputeNodesCount: 6

--- a/test-cases/tests/installation/a34-verify-quota-values.md
+++ b/test-cases/tests/installation/a34-verify-quota-values.md
@@ -106,4 +106,51 @@ echo rate limit replicas: $ratelimit_replicas
 echo rate limit resources: $ratelimit_resources
 ```
 
-8. Go to OCM UI, select the testing cluster and change the quota parameter to a different value using the mapping from step 3 and repeat the steps from step 5. Repeat this for all available quota values.
+8. Login to OCM with provided token
+
+```bash
+ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
+```
+
+9. Set cluster name variable
+
+```bash
+CLUSTER_NAME="<CLUSTER_NAME>"
+```
+
+10. Get cluster id and assign it to a variable
+
+```bash
+CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+```
+
+11. Set quota value
+
+```bash
+QUOTA_VALUE=<QUOTA_VALUE>
+```
+
+12. Update quota
+
+```bash
+ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service --body=<<EOF
+{
+   "parameters":{
+      "items":[
+         {
+            "id":"addon-managed-api-service",
+            "value":"$QUOTA_VALUE"
+         }
+      ]
+   }
+}
+EOF
+```
+
+13. Check addon parameters updated successfully
+
+```bash
+ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
+```
+
+14. Repeat this for all available quota values.

--- a/test-cases/tests/installation/a37-rhoam-on-rosa.md
+++ b/test-cases/tests/installation/a37-rhoam-on-rosa.md
@@ -16,6 +16,9 @@ Verify RHOAM installation on ROSA works as expected.
 
 ## Steps
 
-1. Trigger the pipeline and validate the results
+1. Login to [OCM UI (staging environment)](https://qaprodauth.cloud.redhat.com/beta/openshift/)
+2. Get the [OCM API Token](https://qaprodauth.cloud.redhat.com/beta/openshift/token)
+3. Trigger the pipeline and specify your ocmAccessToken in the pipeline parameters.
+4. Validate pipeline results
 
 > [ROSA pipeline](https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-rosa/)

--- a/test-cases/tests/installation/a39-installation-verify-rhoam-on-private-cluster.md
+++ b/test-cases/tests/installation/a39-installation-verify-rhoam-on-private-cluster.md
@@ -20,7 +20,7 @@ tags:
 2. Follow [this guide](https://docs.google.com/document/d/1BwjzezNFtE7gd2y6FY6v2W6KRXCn0jMZk58ilJ8zSa8/edit) to make it private
 3. Install RHOAM on the cluster
 
-- manually via OCM UI, see [A30](./a30-validate-installation-of-rhoam-addon-and-integration-with-ld.md)
+- manually via OCM CLI, see [A30](./a30-validate-installation-of-rhoam-addon-and-integration-with-ld.md)
 
 4. Run the RHOAM functional test suite locally
 

--- a/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
+++ b/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
@@ -16,31 +16,93 @@ Verify RHOAM installation on OSD Trial works as expected.
 
 ## Steps
 
-1. Provision an OSD Trial Cluster through [Jenkins](https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-addon-flow/)
+1. Login to [OCM UI (staging environment)](https://qaprodauth.cloud.redhat.com/beta/openshift/)
+2. Get the [OCM API Token](https://qaprodauth.cloud.redhat.com/beta/openshift/token)
+3. Provision an OSD Trial Cluster through [Jenkins](https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-addon-flow/)
+   - Specify your ocmAccessToken in the pipeline parameters.
    - Reach out for AWS credentials needed to provision an OSD Trial Cluster
    - Check `osdTrial` checkbox and for phases choose `provisionCluster` and `installProduct`
-2. After pipeline finishes log into the cluster using `oc` and the provided kubeadmin credentials
-3. Verify RHOAM installation completed successfully, and uses the correct `Evaluation` (`0`) quota config
+4. After pipeline finishes log into the cluster using `oc` and the provided kubeadmin credentials
+5. Verify RHOAM installation completed successfully, and uses the correct `Evaluation` (`0`) quota config
 
 ```
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status'
 ```
 
-4. Go to OCM UI, select your OSD Trial cluster and select "upgrade", then select "using quota"
-5. Your OSD cluster should now have the type "OSD" (previously it was OSD Trial)
-6. Select your cluster, go to Addons -> RHOAM -> Configuration
-7. Try to change the "Quota" param and click on "Update"
-8. After a while, .toQuota field should be updated to the value you've selected
+6.  Login to OCM with the token provided.
+
+```bash
+ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
+```
+
+7.  Upgrade your trial cluster "using quota"
+
+```bash
+ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID --body=<<EOF
+{
+   "billing_model":"standard",
+   "product":{
+      "id":"osd"
+   }
+}
+EOF
+```
+
+8. Your OSD cluster should now have the `red-hat-clustertype:OSD`.
+
+```bash
+ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID | jq '.aws.tags'
+```
+
+9. Set Quota value
+
+```bash
+QUOTA_VALUE=<QUOTA_VALUE>
+```
+
+10. Change Quota value
+
+```bash
+ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service --body=<<EOF
+{
+   "parameters":{
+      "items":[
+         {
+            "id":"addon-managed-api-service",
+            "value":"$QUOTA_VALUE"
+         }
+      ]
+   }
+}
+EOF
+```
+
+11. After a while, .toQuota field should be updated to the value you've selected
 
 ```bash
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toQuota'
 ```
 
-9. Once the new quota has been applied to the RHOAM cluster, `.quota` field should be updated
+11. Once the new quota has been applied to the RHOAM cluster, `.quota` field should be updated
 
 ```bash
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.quota'
 ```
 
-10. Trigger uninstall of the addon via the Cluster OCM UI
-11. Verify uninstall completes successfully
+12. Trigger uninstall of the addon via the Cluster
+
+```bash
+ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
+```
+
+13. Verify uninstall completes successfully. Once the RHOAM CR is deleted the addon installation with id=managed-api-service shouldn't be listed.
+
+```bash
+ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons
+```
+
+Additionally,during the uninstallation you can monitor the RHMI CR stage or log into the openshift console and ensure all the redhat-rhoam namespaces have been deleted.
+
+```bash
+oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
+```

--- a/test-cases/tests/products/h27-verify-that-user-with-uppercase-letters-can-be-created-in-3s.md
+++ b/test-cases/tests/products/h27-verify-that-user-with-uppercase-letters-can-be-created-in-3s.md
@@ -32,18 +32,68 @@ This test verifies that if there is an existing user with uppercase letters in t
 
 **Set up Github IDP for OSD cluster**
 
-1. Go to https://qaprodauth.cloud.redhat.com/beta/openshift/ -> select your cluster -> Access control -> Add identity providers
-2. Fill in the details (Client ID, Client Secret, add the organization you are a member of and have admin access to it)
-3. Log in to your cluster via Github IDP (go to OpenShift console, select Github IDP)
-4. Verify that the user you've logged in with has an uppercase letters in its name
+1. Register an openshift application by following this [guide](https://docs.openshift.com/container-platform/4.10/authentication/identity_providers/configuring-github-identity-provider.html#identity-provider-overview_configuring-github-identity-provider).
+
+2. Grant the [application](https://github.com/settings/connections/applications) access to an org where you have admin access. Select the application and under orgnization access grant the application permissions to the org.
+
+3. Retrieve and save the client secret and client id from the github [application](https://github.com/settings/developers).
+
+4. Login to OCM with the token provided
+
+```bash
+ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
+```
+
+5. Set cluster name variable
+
+```bash
+CLUSTER_NAME="<CLUSTER_NAME>"
+```
+
+6. Get id of cluster and assign it to a variable
+
+```bash
+CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+```
+
+7. Set Client secret, id and org name variables (Values from step 3)
+
+```bash
+CLIENT_SECRET="<CLIENT_SECRET>"
+CLIENT_ID="<CLIENT_ID>"
+ORG_NAME="<ORG_NAME>"
+```
+
+8. Add GitHub IDP
+
+```bash
+ocm post https://api.stage.openshift.com/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers --body=<<EOF
+{
+   "type":"GithubIdentityProvider",
+   "name":"GitHub",
+   "id":null,
+   "mapping_method":"claim",
+   "github":{
+      "client_id":"$CLIENT_ID",
+      "client_secret":"$CLIENT_SECRET",
+      "organizations":[
+         "$ORG_NAME"
+      ]
+   }
+}
+EOF
+```
+
+9. Log in to your cluster via Github IDP (go to OpenShift console, select Github IDP)
+10. Verify that the user you've logged in with has an uppercase letters in its name
 
 ```bash
 oc get users | awk '{print $1}' | grep -i <your-username>
 ```
 
-5. In OpenShift console (when logged in as your github user), select the launcher on the top right menu -> API Management -> Github IDP and log in to 3scale
-   > Verify that you can successfully log in
-6. Go to Account settings (top right menu) -> Personal -> Personal Details
-   > Verify that your username contains only lowercase letters
-7. Change some letter in your username to uppercase letter (e.g. myuser -> Myuser) and confirm the change
-   > Verify that after RHOAM operator reconciles (~5 minutes), your username is changed back to lowercase letters
+11. In OpenShift console (when logged in as your github user), select the launcher on the top right menu -> API Management -> Github IDP and log in to 3scale
+    > Verify that you can successfully log in
+12. Go to Account settings (top right menu) -> Personal -> Personal Details
+    > Verify that your username contains only lowercase letters
+13. Change some letter in your username to uppercase letter (e.g. myuser -> Myuser) and confirm the change
+    > Verify that after RHOAM operator reconciles (~5 minutes), your username is changed back to lowercase letters

--- a/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
+++ b/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
@@ -25,9 +25,9 @@ Mesure the downtime of the RHOAM components during the OpenShift upgrade (not to
 
 1. Login via `oc` as a user with **cluster-admin** role (kubeadmin):
 
-   ```
-   oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:6443
-   ```
+```bash
+oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:6443
+```
 
 2. Make sure **nobody is using the cluster** for performing the test cases, because the RHOAM components will have a downtime during the upgrade
 
@@ -56,13 +56,25 @@ Mesure the downtime of the RHOAM components during the OpenShift upgrade (not to
      - `oc patch clusterversion/version -p '{"spec":{"channel":"stable-4.y"}}' --type=merge`
      - see the [Knowledgebase article](https://access.redhat.com/solutions/4606811) for details
 
-5. Ask QE team to login to the ocm staging environment and get the ID of the cluster that is going to be upgraded:
+5. Get the ID of the cluster that is going to be upgraded:
 
-   ```bash
-   # Get the token at https://qaprodauth.cloud.redhat.com/openshift/token
-   ocm login --url=https://api.stage.openshift.com --token=YOUR_TOKEN
-   CLUSTER_ID=$(ocm cluster list | grep <CLUSTER-NAME> | awk '{print $1}')
-   ```
+5.1 Log in to OCM with token provided
+
+```bash
+ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
+```
+
+5.2 Set cluster name variable
+
+```bash
+CLUSTER_NAME="<CLUSTER_NAME>"
+```
+
+5.3 Get id of cluster and assign it to a variable
+
+```bash
+CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+```
 
 6. Run this command to wait for the OpenShift upgrade to complete:
 

--- a/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
+++ b/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
@@ -61,7 +61,52 @@ echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=json
 
 5. Update the quota for a cluster in OCM to e.g. `5 million` and wait for an operator to finish quota configuration
 
-> To change the Quota go to the OCM UI -> Cluster -> select desired cluster -> Add-ons tab -> Click on RHOAM Addon tile -> Edit -> change the Quota
+5.1 Login to OCM with provided token
+
+```bash
+ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
+```
+
+5.2 Set cluster name variable
+
+```bash
+CLUSTER_NAME="<CLUSTER_NAME>"
+```
+
+5.3 Get cluster id and assign it to a variable
+
+```bash
+CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+```
+
+5.4 Set quota value
+
+```bash
+QUOTA_VALUE=<QUOTA_VALUE>
+```
+
+5.5 Update quota
+
+```bash
+ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service --body=<<EOF
+{
+   "parameters":{
+      "items":[
+         {
+            "id":"addon-managed-api-service",
+            "value":"$QUOTA_VALUE"
+         }
+      ]
+   }
+}
+EOF
+```
+
+5.6 Check addon parameters updated successfully
+
+```bash
+ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
+```
 
 6. After Quota change is done, open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace again
 


### PR DESCRIPTION
# Issue link
[MGDAPI-4134](https://issues.redhat.com/browse/MGDAPI-4134)

# What
Changed any step that required OCM UI (QE OCM permissions) to use OCM CLI

# Verification steps
Read through the new steps and make sure that they are clear

Verify that the new CLI commands work.

1. Provision OSD trial Cluster, through [Jenkins](https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-addon-flow/build?delay=0sec)
1.1  Set the ocmAccessToken to your own token, which can be found [here](https://qaprodauth.cloud.redhat.com/openshift/token/show#)
1.2   Check the osdTrial cluster checkbox
1.3 In pipeline steps check the provisionCluster and installProduct checkboxes , leave the rest empty 
1.4 Build the pipeline

2. Log in to OCM 
```bash
 ocm login --url=https://api.stage.openshift.com --token=YOUR_TOKEN
```

3.  Set the CLUSTER_NAME variable
```bash
CLUSTER_NAME=<YOUR_CLUSTER_NAME>
```

4. Get cluster-ID and assign it to a variable
```bash
CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
```

5.  Log in to the cluster with OC and wait until RHOAM is installed successfully 
```bash
watch "oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage"
```

6. Once RHOAM is installed, upgrade the OSD trial cluster to  standard OSD
```bash 
ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID --body=<<EOF
{
   "billing_model":"standard",
   "product":{
      "id":"osd"
   }
}
EOF
```

7. Check that the OSD cluster now has `red-hat-clustertype:OSD`.
```bash
ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID | jq '.product.id'
```

8.  Set Quota value
```bash
QUOTA_VALUE=50
```

9.  Change Quota 
```bash
ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service --body=<<EOF
{
   "parameters":{
      "items":[
         {
            "id":"addon-managed-api-service",
            "value":"$QUOTA_VALUE"
         }
      ]
   }
}
EOF
```

10. After a while, `.toQuota` field should be updated to the value you've selected
```bash
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toQuota'
```

12. Trigger uninstall of the addon
```bash
ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
```

13. Verify uninstall completes successfully. Once the RHOAM CR is deleted the addon installation with id=managed-api-service shouldn't be listed.
```bash 
ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons
```
**Note:** make sure that all redhat-rhoam namespaces are gone before proceeding 

14. Set dummy GitHub application values.
```bash
CLIENT_SECRET="dummysecret"
CLIENT_ID="dummyid"
ORG_NAME="dummyorg"
```

15. Add github as IDP 
```bash
ocm post https://api.stage.openshift.com/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers --body=<<EOF
{
   "type":"GithubIdentityProvider",
   "name":"GitHub",
   "id":null,
   "mapping_method":"claim",
   "github":{
      "client_id":"$CLIENT_ID",
      "client_secret":"$CLIENT_SECRET",
      "organizations":[
         "$ORG_NAME"
      ]
   }
}
EOF
```

16.  Add LDAP as IDP 
```bash
ocm post https://api.stage.openshift.com/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers --body=<<EOF
{
   "type":"LDAPIdentityProvider",
   "name":"LDAP",
   "id":null,
   "mapping_method":"claim",
   "ldap":{
      "attributes":{
         "id":[
            "dn"
         ],
         "email":[
         ],
         "name":[
            "cn"
         ],
         "preferred_username":[
            "uid"
         ]
      },
      "insecure":true,
      "url":"dummyldapurl.com"
   }
}
EOF
```

17.Check that GitHub and LDAP have been added as an IDP, GithubIdentityProvider  and LDAPIdentityProvider should be listed.
```bash
ocm get https://api.stage.openshift.com/api/clusters_mgmt/v1/clusters/$CLUSTER_ID/identity_providers | jq '.items'
```

18. Uninstall RHOAM 
```bash
ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
```

19. Verify uninstall completes successfully. Once the RHOAM CR is deleted the addon installation with id=managed-api-service shouldn't be listed.
```bash 
ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons
```
**Note:** make sure that all redhat-rhoam namespaces are gone before proceeding 

20. Once RHOAM has been uninstalled successfully you can delete the cluster.






