### PR TITLE
MGDAPI-4309 token retrieval for 4.11 clusters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ setup/moq:
 
 .PHONY: setup/service_account/oc_login
 setup/service_account/oc_login:
-	@oc login --token=$(shell sh -c "oc serviceaccounts get-token rhmi-operator -n ${NAMESPACE}") --server=$(shell sh -c "oc whoami --show-server") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
+	@oc login --token=$(shell sh -c "oc create token rhmi-operator -n ${NAMESPACE} --duration=24h") --server=$(shell sh -c "oc whoami --show-server") --kubeconfig=TMP_SA_KUBECONFIG --insecure-skip-tls-verify=true
 
 .PHONY: setup/service_account
 setup/service_account: kustomize


### PR DESCRIPTION
# Issue link
[MGDAPI-4309 ](https://issues.redhat.com/browse/MGDAPI-4309)

# What
Support for login into OSD 4.11 clusters. 

# Verification steps
You would need to verify that it is possible to login into 4.11 clusters as well as 4.10 clusters. The 4.11 oc client is required and can be downloaded from [here](https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.11.0-rc.2/)
## 4.10 cluster
1. Provision a cluster (current default for dev environment in 4.10.20 - will do nicely). 
2. Ensure you have 4.11 oc cli by `oc version`
3. Initiate installation 
4. Once reconcile loops have started - you were able to log into the cluster. 
## 4.11 Cluster
1. Provision cluster. I've used elorean CLI for this. You could get the list of versions by `ocm get "/api/clusters_mgmt/v1/versions?size=2000" | jq '.items[] | select(.id | contains("nightly") | not).id | select (. | contains("v4.11"))'`. Select the latest RC candidate. 
2. Ensure you have 4.11 oc cli by `oc version`
3. Initiate installation 
4. Once reconcile loops have started - you were able to log into the cluster. 