### PR TITLE
MGDAPI-4404 Increased timeout for all tests

### DIFF
--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -27,4 +27,4 @@ RUN dnf -y install google-chrome-stable && dnf clean all
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
 
-ENTRYPOINT [ "/integreatly-operator-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.noColor" ]
+ENTRYPOINT [ "/integreatly-operator-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.no-color" ]

--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -23,4 +23,4 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/managed-api-test-harness.test managed-api-test-harness.test
 
-ENTRYPOINT [ "/managed-api-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.noColor" ]
+ENTRYPOINT [ "/managed-api-test-harness.test", "-test.v", "-ginkgo.v", "-ginkgo.progress", "-ginkgo.no-color" ]

--- a/Makefile
+++ b/Makefile
@@ -256,7 +256,7 @@ test/e2e/single:
 test/functional: export WATCH_NAMESPACE := $(NAMESPACE)
 test/functional:
 	# Run the functional tests against an existing cluster. Make sure you have logged in to the cluster.
-	go clean -testcache && go test -v ./test/functional -timeout=80m
+	go clean -testcache && go test -v ./test/functional -timeout=120m
 
 .PHONY: test/osde2e
 test/osde2e: export WATCH_NAMESPACE := $(NAMESPACE)

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -76,7 +76,11 @@ func TestAPIs(t *testing.T) {
 		t.Fatalf("could not get install type %s", err)
 	}
 
-	RunSpecs(t, "E2E Test Suite")
+	// Fetch the current config
+	suiteConfig, _ := GinkgoConfiguration()
+	suiteConfig.Timeout = time.Minute * 90
+
+	RunSpecs(t, "E2E Test Suite", suiteConfig)
 }
 
 var _ = BeforeSuite(func() {

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -3,6 +3,7 @@ package functional
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	threescaleBv1 "github.com/3scale/3scale-operator/apis/capabilities/v1beta1"
 	"github.com/integr8ly/integreatly-operator/test/utils"
@@ -64,6 +65,7 @@ func TestAPIs(t *testing.T) {
 
 	// Fetch the current config
 	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteConfig.Timeout = time.Minute * 90
 	// Update the JUnitReport
 	reporterConfig.JUnitReport = jUnitReportLocation
 	// Pass the updated config to RunSpecs()

--- a/test/osde2e/suite_test.go
+++ b/test/osde2e/suite_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -66,6 +67,8 @@ func TestAPIs(t *testing.T) {
 
 	// Fetch the current config
 	suiteConfig, reporterConfig := GinkgoConfiguration()
+	suiteConfig.Timeout = time.Minute * 90
+
 	// Update the JUnitReport
 	reporterConfig.JUnitReport = jUnitReportLocation
 	// Pass the updated config to RunSpecs()


### PR DESCRIPTION
# Issue link
[MGDAPI-4404
](https://issues.redhat.com/browse/MGDAPI-4404)

# What
In Gingko v2 the default timeout was changed from 24hr to 1hr. This was not long enough, therefore we needed to specify a new timeout in the test suites. The timeout has been updated to 90 minutes. 

# Verification steps
Ensuring that this PR is passing the automated tests along with reviewing the changed files should be sufficient verification.

