### PR TITLE
MGDAPI-4488 : Adding Telemetry Rules

### DIFF
--- a/controllers/rhmi/prometheusRules.go
+++ b/controllers/rhmi/prometheusRules.go
@@ -79,6 +79,26 @@ func (r *RHMIReconciler) newAlertsReconciler(installation *integreatlyv1alpha1.R
 				},
 			},
 		},
+		{
+			AlertName: fmt.Sprintf("%s-telemetry", installationName),
+			Namespace: observability.OpenshiftMonitoringNamespace,
+			GroupName: fmt.Sprintf("%s-telemetry.rules", installationName),
+			Interval:  "30s",
+			Rules: []monitoringv1.Rule{
+				{
+					Expr:   intstr.FromString(fmt.Sprintf("max by(status, upgrading, version) (%s_state)", installationName)),
+					Record: fmt.Sprintf("status:upgrading:version:%s_state:max", installationName),
+				},
+				{
+					Expr:   intstr.FromString(fmt.Sprintf("max by(state) (%s_critical_alerts)", installationName)),
+					Record: fmt.Sprintf("state:%ss_critical_alerts:max", installationName),
+				},
+				{
+					Expr:   intstr.FromString(fmt.Sprintf("max by(state) (%s_warning_alerts)", installationName)),
+					Record: fmt.Sprintf("state:%ss_warning_alerts:max", installationName),
+				},
+			},
+		},
 	}
 
 	return &resources.AlertReconcilerImpl{


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4488

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Add reformatted version of rhoam metrics to the cluster Prometheus. 

This work is need to allow   https://github.com/openshift/cluster-monitoring-operator/pull/1771 to work correctly

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Build and install the operator via OLM
* Check that a new prometheus has being created in the openshift-monitoring namespace called rhoam-telemetry
* From the cluster metrics run the following  queries
  * status:upgrading:version:rhoam_state:max
  * status:upgrading:version:rhoam_state:max
  *  state:rhoams_warning_alerts:max
* Expected: there should be entries for all mertics