### PR TITLE
MGDAPI-4422 Updating command to use cluster name instead of display_name

### DIFF
--- a/test-cases/tests/installation/a34-verify-quota-values.md
+++ b/test-cases/tests/installation/a34-verify-quota-values.md
@@ -121,7 +121,7 @@ CLUSTER_NAME="<CLUSTER_NAME>"
 10. Get cluster id and assign it to a variable
 
 ```bash
-CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
 ```
 
 11. Set quota value

--- a/test-cases/tests/installation/a38-installation-verify-rhoam-on-nonbyoc-cluster.md
+++ b/test-cases/tests/installation/a38-installation-verify-rhoam-on-nonbyoc-cluster.md
@@ -50,7 +50,7 @@ Notification email: "cloud-services-qe-reporting@redhat.com"
 # Copy your cluster's name from OCM UI ("test-ldap-idp" by default) and assign it to the env var CLUSTER_NAME
 CLUSTER_NAME=<your-cluster-name>
 # Get cluster's CID
-CID=$(ocm get clusters --parameter search="display_name like '$CLUSTER_NAME'" | jq -r '.items[0].id')
+CID=$(ocm get clusters --parameter search="name like '$CLUSTER_NAME'" | jq -r '.items[0].id')
 # Get your cluster API URL and kubeadmin password
 API_URL=$(ocm get cluster $CID | jq -r .api.url)
 KUBEADMIN_PASSWORD=$(ocm get cluster $CID/credentials | jq -r .admin.password)

--- a/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
+++ b/test-cases/tests/installation/a40-rhoam-on-osd-trial.md
@@ -35,7 +35,14 @@ oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status'
 ocm login --url=https://api.stage.openshift.com/ --token=<YOUR_TOKEN>
 ```
 
-7.  Upgrade your trial cluster "using quota"
+7.  Retrieve CLUSTER_ID
+
+```bash
+CLUSTER_NAME=<your-cluster-name>
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '$CLUSTER_NAME'" | jq -r '.items[0].id')
+```
+
+8. Upgrade your trial cluster "using quota"
 
 ```bash
 ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID --body=<<EOF
@@ -48,19 +55,19 @@ ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID --body=<<EOF
 EOF
 ```
 
-8. Your OSD cluster should now have the `red-hat-clustertype:OSD`.
+9. Your OSD cluster should now have the `red-hat-clustertype:OSD`.
 
 ```bash
 ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID | jq '.aws.tags'
 ```
 
-9. Set Quota value
+10. Set Quota value
 
 ```bash
 QUOTA_VALUE=<QUOTA_VALUE>
 ```
 
-10. Change Quota value
+11. Change Quota value
 
 ```bash
 ocm patch /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service --body=<<EOF
@@ -83,19 +90,19 @@ EOF
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.toQuota'
 ```
 
-11. Once the new quota has been applied to the RHOAM cluster, `.quota` field should be updated
+12. Once the new quota has been applied to the RHOAM cluster, `.quota` field should be updated
 
 ```bash
 oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.quota'
 ```
 
-12. Trigger uninstall of the addon via the Cluster
+13. Trigger uninstall of the addon via the Cluster
 
 ```bash
 ocm delete /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
 ```
 
-13. Verify uninstall completes successfully. Once the RHOAM CR is deleted the addon installation with id=managed-api-service shouldn't be listed.
+14. Verify uninstall completes successfully. Once the RHOAM CR is deleted the addon installation with id=managed-api-service shouldn't be listed.
 
 ```bash
 ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons

--- a/test-cases/tests/products/h23-validate-rate-limit-service-with-default-customer-config.md
+++ b/test-cases/tests/products/h23-validate-rate-limit-service-with-default-customer-config.md
@@ -154,7 +154,7 @@ CLUSTER_NAME="<CLUSTER_NAME>"
 3. Get cluster id and assign it to a variable
 
 ```bash
-CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
 ```
 
 4. Change quota to 20 million

--- a/test-cases/tests/products/h27-verify-that-user-with-uppercase-letters-can-be-created-in-3s.md
+++ b/test-cases/tests/products/h27-verify-that-user-with-uppercase-letters-can-be-created-in-3s.md
@@ -53,7 +53,7 @@ CLUSTER_NAME="<CLUSTER_NAME>"
 6. Get id of cluster and assign it to a variable
 
 ```bash
-CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
 ```
 
 7. Set Client secret, id and org name variables (Values from step 3)

--- a/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
+++ b/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
@@ -73,7 +73,7 @@ CLUSTER_NAME="<CLUSTER_NAME>"
 5.3 Get id of cluster and assign it to a variable
 
 ```bash
-CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
 ```
 
 6. Run this command to wait for the OpenShift upgrade to complete:

--- a/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
+++ b/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
@@ -76,7 +76,7 @@ CLUSTER_NAME="<CLUSTER_NAME>"
 5.3 Get cluster id and assign it to a variable
 
 ```bash
-CLUSTER_ID=$(ocm get clusters --parameter search="display_name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
+CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" | jq -r '.items[].id')
 ```
 
 5.4 Set quota value


### PR DESCRIPTION
# Issue link
[MGDAPI-4422](https://issues.redhat.com/browse/MGDAPI-4422)

# What
While working on MGDAPI-4422  the command to retrieve the cluster-ID didn't work , this was because the display name was slightly different from the name. Seen as the openshift URL uses the actual name I think we should retrieve the cluster id by it name rather than the display  name

# Verification steps
make sure the new command works
```
CLUSTER_ID=$(ocm get clusters --parameter search="name like '<CLUSTER_NAME>'" | jq -r '.items[0].id')
echo $CLUSTER_ID
```

Should return ID of  desired cluster
