### PR TITLE
MGDAPI-4478 - Increase UpgradeExpectedDuration - update alert RHOAMUp…

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -68,13 +68,13 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 					Labels: map[string]string{"severity": "warning", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 				},
 				{
-					Alert: fmt.Sprintf("%sUpgradeExpectedDuration30minExceeded", strings.ToUpper(installationName)),
+					Alert: fmt.Sprintf("%sUpgradeExpectedDuration60minExceeded", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlUpgradeExpectedDurationExceeded,
-						"message": fmt.Sprintf("%s operator upgrade is taking more than 30 minutes", strings.ToUpper(installationName)),
+						"message": fmt.Sprintf("%s operator upgrade is taking more than 60 minutes", strings.ToUpper(installationName)),
 					},
 					Expr:   intstr.FromString(fmt.Sprintf(`%s_version{to_version=~".+",version=~".+"} and (absent((%s_version{job=~"%s.+"} * on(version) csv_succeeded{exported_namespace=~"%s"})) or %s_version)`, installationName, installationName, installationName, installation.Namespace, installationName)),
-					For:    "30m",
+					For:    "60m",
 					Labels: map[string]string{"severity": "critical", "product": installationName, "addon": getAddonName(installation), "namespace": "openshift-monitoring"},
 				},
 			},

--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -68,6 +68,13 @@ func (r *AlertReconcilerImpl) ReconcileAlerts(ctx context.Context, client k8scli
 		}
 	}
 
+	//removing RHOAMUpgradeExpectedDuration30minExceeded alert as it was renamed (30min -> 60min)
+	alertToDelete := AlertConfiguration{
+		AlertName: "RHOAMUpgradeExpectedDuration30minExceeded",
+		Namespace: "openshift-monitoring",
+	}
+	r.RemovedAlerts = append(r.RemovedAlerts, alertToDelete)
+
 	if err := r.deleteAlerts(ctx, client, r.RemovedAlerts); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4478
Increase UpgradeExpectedDuration - update alert RHOAMUpgradeExpectedDuration30minExceeded

# What
- change RHOAMUpgradeExpectedDuration30minExceeded Alert, to increase Rhoam Upgrade Expected Duration time from 30 min to 60 min.
- rename alert to RHOAMUpgradeExpectedDuration60minExceeded
- delete RHOAMUpgradeExpectedDuration30minExceeded alert that remained after upgrade from previous version.

## What was tested
- Pipeline https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/valerym/job/managed-api-upgrade-4390/30/   (builds 29 (install) and 30 upgrade)
- new alert name and properties
- old alert with name *30min* not present  (deleted) after upgrade

# Verification steps
- install rhoam (could be locally) and check that Alert name changed (30->60 min), and properties of alert changed - waiting time and description - 60 min. Note - please see alert in Prometheus in `openshift-monitoring` namespace
- (optional) run pipeline `managed-api-upgrade` and check upgrade time and alert behavior