### PR TITLE
MGDAPI-1727 remove arn checks from feature branch for sts

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1094,12 +1094,7 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 		return result, err
 	}
 	if isSTS {
-		log.Info("validation of STS role ARN parameter ")
-		validArn, err := checkStsCredentialsPresent(r.Client, installation.Spec.NamespacePrefix+"-cloud-resources-operator")
-		if err != nil || !validArn {
-			log.Error("STS role ARN parameter pattern validation failed", err)
-			return result, err
-		}
+		log.Info("STS mode enabled for cluster")
 	}
 
 	installation.Status.PreflightStatus = rhmiv1alpha1.PreflightSuccess
@@ -1682,18 +1677,6 @@ func getInstallation() (*rhmiv1alpha1.RHMI, error) {
 			Type: installType,
 		},
 	}, nil
-}
-
-// function is checking if STS secret exists
-func checkStsCredentialsPresent(client k8sclient.Client, namespace string) (bool, error) {
-	stsCredentials := &corev1.Secret{}
-	err := client.Get(context.TODO(), types.NamespacedName{Namespace: namespace, Name: sts.CredsSecretName}, stsCredentials)
-
-	if err != nil {
-		return false, fmt.Errorf("failed to get %s secret", sts.CredsSecretName)
-	}
-
-	return true, nil
 }
 
 func formatAlerts(alerts []prometheusv1.Alert) (critical resources.AlertMetrics, warning resources.AlertMetrics) {

--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -117,16 +117,6 @@ func TestRHMIReconciler_getAlertingNamespace(t *testing.T) {
 	}
 }
 
-func buildAddonSecret(namespace string, secretData map[string][]byte) *corev1.Secret {
-	return &corev1.Secret{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "addon-managed-api-service-parameters",
-			Namespace: namespace,
-		},
-		Data: secretData,
-	}
-}
-
 func TestFormatAlerts(t *testing.T) {
 	input := []prometheusv1.Alert{
 		{
@@ -434,52 +424,5 @@ func getCROConfigMap() *corev1.ConfigMap {
 				deletionFinalizer,
 			},
 		},
-	}
-}
-
-func Test_checkStsCredentialsPresent(t *testing.T) {
-	scheme := runtime.NewScheme()
-	_ = corev1.SchemeBuilder.AddToScheme(scheme)
-
-	type args struct {
-		client    client.Client
-		namespace string
-	}
-	tests := []struct {
-		name    string
-		args    args
-		want    bool
-		wantErr bool
-	}{
-		{
-			name: "Test sts-credentials exist",
-			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sts-credentials", Namespace: "test"}}),
-				namespace: "test",
-			},
-			want:    true,
-			wantErr: false,
-		},
-		{
-			name: "Test sts-credentials do not exist",
-			args: args{
-				client:    fakeclient.NewFakeClientWithScheme(scheme, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "sts-credentials", Namespace: "other"}}),
-				namespace: "test",
-			},
-			want:    false,
-			wantErr: true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := checkStsCredentialsPresent(tt.args.client, tt.args.namespace)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("checkStsCredentialsPresent() error = %v, wantErr %v", err, tt.wantErr)
-				return
-			}
-			if got != tt.want {
-				t.Errorf("checkStsCredentialsPresent() got = %v, want %v", got, tt.want)
-			}
-		})
 	}
 }


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
[MGDAPI-1727](https://issues.redhat.com/browse/MGDAPI-1727)

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Remove arn checks as the secret is now created by a credentialsRequest in managed tenants 


# Verification steps
The steps taken to install the addon with the feature branch

1. install the addon on an sts cluster with the rosa cli
```bash
rosa install addon --cluster <cluster_name> managed-api-service -y --cidr-range 10.1.0.0/26 --notification-email <your_email>@redhat.com --addon-managed-api-service 10 --addon-resource-required true --s3-access-key-id <aws_access_key> --s3-secret-access-key <aws_access_secret>
```
2. Patch the rhoam operator CSV with the following rbac (due to the bundle in the old addon not having these rbac permissions)
```yaml
- apiGroups: 
  - operator.openshift.io
  resources: 
  - cloudcredentials
  verbs: 
  - get
  - list
  - watch
- apiGroups:
  - operators.coreos.com
  resources:
  - subscriptions
  verbs:
  - update
 ```
3. patch the managed-api-service cluster role with the same rbac 

4. build a operator image off the dev branch
```bash
export ORG=austincunningham
OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/build
OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/push
```

5. Run the patch-image-csv.sh from the /scripts directory to patch the operator image

```bash
# e.g.
export VERSION=v1.27.0
export ADDON_VERSION=v1.26.0
export USE_CLUSTER_STORAGE=false
./scripts/patch-image-csv.sh
```
6. Confirm that the operator installs as expected 
