### PR TITLE
[MGDAPI-4458] skip custom domain checks if 3scale is installed

### DIFF
--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -11,6 +11,7 @@ import (
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
 	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
+	"github.com/integr8ly/integreatly-operator/test/common"
 	configv1 "github.com/openshift/api/config/v1"
 	routev1 "github.com/openshift/api/route/v1"
 	olmv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -942,6 +943,82 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 			},
 			want:    integreatlyv1alpha1.PhaseFailed,
 			wantErr: true,
+		},
+		{
+			name: "silence any errors other than not found when retrieving 3scale operator namespace",
+			fields: fields{
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "managed-api",
+						Namespace: "test",
+					},
+					Spec: integreatlyv1alpha1.RHMISpec{
+						Type: "managed-api",
+					},
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: func() k8sclient.Client {
+					mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+					mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+						switch obj.(type) {
+						case *routev1.Route:
+							obj.(*routev1.Route).Status.Ingress = make([]routev1.RouteIngress, 1)
+							obj.(*routev1.Route).Status.Ingress[0].Host = "dummy host"
+							return nil
+						case *corev1.Namespace:
+							return errors.New("generic error")
+						default:
+							return nil
+						}
+					}
+					return mockClient
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "default flow if 3scale operator is installed",
+			fields: fields{
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "managed-api",
+						Namespace: "test",
+					},
+					Spec: integreatlyv1alpha1.RHMISpec{
+						Type: "managed-api",
+					},
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: func() k8sclient.Client {
+					return moqclient.NewSigsClientMoqWithScheme(scheme,
+						&routev1.Route{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "console",
+								Namespace: "openshift-console",
+							},
+							Status: routev1.RouteStatus{
+								Ingress: []routev1.RouteIngress{
+									{
+										Host: "host",
+									},
+								},
+							},
+						},
+						&corev1.Namespace{
+							ObjectMeta: v1.ObjectMeta{
+								Name: common.ThreeScaleOperatorNamespace,
+							},
+						},
+					)
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
 		},
 		{
 			name: "cannot find console route cr",

--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -945,7 +945,7 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "silence any errors other than not found when retrieving 3scale operator namespace",
+			name: "unexpected error when retrieving 3scale operator namespace",
 			fields: fields{
 				installation: &integreatlyv1alpha1.RHMI{
 					ObjectMeta: v1.ObjectMeta{
@@ -976,8 +976,8 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 					return mockClient
 				},
 			},
-			want:    integreatlyv1alpha1.PhaseCompleted,
-			wantErr: false,
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
 		},
 		{
 			name: "default flow if 3scale operator is installed",


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4458

# What
It was noticed that alerts were firing and the rhmi cr was not reconciling in the following scenario: adding a custom domain parameter to the addon-params secret after 3scale has been installed.
In this scenario RHOAM should ignore the custom domain. It should fully reconcile RHOAM and no alerts should be firing. 

# Verification steps
1. Provision/borrow an OSD cluster
2. `make cluster/prepare` from the master branch
3. Create a CatalogSource CR and install RHOAM from it:
```
oc apply -f - <<EOF
---
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhmi-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/tdimov0/managed-api-service-index:1.25.0
EOF
```
4. Wait for the RHOAM installation to complete or at least until the 3scale-operator namespace is created
5. Patch the addon params secret with a custom domain value
```
echo -n "apps.rhmi.me" | base64 | xargs -I {} \
oc patch secret addon-managed-api-service-parameters \
-n redhat-rhoam-operator --type=json \
-p='[{"op": "replace", "path": /data/custom-domain_domain, "value": "{}"}]'
```
6. Observe no changes to the RHMI CR relating to custom domain (`customDomain` property under status block) after a successful reconcile.
7. No alerts firing after addon param patch 
