### PR TITLE
MGDAPI-1729 fix H34 functional test

### DIFF
--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -364,8 +364,8 @@ func checkHostAddressIsReady(ctx *TestingContext, t TestingTB, retryInterval, ti
 			t.Fatalf("error getting RHMI CR: %v", err)
 		}
 
-		host := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Host
-		status := rhmi.Status.Stages[rhmiv1alpha1.ProductsStage].Products[rhmiv1alpha1.Product3Scale].Phase
+		host := rhmi.Status.Stages[rhmiv1alpha1.InstallStage].Products[rhmiv1alpha1.Product3Scale].Host
+		status := rhmi.Status.Stages[rhmiv1alpha1.InstallStage].Products[rhmiv1alpha1.Product3Scale].Phase
 		if host == "" || status == "in progress" {
 			t.Log("3scale host URL not ready yet.")
 			return false, nil


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-1729

# What
The H34 functional test (verify 3scale custom SMTP full config) is failing on ROSA STS clusters installed using Jenkins pipeline [var installRhmi](https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/blob/master/vars/installRhmi.groovy). The failure reason is that is still using the old rhmi stages structure, before single stage installation stage was introduced.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
