### PR TITLE
MGDAPI-1905 Implement a workaround for the lack of STS support in 3Sc…

### DIFF
--- a/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
+++ b/apis/v1alpha1/addtoscheme_integreatly_v1alpha1.go
@@ -51,6 +51,8 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
+
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 )
 
 // AddToSchemes may be used to add all resources defined in the project to a Scheme
@@ -97,5 +99,6 @@ func init() {
 		apiextensionv1.SchemeBuilder.AddToScheme,
 		observabilityoperator.SchemeBuilder.AddToScheme,
 		customdomainv1alpha1.AddToScheme,
+		cloudcredentialv1.AddToScheme,
 	)
 }

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -249,6 +249,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - operator.openshift.io
+  resources:
+  - cloudcredentials
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operators.coreos.com
   resourceNames:
   - rhmi-registry-cs

--- a/config/secrets/custom-addon-secret.yaml
+++ b/config/secrets/custom-addon-secret.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: quota-secret
+  name: addon-params-secret
 objects:
   - apiVersion: v1
     kind: Secret
@@ -14,6 +14,9 @@ objects:
       custom-smtp-password: ${PASSWORD}
       custom-smtp-port: ${PORT}
       custom-smtp-from_address: ${FROM}
+      sts-role-arn: ${StsRoleARN}
+      s3-access-key-id: ${S3_ACCESS_KEY_ID}
+      s3-secret-access-key: ${S3_SECRET_ACCESS_KEY}
 parameters:
   - name: QUOTA
     # QUOTA value is per 100,000
@@ -28,3 +31,9 @@ parameters:
     value: "567"
   - name: FROM
     value: "test@example.com"
+  - name: StsRoleARN
+    value: "arn:aws:iam::485026278258:role/12345"
+  - name: S3_ACCESS_KEY_ID
+    value: "123"
+  - name: S3_SECRET_ACCESS_KEY
+    value: "secret"

--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -2,10 +2,14 @@ package controllers
 
 import (
 	"context"
+	"fmt"
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
+	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	v1 "github.com/prometheus/client_golang/api/prometheus/v1"
 	"github.com/prometheus/common/model"
 	corev1 "k8s.io/api/core/v1"
@@ -208,5 +212,105 @@ func TestGetCrName(t *testing.T) {
 		if !reflect.DeepEqual(got, tt.want) {
 			t.Errorf("getCrName() got = %v, want %v", got, tt.want)
 		}
+	}
+}
+
+func Test_validateAddOnStsRoleArnParameterPattern(t *testing.T) {
+	scheme := runtime.NewScheme()
+	_ = corev1.SchemeBuilder.AddToScheme(scheme)
+	_ = olmv1alpha1.SchemeBuilder.AddToScheme(scheme)
+
+	const namespace = "test"
+
+	type args struct {
+		client    client.Client
+		namespace string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "test: can't get secret",
+			args: args{
+				client: &moqclient.SigsClientInterfaceMock{
+					ListFunc: func(ctx context.Context, list runtime.Object, opts ...client.ListOption) error {
+						return fmt.Errorf("listError")
+					},
+				},
+				namespace: namespace,
+			},
+			wantErr: true,
+			want:    false,
+		},
+		{
+			name: "test: role arn not found",
+			args: args{
+				client:    fakeclient.NewFakeClientWithScheme(scheme),
+				namespace: namespace,
+			},
+			wantErr: true,
+			want:    false,
+		},
+		{
+			name: "test: role arn empty",
+			args: args{
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("")})),
+				namespace: namespace,
+			},
+			wantErr: true,
+			want:    false,
+		},
+		{
+			name: "test: role arn regex not match",
+			args: args{
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("notAnARN")})),
+				namespace: namespace,
+			},
+			wantErr: true,
+			want:    false,
+		},
+		{
+			name: "test: role arn regex match",
+			args: args{
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("arn:aws:iam::123456789012:role/12345")})),
+				namespace: namespace,
+			},
+			wantErr: false,
+			want:    true,
+		},
+		{
+			name: "test: role arn regex match for AWS GovCloud (US) Regions",
+			args: args{
+				client:    fakeclient.NewFakeClientWithScheme(scheme, buildAddonSecret(namespace, map[string][]byte{sts.RoleArnParameterName: []byte("arn:aws-us-gov:iam::123456789012:role/12345")})),
+				namespace: namespace,
+			},
+			wantErr: false,
+			want:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateAddOnStsRoleArnParameterPattern(tt.args.client, tt.args.namespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateAddOnStsRoleArnParameterPattern() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateAddOnStsRoleArnParameterPattern() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func buildAddonSecret(namespace string, secretData map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "addon-managed-api-service-parameters",
+			Namespace: namespace,
+		},
+		Data: secretData,
 	}
 }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	"strings"
 	"time"
 
