### PR TITLE
MGDAPI-4311 - add grafanadashboard CRD check to rhsso

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -3,6 +3,7 @@ package rhsso
 import (
 	"context"
 	"fmt"
+
 	grafanav1alpha1 "github.com/grafana-operator/grafana-operator/v4/api/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
@@ -153,6 +154,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.SetRollingStrategyForUpgrade(r.isUpgrade, ctx, serverClient, r.Config.RHSSOCommon, integreatlyv1alpha1.VersionRHSSO, keycloakName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to set rolling strategy for upgrade", err)
+		return phase, err
+	}
+
+	phase, err = r.CheckGrafanaDashboardCRD(ctx, r.Oauthv1Client)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to retrieve grafana dashboard crd", err)
 		return phase, err
 	}
 

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -196,6 +196,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.CheckGrafanaDashboardCRD(ctx, r.Oauthv1Client)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to retrieve grafana dashboard crd", err)
+		return phase, err
+	}
+
 	phase, err = r.ReconcileSubscription(ctx, serverClient, installation, productNamespace, operatorNamespace, postgresResourceName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.RHSSOSubscriptionName), err)


### PR DESCRIPTION
# Issue link
[MGDAPI-4311](https://issues.redhat.com/browse/MGDAPI-4311)

# What
- Add check for `GrafanaDashboard` CRD in rhsso before continuing with installation

# Verification steps
- Create cluster
- Complete installation
- Delete `GrafanaDashboard` CRD
- Should see reconcile events stating rhsso is awaiting `GrafanaDashboard` CRD
- RHMI CR will show awaiting components
