### PR TITLE
MGDAPI-4388 - fix: wait for rhsso postgres to be completed 

### DIFF
--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -180,6 +180,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	// Wait for RHSSO postgres to be completed
+	phase, err = resources.WaitForRHSSOPostgresToBeComplete(client, installation.Name, r.ConfigManager.GetOperatorNamespace())
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileRedis(ctx, client)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -220,6 +220,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	// Wait for RHSSO postgres to be completed
+	phase, err = resources.WaitForRHSSOPostgresToBeComplete(serverClient, installation.Name, r.ConfigManager.GetOperatorNamespace())
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+		return phase, err
+	}
+
 	phase, err = r.ReconcileCloudResources(constants.RHSSOUserProstgresPrefix, defaultNamespace, ssoType, r.Config.RHSSOCommon, ctx, installation, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile cloud resources", err)

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/RHsyseng/operator-utils/pkg/olm"
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -722,6 +724,14 @@ var clusterVersion = &v12.ClusterVersion{
 	},
 }
 
+var rhssoPostgres = &crov1.Postgres{
+	ObjectMeta: metav1.ObjectMeta{
+		Name:      fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, "test-installation"),
+		Namespace: nsPrefix + defaultInstallationNamespace,
+	},
+	Status: crotypes.ResourceTypeStatus{Phase: crotypes.PhaseComplete},
+}
+
 func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallationNamespace string) []runtime.Object {
 	configManagerConfigMap.Namespace = integreatlyOperatorNamespace
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
@@ -747,6 +757,7 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 	zyncDatabase.Namespace = threeScaleInstallationNamespace
 	zyncQue.Namespace = threeScaleInstallationNamespace
 	threescale.Namespace = threeScaleInstallationNamespace
+	rhssoPostgres.Namespace = integreatlyOperatorNamespace
 
 	return []runtime.Object{
 		s3BucketSecret,
@@ -793,5 +804,6 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		zyncQue,
 		threescale,
 		clusterVersion,
+		rhssoPostgres,
 	}
 }

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -261,6 +261,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 			return phase, err
 		}
 
+		// Wait for RHSSO postgres to be completed
+		phase, err = resources.WaitForRHSSOPostgresToBeComplete(serverClient, installation.Name, r.ConfigManager.GetOperatorNamespace())
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+			return phase, err
+		}
+
 		phase, err = r.reconcileExternalDatasources(ctx, serverClient)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 			events.HandleError(r.recorder, installation, phase, "Failed to reconcile external data sources", err)

--- a/pkg/resources/waitForResources.go
+++ b/pkg/resources/waitForResources.go
@@ -1,0 +1,24 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
+	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func WaitForRHSSOPostgresToBeComplete(serverClient k8sclient.Client, installName, installNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+	postgres := &crov1alpha1.Postgres{}
+	if err := serverClient.Get(context.TODO(), k8sclient.ObjectKey{Name: fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installName), Namespace: installNamespace}, postgres); err != nil {
+		return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+	}
+
+	if postgres.Status.Phase == crotypes.PhaseComplete {
+		return integreatlyv1alpha1.PhaseCompleted, nil
+	}
+
+	return integreatlyv1alpha1.PhaseAwaitingComponents, nil
+}

--- a/pkg/resources/waitForResources_test.go
+++ b/pkg/resources/waitForResources_test.go
@@ -1,0 +1,87 @@
+package resources
+
+import (
+	"fmt"
+	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
+	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"testing"
+)
+
+func TestWaitForRHSSOPostgresToBeComplete(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = crov1alpha1.SchemeBuilder.AddToScheme(scheme)
+
+	const installationName = "test"
+	const installationNameSpace = "testNamespace"
+
+	type args struct {
+		serverClient     client.Client
+		installName      string
+		installNamespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    integreatlyv1alpha1.StatusPhase
+		wantErr bool
+	}{
+		{
+			name: "test phase complete when postgres phase complete",
+			args: args{
+				serverClient: fake.NewFakeClientWithScheme(scheme, &crov1alpha1.Postgres{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installationName),
+						Namespace: installationNameSpace,
+					},
+					Status: crotypes.ResourceTypeStatus{Phase: crotypes.PhaseComplete},
+				}),
+				installName:      installationName,
+				installNamespace: installationNameSpace,
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+		{
+			name: "test phase awaiting components when postgres phase not complete",
+			args: args{
+				serverClient: fake.NewFakeClientWithScheme(scheme, &crov1alpha1.Postgres{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      fmt.Sprintf("%s%s", constants.RHSSOPostgresPrefix, installationName),
+						Namespace: installationNameSpace,
+					},
+					Status: crotypes.ResourceTypeStatus{Phase: crotypes.PhaseInProgress},
+				}),
+				installName:      installationName,
+				installNamespace: installationNameSpace,
+			},
+			want: integreatlyv1alpha1.PhaseAwaitingComponents,
+		},
+		{
+			name: "test phase awaiting components when unable to get postgres cr",
+			args: args{
+				serverClient:     fake.NewFakeClientWithScheme(scheme),
+				installName:      installationName,
+				installNamespace: installationNameSpace,
+			},
+			want: integreatlyv1alpha1.PhaseAwaitingComponents,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := WaitForRHSSOPostgresToBeComplete(tt.args.serverClient, tt.args.installName, tt.args.installNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("WaitForRHSSOPostgresToBeComplete() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("WaitForRHSSOPostgresToBeComplete() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4388

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Wait for RHSSO postgres to be complete before provisioning other cloud resources

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Install RHOAM from this branch
* Verify other cloud resources are not provisioned until RHSSO postgres is complete
```
watch "oc get postgres -n redhat-rhoam-operator; oc get redis -n redhat-rhoam-operator; oc get blobstorage -n redhat-rhoam-operator"
```