@@ -161,6 +162,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s namespace", operatorNamespace), err)
 		return phase, err
+	}
+
+	// Check if STS Cluster, get STS role ARN addon parameter and pass ARN to Secret in CRO namespace
+	r.log.Info("checking if STS mode")
+	isSTS, err := sts.IsClusterSTS(ctx, client, r.log)
+	if err != nil {
+		r.log.Error("Error checking STS mode", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if isSTS {
+		phase, err = r.createSTSARNSecret(ctx, client, operatorNamespace)
+		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+			events.HandleError(r.recorder, installation, phase, "Failed to create STS secret", err)
+			return phase, err
+		}
 	}
 
 	if err := r.reconcileCIDRValue(ctx, client); err != nil {
@@ -596,4 +612,33 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 	cfgMap.Data["_network"] = string(networkJSON)
 
 	return client.Patch(ctx, cfgMap, k8sclient.Merge)
+}
+
+// createSTSARNSecret create the STS arn secret - should be already validated in preflight checks
+func (r *Reconciler) createSTSARNSecret(ctx context.Context, client k8sclient.Client, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+	stsRoleArn, err := sts.GetSTSRoleARN(ctx, client, r.installation.Namespace)
+	if err != nil {
+		r.log.Error("STS role ARN parameter pattern validation failed", err)
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	// create CRO credentials secret
+	credSec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      sts.CredsSecretName,
+			Namespace: operatorNamespace,
+		},
+		Data: map[string][]byte{},
+	}
+
+	_, err = controllerutil.CreateOrUpdate(ctx, client, credSec, func() error {
+		credSec.Data[sts.CredsSecretRoleARNKeyName] = []byte(stsRoleArn)
+		credSec.Data[sts.CredsSecretTokenPathKeyName] = []byte("/var/run/secrets/openshift/serviceaccount/token")
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to update CRO credentials Secret. Failed to pass ARN into secret: %w", err)
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
 }

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	keycloak "github.com/keycloak/keycloak-operator/pkg/apis/keycloak/v1alpha1"
 	oauthv1 "github.com/openshift/api/oauth/v1"
 	projectv1 "github.com/openshift/api/project/v1"
@@ -22,6 +23,7 @@ import (
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -241,4 +243,90 @@ func getBuildScheme() (*runtime.Scheme, error) {
 		return nil, err
 	}
 	return scheme, err
+}
+
+func TestReconciler_createSTSArnSecret(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("Error obtaining scheme")
+	}
+
+	type fields struct {
+		Config        *config.CloudResources
+		ConfigManager config.ConfigReadWriter
+		installation  *integreatlyv1alpha1.RHMI
+		mpm           marketplace.MarketplaceInterface
+		log           logger.Logger
+		Reconciler    *resources.Reconciler
+		recorder      record.EventRecorder
+	}
+	type args struct {
+		ctx               context.Context
+		client            client.Client
+		operatorNamespace string
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    integreatlyv1alpha1.StatusPhase
+		wantErr bool
+	}{
+		{
+			name: "test: phase failed on error getting role arn",
+			fields: fields{
+				log: getLogger(),
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{Namespace: defaultInstallationNamespace},
+				},
+			},
+			args: args{
+				client: moqclient.NewSigsClientMoqWithScheme(scheme),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "test: phase complete on creating secret",
+			fields: fields{
+				log: getLogger(),
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{Namespace: defaultInstallationNamespace},
+				},
+			},
+			args: args{
+				client: moqclient.NewSigsClientMoqWithScheme(scheme, &corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "addon-managed-api-service-parameters",
+						Namespace: defaultInstallationNamespace,
+					},
+					Data: map[string][]byte{
+						sts.RoleArnParameterName: []byte("arn:aws:iam::123456789012:role/12345"),
+					},
+				}),
+			},
+			want: integreatlyv1alpha1.PhaseCompleted,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				Config:        tt.fields.Config,
+				ConfigManager: tt.fields.ConfigManager,
+				installation:  tt.fields.installation,
+				mpm:           tt.fields.mpm,
+				log:           tt.fields.log,
+				Reconciler:    tt.fields.Reconciler,
+				recorder:      tt.fields.recorder,
+			}
+			got, err := r.createSTSARNSecret(tt.args.ctx, tt.args.client, tt.args.operatorNamespace)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("createSTSARNSecret() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("createSTSARNSecret() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
@@ -23,6 +24,7 @@ import (
 	v12 "github.com/openshift/api/config/v1"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -771,6 +773,15 @@ var ingressRouterService = &corev1.Service{
 	},
 }
 
+var cloudCredential = &cloudcredentialv1.CloudCredential{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: sts.ClusterCloudCredentialName,
+	},
+	Spec: cloudcredentialv1.CloudCredentialSpec{
+		CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+	},
+}
+
 func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallationNamespace string) []runtime.Object {
 	configManagerConfigMap.Namespace = integreatlyOperatorNamespace
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
@@ -845,5 +856,6 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		clusterVersion,
 		rhssoPostgres,
 		ingressRouterService,
+		cloudCredential,
 	}
 }

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"github.com/foxcpp/go-mockdns"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
 	"net"
 	"net/http"
