### PR TITLE
MGDAPI-4357 - Fix script #3 in Test E04B - Verify SLO dashboard - userr-sso statefulset not scaling down

### DIFF
--- a/test-cases/tests/dashboards/e04b-verify-slo-dashboard.md
+++ b/test-cases/tests/dashboards/e04b-verify-slo-dashboard.md
@@ -84,8 +84,12 @@ while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-rhsso-op
 ### Code #3
 
 ```bash
-while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-user-sso-operator -o json | jq '.spec.replicas' | grep 1; then     oc scale deployment keycloak-operator --replicas=0 -n redhat-rhoam-user-sso-operator;   fi;   if oc get statefulset keycloak -n redhat-rhoam-user-sso -o json | jq '.spec.replicas' | grep 3; then     oc scale statefulset keycloak --replicas=0 -n redhat-rhoam-user-sso;   fi;   sleep 5; done
+while true; do   if oc get deployment keycloak-operator -n redhat-rhoam-user-sso-operator -o json | jq '.spec.replicas' | grep 1; then     oc scale deployment keycloak-operator --replicas=0 -n redhat-rhoam-user-sso-operator;   fi;   if oc get statefulset keycloak -n redhat-rhoam-user-sso -o json | jq '.spec.replicas' | grep 2; then     oc scale statefulset keycloak --replicas=0 -n redhat-rhoam-user-sso;   fi;   sleep 5; done
 ```
+
+**_NOTE_** _(for Code #3). The number of user sso statefulset replicas depends on quota and might need to be manually adjusted.
+Pods increase from 2 to 3 when the quota is 5 million or higher (see https://github.com/integr8ly/integreatly-operator/blob/master/pkg/addon/quota.go).
+For example, 50M quota results in 3 user sso pods while 100k quota results in 2 user sso pods._
 
 ### Code #4
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4357
Fix script # 3 in Test E04B - Verify SLO dashboard - user-sso statefulset not scaling down

# What
Issue was in doc (e04b-verify-slo-dashboard.md) of Manual test  `E04B - Verify SLO dashboard`, in script, `Code # 3 `
User-sso statefulset did not scale down, because of incorrect expected replicas number (`3`).
The fix was - change the number of expected replicas to `2` (`grep 2`  instead of `grep 3`).

# Verification steps
It's a Manual test.
All test details are described in doc (file e04b-verify-slo-dashboard.md, in PR)
- To check that User-sso statefulset was scaled to zero:
$ oc get statefulset -n redhat-rhoam-user-sso
NAME READY AGE
keycloak 0/0 ....
-  Check Grafana Dashboard `Critical SLO summary`, see that user-sso panel shows the number of firing alerts.
(all panels should show number of firing alerts except Marin3r)
