### PR TITLE
MGDAPI-3855 - Implement persistent volume for alert manager

### DIFF
--- a/pkg/config/observability.go
+++ b/pkg/config/observability.go
@@ -127,6 +127,10 @@ func (m *Observability) GetAlertManagerServiceName() string {
 	return AlertManagerOverride
 }
 
+func (m *Observability) GetAlertManagerStorageRequest() string {
+	return "1Gi"
+}
+
 func (m *Observability) GetPrometheusVersion() string {
 	return "v2.29.2"
 }

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -406,6 +406,17 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 					},
 				},
 			},
+			AlertManagerStorageSpec: &prometheus.StorageSpec{
+				VolumeClaimTemplate: prometheus.EmbeddedPersistentVolumeClaim{
+					Spec: v1.PersistentVolumeClaimSpec{
+						Resources: v1.ResourceRequirements{
+							Requests: v1.ResourceList{
+								"storage": resource.MustParse(r.Config.GetAlertManagerStorageRequest()),
+							},
+						},
+					},
+				},
+			},
 		}
 
 		oo.Spec.Retention = r.Config.GetPrometheusRetention()

--- a/test/common/pvc_validate.go
+++ b/test/common/pvc_validate.go
@@ -45,6 +45,7 @@ func commonPvcNamespaces() []PersistentVolumeClaim {
 			Namespace: NamespacePrefix + "observability",
 			PersistentVolumeClaimNames: []string{
 				"prometheus-prometheus-db-prometheus-prometheus-0",
+				"alertmanager-alertmanager-db-alertmanager-alertmanager-0",
 			},
 		},
 	}


### PR DESCRIPTION
# Issue link
Implement persistent volume for alert manager
https://issues.redhat.com/browse/MGDAPI-3855
- It's new PR (instead of https://github.com/integr8ly/integreatly-operator/pull/2774). New PR is using OO v3.0.13 (OO includes fix of issue of duplicated Prometheus PVC in case of Upgrade)

# What
- Implement persistent volume for alert manager

# Verification steps
1. Check that Alertmanager PVC created in redhat-rhoam-observability namespace. For example:
```
$ oc get pvc -n redhat-rhoam-observability
NAME                                                       STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
alertmanager-alertmanager-db-alertmanager-alertmanager-0   Bound    pvc-214aa865-88bf-485f-8aa1-499635762fc9   1Gi        RWO            gp3            14m
prometheus-prometheus-db-prometheus-prometheus-0           Bound    pvc-2273db8a-6534-48db-8889-e67d6fcd4c8c   50Gi       RWO            gp3            6h19m
```
2, Enter Alertmanager UI, Silent/Snooze any alert (for example alertname="DeadMansSwitch"), kill alertmanager pod , wait for recreation of the pod, enter again Alertmanager UI, and see that alert still snoozed


