### PR TITLE
MGDAPI-1905 Implement a workaround for the lack of STS support in 3Scale

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ SMTP_PASS ?= ''
 SMTP_PORT ?= ''
 SMTP_FROM ?= ''
 ROLE_ARN ?= "arn:aws:iam::485026278258:role/12345"
+S3_ACCESS_KEY_ID ?= "123"
+S3_SECRET_ACCESS_KEY ?= "secret"
 TYPE_OF_MANIFEST ?= master
 
 CONTAINER_ENGINE ?= docker
@@ -379,8 +381,9 @@ cluster/prepare/dms:
 
 .PHONY: cluster/prepare/addon-params
 cluster/prepare/addon-params:
-	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) StsRoleARN=$(ROLE_ARN) USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) -f config/secrets/addon-params-secret.yaml | oc apply -f -
-
+	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) StsRoleARN=$(ROLE_ARN) \
+		S3_ACCESS_KEY_ID=$(S3_ACCESS_KEY_ID) S3_SECRET_ACCESS_KEY=$(S3_SECRET_ACCESS_KEY) \
+ 		USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) -f config/secrets/addon-params-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/quota/trial
 cluster/prepare/quota/trial:

--- a/config/secrets/addon-params-secret.yaml
+++ b/config/secrets/addon-params-secret.yaml
@@ -15,6 +15,8 @@ objects:
       custom-smtp-port: ${PORT}
       custom-smtp-from_address: ${FROM}
       sts-role-arn: ${StsRoleARN}
+      s3-access-key-id: ${S3_ACCESS_KEY_ID}
+      s3-secret-access-key: ${S3_SECRET_ACCESS_KEY}
 parameters:
   - name: QUOTA
     # QUOTA value is per 100,000
@@ -31,3 +33,7 @@ parameters:
     value: "test@example.com"
   - name: StsRoleARN
     value: "arn:aws:iam::485026278258:role/12345"