@@ -44,6 +45,7 @@ import (
 	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	consolev1 "github.com/openshift/api/console/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -79,6 +81,7 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	err = openshiftv1.AddToScheme(scheme)
 	err = configv1.AddToScheme(scheme)
 	err = customdomainv1alpha1.AddToScheme(scheme)
+	err = cloudcredentialv1.AddToScheme(scheme)
 
 	return scheme, err
 }
@@ -448,9 +451,13 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test successful reconcile of s3 blob storage",
+			name: "test successful reconcile of s3 blob storage, non STS mode",
 			fields: fields{
-				ConfigManager: nil,
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
 				Config: config.NewThreeScale(config.ProductConfig{
 					"NAMESPACE": "test",
 				}),
@@ -463,16 +470,17 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			},
 			args: args{
 				ctx: context.TODO(),
-				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(), &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
 					},
-					Data: map[string][]byte{
-						"credentialKeyID":     []byte("test"),
-						"credentialSecretKey": []byte("test"),
-					},
-				},
 					&threescalev1.APIManager{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -481,6 +489,76 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 						},
 						Spec:   threescalev1.APIManagerSpec{},
 						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseInProgress,
+			wantErr: false,
+		},
+		{
+			name: "test successful reconcile of s3 blob storage, STS mode",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							sts.CredsS3AccessKeyId:     []byte("123"),
+							sts.CredsS3SecretAccessKey: []byte("123"),
+						},
 					}),
 			},
 			want:    integreatlyv1alpha1.PhaseInProgress,

