### PR TITLE
MGDAPI-4530 refactoring tests regarding deletion of users

### DIFF
--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -256,14 +256,7 @@ func restoreClusterStatePreTest(t TestingTB, ctx *TestingContext) {
 	if err != nil {
 		t.Fatalf("failed to delete openshift user: %s, err: %v", userLongName, err)
 	}
-	err = ctx.Client.Delete(goCtx, &userv1.User{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: userLong2,
-		},
-	})
-	if err != nil {
-		t.Fatalf("failed to delete openshift user: %s, err: %v", userLong2, err)
-	}
+
 	// Ensure Keycloak CR created are deleted
 	err = ctx.Client.Delete(goCtx, &keycloak.KeycloakUser{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
# Issue link
[MGDAPI-4530
](https://issues.redhat.com/browse/MGDAPI-4530)

# What
cleanUpTestDedicatedAdminUsersSyncedSSO function has been refactored to poll the keycloak user cr to ensure it has been deleted as expected.

# Verification steps
 - This can be verified by successfully running the test suite(or specifically B09 and C19) on a cluster with RHOAM installed.
