### PR TITLE
MGDAPI-3796: G107 Url provided to HTTP request as taint input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -542,7 +542,7 @@ commits/check:
 
 .PHONY: gosec/exclude
 gosec/exclude:
-	gosec -exclude=G107,G404,G601 ./...
+	gosec -exclude=G404,G601 ./...
 
 ##@ Build Dependencies
 

--- a/test/common/selfmanaged_apicast.go
+++ b/test/common/selfmanaged_apicast.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"math/rand"
 	"net/http"
+	"net/url"
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
@@ -470,8 +471,15 @@ func promoteSelfManagedAPIcast(threeScaleAdminPortal, token3scale string) (strin
 }
 
 func validateDeploymentRequest(userKey, routeHost string) (int, error) {
-	httpRequest := "https://" + routeHost + "/?user_key=" + userKey
-	resp, err := http.Get(httpRequest)
+	query := make(url.Values)
+	query.Add("user_key", userKey)
+	httpRequest := &url.URL{
+		Scheme:     "https",
+		Host:       routeHost,
+		ForceQuery: false,
+		RawQuery:   query.Encode(),
+	}
+	resp, err := http.Get(httpRequest.String())
 	if err != nil {
 		log.Error("HTTP Get error", err)
 		return 0, err

--- a/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/h24-verify-selfmanaged-apicast-and-custom-policy.go
+++ b/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/h24-verify-selfmanaged-apicast-and-custom-policy.go
@@ -16,6 +16,7 @@ import (
 	"io/ioutil"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"strconv"
@@ -572,8 +573,15 @@ func promoteSelfManagedAPIcast(ctx context.Context, client k8sclient.Client, int
 }
 
 func validateDeploymentRequest(userKey, routeHost string) (int, error) {
-	httpRequest := "https://" + routeHost + "/?user_key=" + userKey
-	resp, err := http.Get(httpRequest)
+	query := make(url.Values)
+	query.Add("user_key", userKey)
+	httpRequest := &url.URL{
+		Scheme:     "https",
+		Host:       routeHost,
+		ForceQuery: false,
+		RawQuery:   query.Encode(),
+	}
+	resp, err := http.Get(httpRequest.String())
 	if err != nil {
 		log.Error("HTTP Get error", err)
 		return 0, err


### PR DESCRIPTION
# Issue link
[MGDAPI-3796](https://issues.redhat.com/browse/MGDAPI-3796)

# What
- Changed how URLs are constructed with parameters in two tests

# Verification steps
- Run `make gosec/exclude` from this branch and make sure there are no issues reported by gosec
