### PR TITLE
MGDAPI-3582 - Add checks for tags in e2e tests

### DIFF
--- a/test/functional/aws_strategy_override.go
+++ b/test/functional/aws_strategy_override.go
@@ -112,10 +112,10 @@ func CROStrategyOverrideAWSResourceTest(t common.TestingTB, testingContext *comm
 }
 
 /*
-	From a list of ResourceID's we iterate through them
-	For every resource we describe the resource, checking the backup and maintenance windows are as expected
-	We build a list of errors, to ensure we catch every verification
-	If there is an error we return the list as an error
+From a list of ResourceID's we iterate through them
+For every resource we describe the resource, checking the backup and maintenance windows are as expected
+We build a list of errors, to ensure we catch every verification
+If there is an error we return the list as an error
 */
 func verifyRDSMaintenanceBackupWindows(ctx context.Context, client client.Client, expectedBackupWindow, expectedMaintenanceWindow string) error {
 
@@ -134,7 +134,7 @@ func verifyRDSMaintenanceBackupWindows(ctx context.Context, client client.Client
 	}
 
 	// create aws session
-	sess, err := CreateAWSSession(ctx, client)
+	sess, _, err := CreateAWSSession(ctx, client)
 	if err != nil {
 		return fmt.Errorf("failed to create aws session: %v", err)
 	}
@@ -169,10 +169,10 @@ func verifyRDSMaintenanceBackupWindows(ctx context.Context, client client.Client
 }
 
 /*
-	From a list of ResourceID's we iterate through them
-	For every resource we describe the resource, checking the backup and maintenance windows are as expected
-	We build a list of errors, to ensure we catch every verification
-	If there is an error we return the list as an error
+From a list of ResourceID's we iterate through them
+For every resource we describe the resource, checking the backup and maintenance windows are as expected
+We build a list of errors, to ensure we catch every verification
+If there is an error we return the list as an error
 */
 func verifyElasticacheMaintenanceBackupWindows(ctx context.Context, client client.Client, expectedBackupWindow, expectedMaintenanceWindow string) error {
 	rhmi, err := common.GetRHMI(client, true)
@@ -190,7 +190,7 @@ func verifyElasticacheMaintenanceBackupWindows(ctx context.Context, client clien
 	}
 
 	// create AWS session
-	sess, err := CreateAWSSession(ctx, client)
+	sess, _, err := CreateAWSSession(ctx, client)
 	if err != nil {
 		return fmt.Errorf("failed to create aws session: %v", err)
 	}


### PR DESCRIPTION
# Issue link
[MGDAPI-3582](https://issues.redhat.com/browse/MGDAPI-3582)

# What
- Add some checks to ensure that the resources have been tagged with `red-hat-managed` and the appropriate `red-hat-clustertype` if we are an STS cluster
- Fix some minor lint issues

# Verification steps
### Create an STS cluster:

Once you have some AWS credentials login with:

```
aws configure
```

Ensure you have the `rosa` cli and are logged into ocm, and from the related delorean branch integr8ly/delorean#279 create a cluster filling in appropriate settings:

```
CLUSTER_NAME=mycluster-sts AWS_REGION=us-east-1 make ocm/sts/cluster/create
```
Run the following to create the prereq roles:
```
CLUSTER_NAME=mycluster-sts AWS_REGION=us-east-1 make ocm/sts/rhoam-prerequisites
```
The output will include an ARN for the `rhoam_role` and the `functional_test_role`

### Install RHOAM

You can then start RHOAM from this PR using the **rhoam_role** ARN:
```
ROLE_ARN="<rhoam_role arn>" INSTALLATION_TYPE=managed-api make cluster/prepare/local
ROLE_ARN="<rhoam_role arn>" INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
ROLE_ARN="<rhoam_role arn>" INSTALLATION_TYPE=managed-api make code/run
```

### Run Tests

The tests affected by this PR are:
- F01,F03,A21,A25,F04

To run them using the **functional_test_role** ARN:
```
ROLE_ARN="<functional_test_role arn>" TOKEN_PATH="/var/run/secrets/openshift/serviceaccount/token" INSTALLATION_TYPE=managed-api TEST="(F01|F03|A21|A25|F04)" make test/e2e/single
```
