### PR TITLE
MGDAPI-3795 G104: Audit errors not checked. Error handling added where required. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ commits/check:
 
 .PHONY: gosec/exclude
 gosec/exclude:
-	gosec -exclude=G104,G107,G404,G601 ./...
+	gosec -exclude=G107,G404,G601 ./...
 
 ##@ Build Dependencies
 

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -491,7 +491,10 @@ func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClie
 	}
 
 	for _, tenant := range allTenants {
-		_ = r.reconcileOauthSecretData(ctx, serverClient, oauthClientSecrets, tenant.TenantName)
+		err = r.reconcileOauthSecretData(ctx, serverClient, oauthClientSecrets, tenant.TenantName)
+		if err != nil {
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("error reconciling OAuth secret data for tenant %v: %w", tenant.TenantName, err)
+		}
 	}
 
 	// Remove redundant tenant secrets

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -491,7 +491,7 @@ func (r *Reconciler) reconcileTenantOauthSecrets(ctx context.Context, serverClie
 	}
 
 	for _, tenant := range allTenants {
-		r.reconcileOauthSecretData(ctx, serverClient, oauthClientSecrets, tenant.TenantName)
+		_ = r.reconcileOauthSecretData(ctx, serverClient, oauthClientSecrets, tenant.TenantName)
 	}
 
 	// Remove redundant tenant secrets

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -21,8 +21,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -31,6 +29,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
+	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
 	"github.com/go-openapi/strfmt"
 	routev1 "github.com/openshift/api/route/v1"
