### PR TITLE
MGDAPI-4595 add golangci-lint checks

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,29 @@
+output:
+  format: tab
+  sort-results: true
+
+linters:
+  disable:
+    - errcheck
+    - ineffassign
+    - unused
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters-settings:
+  gosimple:
+    checks: ["all", -S1004, -S1008, -S1028, -S1039, -S1002, -S1005, -S1031, -S1011, -S1023, -S1025, -S1034, -S1001]
+  staticcheck:
+    checks: ["all", -SA4006, -SA9003, -SA5011, -SA4001, -SA4010, -SA1019, -SA1030, -SA6000, -SA4009, -SA4022, -SA5001]
+
+presets:
+  - bugs
+  - error
+  - metalinter
+  - style
+  - unused
+
+run:
+  modules-download-mode: vendor


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4595

# What
Configured the installation of `golangci-lint` binary.
Added linter presets and disabled all failing linters (temporary).
In subsequent tasks, the disabled linters will have to be re-enabled as we fix the issues that cause the failures.

# Verification steps
- Run the lint make command:
```
make test/lint
```
- It should install the `golangci-lint` binary to the `bin` folder of your project if it doesn't already exist there
- The output of running the linting should be empty. If it isn't, there's a problem...