### PR TITLE
MGDAPI-4588 updating namePrefix from rhmi- to rhoam-

### DIFF
--- a/config/rbac-local-rhoam/kustomization.yaml
+++ b/config/rbac-local-rhoam/kustomization.yaml
@@ -2,7 +2,7 @@ bases:
   - ../rbac
 
 namespace: local-rhoam-operator
-namePrefix: rhmi-
+namePrefix: rhoam-
 
 patchesStrategicMerge:
   - patches/leader_election_role_binding.yaml


### PR DESCRIPTION
# Issue link
[MGDAPI-4588](https://issues.redhat.com/browse/MGDAPI-4588)

# What
When installing rhoam locally a service called rhmi-operator-metrics-service is created. 
This fix is updating namePrefix in the rbac-local-rhoam kustomization.yaml file from rhmi- to rhoam- so that rhoam-operator-metrics service is created instead.

# Verification steps
- Provision a cluster
- Run INSTALLATION_TYPE=managed-api make cluster/prepare/local
- On OSD check that the rhoam-operator-metrics-service is created and not rhmi-operator-metrics-service.
