### PR TITLE
[MGDAPI-4283] when hive managed, proceed with observability uninstall after the dms secret has been removed

### DIFF
--- a/pkg/products/monitoring/reconciler.go
+++ b/pkg/products/monitoring/reconciler.go
@@ -803,29 +803,6 @@ func (r *Reconciler) getPagerDutySecret(ctx context.Context, serverClient k8scli
 	return secret, nil
 }
 
-func (r *Reconciler) getDMSSecret(ctx context.Context, serverClient k8sclient.Client) (string, error) {
-
-	var secret string
-
-	dmsSecret := &corev1.Secret{}
-	err := serverClient.Get(ctx, types.NamespacedName{Name: r.installation.Spec.DeadMansSnitchSecret,
-		Namespace: r.installation.Namespace}, dmsSecret)
-
-	if err != nil {
-		return "", fmt.Errorf("could not obtain dead mans snitch credentials secret: %w", err)
-	}
-
-	if len(dmsSecret.Data["SNITCH_URL"]) != 0 {
-		secret = string(dmsSecret.Data["SNITCH_URL"])
-	} else if len(dmsSecret.Data["url"]) != 0 {
-		secret = string(dmsSecret.Data["url"])
-	} else {
-		return "", fmt.Errorf("url is undefined in dead mans snitch secret")
-	}
-
-	return secret, nil
-}
-
 // prepareEmailAddresses converts a space separated string into a comma separated
 // string. Example:
 //

--- a/pkg/products/monitoringcommon/alertmanagerConfig.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig.go
@@ -98,7 +98,7 @@ func ReconcileAlertManagerSecrets(ctx context.Context, serverClient k8sclient.Cl
 	}
 
 	//Get dms credentials
-	dmsSecret, err := getDMSSecret(ctx, serverClient, *installation)
+	dmsSecret, err := GetDMSSecret(ctx, serverClient, *installation)
 	if err != nil {
 		log.Warningf("Could not get DMS secret", l.Fields{"error": err.Error()})
 	}
@@ -253,7 +253,7 @@ func getPagerDutySecret(ctx context.Context, serverClient k8sclient.Client, inst
 	return secret, nil
 }
 
-func getDMSSecret(ctx context.Context, serverClient k8sclient.Client, installation integreatlyv1alpha1.RHMI) (string, error) {
+func GetDMSSecret(ctx context.Context, serverClient k8sclient.Client, installation integreatlyv1alpha1.RHMI) (string, error) {
 
 	var secret string
 

--- a/pkg/products/monitoringcommon/alertmanagerConfig_test.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig_test.go
@@ -610,13 +610,13 @@ func TestReconciler_getDMSSecret(t *testing.T) {
 
 			serverClient := tt.serverClient()
 
-			got, err := getDMSSecret(context.TODO(), serverClient, *installation)
+			got, err := GetDMSSecret(context.TODO(), serverClient, *installation)
 			if tt.wantErr != "" && err.Error() != tt.wantErr {
-				t.Errorf("getDMSSecret() error = %v, wantErr %v", err.Error(), tt.wantErr)
+				t.Errorf("GetDMSSecret() error = %v, wantErr %v", err.Error(), tt.wantErr)
 				return
 			}
 			if got != tt.want {
-				t.Errorf("getDMSSecret() got = %v, want %v", got, tt.want)
+				t.Errorf("GetDMSSecret() got = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -6,6 +6,7 @@ import (
 	grafanav1alpha1 "github.com/grafana-operator/grafana-operator/v4/api/integreatly/v1alpha1"
 	"github.com/integr8ly/application-monitoring-operator/pkg/apis/applicationmonitoring/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/metrics"
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoringcommon"
@@ -558,6 +559,21 @@ func (r *Reconciler) deleteObservabilityCR(ctx context.Context, serverClient k8s
 		return integreatlyv1alpha1.PhaseCompleted, nil
 	}
 
+	isHiveManaged, err := addon.OperatorIsHiveManaged(ctx, serverClient, inst)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if isHiveManaged {
+		// proceed after the dms secret is deleted by the deadmanssnitch-operator to prevent alert false positive
+		dmsSecret, err := monitoringcommon.GetDMSSecret(ctx, serverClient, *inst)
+		if err != nil && !k8serr.IsNotFound(err) {
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("unexpected error retrieving dead man's snitch secret: %w", err)
+		}
+		if dmsSecret != "" {
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("dead man's snitch secret is still present, requeing")
+		}
+	}
+
 	oo := &observability.Observability{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      observabilityName,
@@ -566,7 +582,7 @@ func (r *Reconciler) deleteObservabilityCR(ctx context.Context, serverClient k8s
 	}
 
 	// Get the observability CR; return if not found
-	err := serverClient.Get(ctx, k8sclient.ObjectKey{Name: oo.Name, Namespace: oo.Namespace}, oo)
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: oo.Name, Namespace: oo.Namespace}, oo)
 	if err != nil {
 		if k8serr.IsNotFound(err) {
 			return integreatlyv1alpha1.PhaseCompleted, nil
@@ -577,7 +593,7 @@ func (r *Reconciler) deleteObservabilityCR(ctx context.Context, serverClient k8s
 	// Mark the observability CR for deletion
 	err = serverClient.Delete(ctx, oo)
 	if err != nil {
-		return integreatlyv1alpha1.PhaseFailed, nil
+		return integreatlyv1alpha1.PhaseFailed, err
 	}
 
 	return integreatlyv1alpha1.PhaseInProgress, nil


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4283

# What
Link to thread where the issue and solution were discussed: https://coreos.slack.com/archives/C01L46M0FQC/p1659716042983509

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
