### PR TITLE
MGDAPI-4565 add permissions to update subscriptions in other namespaces

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -175,6 +175,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources;operatorgroups,verbs=create;list;get
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=update,resourceNames=rhmi-registry-cs
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=update
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=update
 
 // Monitoring resources not covered by namespace "admin" permissions
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors;podmonitors,verbs=get;list;create;update;delete


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
MGDAPI-4565

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
hive now creates the CRO namespace on stage so rhmi-operator service account no longer has access to create subscription to namespaces it doesn't own, adding permissions to allow subscription updates 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
