### PR TITLE
MGDAPI-4287 Removed code that deleted old stages during upgrade to 1.24 since no longer needed

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -448,9 +448,6 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 		installation.Status.ToVersion = ""
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, string(externalClusterId), installation.CreationTimestamp.Unix())
 		if rhmiv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installation.Spec.Type)) {
-			// remove the code for next release
-			removeOldStages(installation)
-			// end of removal
 			installation.Status.Quota = installationQuota.GetName()
 			installation.Status.ToQuota = ""
 		}
@@ -1688,11 +1685,4 @@ func formatAlerts(alerts []v1.Alert) resources.AlertMetrics {
 	}
 
 	return alertMetrics
-}
-
-func removeOldStages(installation *rhmiv1alpha1.RHMI) {
-	delete(installation.Status.Stages, rhmiv1alpha1.CloudResourcesStage)
-	delete(installation.Status.Stages, rhmiv1alpha1.ObservabilityStage)
-	delete(installation.Status.Stages, rhmiv1alpha1.AuthenticationStage)
-	delete(installation.Status.Stages, rhmiv1alpha1.ProductsStage)
 }


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4287

# What
As part of [MGDAPI-4150](https://github.com/integr8ly/integreatly-operator/pull/2729) (which squashed the installation stages into one stage), a small [function](https://github.com/integr8ly/integreatly-operator/pull/2729/files#diff-239eca6331989433c0101fe047f78aa8ce2dab5047a733719972e99206a6d9faR1686-R1692) was added to  `rhmi_controller.go` which removed the old installation stages in order to cover upgrade scenarios. Now that this work is complete, that function should be removed before the next release.

# Verification steps
Passing the e2e tests should be sufficient verification but this PR can also be verified by installing RHOAM locally and/or via OLM. Then after verifying that the installation completed successfully, delete the rhmi CR and verify that everything is cleaned up.