### PR TITLE
MGDAPI-4310 - Fix commit check

### DIFF
--- a/scripts/commits-check.sh
+++ b/scripts/commits-check.sh
@@ -3,9 +3,12 @@
 # This script retrieves the list of commits difference from master
 # and ensures that each commit starts with a MGDAPI- numbered ticket
 # See https://issues.redhat.com/browse/MGDAPI-3097
+# PULL_BASE_SHA and PULL_PULL_SHA are set by prow
 
-merge_base=$(git merge-base master HEAD)
-commits=$(git rev-list --no-merges $merge_base..HEAD)
+PULL_BASE_SHA="${PULL_BASE_SHA:-$(git merge-base master HEAD)}"
+PULL_PULL_SHA="${PULL_PULL_SHA:-HEAD}"
+
+commits=$(git rev-list --no-merges $PULL_BASE_SHA..$PULL_PULL_SHA)
 invalidCommits=()
 
 if [ -z "$commits" ]; then


### PR DESCRIPTION
# Issue link
[MGDAPI-4310](https://issues.redhat.com/browse/MGDAPI-4310)

# What
Issue with commit check function - the git repo created by prow does not have remotes and performs a merge, making `git merge-base` return the current PR HEAD. This means the check is effectively skipped on every PR and will pass.
- Add environment variables that use the commit SHA's provided by prow
- Use these references to determine which commits belong to the PR

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
