### PR TITLE
MGDAPI-4578 delete rhmi-operator-metrics service

### DIFF
--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -296,21 +296,7 @@ func (r *Reconciler) deleteObsoleteService(ctx context.Context, serverClient k8s
 			}
 		}
 	}
-	
-	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
-		rhoamService := &corev1.Service{}
-		err := serverClient.Get(ctx, k8sclient.ObjectKey {
-			Name: 	"rhmi-operator-metrics",
-			Namespace: r.installation.Namespace,
-		}, rhoamService)
-		if err == nil {
-			if err := serverClient.Delete(ctx, rhoamService); err != nil {
-				r.log.Info("Service \"rhmi-operator-metrics\" has been deleted")
-			}
-		}
-	}
 }
-
 
 func (r *Reconciler) setTenantMetrics(ctx context.Context, serverClient k8sclient.Client) error {
 	total, err := userHelper.GetTotalAPIManagementTenantsCount(ctx, serverClient)

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -296,7 +296,21 @@ func (r *Reconciler) deleteObsoleteService(ctx context.Context, serverClient k8s
 			}
 		}
 	}
+	
+	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		rhoamService := &corev1.Service{}
+		err := serverClient.Get(ctx, k8sclient.ObjectKey {
+			Name: 	"rhmi-operator-metrics",
+			Namespace: r.installation.Namespace,
+		}, rhoamService)
+		if err == nil {
+			if err := serverClient.Delete(ctx, rhoamService); err != nil {
+				r.log.Info("Service \"rhmi-operator-metrics\" has been deleted")
+			}
+		}
+	}
 }
+
 
 func (r *Reconciler) setTenantMetrics(ctx context.Context, serverClient k8sclient.Client) error {
 	total, err := userHelper.GetTotalAPIManagementTenantsCount(ctx, serverClient)

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -282,17 +282,17 @@ func getRHOAMNamespaces(ctx context.Context, serverClient k8sclient.Client, nsPr
 	return namespaces, nil
 }
 
-// temp code for rhmi 2.8 to 2.9.0 upgrades, remove this when all clusters upgraded to 2.9.0
+// temp code to be removed once all versions of RHOAM are bumped to 1.27
 func (r *Reconciler) deleteObsoleteService(ctx context.Context, serverClient k8sclient.Client) {
-	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManaged) {
-		service := &corev1.Service{}
+	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
+		rhoamService := &corev1.Service{}
 		err := serverClient.Get(ctx, k8sclient.ObjectKey{
 			Name:      "rhmi-operator-metrics",
-			Namespace: "redhat-rhmi-operator",
-		}, service)
+			Namespace: r.installation.Namespace,
+		}, rhoamService)
 		if err == nil {
-			if err := serverClient.Delete(ctx, service); err != nil {
-				r.log.Info("Service \"rhmi-operator-metrics\" was deleted from redhat-rhmi-operator")
+			if err := serverClient.Delete(ctx, rhoamService); err != nil {
+				r.log.Info("Service \"rhmi-operator-metrics\" has been deleted")
 			}
 		}
 	}

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -199,7 +199,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
-	// temp code for rhmi 2.8 to 2.9.0 upgrades, remove this when all clusters upgraded to 2.9.0
+	// temp code to be removed once all versions of RHOAM are bumped to 1.27
 	r.deleteObsoleteService(ctx, serverClient)
 
 	if integreatlyv1alpha1.IsRHOAM(rhmiv1alpha1.InstallationType(installation.Spec.Type)) {
@@ -285,13 +285,13 @@ func getRHOAMNamespaces(ctx context.Context, serverClient k8sclient.Client, nsPr
 // temp code to be removed once all versions of RHOAM are bumped to 1.27
 func (r *Reconciler) deleteObsoleteService(ctx context.Context, serverClient k8sclient.Client) {
 	if r.installation.Spec.Type == string(integreatlyv1alpha1.InstallationTypeManagedApi) {
-		rhoamService := &corev1.Service{}
+		service := &corev1.Service{}
 		err := serverClient.Get(ctx, k8sclient.ObjectKey{
 			Name:      "rhmi-operator-metrics",
 			Namespace: r.installation.Namespace,
-		}, rhoamService)
+		}, service)
 		if err == nil {
-			if err := serverClient.Delete(ctx, rhoamService); err != nil {
+			if err := serverClient.Delete(ctx, service); err != nil {
 				r.log.Info("Service \"rhmi-operator-metrics\" has been deleted")
 			}
 		}


### PR DESCRIPTION
# Issue link
[MGDAPI-4578
](https://issues.redhat.com/browse/MGDAPI-4578)

# What
deleteObsoleteService function has been refactored for rhoam in order to remove the rhmi-operator-metrics service if present as it is no longer needed and has been replaced by rhoam-operator-metrics service. This functionality is only required until all versions of rhoam are bumped to 1.27.

# Verification steps
 - Install RHOAM
 - Create a fake service called rhmi-operator-metrics in the installation namespace via OSD.
 - Verify that rhoam has deleted this service.

