### PR TITLE
MGDAPI-4594 - Update products/products.yaml - for productised RHSSO

### DIFF
--- a/products/products.yaml
+++ b/products/products.yaml
@@ -42,9 +42,9 @@ products:
     installType: "rhmi"
     manifestsDir: "integreatly-monitoring"
     quayScan: true
-  - name: keycloak-operator
-    version: 18.0.0
-    url: "https://github.com/keycloak/keycloak-operator"
+  - name: rhsso-operator
+    version: 18.0.x
+    url: "git@gitlab.cee.redhat.com:keycloak/keycloak-operator-prod.git"
     installType: "rhmi/rhoam"
     manifestsDir: "integreatly-rhsso"
     quayScan: true


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4594

# What
products/products.yaml was updated to support Productised RHSSO

# Verification steps
Run following commands and check that it's working correctly
OLM_TYPE=managed-api-service SEMVER=1.28.0 make release/prepare
TYPE_OF_MANIFEST=master OLM_TYPE=managed-api-service  make manifest/prodsec
