### PR TITLE
MGDAPI-4727 Added LimitRanges to each Namespace managed by RHOAM

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -14,6 +14,15 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - limitranges
+  verbs:
+  - create
+  - delete
+  - get
+  - update
+- apiGroups:
+  - ""
+  resources:
   - namespaces
   verbs:
   - get

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -113,6 +113,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	}
 	// MGDAPI-4641 block end
 
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, r.installation.Namespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", r.installation.Namespace), err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileOauthSecrets(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile oauth secrets", err)

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -214,6 +214,9 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // For accessing limitador api from pod
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create
 
+// LimitRanges are used to assign default CPU/Memory requests and limits for containers that don't specify values for compute resources
+// +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;create;update;delete
+
 // Role permissions
 
 // +kubebuilder:rbac:groups="",resources=pods;events;configmaps;secrets,verbs=list;get;watch;create;update;patch,namespace=integreatly-operator

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -164,6 +164,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, client, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
 	// Check if STS Cluster, get STS role ARN addon parameter and pass ARN to Secret in CRO namespace
 	isSTS, err := sts.IsClusterSTS(ctx, client, r.log)
 	if err != nil {

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -137,6 +137,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, client, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileSecrets(ctx, client, installation)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s ns", productNamespace), err)

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -165,6 +165,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, client, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
+	phase, err = resources.ReconcileLimitRange(ctx, client, productNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", productNamespace), err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileSubscription(ctx, client, operatorNamespace, operatorNamespace)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s subscription", constants.CloudResourceSubscriptionName), err)

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -184,6 +184,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, client, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
+	phase, err = resources.ReconcileLimitRange(ctx, client, productNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", productNamespace), err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileConfigMap(ctx, client)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s configmap which is required to disable observability operator initilisting it's own cr", configMapNoInit), err)

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -145,6 +145,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, productNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", productNamespace), err)
+		return phase, err
+	}
+
 	phase, err = resources.ReconcileSecretToProductNamespace(ctx, serverClient, r.ConfigManager, adminCredentialSecretName, productNamespace, r.Log)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile admin credentials secret", err)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -181,6 +181,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, productNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", productNamespace), err)
+		return phase, err
+	}
+
 	phase, err = r.SetRollingStrategyForUpgrade(r.isUpgrade, ctx, serverClient, r.Config.RHSSOCommon, integreatlyv1alpha1.VersionRHSSOUser, keycloakName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to set rolling strategy for upgrade", err)

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -260,6 +260,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, operatorNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", operatorNamespace), err)
+		return phase, err
+	}
+
+	phase, err = resources.ReconcileLimitRange(ctx, serverClient, productNamespace, resources.DefaultLimitRangeParams)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile LimitRange for Namespace %s", productNamespace), err)
+		return phase, err
+	}
+
 	phase, err = r.restoreSystemSecrets(ctx, serverClient, installation)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile %s ns", productNamespace), err)

