### PR TITLE
MGDAPI-4498 - fix: prevent using custom domain when addon param is empty string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ IN_PROW ?= "false"
 # if 500 then 50M
 # if 1 then 100k
 DEV_QUOTA ?= "1"
+CUSTOM_DOMAIN ?= ''
 SMTP_USER  ?= ''
 SMTP_ADDRESS ?= ''
 SMTP_PASS ?= ''
@@ -391,7 +392,7 @@ cluster/prepare/dms:
 
 .PHONY: cluster/prepare/quota
 cluster/prepare/quota:
-	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) -f config/secrets/custom-addon-secret.yaml | oc apply -f -
+	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) DOMAIN=$(CUSTOM_DOMAIN) USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) -f config/secrets/custom-addon-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/quota/trial
 cluster/prepare/quota/trial:

--- a/config/secrets/custom-addon-secret.yaml
+++ b/config/secrets/custom-addon-secret.yaml
@@ -9,6 +9,7 @@ objects:
       name: addon-managed-api-service-parameters
     stringData:
       addon-managed-api-service: ${QUOTA}
+      custom-domain_domain: ${DOMAIN}
       custom-smtp-username: ${USERNAME}
       custom-smtp-address: ${HOST}
       custom-smtp-password: ${PASSWORD}
@@ -18,6 +19,8 @@ parameters:
   - name: QUOTA
     # QUOTA value is per 100,000
     value: "1"
+  - name: DOMAIN
+    value: ""
   - name: USERNAME
     value: "dummy"
   - name: HOST

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -621,11 +621,12 @@ func (r *Reconciler) retrieveConsoleURLAndSubdomain(ctx context.Context, serverC
 	}
 	r.installation.Spec.MasterURL = consoleRouteCR.Status.Ingress[0].Host
 	ok, domain, err := customDomain.GetDomain(ctx, serverClient, r.installation)
+	// Only fail when unable to get custom domain parameter from the addon secret to allow for installation of monitoring stack
 	if err != nil && !ok {
 		log.Warning(err.Error())
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("customDomain.GetDomain() failure: %w", err)
 	}
-	if ok {
+	if ok && domain != "" {
 		r.installation.Spec.RoutingSubdomain = domain
 		if r.installation.Status.CustomDomain == nil {
 			r.installation.Status.CustomDomain = &integreatlyv1alpha1.CustomDomainStatus{}

--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -970,7 +970,7 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "fallback to RouterCanonicalHostname as routing subdomain",
+			name: "fallback to RouterCanonicalHostname as routing subdomain when custom domain addon param not present",
 			fields: fields{
 				installation: &integreatlyv1alpha1.RHMI{
 					ObjectMeta: v1.ObjectMeta{
@@ -1003,6 +1003,52 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 							ObjectMeta: v1.ObjectMeta{
 								Name:      "addon-managed-api-service-parameters",
 								Namespace: "test",
+							},
+						},
+					)
+					return mockClient
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "fallback to RouterCanonicalHostname as routing subdomain when empty custom domain addon param",
+			fields: fields{
+				installation: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: v1.ObjectMeta{
+						Name:      "managed-api",
+						Namespace: "test",
+					},
+					Spec: integreatlyv1alpha1.RHMISpec{
+						Type: "managed-api",
+					},
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+				serverClient: func() k8sclient.Client {
+					mockClient := moqclient.NewSigsClientMoqWithScheme(scheme,
+						&routev1.Route{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "console",
+								Namespace: "openshift-console",
+							},
+							Status: routev1.RouteStatus{
+								Ingress: []routev1.RouteIngress{
+									{
+										Host: "host",
+									},
+								},
+							},
+						},
+						&corev1.Secret{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "addon-managed-api-service-parameters",
+								Namespace: "test",
+							},
+							Data: map[string][]byte{
+								"custom-domain_domain": []byte(""),
 							},
 						},
 					)

--- a/pkg/resources/custom-domain/custom-domain.go
+++ b/pkg/resources/custom-domain/custom-domain.go
@@ -22,14 +22,13 @@ func GetDomain(ctx context.Context, serverClient client.Client, installation *v1
 		return false, "", fmt.Errorf("nil pointer passed in for installation parameter")
 	}
 
-	parameter, ok, err := addon.GetParameter(ctx, serverClient, installation.Namespace, CustomDomainDomain)
+	parameter, ok, err := addon.GetStringParameter(ctx, serverClient, installation.Namespace, CustomDomainDomain)
 
 	if err != nil {
 		return false, "", err
 	}
 
 	if ok {
-		parameter := string(parameter)
 		parameter = strings.TrimSpace(parameter)
 		valid := IsValidDomain(parameter)
 
@@ -37,6 +36,7 @@ func GetDomain(ctx context.Context, serverClient client.Client, installation *v1
 			return true, parameter, nil
 		}
 
+		// Not returning false here to allow monitoring stack to install - will fail on 3scale installation stage
 		return true, parameter, fmt.Errorf("not valid domain \"%v\"", parameter)
 	}
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4498

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
In the bootstrap reconciler, there is no check for the domain parameter to be an empty string. Because of this, if an empty string is in the domain field in the addon parameters secret, the bootstrap reconciler will set the installation as a custom domain installation. 

This will prevent the installation from completing due to being an invalid domain.

What should happen is that if there custom domain is empty on installation, the default cluster route should be used instead

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Passing prow checks with e2e passing should be sufficient

However if you want to do a manual verification:
* Checkout this branch
* Install RHOAM
```
export INSTALLATION_TYPE=managed-api
make cluster/prepare/local
make code/run
```
* Verifiy installation completes successfully