--- a/pkg/resources/sts/sts.go
+++ b/pkg/resources/sts/sts.go
@@ -1,0 +1,89 @@
+package sts
+
+import (
+	"context"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"os"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	ClusterCloudCredentialName  = "cluster"
+	RoleArnParameterName        = "sts-role-arn"
+	RoleSessionName             = "Red-Hat-cloud-resources-operator"
+	CredsSecretName             = "sts-credentials"
+	CredsSecretRoleARNKeyName   = "role_arn"
+	CredsSecretTokenPathKeyName = "web_identity_token_file"
+	CredsRoleEnvKey             = "ROLE_ARN"
+	CredsTokenPathEnvKey        = "TOKEN_PATH"
+	CredsS3AccessKeyId          = "s3-access-key-id"
+	CredsS3SecretAccessKey      = "s3-secret-access-key"
+)
+
+func IsClusterSTS(ctx context.Context, client k8sclient.Client, log logger.Logger) (bool, error) {
+	cloudCredential := &cloudcredentialv1.CloudCredential{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{Name: ClusterCloudCredentialName}, cloudCredential); err != nil {
+		log.Error("failed to get cloudCredential whle checking if STS mode", err)
+		return false, err
+	}
+
+	if cloudCredential.Spec.CredentialsMode == cloudcredentialv1.CloudCredentialsModeManual {
+		log.Info("STS mode")
+		return true, nil
+	}
+	log.Info("non STS mode")
+	return false, nil
+}
+
+// GetSTSRoleARN retrieves the role ARN addon parameter to be used by CRO
+func GetSTSRoleARN(ctx context.Context, client k8sclient.Client, namespace string) (string, error) {
+	stsRoleArn, stsFound, err := addon.GetStringParameter(
+		ctx,
+		client,
+		namespace,
+		RoleArnParameterName,
+	)
+	if err != nil {
+		return "", fmt.Errorf("failed while retrieving addon parameter %w", err)
+	}
+	if !stsFound || stsRoleArn == "" {
+		return "", fmt.Errorf("no STS configuration found")
+	}
+
+	return stsRoleArn, nil
+}
+
+// GetSTSCredentials retrieves the STS secret used by CRO
+func GetSTSCredentials(ctx context.Context, client k8sclient.Client, namespace string) (string, string, error) {
+	secret := &corev1.Secret{}
+	if err := client.Get(ctx, types.NamespacedName{Name: CredsSecretName, Namespace: namespace}, secret); err != nil {
+		return "", "", fmt.Errorf("failed getting secret %s from ns %s: %w", CredsSecretName, namespace, err)
+	}
+	roleARN := string(secret.Data[CredsSecretRoleARNKeyName])
+	tokenPath := string(secret.Data[CredsSecretTokenPathKeyName])
+	if roleARN == "" || tokenPath == "" {
+		return "", "", fmt.Errorf("sts credentials secret can't be empty")
+	}
+	return roleARN, tokenPath, nil
+}
+
+// GetSTSCredentialsFromEnvVar Gets the role arn and token file path from environment variable
+// Should only be used in functional test container
+func GetSTSCredentialsFromEnvVar() (string, string, error) {
+	roleARN, found := os.LookupEnv(CredsRoleEnvKey)
+	if !found {
+		return "", "", fmt.Errorf("%s key should not be empty", CredsRoleEnvKey)
+	}
+
+	tokenPath, found := os.LookupEnv(CredsTokenPathEnvKey)
+	if !found {
+		return "", "", fmt.Errorf("%s key should not be empty", CredsRoleEnvKey)
+	}
+
+	return roleARN, tokenPath, nil
+}

--- a/pkg/resources/sts/sts_test.go
+++ b/pkg/resources/sts/sts_test.go
@@ -1,0 +1,108 @@
+package sts
+
+import (
+	"context"
+	"fmt"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func getBuildScheme() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	err := cloudcredentialv1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+	err = corev1.AddToScheme(scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return scheme, err
+}
+
+func TestIsClusterSTS(t *testing.T) {
+	scheme, err := getBuildScheme()
+	if err != nil {
+		t.Fatalf("Error obtaining scheme")
+	}
+
+	type args struct {
+		ctx    context.Context
+		client client.Client
+		log    logger.Logger
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    bool
+		wantErr bool
+	}{
+		{
+			name: "failed to get cluster cloud credential",
+			args: args{
+				ctx: context.TODO(),
+				client: &moqclient.SigsClientInterfaceMock{GetFunc: func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					return fmt.Errorf("get error")
+				}},
+				log: logger.NewLogger(),
+			},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name: "STS cluster",
+			args: args{
+				ctx: context.TODO(),
+				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterCloudCredentialName,
+					},
+					Spec: cloudcredentialv1.CloudCredentialSpec{
+						CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+					},
+				}),
+				log: logger.NewLogger(),
+			},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "Non STS cluster",
+			args: args{
+				ctx: context.TODO(),
+				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: ClusterCloudCredentialName,
+					},
+					Spec: cloudcredentialv1.CloudCredentialSpec{
+						CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+					},
+				}),
+				log: logger.NewLogger(),
+			},
+			want:    false,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := IsClusterSTS(tt.args.ctx, tt.args.client, tt.args.log)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsClusterSTS() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsClusterSTS() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/test-cases/tests/backup-restore/j05b-verify-3scale-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j05b-verify-3scale-backup-and-restore.md
@@ -77,11 +77,18 @@ Once verified, delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 ./j05-verify-3scale-postgres-backup-and-restore.sh | tee test-output.txt
+```
+
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j05-verify-3scale-postgres-backup-and-restore.sh | tee test-output.txt
 ```
 
 4. Wait for the script to finish without errors

