### PR TITLE
[MGDAPI-4354] improve reconcile delay tracking logic

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func init() {
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumReconciledTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NumFailedTenants)
 	customMetrics.Registry.MustRegister(integreatlymetrics.NoActivated3ScaleTenantAccount)
-	customMetrics.Registry.MustRegister(integreatlymetrics.InstallationControllerReconcileDurationSeconds)
+	customMetrics.Registry.MustRegister(integreatlymetrics.InstallationControllerReconcileDelayed)
 
 	integreatlymetrics.OperatorVersion.Add(1)
 	utilruntime.Must(v1.Install(clientgoscheme.Scheme))

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -173,10 +173,10 @@ var (
 		},
 	)
 
-	InstallationControllerReconcileDurationSeconds = prometheus.NewGauge(
+	InstallationControllerReconcileDelayed = prometheus.NewGauge(
 		prometheus.GaugeOpts{
-			Name: "installation_controller_reconcile_duration_seconds",
-			Help: "Duration in seconds for the last call to the rhmi_controller's Reconcile(). It equals to 0 if the function is in progress",
+			Name: "installation_controller_reconcile_delayed",
+			Help: "Measures if the last reconcile of the installation controller is delayed",
 		},
 	)
 )

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -330,13 +330,13 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 					Labels: map[string]string{"severity": "warning", "product": installationName},
 				},
 				{
-					Alert: fmt.Sprintf("%sInstallationControllerReconcileLoopDelayed", strings.ToUpper(installationName)),
+					Alert: fmt.Sprintf("%sInstallationControllerReconcileDelayed", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-						"message": fmt.Sprintf("The reconcile loop for the installation controller in a completed installation of %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
+						"message": fmt.Sprintf("The reconcile function of the installation controller in a completed state of %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
 					},
-					Expr:   intstr.FromString(installationName + `_version{version=~".+", to_version=""} * on(pod) installation_controller_reconcile_duration_seconds == 0`),
-					For:    "12m",
+					Expr:   intstr.FromString(installationName + `_version{version=~".+", to_version=""} * on(pod) (installation_controller_reconcile_delayed == 1)`),
+					For:    "1m",
 					Labels: map[string]string{"severity": "warning", "product": installationName},
 				},
 			},

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -404,7 +404,7 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
-				"RHOAMInstallationControllerReconcileLoopDelayed",
+				"RHOAMInstallationControllerReconcileDelayed",
 			},
 		},
 	}
@@ -477,7 +477,7 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
-				"RHOAMInstallationControllerReconcileLoopDelayed",
+				"RHOAMInstallationControllerReconcileDelayed",
 			},
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4354

# What
The alert that tracks if the rhmi controller reconcile function takes more than 12 minutes to complete was firing continuously which is not what we want. The issue was caused by not giving enough time to Prometheus to detect if the metric has a non-zero value. To address that I refactored the logic to not track the duration, but only track whether the function has completed in the specified time. The way this works is by using a goroutine which will execute in 12 minutes if the reconcile hasn't completed. The goroutine will be killed if the function completes before the timer runs out, so there's no possibility of false alerts.

# Verification steps

