### PR TITLE
MGDAPI-4375 / Added CriticalMetricsMissing Alert

### DIFF
--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -352,7 +352,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 						"sop_url": resources.SopUrlCriticalMetricsMissing,
 						"message": fmt.Sprintf("%s metrics have been missing for more than 5 minutes", strings.ToUpper(installationName)),
 					},
-					Expr:   intstr.FromString(`(` + installationName + `_version{version=~".*", to_version=~""} > 0) * on(pod) group_left(` + installationName + `_custom_domain)(absent(` + installationName + `_custom_domain)) or absent(` + installationName + `_version)`),
+					Expr:   intstr.FromString(fmt.Sprintf(`(%[1]s_version{version=~".*", to_version=~""} > 0) * on(pod) group_left(%[1]s_custom_domain)(absent(%[1]s_custom_domain)) or absent(%[1]s_version)`, installationName)),
 					For:    "5m",
 					Labels: map[string]string{"severity": "critical"},
 				},

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -341,6 +341,23 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 				},
 			},
 		},
+		{
+			AlertName: fmt.Sprintf("%s-missing-metrics", installationName),
+			Namespace: namespace,
+			GroupName: fmt.Sprintf("%s-general.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sCriticalMetricsMissing", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlCriticalMetricsMissing,
+						"message": fmt.Sprintf("%s metrics have been missing for more than 5 minutes", strings.ToUpper(installationName)),
+					},
+					Expr:   intstr.FromString(`(` + installationName + `_version{version=~".*", to_version=~""} > 0) * on(pod) group_left(` + installationName + `_custom_domain)(absent(` + installationName + `_custom_domain)) or absent(` + installationName + `_version)`),
+					For:    "5m",
+					Labels: map[string]string{"severity": "critical"},
+				},
+			},
+		},
 	}
 
 	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -48,4 +48,5 @@ const (
 	SopUrlDnsBypassThreeScaleDeveloperUI                       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/DnsBypassThreeScaleDeveloperUI.asciidoc"
 	SopUrlDnsBypassThreeScaleSystemAdminUI                     = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/DnsBypassThreeScaleSystemAdminUI.asciidoc"
 	SopUrlKeycloakInstanceNotAvailable                         = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/KeycloakInstanceNotAvailable.asciidoc"
+	SopUrlCriticalMetricsMissing                               = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/CriticalMetricsMissing.asciidoc"
 )


### PR DESCRIPTION
# Issue link
[MGDAPI-4375](https://issues.redhat.com/browse/MGDAPI-4375)

# What
Added an alert as well as a SOP to check if Critical metrics are missing.

# Verification steps
1. Checkout this branch.
2. Install rhoam through OLM.
3. Make sure alert is not triggered during install.
4. Once installed is finished disable rhmi-operator pod and wait for alert to trigger.
5. Enable the pod again.
6. Upgrade the version.
7. Make sure alert doesn't trigger.

- You can use images: 
quay.io/dmoskale/managed-api-service:v1.26.3
quay.io/dmoskale/managed-api-service:v1.26.4

- index: 
quay.io/dmoskale/managed-api-service-index:1.26.3
quay.io/dmoskale/managed-api-service-index:1.26.4