--- a/test-cases/tests/backup-restore/j07b-verify-cluster-sso-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j07b-verify-cluster-sso-backup-and-restore.md
@@ -73,15 +73,22 @@ Once verified. Delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 NS_PREFIX=redhat-rhoam ./j07-verify-rhsso-backup-and-restore.sh | tee test-output.txt
 ```
 
-4. Wait for the script to finish without errors
-5. Verify in the `test-output.txt` log that the test finished successfully.
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j07-verify-rhsso-backup-and-restore.sh | tee test-output.txt
+```
+
+5. Wait for the script to finish without errors
+6. Verify in the `test-output.txt` log that the test finished successfully.
 
 **Note**
 Sometimes there could be a difference between the DB dump files, caused by a changed order of lines in these files. That is not considered to be an issue. More details: https://issues.redhat.com/browse/MGDAPI-2380

--- a/test-cases/tests/backup-restore/j08b-verify-user-sso-backup-and-restore.md
+++ b/test-cases/tests/backup-restore/j08b-verify-user-sso-backup-and-restore.md
@@ -74,15 +74,22 @@ Once verified. Delete the throwaway Postgres
 oc delete -n redhat-rhoam-operator postgres/throw-away-postgres
 ```
 
-3. Run the backup and restore script
+3. **Non-STS** - Run the backup and restore script
 
 ```sh
 cd test/scripts/backup-restore
 NS_PREFIX=redhat-rhoam ./j08-verify-user-sso-backup-and-restore.sh | tee test-output.txt
 ```
 
-4. Wait for the script to finish without errors
-5. Verify in the `test-output.txt` log that the test finished successfully.
+4. **STS** - Reach out to QE for the `osdCcsAdmin` credentials in order to run the backup and restore script
+
+```sh
+cd test/scripts/backup-restore
+AWS_ACCESS_KEY_ID=<aws_access_key_id> AWS_SECRET_ACCESS_KEY=<aws_secret_access_key> NS_PREFIX=redhat-rhoam ./j08-verify-user-sso-backup-and-restore.sh | tee test-output.txt
+```
+
+5. Wait for the script to finish without errors
+6. Verify in the `test-output.txt` log that the test finished successfully.
 
 **Note**
 Sometimes there could be a difference between the DB dump files, caused by a changed order of lines in these files. That is not considered to be an issue. More details: https://issues.redhat.com/browse/MGDAPI-2380

--- a/test/functional/aws_shared_functions.go
+++ b/test/functional/aws_shared_functions.go
@@ -5,13 +5,18 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
+	stsSvc "github.com/aws/aws-sdk-go/service/sts"
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	croTypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
@@ -184,37 +189,40 @@ func GetS3BlobStorageResourceIDs(ctx context.Context, client client.Client, rhmi
 	return foundResourceIDs, foundErrors
 }
 
-// creates a session to be used in getting an api instance for aws
+// CreateAWSSession creates a session to be used in getting an api instance for aws
 func CreateAWSSession(ctx context.Context, client client.Client) (*session.Session, error) {
-	//retrieve aws credentials for creating an aws session
-	awsSecretAccessKey, awsAccessKeyID, err := getAWSCredentials(ctx, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get AWS credentials : %w", err)
-	}
-
-	//retrieve aws region for creating an aws session
 	region, err := getAWSRegion(ctx, client)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get AWS cluster region : %w", err)
 	}
-
-	//create new session for aws api's
-	sess, err := createAWSSession(awsSecretAccessKey, awsAccessKeyID, region)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create session : %w", err)
+	awsConfig := aws.Config{
+		Region: aws.String(region),
 	}
-	return sess, nil
-}
-
-// createAWSSession returns a new session from aws
-func createAWSSession(awsAccessKeyID, awsSecretAccessKey, region string) (*session.Session, error) {
-	sess, err := session.NewSession(&aws.Config{
-		Credentials: credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, ""),
-		Region:      aws.String(region),
-	})
+	isSTS, err := sts.IsClusterSTS(ctx, client, logger.NewLogger())
 	if err != nil {
-		return nil, fmt.Errorf("cannot create new session with aws : %w", err)
+		return nil, err
 	}
+	if isSTS {
+		roleARN, tokenPath, err := sts.GetSTSCredentialsFromEnvVar()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get STS credentials: %w", err)
+		}
+		if k8s.IsRunLocally() {
+			sess := session.Must(session.NewSession(&awsConfig))
+			awsConfig.Credentials = stscreds.NewCredentials(sess, roleARN)
+		} else {
+			svc := stsSvc.New(session.Must(session.NewSession(&awsConfig)))
+			credentialsProvider := stscreds.NewWebIdentityRoleProvider(svc, roleARN, sts.RoleSessionName, tokenPath)
+			awsConfig.Credentials = credentials.NewCredentials(credentialsProvider)
+		}
+	} else {
+		awsSecretAccessKey, awsAccessKeyID, err := getAWSCredentials(ctx, client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get AWS credentials: %w", err)
+		}
+		awsConfig.Credentials = credentials.NewStaticCredentials(awsAccessKeyID, awsSecretAccessKey, "")
+	}
+	sess := session.Must(session.NewSession(&awsConfig))
 	return sess, nil
 }
 
@@ -231,15 +239,14 @@ func getAWSRegion(ctx context.Context, client client.Client) (string, error) {
 	return infra.Status.PlatformStatus.AWS.Region, nil
 }
 
-//getAWSCredentials retrieves credentials from secret namespace
+//getAWSCredentials retrieves aws credentials from secret namespace
 func getAWSCredentials(ctx context.Context, client client.Client) (string, string, error) {
 	secret := &corev1.Secret{}
 	if err := client.Get(ctx, types.NamespacedName{Name: awsCredsSecretName, Namespace: awsCredsNamespace}, secret); err != nil {
-		return "", "", fmt.Errorf("failed getting secret: %v from cluster: %w ", awsCredsSecretName, err)
+		return "", "", fmt.Errorf("failed getting secret %s from ns %s: %w", awsCredsSecretName, awsCredsNamespace, err)
 	}
 	awsAccessKeyID := string(secret.Data["aws_access_key_id"])
 	awsSecretAccessKey := string(secret.Data["aws_secret_access_key"])
-
 	if awsAccessKeyID == "" && awsSecretAccessKey == "" {
 		return "", "", errors.New("aws credentials secret can't be empty")
 	}
@@ -274,24 +281,6 @@ func getStrategyForResource(configMap *v1.ConfigMap, resourceType, tier string) 
 		return nil, fmt.Errorf("no strategy found for deployment type: %s and deployment tier: %s", resourceType, tier)
 	}
 	return strategyMapping[tier], nil
-}
-
-func putStrategyForResource(configMap *v1.ConfigMap, stratMap *strategyMap, resourceType, tier string) error {
-	rawStrategyMapping := configMap.Data[resourceType]
-	if rawStrategyMapping == "" {
-		return fmt.Errorf("aws strategy for resource type: %s is not defined", resourceType)
-	}
-	var strategyMapping map[string]*strategyMap
-	if err := json.Unmarshal([]byte(rawStrategyMapping), &strategyMapping); err != nil {
-		return fmt.Errorf("failed to unmarshal strategy mapping for resource type %s: %v", resourceType, err)
-	}
-	strategyMapping[tier] = stratMap
-	updatedRawStrategyMapping, err := json.Marshal(strategyMapping)
-	if err != nil {
-		return fmt.Errorf("failed to marshal strategy mapping for resource type %s: %v", resourceType, err)
-	}
-	configMap.Data[resourceType] = string(updatedRawStrategyMapping)
-	return nil
 }
 
 // GetClustersAvailableZones returns a map containing zone names that are currently available

--- a/test/scripts/backup-restore/j05-verify-3scale-postgres-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j05-verify-3scale-postgres-backup-and-restore.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+# USAGE
+# ./j05-verify-3scale-postgres-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests 3scale postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
@@ -15,9 +25,14 @@ else
 fi
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhoam}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)
 AWS_DB_ID=$(oc get secret/system-database -o go-template --template="{{.data.URL|base64decode}}" -n ${NS_PREFIX}-3scale | $grep_cmd -Po "(?<=@).*?(?=\.)")
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')

--- a/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j07-verify-rhsso-backup-and-restore.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
+# USAGE
+# ./j07-verify-rhsso-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests RHSSO postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhmi}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_secret_access_key} | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_access_key_id} | base64 --decode)
 AWS_DB_ID=$(oc get secret/keycloak-db-secret -o go-template --template="{{.data.POSTGRES_EXTERNAL_ADDRESS|base64decode}}" -n ${NS_PREFIX}-rhsso | awk -F\. '{print $1}')
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')

--- a/test/scripts/backup-restore/j08-verify-user-sso-backup-and-restore.sh
+++ b/test/scripts/backup-restore/j08-verify-user-sso-backup-and-restore.sh
@@ -1,12 +1,27 @@
 #!/bin/sh
+# USAGE
+# ./j08-verify-user-sso-backup-and-restore <optional NS_PREFIX> <optional AWS_ACCESS_KEY_ID> <optional AWS_SECRET_ACCESS_KEY>
+# ^C to break
+# Tests User SSO postgres back up and restore
+#
+# AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID should be set before running the script to support STS clusters as AWS
+# AWS credentials are not available on STS clusters. By default the script will try to use the credentials on cluster.
+#
+# PREREQUISITES
+# - oc (logged in at the cmd line)
 
 # Import the test function
 . ./postgres.sh --source-only
 
 # Set the parameters
+# Use passed in AWS credentials for STS, otherwise default to getting from cluster for normal OSD. Exit if these credentials are empty
+export AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_access_key_id}' | base64 --decode)}
+[[ -z "$AWS_ACCESS_KEY_ID" ]] && { echo "AWS_ACCESS_KEY_ID cannot be empty"; exit 1; }
+
+export AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:=$(oc get secret aws-creds -n kube-system -o jsonpath='{.data.aws_secret_access_key}' | base64 --decode)}
+[[ -z "$AWS_SECRET_ACCESS_KEY" ]] && { echo "AWS_SECRET_ACCESS_KEY cannot be empty"; exit 1; }
+
 NS_PREFIX="${NS_PREFIX:=redhat-rhmi}"
-export AWS_SECRET_ACCESS_KEY=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_secret_access_key} | base64 --decode)
-export AWS_ACCESS_KEY_ID=$(oc get secret aws-creds -n kube-system -o jsonpath={.data.aws_access_key_id} | base64 --decode)
 AWS_DB_ID=$(oc get secret/keycloak-db-secret -o go-template --template="{{.data.POSTGRES_EXTERNAL_ADDRESS|base64decode}}" -n ${NS_PREFIX}-user-sso | awk -F\. '{print $1}')
 AWS_REGION=$(oc get infrastructure cluster -o jsonpath='{.status.platformStatus.aws.region}')
 RHMI_CR_NAME=$(oc get rhmi -n ${NS_PREFIX}-operator -o json | jq -r '.items[0].metadata.name')


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1905
This is New branch/PR recreated from https://github.com/integr8ly/integreatly-operator/pull/2806

# What
3Scale does not support STS mode of authentication with AWS, and we need to provide a temporary workaround.
Our workaround would be to ask customer to create an IAM account dedicated to 3Scale and pass credentials for this IAM account through two new addon parameters. This IAM account would allow access only to S3 bucket(s) with a predefined name(s). 
This logic is implemented in current PR

# Verification steps
**STS Cluster**
- Prepare STS cluster
- Install Rhoam from this branch
- Open your cluster OSD UI
- Open Secret *addon-managed-api-service-parameters* in Project *redhat-rhoam-operator*
  - Edit Secret, set your values for *tmp-s3-access-key-id* and *tmp-s3-secret-access-key* parameters
- Open Secret *s3-credentials* in Project *redhat-rhoam-3scale*
  - Reveal values and check that *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* - updated, and have same values as *tmp-s3-access-key-id* and *tmp-s3-secret-access-key* parameters in *addon-managed-api-service-parameters* in Project *redhat-rhoam-operator*.

**NON-STS cluster**
- Prepare Non-STS cluster
- Do similar steps as for STS cluster
- See that *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* parameters of *s3-credentials* Secret have not changed.