@@ -790,7 +791,10 @@ func (r *RHMIReconciler) handleUninstall(installation *rhmiv1alpha1.RHMI, instal
 		if pendingUninstalls {
 			if len(merr.Errors) > 0 {
 				installation.Status.LastError = merr.Error()
-				r.Client.Status().Update(context.TODO(), installation)
+				err = r.Client.Status().Update(context.TODO(), installation)
+				if err != nil {
+					merr.Add(err)
+				}
 			}
 			err = r.Client.Update(context.TODO(), installation)
 			if err != nil {

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -31,7 +31,7 @@ import (
 	"time"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
-	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	prometheusv1 "github.com/prometheus/client_golang/api/prometheus/v1"
 
 	"github.com/go-openapi/strfmt"
 	routev1 "github.com/openshift/api/route/v1"
@@ -1483,7 +1483,7 @@ func (r *RHMIReconciler) composeAlertMetric(route string, namespace string) (res
 	var alertResp struct {
 		Status string `json:"status"`
 		Data   struct {
-			Alerts []v1.Alert `json:"alerts"`
+			Alerts []prometheusv1.Alert `json:"alerts"`
 		} `json:"data"`
 	}
 
@@ -1667,7 +1667,7 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 	}, nil
 }
 
-func formatAlerts(alerts []v1.Alert) resources.AlertMetrics {
+func formatAlerts(alerts []prometheusv1.Alert) resources.AlertMetrics {
 	alertMetrics := make(resources.AlertMetrics)
 
 	for _, alert := range alerts {

--- a/controllers/rhmiconfig/helpers/update_status.go
+++ b/controllers/rhmiconfig/helpers/update_status.go
@@ -31,7 +31,10 @@ func UpdateStatus(ctx context.Context, client k8sclient.Client, config *rhmiconf
 		config.Status.Maintenance.Duration = strconv.Itoa(WINDOW) + "hrs"
 	}
 
-	client.Status().Update(ctx, config)
+	err := client.Status().Update(ctx, config)
+	if err != nil {
+		return err
+	}
 
 	// Calculate the upgrade schedule based on the spec:
 	// We can assume there's no error parsing the value as it was validated

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -428,11 +428,11 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to list the keycloak users: %w", err)
 	}
 
-	r.reconcileGroups(ctx, serverClient, kc)
+	_, err = r.reconcileGroups(ctx, serverClient, kc)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
-	r.reconcileAdminUsers(ctx, serverClient, kcClient, keycloakUsers)
+	_, err = r.reconcileAdminUsers(ctx, serverClient, kcClient, keycloakUsers)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/pkg/products/ups/reconciler.go
+++ b/pkg/products/ups/reconciler.go
@@ -238,7 +238,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		},
 	}
 
-	controllerutil.CreateOrUpdate(ctx, client, postgresSecret, func() error {
+	_, err = controllerutil.CreateOrUpdate(ctx, client, postgresSecret, func() error {
 		postgresSecret.StringData = map[string]string{
 			"POSTGRES_DATABASE":  string(connSec.Data["database"]),
 			"POSTGRES_HOST":      string(connSec.Data["host"]),
@@ -250,6 +250,9 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 		}
 		return nil
 	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to createOrUpdate postgresSecret: %w", err)
+	}
 
 	// Reconcile ups custom resource
 	r.log.Info("Reconciling unified push server cr")

--- a/pkg/resources/marketplace/implicit_catalog_source_reconciler.go
+++ b/pkg/resources/marketplace/implicit_catalog_source_reconciler.go
@@ -73,10 +73,13 @@ func (r *ImplicitCatalogSourceReconciler) Reconcile(ctx context.Context, subName
 			},
 		}
 
-		controllerutil.CreateOrUpdate(ctx, r.Client, cs, func() error {
+		_, err = controllerutil.CreateOrUpdate(ctx, r.Client, cs, func() error {
 			cs.Spec = catalogSource.DeepCopy().Spec
 			return nil
 		})
+		if err != nil {
+			return reconcile.Result{}, errors.Wrapf(err, "could not createOrUpdate catalogSource in ImplicitCatalogSourceReconciler")
+		}
 
 		r.Log.Infof("Created 3Scale catalog source ", l.Fields{"image": cs.Spec.Image})
 		r.selfCatalogSource = cs

--- a/pkg/resources/marketplace/manifestHelper.go
+++ b/pkg/resources/marketplace/manifestHelper.go
@@ -131,7 +131,10 @@ func GetCRDsFromManifestAsStringList(dir string, regex string, packageYaml strin
 							found := CheckFoldersForMatch(dir, vs, currentFolder, crdConfig, libRegEx)
 							if !found {
 								// if match isn't found, add file contents to stringlist
-								ProcessYamlFile(currentFolder+string(os.PathSeparator)+f.Name(), &stringList)
+								err = ProcessYamlFile(currentFolder+string(os.PathSeparator)+f.Name(), &stringList)
+								if err != nil {
+									log.Error("contents not added to stringlist", err)
+								}
 							}
 
 						}

--- a/pkg/resources/openshift.go
+++ b/pkg/resources/openshift.go
@@ -74,8 +74,8 @@ func setIntegreatlyLabel(u *unstructured.Unstructured) {
 
 func init() {
 	codecsScheme := runtime.NewScheme()
-	scheme.AddToScheme(codecsScheme)
-	v1alpha1.AddToSchemes.AddToScheme(codecsScheme)
+	_ = scheme.AddToScheme(codecsScheme)
+	_ = v1alpha1.AddToSchemes.AddToScheme(codecsScheme)
 
 	codecs = serializer.NewCodecFactory(codecsScheme)
 }

--- a/pkg/webhooks/webhook_register.go
+++ b/pkg/webhooks/webhook_register.go
@@ -141,7 +141,7 @@ func (awr AdmissionWebhookRegister) RegisterToBuilder(bldr *builder.WebhookBuild
 
 // RegisterToServer regsiters the webhook to the path of `awr`
 func (awr AdmissionWebhookRegister) RegisterToServer(scheme *runtime.Scheme, srv *webhook.Server) {
-	awr.Hook.InjectScheme(scheme)
+	_ = awr.Hook.InjectScheme(scheme)
 	srv.Register(awr.Path, awr.Hook)
 }
 

--- a/test/common/user_dedicated_admin_synced_sso.go
+++ b/test/common/user_dedicated_admin_synced_sso.go
@@ -428,7 +428,7 @@ func cleanUpTestDedicatedAdminUsersSyncedSSO(ctx context.Context, t TestingTB, c
 	err := c.Delete(ctx, testUser)
 	if err != nil {
 		t.Fatalf("Failed to delete OpenShift user %s, err: %v", testUser.Name, err)
-	} 
+	}
 
 	// Ensure KeycloakUser CR is deleted
 	err = c.Delete(ctx, &keycloak.KeycloakUser{

--- a/test/common/user_dedicated_admin_synced_sso.go
+++ b/test/common/user_dedicated_admin_synced_sso.go
@@ -4,25 +4,26 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"reflect"
+	"strconv"
+	"strings"
+	"time"
+
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	routev1 "github.com/openshift/api/route/v1"
 	userv1 "github.com/openshift/api/user/v1"
-	"io/ioutil"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/utils/pointer"
-	"net/http"
-	"net/http/httputil"
-	"net/url"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"strconv"
-	"strings"
-	"time"
 )
 
 const (
@@ -427,7 +428,7 @@ func cleanUpTestDedicatedAdminUsersSyncedSSO(ctx context.Context, t TestingTB, c
 	// Ensure OpenShift user is deleted
 	err := c.Delete(ctx, testUser)
 	if err != nil {
-		t.Fatalf("Failed to delete OpenShift user %s, err: %v", testUser.Name, err)
+		t.Fatalf("failed to delete OpenShift user %s, err: %v", testUser.Name, err)
 	}
 
 	// Ensure KeycloakUser CR is deleted

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -32,7 +32,10 @@ func TestMultiAZPodDistribution(t common.TestingTB, ctx *common.TestingContext) 
 	pods := &v1.PodList{}
 	nodes := &v1.NodeList{}
 
-	ctx.Client.List(goctx.TODO(), nodes)
+	err := ctx.Client.List(goctx.TODO(), nodes)
+	if err != nil {
+		t.Fatalf("Error listing nodes: %s", err)
+	}
 
 	availableZones = GetClustersAvailableZones(nodes)
 

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -34,7 +34,7 @@ func TestMultiAZPodDistribution(t common.TestingTB, ctx *common.TestingContext) 
 
 	err := ctx.Client.List(goctx.TODO(), nodes)
 	if err != nil {
-		t.Fatalf("Error listing nodes: %s", err)
+		t.Fatalf("error listing nodes: %s", err)
 	}
 
 	availableZones = GetClustersAvailableZones(nodes)

--- a/test/resources/codeready_login.go
+++ b/test/resources/codeready_login.go
@@ -125,7 +125,10 @@ func (c *CodereadyLoginClient) CodereadyLogin(keycloakHost, redirectUrl string) 
 		AccessToken string `json:"access_token"`
 	}{}
 
-	json.Unmarshal(postBody, &tokenResponse)
+	err = json.Unmarshal(postBody, &tokenResponse)
+	if err != nil {
+		return "", err
+	}
 
 	if tokenResponse.AccessToken == "" {
 		return "", fmt.Errorf("failed to get access token: %v", string(postBody))

--- a/test/resources/oauth_proxy_auth.go
+++ b/test/resources/oauth_proxy_auth.go
@@ -107,7 +107,10 @@ func Auth3Scale(client *http.Client, redirectUrl, keycloakHost, clientId, secret
 		AccessToken string `json:"access_token"`
 	}{}
 
-	json.Unmarshal(postBody, &tokenResponse)
+	err = json.Unmarshal(postBody, &tokenResponse)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal json: %v", err)
+	}
 	return tokenResponse.AccessToken, nil
 }
 


### PR DESCRIPTION
# Issue link
[MGDAPI-3795](https://issues.redhat.com/browse/MGDAPI-3795)

# What
Removing G104 from gosec/exclude command showed a list of 22 unhandled errors. 
Error handling has been added in all cases.

# Verification steps
1. On master branch edit makefile line 543 removing G104
2. Run make gosec/exclude command. This will show 22 issues.
3. Using this [PR,](https://github.com/integr8ly/integreatly-operator/pull/2782) run the gosec/exclude command which will show 0 issues.

