### PR TITLE
MGDAPI-4407 critical metrics missing alert & prometheus unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -591,3 +591,11 @@ $(ENVTEST): $(LOCALBIN)
 .PHONY: mkdocs/serve
 mkdocs/serve:
 	mkdocs serve
+
+.PHONY: test/unit/prometheus
+test/unit/prometheus:
+	@find prometheus-unit-testing/tests -type f | xargs promtool test rules
+
+.PHONY: test/unit/prometheus/single
+test/unit/prometheus/single:
+	@promtool test rules $(PROM_TEST_RULE_FILE)

--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ The operator installs the following products:
 - [moq](https://github.com/matryer/moq)
 - [oc](https://docs.okd.io/latest/cli_reference/openshift_cli/getting-started-cli.html) version v4.6+
 - [yq](https://github.com/mikefarah/yq) version v4+
-- [jq](https://github.com/stedolan/jq)   
+- [jq](https://github.com/stedolan/jq)
+- [promtool](https://prometheus.io/docs/prometheus/latest/configuration/unit_testing_rules)
 - Access to an Openshift v4.6.0+ cluster
 - A user with administrative privileges in the OpenShift cluster
 

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -374,12 +374,12 @@ func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 			return ctrl.Result{}, err
 		}
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, string(externalClusterId), installation.CreationTimestamp.Unix())
+		metrics.SetThreeScalePortals(nil, 0) // expose metric and set default value
 	}
 
 	// Check for stage complete to avoid setting the metric when installation is happening
 	if string(installation.Status.Stage) == "complete" {
 		metrics.SetRhmiVersions(string(installation.Status.Stage), installation.Status.Version, installation.Status.ToVersion, string(externalClusterId), installation.CreationTimestamp.Unix())
-
 		metrics.SetQuota(installation.Status.Quota, installation.Status.ToQuota)
 	}
 

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -3,7 +3,8 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.18
 # OPERATOR_SDK should match the version of operator-sdk version in go.mod
 ENV OPERATOR_SDK_VERSION=v1.21.0 \
     DELOREAN_VERSION=master \
-    GOFLAGS=""
+    GOFLAGS="" \
+    PROMETHEUS_VERSION=2.37.0
 
 RUN set -o pipefail && \
     INSTALL_PKGS="skopeo rsync" && \
@@ -50,3 +51,10 @@ RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.
 
 # install gosec
 RUN curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $GOPATH/bin v2.11.0
+
+# install promtool
+RUN wget https://github.com/prometheus/prometheus/releases/download/v$PROMETHEUS_VERSION/prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz \
+    && tar xvf prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz \
+    && cp prometheus-$PROMETHEUS_VERSION.linux-amd64/promtool /usr/local/bin \
+    && chmod +x /usr/local/bin/promtool \
+    && rm -rf prometheus-$PROMETHEUS_VERSION.linux-amd64.tar.gz prometheus-$PROMETHEUS_VERSION.linux-amd64

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -341,6 +341,23 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 				},
 			},
 		},
+		{
+			AlertName: fmt.Sprintf("%s-missing-metrics", installationName),
+			Namespace: namespace,
+			GroupName: fmt.Sprintf("%s-general.rules", installationName),
+			Rules: []monitoringv1.Rule{
+				{
+					Alert: fmt.Sprintf("%sCriticalMetricsMissing", strings.ToUpper(installationName)),
+					Annotations: map[string]string{
+						"sop_url": resources.SopUrlCriticalMetricsMissing,
+						"message": "one or more critical metrics have been missing for 10+ minutes",
+					},
+					Expr:   intstr.FromString(`(absent(kube_endpoint_address_available) or absent(kube_pod_container_status_ready) or absent(kube_pod_labels) or absent(kube_pod_status_phase) or absent(kube_pod_status_ready) or absent(kube_secret_info) or absent(rhoam_version) or absent(threescale_portals)) == 1`),
+					For:    "10m",
+					Labels: map[string]string{"severity": "critical"},
+				},
+			},
+		},
 	}
 
 	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -48,4 +48,5 @@ const (
 	SopUrlDnsBypassThreeScaleDeveloperUI                       = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/DnsBypassThreeScaleDeveloperUI.asciidoc"
 	SopUrlDnsBypassThreeScaleSystemAdminUI                     = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/DnsBypassThreeScaleSystemAdminUI.asciidoc"
 	SopUrlKeycloakInstanceNotAvailable                         = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/KeycloakInstanceNotAvailable.asciidoc"
+	SopUrlCriticalMetricsMissing                               = "https://github.com/RHCloudServices/integreatly-help/blob/master/sops/rhoam/alerts/CriticalMetricsMissing.asciidoc"
 )

