### PR TITLE
MGDAPI-4749 bump envoy image

### DIFF
--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.2-2"
+	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.3-6"
 	EnvoyAPIVersion = "v3"
 )
 

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -3,7 +3,7 @@
 # url - url to quay / redhat registry repo of the component
 additionalImages:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.1.2-2"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.3-6"
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"
   - name: observability-grafana-plugins-init


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4749

# What
Bump to envoy image to latest available

# Verification steps
- provision OSD cluster
- run `INSTALLATION_TYPE=managed-api make cluster/prepare/local LOCAL=false`
- create catalog source:
```
cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.27.0
EOF
```
- install RHOAM via operator hub under rhoam namespace
- run `INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml`
- wait for installation to complete
- update catalogue source to point to quay.io/mstoklus/managed-api-service-index:1.28.0
- wait for upgrade to complete
- scale down rhoam operator
- login to 3scale admin portal via `https://3scale-admin.[your_admin_domain].devshift.org/p/admin/onboarding/wizard/intro` link
- follow the wizard to create backend and product
- in 3scale, navigate to integrations 
- pull the apicast staging link
- go to marin3r ns config maps and find rate limit config map
- update rate limit to 5 request per 60 seconds
- restart marin3r deployment
- go to 3scale services and find apicast service
- ensure that the target port is 8443 instead of 8080 (if not, update it to 8443 manually)
- curl the apicast endpoint 5 times and ensure that 6 th request is ratelimited.