+  - name: S3_ACCESS_KEY_ID
+    value: "123"
+  - name: S3_SECRET_ACCESS_KEY
+    value: "secret"

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -22,6 +23,7 @@ import (
 	v12 "github.com/openshift/api/config/v1"
 	coreosv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -732,6 +734,15 @@ var rhssoPostgres = &crov1.Postgres{
 	Status: crotypes.ResourceTypeStatus{Phase: crotypes.PhaseComplete},
 }
 
+var cloudCredential = &cloudcredentialv1.CloudCredential{
+	ObjectMeta: metav1.ObjectMeta{
+		Name: sts.ClusterCloudCredentialName,
+	},
+	Spec: cloudcredentialv1.CloudCredentialSpec{
+		CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+	},
+}
+
 func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallationNamespace string) []runtime.Object {
 	configManagerConfigMap.Namespace = integreatlyOperatorNamespace
 	s3BucketSecret.Namespace = integreatlyOperatorNamespace
@@ -805,5 +816,6 @@ func getSuccessfullTestPreReqs(integreatlyOperatorNamespace, threeScaleInstallat
 		threescale,
 		clusterVersion,
 		rhssoPostgres,
+		cloudCredential,
 	}
 }

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -5,8 +5,10 @@ import (
 	"errors"
 	"fmt"
 	envoycorev3 "github.com/envoyproxy/go-control-plane/envoy/config/core/v3"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	"github.com/integr8ly/integreatly-operator/pkg/products/observability"
 	cs "github.com/integr8ly/integreatly-operator/pkg/resources/custom-smtp"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	prometheus "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"os"
 
@@ -907,14 +909,44 @@ func (r *Reconciler) getBlobStorageFileStorageSpec(ctx context.Context, serverCl
 		Data: map[string][]byte{},
 	}
 
+	r.log.Info("checking if STS mode")
+	isSTS, err := sts.IsClusterSTS(ctx, serverClient, r.log)
+	if err != nil {
+		return nil, fmt.Errorf("Error checking STS mode: %w", err)
+	}
+	addOnSecretNamespace := r.ConfigManager.GetOperatorNamespace()
+
 	_, err = controllerutil.CreateOrUpdate(ctx, serverClient, credSec, func() error {
 		// Map known key names from CRO, and append any additional values that may be used for Minio
+		// In case of STS cluster - get AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from addon secret (temporary solution)
 		for key, value := range blobStorageSec.Data {
 			switch key {
 			case "credentialKeyID":
-				credSec.Data["AWS_ACCESS_KEY_ID"] = blobStorageSec.Data["credentialKeyID"]
+				if isSTS {
+					credentialKeyID, found, err := addon.GetStringParameter(context.TODO(), serverClient, addOnSecretNamespace, sts.CredsS3AccessKeyId)
+					if err != nil {
+						return fmt.Errorf("Error getting addon parameter %s: %w", sts.CredsS3AccessKeyId, err)
+					}
+					if !found {
+						return fmt.Errorf("AddOn parameter %s not found in secret %s", sts.CredsS3AccessKeyId, addon.DefaultSecretName)
+					}
+					credSec.Data["AWS_ACCESS_KEY_ID"] = []byte(credentialKeyID)
+				} else {
+					credSec.Data["AWS_ACCESS_KEY_ID"] = blobStorageSec.Data["credentialKeyID"]
+				}
 			case "credentialSecretKey":
-				credSec.Data["AWS_SECRET_ACCESS_KEY"] = blobStorageSec.Data["credentialSecretKey"]
+				if isSTS {
+					credentialSecretKey, found, err := addon.GetStringParameter(context.TODO(), serverClient, addOnSecretNamespace, sts.CredsS3SecretAccessKey)
+					if err != nil {
+						return fmt.Errorf("Error getting addon parameter %s: %w", sts.CredsS3SecretAccessKey, err)
+					}
+					if !found {
+						return fmt.Errorf("AddOn parameter %s not found in secret %s", sts.CredsS3SecretAccessKey, addon.DefaultSecretName)
+					}
+					credSec.Data["AWS_SECRET_ACCESS_KEY"] = []byte(credentialSecretKey)
+				} else {
+					credSec.Data["AWS_SECRET_ACCESS_KEY"] = blobStorageSec.Data["credentialSecretKey"]
+				}
 			case "bucketName":
 				credSec.Data["AWS_BUCKET"] = blobStorageSec.Data["bucketName"]
 			case "bucketRegion":

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -40,8 +40,10 @@ import (
 	coreosv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
+	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	consolev1 "github.com/openshift/api/console/v1"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -74,6 +76,7 @@ func getBuildScheme() (*runtime.Scheme, error) {
 	err = consolev1.AddToScheme(scheme)
 	err = openshiftv1.AddToScheme(scheme)
 	err = configv1.AddToScheme(scheme)
+	err = cloudcredentialv1.AddToScheme(scheme)
 
 	return scheme, err
 }
@@ -308,9 +311,13 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "test successful reconcile of s3 blob storage",
+			name: "test successful reconcile of s3 blob storage, non STS mode",
 			fields: fields{
-				ConfigManager: nil,
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
 				Config: config.NewThreeScale(config.ProductConfig{
 					"NAMESPACE": "test",
 				}),
@@ -323,16 +330,17 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 			},
 			args: args{
 				ctx: context.TODO(),
-				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(), &corev1.Secret{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test",
-						Namespace: "test",
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
 					},
-					Data: map[string][]byte{
-						"credentialKeyID":     []byte("test"),
-						"credentialSecretKey": []byte("test"),
-					},
-				},
 					&threescalev1.APIManager{
 						TypeMeta: metav1.TypeMeta{},
 						ObjectMeta: metav1.ObjectMeta{
@@ -341,10 +349,367 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 						},
 						Spec:   threescalev1.APIManagerSpec{},
 						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,
+						},
 					}),
 			},
 			want:    integreatlyv1alpha1.PhaseInProgress,
 			wantErr: false,
+		},
+		{
+			name: "test successful reconcile of s3 blob storage, STS mode",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							sts.CredsS3AccessKeyId:     []byte("123"),
+							sts.CredsS3SecretAccessKey: []byte("123"),
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseInProgress,
+			wantErr: false,
+		},
+		{
+			name: "test Unsuccessful reconcile of s3 blob storage, STS mode, Error getting credentialKeyID parameter",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "null"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID": []byte("test"),
+							//"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							sts.CredsS3AccessKeyId: []byte("123"),
+							//sts.CredsS3SecretAccessKey: []byte("123"),
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "test Unsuccessful reconcile of s3 blob storage, STS mode, Error getting credentialSecretKey parameter",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "null"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							//"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							//sts.CredsS3AccessKeyId:     []byte("123"),
+							sts.CredsS3SecretAccessKey: []byte("123"),
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "test Unsuccessful reconcile of s3 blob storage, STS mode, missing credentialKeyID parameter",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							//sts.CredsS3AccessKeyId:     []byte("123"),
+							sts.CredsS3SecretAccessKey: []byte("123"),
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "test Unsuccessful reconcile of s3 blob storage, STS mode, missing CredsS3SecretAccessKey parameter",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+						Data: map[string][]byte{
+							"credentialKeyID":     []byte("test"),
+							"credentialSecretKey": []byte("test"),
+						},
+					},
+					&threescalev1.APIManager{
+						TypeMeta: metav1.TypeMeta{},
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "3scale",
+							Namespace: "test",
+						},
+						Spec:   threescalev1.APIManagerSpec{},
+						Status: threescalev1.APIManagerStatus{},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: sts.ClusterCloudCredentialName,
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					},
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "addon-managed-api-service-parameters",
+							Namespace: "redhat-rhoam-operator",
+						},
+						Data: map[string][]byte{
+							sts.CredsS3AccessKeyId: []byte("123"),
+							//sts.CredsS3SecretAccessKey: []byte("123"),
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "Error in STS mode checking",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return "redhat-rhoam-operator"
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": "test",
+				}),
+				mpm:           nil,
+				installation:  getTestInstallation(),
+				tsClient:      nil,
+				appsv1Client:  nil,
+				oauthv1Client: nil,
+				Reconciler:    nil,
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewFakeClientWithScheme(scheme, getTestBlobStorage(),
+					&corev1.Secret{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test",
+							Namespace: "test",
+						},
+					},
+					&cloudcredentialv1.CloudCredential{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "not-exists",
+						},
+						Spec: cloudcredentialv1.CloudCredentialSpec{
+							CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
+						},
+					}),
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/resources/sts/sts.go
+++ b/pkg/resources/sts/sts.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	clusterCloudCredentialName  = "cluster"
+	ClusterCloudCredentialName  = "cluster"
 	RoleArnParameterName        = "sts-role-arn"
 	RoleSessionName             = "Red-Hat-cloud-resources-operator"
 	CredsSecretName             = "sts-credentials"