--- a/prometheus-unit-testing/rules/rhoam_general.yml
+++ b/prometheus-unit-testing/rules/rhoam_general.yml
@@ -1,0 +1,10 @@
+groups:
+ - name: rhoam-general.rules
+   rules:
+    - alert: CriticalMetricsMissing
+      annotations:
+        message: one or more critical metrics have been missing for 10+ minutes
+      expr: (absent(kube_endpoint_address_available) or absent(kube_pod_container_status_ready) or absent(kube_pod_labels) or absent(kube_pod_status_phase) or absent(kube_pod_status_ready) or absent(kube_secret_info) or absent(rhoam_version) or absent(threescale_portals)) == 1
+      for: 10m
+      labels:
+        severity: critical

--- a/prometheus-unit-testing/tests/critical_metrics_missing.yml
+++ b/prometheus-unit-testing/tests/critical_metrics_missing.yml
@@ -1,0 +1,201 @@
+rule_files:
+  - ../rules/rhoam_general.yml
+evaluation_interval: 1m
+tests:
+  - interval: 1m
+    input_series:
+      - series: kube_endpoint_address_available
+        values: "stale _x10 0 stale _x10 0+0x84"
+      - series: kube_pod_container_status_ready
+        values: "stale _x10 0+0x12 stale _x10 0+0x72"
+      - series: kube_pod_labels
+        values: "stale _x10 0+0x24 stale _x10 0+0x60"
+      - series: kube_pod_status_phase
+        values: "stale _x10 0+0x36 stale _x10 0+0x48"
+      - series: kube_pod_status_ready
+        values: "stale _x10 0+0x48 stale _x10 0+0x36"
+      - series: kube_secret_info
+        values: "stale _x10 0+0x60 stale _x10 0+0x24"
+      - series: rhoam_version
+        values: "stale _x10 0+0x72 stale _x10 0+0x12"
+      - series: threescale_portals
+        values: "stale _x10 0+0x84 stale _x10 0"
+    alert_rule_test:
+      # [-] kube_endpoint_address_available
+      # [-] kube_pod_container_status_ready
+      # [-] kube_pod_labels
+      # [-] kube_pod_status_phase
+      # [-] kube_pod_status_ready
+      # [-] kube_secret_info
+      # [-] rhoam_version
+      # [-] threescale_portals
+      # alert expected to fire
+      - eval_time: 10m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 11m
+        alertname: CriticalMetricsMissing
+        exp_alerts: [ ]
+
+      # [-] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert expected to fire
+      - eval_time: 22m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [-] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 34m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [-] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 46m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [-] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 58m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [-] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 70m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [-] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 82m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [-] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 94m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [-] threescale_portals
+      # alert not expected to fire
+      - eval_time: 106m
+        alertname: CriticalMetricsMissing
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              message: one or more critical metrics have been missing for 10+ minutes
+
+      # [+] kube_endpoint_address_available
+      # [+] kube_pod_container_status_ready
+      # [+] kube_pod_labels
+      # [+] kube_pod_status_phase
+      # [+] kube_pod_status_ready
+      # [+] kube_secret_info
+      # [+] rhoam_version
+      # [+] threescale_portals
+      # alert not expected to fire
+      - eval_time: 107m
+        alertname: CriticalMetricsMissing
+        exp_alerts: [ ]

--- a/prometheus-unit-testing/tests/critical_metrics_missing.yml
+++ b/prometheus-unit-testing/tests/critical_metrics_missing.yml
@@ -1,25 +1,47 @@
 rule_files:
   - ../rules/rhoam_general.yml
-evaluation_interval: 1m
 tests:
+  # The interval is closely tied to the values of the input series.
+  # It represents the duration between each value of the metrics.
   - interval: 1m
