### PR TITLE
MGDAPI-4504 : Move custom domain guide for mkdocs support

### DIFF
--- a/docs/custom_domain.md
+++ b/docs/custom_domain.md
@@ -3,7 +3,7 @@ This will explain how to configure the operator to use a custom domain when the 
 
 In this guide the `rhmi.me` domain will be used as the example custom domain.
 
-# Cluster Configuration
+## Cluster Configuration
 There are external steps required to configure a cluster to allow custom domains.
 
 Required Items
@@ -13,7 +13,7 @@ Required Items
 * CNAME edit access for a domain name
 
 
-## Domain Certificate
+### Domain Certificate
 
 Creating a self-signed certificate.
 ```shell
@@ -67,7 +67,7 @@ The endpoint URL will need to be added to a CNAME record for the domain in quest
 Team leads should be able to help get access to the required resources.
 This guide does not cover the steps required to configure the CNAME record in the DNS configuration.
 
-# Configuring the operator installation.
+## Configuring the operator installation.
 Currently, the operator only allows the configuring of the custom domain during installation. 
 Once the routes have being created within 3scale they can not be changed again.
 
@@ -88,7 +88,7 @@ Patch the CR as follows.
 oc patch rhmi rhoam -n redhat-rhoam-operator --type=json -p='[{"op": "replace", "path": /spec/selfSignedCerts, "value": true}]'
 ```
 
-# Finished installation
+## Finished installation
 After installation has complete the following information should be seen.
 
 * The RHMI CR will have a status block for the custom domain settings. 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4504

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Updated the custom domain guide location. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* checkout branch locally 
* run `make mkdoc/serve`
* navigate to http://127.0.0.1:8000/custom_domain
* Check:
  * Side bar navigation links to all sections within the guide.
  * hyper links in the guide are still working
  * There is no poorly or incorrectly formatted section in the guide.  