@@ -21,11 +21,13 @@ const (
 	CredsSecretTokenPathKeyName = "web_identity_token_file"
 	CredsRoleEnvKey             = "ROLE_ARN"
 	CredsTokenPathEnvKey        = "TOKEN_PATH"
+	CredsS3AccessKeyId          = "s3-access-key-id"
+	CredsS3SecretAccessKey      = "s3-secret-access-key"
 )
 
 func IsClusterSTS(ctx context.Context, client k8sclient.Client, log logger.Logger) (bool, error) {
 	cloudCredential := &cloudcredentialv1.CloudCredential{}
-	if err := client.Get(ctx, k8sclient.ObjectKey{Name: clusterCloudCredentialName}, cloudCredential); err != nil {
+	if err := client.Get(ctx, k8sclient.ObjectKey{Name: ClusterCloudCredentialName}, cloudCredential); err != nil {
 		log.Error("failed to get cloudCredential whle checking if STS mode", err)
 		return false, err
 	}

--- a/pkg/resources/sts/sts_test.go
+++ b/pkg/resources/sts/sts_test.go
@@ -64,7 +64,7 @@ func TestIsClusterSTS(t *testing.T) {
 				ctx: context.TODO(),
 				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: clusterCloudCredentialName,
+						Name: ClusterCloudCredentialName,
 					},
 					Spec: cloudcredentialv1.CloudCredentialSpec{
 						CredentialsMode: cloudcredentialv1.CloudCredentialsModeManual,
@@ -81,7 +81,7 @@ func TestIsClusterSTS(t *testing.T) {
 				ctx: context.TODO(),
 				client: fakeclient.NewFakeClientWithScheme(scheme, &cloudcredentialv1.CloudCredential{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: clusterCloudCredentialName,
+						Name: ClusterCloudCredentialName,
 					},
 					Spec: cloudcredentialv1.CloudCredentialSpec{
 						CredentialsMode: cloudcredentialv1.CloudCredentialsModeDefault,


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1905

# What
3Scale does not support STS mode of authentication with AWS, and we need to provide a temporary workaround.
Our workaround would be to ask customer to create an IAM account dedicated to 3Scale and pass credentials for this IAM account through two new addon parameters. This IAM account would allow access only to S3 bucket(s) with a predefined name(s). 
This logic is implemented in current PR

# Verification steps
**STS Cluster**
- Prepare STS cluster
- Install Rhoam from this branch
- Open your cluster OSD UI
- Open Secret *addon-managed-api-service-parameters* in Project *redhat-rhoam-operator*
  - Edit Secret, set your values for **s3-access-key-id** and **s3-secret-access-key** parameters
- Open Secret *s3-credentials* in Project *redhat-rhoam-3scale*
  - Reveal values and check that *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* - updated, and have same values as *s3-access-key-id* and *s3-secret-access-key* parameters in *addon-managed-api-service-parameters* in Project *redhat-rhoam-operator*.

**NON-STS cluster**
- Prepare Non-STS cluster
- Do similar steps as for STS cluster
- See that *AWS_ACCESS_KEY_ID* and *AWS_SECRET_ACCESS_KEY* parameters of *s3-credentials* Secret have not changed (have default value: REPLACE_ME)