+    # The input series define the values for individual metrics throughout their lifecycle.
+    # They should be treated as a whole and not as individual test cases.
+    # `_` indicates a missing scrape sample.
+    # `stale` indicates a stale sample.
+    # `stale _x10` indicates the metric is missing for 10m.
+    # `0` is used as a dummy value to imply that the metric is present and its value is `0`.
+    # `0 0 0 0 0` series represent a metric that is present for 5m with a value of `0`.
+    # To improve readability and address high intervals one can use the expanding notation.
+    # `0 0 0 0 0` is equivalent to `0+0x4`.
+    # `a+bxc` becomes `a a+b a+(2*b) a+(3*b) … a+(c*b)`.
+    # `a-bxc` becomes `a a-b a-(2*b) a-(3*b) … a-(c*b)`.
     input_series:
+      # missing for 10m, present for 1m with value of `0`, missing for 10m, present for 85m with value of `0`.
       - series: kube_endpoint_address_available
         values: "stale _x10 0 stale _x10 0+0x84"
+      # missing for 10m, present for 13m with value of `0`, missing for 10m, present for 73m with value of `0`.
       - series: kube_pod_container_status_ready
         values: "stale _x10 0+0x12 stale _x10 0+0x72"
+      # missing for 10m, present for 25m with value of `0`, missing for 10m, present for 61m with value of `0`.
       - series: kube_pod_labels
         values: "stale _x10 0+0x24 stale _x10 0+0x60"
+      # missing for 10m, present for 37m with value of `0`, missing for 10m, present for 49m with value of `0`.
       - series: kube_pod_status_phase
         values: "stale _x10 0+0x36 stale _x10 0+0x48"
+      # missing for 10m, present for 49m with value of `0`, missing for 10m, present for 37m with value of `0`.
       - series: kube_pod_status_ready
         values: "stale _x10 0+0x48 stale _x10 0+0x36"
+      # missing for 10m, present for 61m with value of `0`, missing for 10m, present for 25m with value of `0`.
       - series: kube_secret_info
         values: "stale _x10 0+0x60 stale _x10 0+0x24"
+      # missing for 10m, present for 73m with value of `0`, missing for 10m, present for 13m with value of `0`.
       - series: rhoam_version
         values: "stale _x10 0+0x72 stale _x10 0+0x12"
+      # missing for 10m, present for 85m with value of `0`, missing for 10m, present for 1m with value of `0`.
       - series: threescale_portals
         values: "stale _x10 0+0x84 stale _x10 0"
+    # In this test suite we are checking whether metric/s are present or not and fire an alert based on that.
+    # If one wants to simulate a metrics
     alert_rule_test:
       # [-] kube_endpoint_address_available
       # [-] kube_pod_container_status_ready

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -702,6 +702,12 @@ func commonExpectedRules(installationName string) []alertsTestRule {
 				"DnsBypassThreeScaleSystemAdminUI",
 			},
 		},
+		{
+			File: ObservabilityNamespacePrefix + "rhoam-missing-metrics.yaml",
+			Rules: []string{
+				"RHOAMCriticalMetricsMissing",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4407

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
- Create/borrow an OSD cluster
- Log in to the cluster
- Checkout this branch
- Prepare the cluster:
```
 LOCAL=false make cluster/prepare/local
```
- Deploy an RHMI resource:
```
LOCAL=false make deploy/integreatly-rhmi-cr.yml
```
- Install the RHOAM operator from my image: `quay.io/tdimov0/managed-api-service-index:1.26.0`
- Observe the alert `RHOAMCriticalMetricsMissing`. It may go into pending state for a brief period of time during fresh install/upgrade until all critical metrics become available, but it must not fire at any point
- After ensuring no alerts are firing and the RHOAM installation has completed, simulate a scenario where the alert must fire by scaling down the RHOAM operator deployment to 0:
```
oc patch deployment rhmi-operator -n redhat-rhoam-operator --type=json -p='[{"op": "replace", "path": /spec/replicas, "value": 0}]'
```
- Scale the RHOAM operator deployment back to 1 and ensure the alert goes away:
```
oc patch deployment rhmi-operator -n redhat-rhoam-operator --type=json -p='[{"op": "replace", "path": /spec/replicas, "value": 1}]'
```
- Run the prometheus unit tests (as `promtool` is a new prerequisite, you'll be expected to have it installed locally):
```
make test/unit/prometheus
```