### PR TITLE
MGDAPI-4474 add health probes to rhmi pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -63,4 +63,15 @@ spec:
             value: "default@test.com"
           - name: QUOTA
             value: "200"
+        livenessProbe:
+          exec:
+            command:
+              - ls
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 10
+        readinessProbe:
+          exec:
+            command:
+              - ls
       terminationGracePeriodSeconds: 10

--- a/main.go
+++ b/main.go
@@ -20,6 +20,7 @@ import (
 	"flag"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"strings"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -89,7 +90,9 @@ func init() {
 func main() {
 	var metricsAddr string
 	var enableLeaderElection bool
+	var probeAddr string
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8383", "The address the metric endpoint binds to.")
+	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
@@ -111,11 +114,12 @@ func main() {
 	var mgr ctrl.Manager
 	if strings.Contains(watchNamespace, "sandbox") || watchNamespace == "" {
 		mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			Scheme:             scheme,
-			MetricsBindAddress: metricsAddr,
-			Port:               9443,
-			LeaderElection:     enableLeaderElection,
-			LeaderElectionID:   "28185cee.integreatly.org",
+			Scheme:                 scheme,
+			MetricsBindAddress:     metricsAddr,
+			Port:                   9443,
+			HealthProbeBindAddress: probeAddr,
+			LeaderElection:         enableLeaderElection,
+			LeaderElectionID:       "28185cee.integreatly.org",
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start multitenant manager")
@@ -123,12 +127,13 @@ func main() {
 		}
 	} else {
 		mgr, err = ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
-			Scheme:             scheme,
-			MetricsBindAddress: metricsAddr,
-			Port:               9443,
-			LeaderElection:     enableLeaderElection,
-			LeaderElectionID:   "28185cee.integreatly.org",
-			Namespace:          watchNamespace,
+			Scheme:                 scheme,
+			MetricsBindAddress:     metricsAddr,
+			Port:                   9443,
+			HealthProbeBindAddress: probeAddr,
+			LeaderElection:         enableLeaderElection,
+			LeaderElectionID:       "28185cee.integreatly.org",
+			Namespace:              watchNamespace,
 		})
 		if err != nil {
 			setupLog.Error(err, "unable to start singletenant manager")
@@ -183,6 +188,15 @@ func main() {
 
 	if err := setupWebhooks(mgr); err != nil {
 		setupLog.Error(err, "Error setting up webhook server")
+	}
+
+	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up health check")
+		os.Exit(1)
+	}
+	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
+		setupLog.Error(err, "unable to set up ready check")
+		os.Exit(1)
 	}
 
 	setupLog.Info("starting manager")


### PR DESCRIPTION
# Issue link
[MGDAPI-4474](https://issues.redhat.com/browse/MGDAPI-4474)

# What
Adding Liveness and Readiness probes. Using `ls` for both of them. 

# Verification steps
1. Generate new index (or you could reuse `quay.io/mvavilov/rhoam-index:2.0.0`) - here is a [guide](https://github.com/RHCloudServices/integreatly-help/blob/master/guides/olm/installing-rhmi-bundle-format.md). You would also need to build your own rhoam image. 
2. Install RHOAM via bundles  
3. Once the pod was created `oc describe pod $(oc get pods -n redhat-rhoam-operator | grep 'rhmi-operator' | awk '{print $1}') -n redhat-rhoam-operator | grep -E 'Liveness|Readiness'` to check probes are present. 