### PR TITLE
[MGDAPI-4378] defer stop of reconcileDelayedMetric timer

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -240,9 +240,10 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()
 	reconcileDelayedMetric := metrics.InstallationControllerReconcileDelayed
 	reconcileDelayedMetric.Set(0) // reset on every reconcile to prevent alert from firing continuously
-	time.AfterFunc(time.Minute*12, func() {
+	timer := time.AfterFunc(time.Minute*12, func() {
 		reconcileDelayedMetric.Set(1)
 	})
+	defer timer.Stop()
 	installInProgress := false
 	installation := &rhmiv1alpha1.RHMI{}
 	err := r.Get(context.TODO(), request.NamespacedName, installation)


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4378

# What
The second parameter (func) of the AfterFunc runs in its own goroutine and has to be killed before we exit the reconcile function. This can be done by using a defer call to https://pkg.go.dev/time#Timer.Stop after the timer has been setup.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
