### PR TITLE
MGDAPI-4355: Allow configuration of CRO maintenance window

### DIFF
--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -236,10 +236,10 @@ func (r *SubscriptionReconciler) allowDatabaseUpdates(ctx context.Context, insta
 			return fmt.Errorf("failed to list postgres instances: %w", err)
 		}
 		for _, pgInst := range postgresInstances.Items {
-			pgInst.Spec.AllowUpdates = true
-
-			if err := r.Client.Update(ctx, &pgInst); err != nil {
-				return err
+			inst := pgInst
+			inst.Spec.MaintenanceWindow = true
+			if err := r.Client.Update(ctx, &inst); err != nil {
+				return pkgerr.Wrap(err, fmt.Sprintf("failed to update maintenance window for postgres %s", inst.Name))
 			}
 		}
 
@@ -248,9 +248,10 @@ func (r *SubscriptionReconciler) allowDatabaseUpdates(ctx context.Context, insta
 			return fmt.Errorf("failed to list redis instances: %w", err)
 		}
 		for _, rdInst := range redisInstances.Items {
-			rdInst.Spec.AllowUpdates = true
-			if err := r.Client.Update(ctx, &rdInst); err != nil {
-				return err
+			inst := rdInst
+			inst.Spec.MaintenanceWindow = true
+			if err := r.Client.Update(ctx, &inst); err != nil {
+				return pkgerr.Wrap(err, fmt.Sprintf("failed to update maintenance window for postgres %s", inst.Name))
 			}
 		}
 	}

--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -9,6 +9,7 @@ import (
 	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/rhmi"
+	"github.com/integr8ly/integreatly-operator/version"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/sirupsen/logrus"
@@ -163,10 +164,6 @@ func (r *SubscriptionReconciler) shouldReconcileSubscription(request ctrl.Reques
 }
 
 func (r *SubscriptionReconciler) HandleUpgrades(ctx context.Context, rhmiSubscription *operatorsv1alpha1.Subscription, installation *integreatlyv1alpha1.RHMI) (ctrl.Result, error) {
-	if !rhmiConfigs.IsUpgradeAvailable(rhmiSubscription) {
-		log.Info("no upgrade available")
-		return ctrl.Result{}, nil
-	}
 	log.Infof("Verifying the fields in the Subscription", l.Fields{"StartingCSV": rhmiSubscription.Spec.StartingCSV, "InstallPlanRef": rhmiSubscription.Status.InstallPlanRef})
 	latestInstallPlan := &olmv1alpha1.InstallPlan{}
 	err := wait.Poll(time.Second*5, time.Minute*5, func() (done bool, err error) {
@@ -202,6 +199,20 @@ func (r *SubscriptionReconciler) HandleUpgrades(ctx context.Context, rhmiSubscri
 		return ctrl.Result{}, err
 	}
 
+	if !rhmiConfigs.IsUpgradeAvailable(rhmiSubscription) {
+		log.Info("no upgrade available")
+
+		// if we have not started update but are due to, and it was a serviceAffecting upgrade
+		// requeue so that we can enable maintenance window
+		if installation.Status.ToVersion != "" && installation.Status.Version != version.GetVersion() && isServiceAffecting {
+			return ctrl.Result{
+				Requeue:      true,
+				RequeueAfter: 10 * time.Second,
+			}, nil
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if !isServiceAffecting && !latestInstallPlan.Spec.Approved {
 		eventRecorder := r.mgr.GetEventRecorderFor("Operator Upgrade")
 		err = rhmiConfigs.ApproveUpgrade(ctx, r.Client, installation, latestInstallPlan, eventRecorder)
@@ -231,6 +242,7 @@ func (r *SubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 func (r *SubscriptionReconciler) allowDatabaseUpdates(ctx context.Context, installation *integreatlyv1alpha1.RHMI, isServiceAffecting bool) error {
 	if installation.Status.ToVersion != "" && isServiceAffecting {
+		log.Info("Service affecting and upgrading, setting maintenanceWindow to true")
 		postgresInstances := &crov1alpha1.PostgresList{}
 		if err := r.Client.List(ctx, postgresInstances); err != nil {
 			return fmt.Errorf("failed to list postgres instances: %w", err)

--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -2,10 +2,14 @@ package controllers
 
 import (
 	"context"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/rhmi"
+	"fmt"
 	"strings"
 	"time"
+
+	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/rhmi"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/sirupsen/logrus"
@@ -194,6 +198,11 @@ func (r *SubscriptionReconciler) HandleUpgrades(ctx context.Context, rhmiSubscri
 
 	isServiceAffecting := rhmiConfigs.IsUpgradeServiceAffecting(latestCSV)
 
+	err = r.allowDatabaseUpdates(ctx, r.Client, installation, isServiceAffecting)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
 	if !isServiceAffecting && !latestInstallPlan.Spec.Approved {
 		eventRecorder := r.mgr.GetEventRecorderFor("Operator Upgrade")
 		err = rhmiConfigs.ApproveUpgrade(ctx, r.Client, installation, latestInstallPlan, eventRecorder)
@@ -219,4 +228,41 @@ func (r *SubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&operatorsv1alpha1.Subscription{}).
 		Complete(r)
+}
+
+func (r *SubscriptionReconciler) allowDatabaseUpdates(ctx context.Context, client k8sclient.Client, installation *integreatlyv1alpha1.RHMI, isServiceAffecting bool) error {
+	if installation.Status.ToVersion != "" && isServiceAffecting {
+		postgresInstances := &crov1alpha1.PostgresList{}
+		err := client.List(ctx, postgresInstances)
+		if err != nil {
+			return fmt.Errorf("failed to list postgres instances: %w", err)
+		}
+		for _, pgInst := range postgresInstances.Items {
+			_, err := controllerutil.CreateOrUpdate(ctx, client, &pgInst, func() error {
+				pgInst.Spec.AllowUpdates = true
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+
+		redisInstances := &crov1alpha1.RedisList{}
+		err = client.List(ctx, redisInstances)
+		if err != nil {
+			return fmt.Errorf("failed to list redis instances: %w", err)
+		}
+
+		for _, rdInst := range redisInstances.Items {
+			_, err := controllerutil.CreateOrUpdate(ctx, client, &rdInst, func() error {
+				rdInst.Spec.AllowUpdates = true
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }

--- a/controllers/subscription/subscription_controller_test.go
+++ b/controllers/subscription/subscription_controller_test.go
@@ -511,7 +511,7 @@ func allowUpdatesValueIsCorrect(client k8sclient.Client, postgresName, redisName
 		return false, err
 	}
 
-	if pg.Spec.AllowUpdates != want || redis.Spec.AllowUpdates != want {
+	if pg.Spec.MaintenanceWindow != want || redis.Spec.MaintenanceWindow != want {
 		return false, nil
 	}
 	return true, nil

--- a/controllers/subscription/subscription_controller_test.go
+++ b/controllers/subscription/subscription_controller_test.go
@@ -99,6 +99,12 @@ func TestSubscriptionReconciler(t *testing.T) {
 				Spec: &v1alpha1.SubscriptionSpec{
 					InstallPlanApproval: v1alpha1.ApprovalAutomatic,
 				},
+				Status: v1alpha1.SubscriptionStatus{
+					InstallPlanRef: &v1.ObjectReference{
+						Name:      installPlan.Name,
+						Namespace: installPlan.Namespace,
+					},
+				},
 			},
 			Verify: func(c k8sclient.Client, res reconcile.Result, err error, t *testing.T) {
 				if err != nil {
@@ -131,6 +137,12 @@ func TestSubscriptionReconciler(t *testing.T) {
 				Spec: &v1alpha1.SubscriptionSpec{
 					InstallPlanApproval: v1alpha1.ApprovalAutomatic,
 				},
+				Status: v1alpha1.SubscriptionStatus{
+					InstallPlanRef: &v1.ObjectReference{
+						Name:      installPlan.Name,
+						Namespace: installPlan.Namespace,
+					},
+				},
 			},
 			Verify: func(c k8sclient.Client, res reconcile.Result, err error, t *testing.T) {
 				if err != nil {
@@ -162,6 +174,12 @@ func TestSubscriptionReconciler(t *testing.T) {
 				},
 				Spec: &v1alpha1.SubscriptionSpec{
 					InstallPlanApproval: v1alpha1.ApprovalAutomatic,
+				},
+				Status: v1alpha1.SubscriptionStatus{
+					InstallPlanRef: &v1.ObjectReference{
+						Name:      installPlan.Name,
+						Namespace: installPlan.Namespace,
+					},
 				},
 			},
 			Verify: func(c k8sclient.Client, res reconcile.Result, err error, t *testing.T) {


### PR DESCRIPTION
# Issue link
[MGDAPI-4355](https://issues.redhat.com/browse/MGDAPI-4355)

# What
- Added new function which will update Postgres and Redis CRs to signify whether or not database updates are allowed
- Added unit test for this function
> **Note**: The new field `allowUpdates` is needed from CRO (via CRO Release and vendor updates) before tests will pass 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
