### PR TITLE
MGDAPI-4485 create alert for absent cro metrics

### DIFF
--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -74,7 +74,7 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 					{
 						Alert: fmt.Sprintf("%sCloudResourceOperatorMetricsMissing", strings.ToUpper(installationName)),
 						Expr: intstr.FromString(
-							fmt.Sprintf(`(absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s)) == 1`,
+							fmt.Sprintf(`(absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s)) == 1 and rhoam_spec{use_cluster_storage="false"}`,
 								croResources.DefaultPostgresAvailMetricName,
 								croResources.DefaultPostgresConnectionMetricName,
 								croResources.DefaultPostgresStatusMetricName,

--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -3,6 +3,7 @@ package cloudresources
 import (
 	"context"
 	"fmt"
+	croResources "github.com/integr8ly/cloud-resource-operator/pkg/resources"
 	"strings"
 
 	crov1alpha1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
@@ -24,7 +25,6 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 	}
 
 	namespace := observabilityConfig.GetNamespace()
-	alertName := "cro-ksm-endpoint-alerts"
 
 	alertsReconciler := &resources.AlertReconcilerImpl{
 		ProductName:  "Cloud Resources Operator",
@@ -32,7 +32,7 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 		Log:          logger,
 		Alerts: []resources.AlertConfiguration{
 			{
-				AlertName: alertName,
+				AlertName: "cro-ksm-endpoint-alerts",
 				Namespace: namespace,
 				GroupName: "cloud-resources-operator-endpoint.rules",
 				Rules: []monitoringv1.Rule{
@@ -63,6 +63,32 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 						Expr:   intstr.FromString(fmt.Sprintf("cro_vpc_action{namespace='%s', status='failed', error!=''} > 0", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "critical", "product": installationName},
+					},
+				},
+			},
+			{
+				AlertName: "cloud-resource-operator-metrics-missing",
+				Namespace: namespace,
+				GroupName: "cloud-resource-operator.rules",
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: fmt.Sprintf("%sCloudResourceOperatorMetricsMissing", strings.ToUpper(installationName)),
+						Expr: intstr.FromString(
+							fmt.Sprintf(`(absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s)) == 1`,
+								croResources.DefaultPostgresAvailMetricName,
+								croResources.DefaultPostgresConnectionMetricName,
+								croResources.DefaultPostgresStatusMetricName,
+								croResources.DefaultRedisAvailMetricName,
+								croResources.DefaultRedisConnectionMetricName,
+								croResources.DefaultRedisStatusMetricName,
+							),
+						),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical"},
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlRHOAMCloudResourceOperatorMetricsMissing,
+							"message": "one or more cloud-resource-operator metrics have been missing for 5+ minutes",
+						},
 					},
 				},
 			},

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -41,16 +41,13 @@ import (
 )
 
 const (
-	// TODO: these Metric names should be imported from github.com/integr8ly/cloud-resource-operator/pkg/resources v0.18.0 once it is possible to update to that version
-	DefaultPostgresDeletionMetricName = "cro_postgres_deletion_timestamp"
-	DefaultRedisDeletionMetricName    = "cro_redis_deletion_timestamp"
-	alertFor5Mins                     = "5m"
-	alertFor15Mins                    = "15m"
-	alertFor10Mins                    = "10m"
-	alertFor20Mins                    = "20m"
-	alertFor30Mins                    = "30m"
-	alertFor60Mins                    = "60m"
-	alertPercentage                   = "90"
+	alertFor5Mins   = "5m"
+	alertFor15Mins  = "15m"
+	alertFor10Mins  = "10m"
+	alertFor20Mins  = "20m"
+	alertFor30Mins  = "30m"
+	alertFor60Mins  = "60m"
+	alertPercentage = "90"
 )
 
 func ReconcilePostgresAlerts(ctx context.Context, client k8sclient.Client, inst *v1alpha1.RHMI, cr *crov1.Postgres, log l.Logger) (v1alpha1.StatusPhase, error) {
@@ -264,7 +261,7 @@ func createPostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 	}
 	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 0",
 			croResources.DefaultPostgresAvailMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("Postgres instance: '%s' (strategy: %s) for product: %s is unavailable", cr.Name, cr.Status.Strategy, productName)
@@ -305,7 +302,7 @@ func createPostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 	}
 	ruleName := fmt.Sprintf("connectivity-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 0",
 			croResources.DefaultPostgresConnectionMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("Unable to connect to Postgres instance. Postgres Custom Resource: %s in namespace %s (strategy: %s) for product: %s", cr.Name, cr.Namespace, cr.Status.Strategy, productName)
@@ -336,7 +333,7 @@ func createPostgresResourceStatusPhasePendingAlert(ctx context.Context, client k
 	alertName := postgresCRName + "PostgresResourceStatusPhasePending"
 	ruleName := fmt.Sprintf("resource-status-phase-pending-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 0",
 			croResources.DefaultPostgresStatusMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("The creation of the Postgres instance has take longer that %s. Postgres Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor20Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
@@ -398,7 +395,7 @@ func createPostgresResourceDeletionStatusFailedAlert(ctx context.Context, client
 	alertName := postgresCRName + "PostgresResourceDeletionStatusPhaseFailed"
 	ruleName := fmt.Sprintf("resource-deletion-status-phase-failed-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='failed'}", DefaultPostgresDeletionMetricName, cr.Namespace, cr.Name, productName),
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='failed'}", croResources.DefaultPostgresDeletionMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("The deletion of the Postgres instance has been failing longer than %s. Postgres Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor5Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
 	labels := map[string]string{
@@ -563,7 +560,7 @@ func createRedisResourceStatusPhasePendingAlert(ctx context.Context, client k8sc
 	alertName := redisCRName + "RedisResourceStatusPhasePending"
 	ruleName := fmt.Sprintf("resource-status-phase-pending-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='complete'} == 0",
 			croResources.DefaultRedisStatusMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("The creation of the Redis cache has take longer that %s. Redis Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor20Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
@@ -684,7 +681,7 @@ func createRedisResourceDeletionStatusFailedAlert(ctx context.Context, client k8
 	alertName := redisCRName + "RedisResourceDeletionStatusPhaseFailed"
 	ruleName := fmt.Sprintf("resource-deletion-status-phase-failed-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='failed'}", DefaultRedisDeletionMetricName, cr.Namespace, cr.Name, productName),
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s',statusPhase='failed'}", croResources.DefaultRedisDeletionMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("The deletion of the Redis instance has been failing longer than %s. Redis Custom Resource: %s in namespace %s (strategy: %s) for product: %s", alertFor5Mins, cr.Name, cr.Namespace, cr.Status.Strategy, productName)
 	labels := map[string]string{
@@ -721,7 +718,7 @@ func createRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 	}
 	ruleName := fmt.Sprintf("availability-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 0",
 			croResources.DefaultRedisAvailMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("Redis instance: '%s' (strategy: %s) for the product: %s is unavailable", cr.Name, cr.Status.Strategy, productName)
@@ -759,7 +756,7 @@ func createRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 	}
 	ruleName := fmt.Sprintf("connectivity-rule-%s", cr.Name)
 	alertExp := intstr.FromString(
-		fmt.Sprintf("absent(%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 1)",
+		fmt.Sprintf("%s{exported_namespace='%s',resourceID='%s',productName='%s'} == 0",
 			croResources.DefaultRedisConnectionMetricName, cr.Namespace, cr.Name, productName),
 	)
 	alertDescription := fmt.Sprintf("Unable to connect to Redis instance. Redis Custom Resource: %s in namespace %s (strategy: %s) for the product: %s", cr.Name, cr.Namespace, cr.Status.Strategy, productName)

--- a/pkg/resources/sop_url.go
+++ b/pkg/resources/sop_url.go
@@ -54,4 +54,5 @@ const (
 	SopUrlKubePersistentVolumeFillingUp                        = "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/blob/master/sops/rhoam/alerts/pvc_storage.asciidoc#kubepersistentvolumefillingup"
 	SopUrlPersistentVolumeErrors                               = "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/blob/master/sops/rhoam/alerts/pvc_storage.asciidoc#persistentvolumeerrors"
 	SopApiManagementTenantCRFailed                             = "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/blob/master/sops/rhoam/alerts/ApiManagementTenantCRFailed.asciidoc"
+	SopUrlRHOAMCloudResourceOperatorMetricsMissing             = "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/blob/master/sops/rhoam/alerts/RHOAMCloudResourceOperatorMetricsMissing.asciidoc"
 )

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -464,6 +464,12 @@ func commonExpectedRules(installationName string) []alertsTestRule {
 				"RHOAMCriticalMetricsMissing",
 			},
 		},
+		{
+			File: ObservabilityNamespacePrefix + "cloud-resource-operator-metrics-missing.yaml",
+			Rules: []string{
+				"RHOAMCloudResourceOperatorMetricsMissing",
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4485

# What
In an effort to help with root cause analysis of CRO alerts ensure that alerts do not fire due to missing or absent CRO metrics. Instead create a separate alert that will fire when metrics are absent.

# Verification steps
- Provision an AWS CCS cluster
- Prepare the cluster and install RHOAM from the latest stable version `v1.27.0`:
```
git checkout tags/rhoam-v1.27.0 -b rhoam-v1.27.0

make cluster/prepare/local LOCAL=false

cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/tdimov0/managed-api-service-index:1.27.0
EOF

make deploy/integreatly-rhmi-cr.yml LOCAL=false USE_CLUSTER_STORAGE=false
```
- Install the RHOAM operator from Operator Hub
- Wait until the Installation completes successfully
- Ensure no alerts are firing
- Patch the catalog source to point at the image which contain the changes from this pull request and upgrade RHOAM:
```
oc patch catalogsource rhoam-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": /spec/image, "value": "quay.io/tdimov0/managed-api-service-index:1.28.0"}]'
```
- Wait until the upgrade completes successfully
- Ensure none of these alerts are firing:
```
***PostgresInstanceUnavailable
***PostgresConnectionFailed
***PostgresResourceStatusPhasePending
***PostgresResourceDeletionStatusPhaseFailed
***RedisCacheUnavailable
***RedisCacheConnectionFailed
***RedisResourceStatusPhasePending
***RedisResourceDeletionStatusPhaseFailed
```
- Scale down the `cloud-resource-operator` deployment to simulate triggering the new alert:
```
oc patch deployment cloud-resource-operator -n redhat-rhoam-cloud-resources-operator --type=json -p='[{"op": "replace", "path": /spec/replicas, "value": 0}]'
```
- After ~5 minutes verify that the `RHOAMCloudResourceOperatorMetricsMissing` alert is firing
- Scale up the `cloud-resource-operator` deployment back to what it was before:
```
oc patch deployment cloud-resource-operator -n redhat-rhoam-cloud-resources-operator --type=json -p='[{"op": "replace", "path": /spec/replicas, "value": 1}]'
```
- Ensure no alerts are firing