--- a/pkg/resources/limitRange.go
+++ b/pkg/resources/limitRange.go
@@ -1,0 +1,71 @@
+package resources
+
+import (
+	"context"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+const (
+	defaultLimitRangeName = "limit-range"
+)
+
+type LimitRangeParams struct {
+	CpuRequest    string
+	CpuLimit      string
+	MemoryRequest string
+	MemoryLimit   string
+	ResourceType  corev1.LimitType
+}
+
+var DefaultLimitRangeParams = LimitRangeParams{
+	CpuRequest:    "5m",
+	MemoryRequest: "10Mi",
+	ResourceType:  corev1.LimitTypeContainer,
+}
+
+func ReconcileLimitRange(ctx context.Context, client k8sclient.Client, namespace string, params LimitRangeParams) (integreatlyv1alpha1.StatusPhase, error) {
+	limitRange := &corev1.LimitRange{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "LimitRange",
+			APIVersion: corev1.SchemeGroupVersion.String(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      defaultLimitRangeName,
+			Namespace: namespace,
+		},
+		Spec: corev1.LimitRangeSpec{
+			Limits: []corev1.LimitRangeItem{
+				{
+					Type:           params.ResourceType,
+					Default:        map[corev1.ResourceName]resource.Quantity{},
+					DefaultRequest: map[corev1.ResourceName]resource.Quantity{},
+				},
+			},
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, client, limitRange, func() error {
+		if params.CpuLimit != "" {
+			limitRange.Spec.Limits[0].Default[corev1.ResourceCPU] = resource.MustParse(params.CpuLimit)
+		}
+		if params.CpuRequest != "" {
+			limitRange.Spec.Limits[0].DefaultRequest[corev1.ResourceCPU] = resource.MustParse(params.CpuRequest)
+		}
+		if params.MemoryLimit != "" {
+			limitRange.Spec.Limits[0].Default[corev1.ResourceMemory] = resource.MustParse(params.MemoryLimit)
+		}
+		if params.MemoryRequest != "" {
+			limitRange.Spec.Limits[0].DefaultRequest[corev1.ResourceMemory] = resource.MustParse(params.MemoryRequest)
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}

--- a/pkg/resources/limitRange_test.go
+++ b/pkg/resources/limitRange_test.go
@@ -1,0 +1,134 @@
+package resources
+
+import (
+	"context"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"testing"
+)
+
+func TestReconcileLimitRange(t *testing.T) {
+	namespaceName := "test-namespace"
+	scheme, err := getBuildSchemeForLimitRangeTests()
+	if err != nil {
+		t.Fatal(err)
+	}
+	client := fake.NewFakeClientWithScheme(scheme, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespaceName,
+		},
+	})
+
+	type args struct {
+		namespace string
+		params    LimitRangeParams
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    v1alpha1.StatusPhase
+		wantErr bool
+	}{
+		{
+			name: "success when requests and limits are set",
+			args: args{
+				namespace: namespaceName,
+				params: LimitRangeParams{
+					CpuRequest:    "5m",
+					CpuLimit:      "10m",
+					MemoryRequest: "5Mi",
+					MemoryLimit:   "10Mi",
+					ResourceType:  corev1.LimitTypeContainer,
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when just CPU values are set",
+			args: args{
+				namespace: namespaceName,
+				params: LimitRangeParams{
+					CpuRequest:   "5m",
+					CpuLimit:     "10m",
+					ResourceType: corev1.LimitTypeContainer,
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when just memory values are set",
+			args: args{
+				namespace: namespaceName,
+				params: LimitRangeParams{
+					MemoryRequest: "5Mi",
+					MemoryLimit:   "10Mi",
+					ResourceType:  corev1.LimitTypeContainer,
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when just requests are set",
+			args: args{
+				namespace: namespaceName,
+				params: LimitRangeParams{
+					CpuRequest:    "5m",
+					MemoryRequest: "5Mi",
+					ResourceType:  corev1.LimitTypeContainer,
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when just limits are set",
+			args: args{
+				namespace: namespaceName,
+				params: LimitRangeParams{
+					CpuLimit:     "5m",
+					MemoryLimit:  "5Mi",
+					ResourceType: corev1.LimitTypeContainer,
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when using DefaultLimitRangeParams",
+			args: args{
+				namespace: namespaceName,
+				params:    DefaultLimitRangeParams,
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ReconcileLimitRange(context.TODO(), client, tt.args.namespace, tt.args.params)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ReconcileLimitRange() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("ReconcileLimitRange() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func getBuildSchemeForLimitRangeTests() (*runtime.Scheme, error) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	return scheme, nil
+}


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4727

# What
In order to support RHOAM on autoscaled clusters, we need to provide a way to assign default CPU/memory request values for every pod/container that doesn't explicitly set them. This is required by the OpenShift autoscaler so it can accurately calculate each node's resource requirements which is a prerequisite for the autoscaler to scale up/down nodes as needed.

We can enforce default CPU/memory request values by creating a LimitRange object in each namespace that RHOAM manages. Note that the LimitRanges are intentionally set to only request a small amount of resources for each container (5m of CPU and 10 Mi of memory) . This is because certain containers need significantly less resources than others and the LimitRange enforces defaults for every container in the namespace. Therefore if the LimitRanges assigned default values to cater to the most resource intensive container for each namespace, most containers will be assigned unnecessarily large CPU/memory request values. This will make it seem like the RHOAM product requires far more resources than it actually requires and may even break installations as the scheduler will reserve so many resources for containers/pods that don't need them, it wont be able to schedule all the necessary pods.

# Verification steps

1. Checkout this [delorean PR](https://github.com/integr8ly/delorean/pull/284) and provision a ROSA cluster with autoscale enabled:
`CLUSTER_NAME=<cluster-name> ENABLE_AUTOSCALING=true STS_ENABLED=false make ocm/rosa/cluster/create`
2. Once the cluster is ready, install RHOAM via CatalogSource using this index image (you can also build your own images if you'd like just make sure to checkout this PR): `quay.io/ckyrillo/managed-api-service-index:1.28.0`
3. Verify that the installation completes and that a LimitRange object was created in each namespace (there should be 13 in all): `oc get limitranges -A`
4. Lastly, verify that the LimitRanges are correctly assigning default requests to containers that don't explictly set them. This can be done by finding a container on eng-long-lived that doesn't have set requests, for example [this one](https://console-openshift-console.apps.eng-long-lived.9p7x.s1.devshift.org/k8s/ns/redhat-rhoami-observability/pods/prometheus-prometheus-0/containers/blackbox-exporter), and comparing it to the same container on your cluster. The container on your cluster should have these values for its Resource requests: `cpu: 5m, memory: 10Mi`
