### PR TITLE
MGDAPI-4639 - Add resource requests to Envoy sidecars and new e2e test

### DIFF
--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -102,6 +102,8 @@ func (envoyProxy *envoyProxyServer) patchDeploymentConfig(dcName, namespace, env
 	dc.Spec.Template.Annotations["marin3r.3scale.net/ports"] = envoyPort
 	dc.Spec.Template.Annotations["marin3r.3scale.net/envoy-api-version"] = EnvoyAPIVersion
 	dc.Spec.Template.Annotations["marin3r.3scale.net/envoy-image"] = EnvoyImage
+	dc.Spec.Template.Annotations["marin3r.3scale.net/resources.requests.cpu"] = "190m"
+	dc.Spec.Template.Annotations["marin3r.3scale.net/resources.requests.memory"] = "90Mi"
 
 	if err := envoyProxy.client.Update(envoyProxy.ctx, dc); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to apply MARIN3R labels to %s deploymentconfig: %v", dcName, err)

--- a/test/common/multitenancy.go
+++ b/test/common/multitenancy.go
@@ -48,7 +48,7 @@ var (
 	testUserForQuickStart = fmt.Sprintf("%v%02v", DefaultTestUserName, 1)
 	quickStartNamespace   = fmt.Sprintf("%v%02v-dev", DefaultTestUserName, 1)
 	quarkusAppName        = "rhoam-quarkus-openapi"
-	quarkusImageName      = "quay.io/evanshortiss/rhoam-quarkus-openapi:latest"
+	quarkusImageName      = "quay.io/integreatly/rhoam-quarkus-openapi:latest"
 	singleTenantMode      = true
 )
 
@@ -540,7 +540,7 @@ func createAndVerifyQuarkusRoute(ctx *TestingContext, rhmi *integreatlyv1alpha1.
 		return true, nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to get Service before creating route %v", err)
+		return fmt.Errorf("failed to verify that route was successfully created %v", err)
 	}
 
 	return nil
@@ -569,7 +569,7 @@ func grantViewRoleToTestUser(ctx *TestingContext) error {
 		return nil
 	})
 	if err != nil {
-		return fmt.Errorf("failed to grant view fole to user %v, error: %v", testUserForQuickStart, err)
+		return fmt.Errorf("failed to grant view role to user %v, error: %v", testUserForQuickStart, err)
 	}
 
 	return nil

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -78,6 +78,7 @@ var (
 		{
 			[]TestCase{
 				{"M02B - Verify RHOAM version metric is exposed in Prometheus", TestRhoamVersionMetricExposed},
+				{"Validate resource requirements are set", ValidateResourceRequirements},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
 		},

--- a/test/common/validate_resource_requirements.go
+++ b/test/common/validate_resource_requirements.go
@@ -1,0 +1,149 @@
+package common
+
+import (
+	"context"
+	"fmt"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+var (
+	namespaceToVerify = []string{
+		RHOAMOperatorNamespace,
+		CloudResourceOperatorNamespace,
+		ObservabilityOperatorNamespace,
+		ObservabilityProductNamespace,
+		CustomerGrafanaNamespace,
+		RHSSOUserProductNamespace,
+		RHSSOUserOperatorNamespace,
+		RHSSOProductNamespace,
+		RHSSOOperatorNamespace,
+		Marin3rOperatorNamespace,
+		Marin3rProductNamespace,
+		ThreeScaleProductNamespace,
+		ThreeScaleOperatorNamespace,
+	}
+	productsToTest = map[v1alpha1.ProductName]map[string]string{
+		v1alpha1.Product3Scale: {
+			quota.BackendListenerName:   "deploymentconfig=backend-listener",
+			quota.BackendWorkerName:     "deploymentconfig=backend-worker",
+			quota.ApicastProductionName: "deploymentconfig=apicast-production",
+			"namespace":                 ThreeScaleProductNamespace,
+		},
+		v1alpha1.ProductRHSSOUser: {
+			quota.KeycloakName: "component=keycloak",
+			"namespace":        RHSSOUserProductNamespace,
+		},
+		v1alpha1.ProductMarin3r: {
+			quota.RateLimitName: "app=ratelimit",
+			"namespace":         Marin3rProductNamespace,
+		},
+	}
+	testLog = l.NewLoggerWithContext(l.Fields{l.ProductLogContext: "TeST"}).Logger
+)
+
+func ValidateResourceRequirements(t TestingTB, ctx *TestingContext) {
+	// Verify that all pods in every RHOAM namespace have requests set for both CPU and memory
+	verifyPodRequests(t, ctx)
+
+	// Verify that the RHOAM has correctly matching the quota config
+	verifyQuotaConfig(t, ctx)
+}
+
+func verifyPodRequests(t TestingTB, ctx *TestingContext) {
+	for _, ns := range namespaceToVerify {
+		pods := &corev1.PodList{}
+		listOpts := []k8sclient.ListOption{
+			k8sclient.InNamespace(ns),
+		}
+
+		err := ctx.Client.List(context.TODO(), pods, listOpts...)
+		if err != nil {
+			t.Fatal(fmt.Sprintf("Failed to get list of Pods from Namespace %s: %s", ns, err))
+		}
+
+		for _, pod := range pods.Items {
+			for _, initContainer := range pod.Spec.InitContainers {
+				if !areRequestsSet(initContainer.Resources.Requests) {
+					t.Fatal(fmt.Sprintf("InitContainer %s from Pod %s in Namespace %s does not have CPU and/or memory requests set", initContainer.Name, pod.Name, ns))
+				}
+			}
+			for _, container := range pod.Spec.Containers {
+				if !areRequestsSet(container.Resources.Requests) {
+					t.Fatal(fmt.Sprintf("Container %s from Pod %s in Namespace %s does not have CPU and/or memory requests set", container.Name, pod.Name, ns))
+				}
+			}
+
+		}
+	}
+}
+
+func areRequestsSet(requests corev1.ResourceList) bool {
+	return requests != nil && requests.Memory() != nil && requests.Cpu() != nil
+}
+
+func verifyQuotaConfig(t TestingTB, ctx *TestingContext) {
+	quotaConfig, err := getQuotaConfig(t, ctx.Client)
+	if err != nil {
+		t.Fatal("Error getting quota")
+		return
+	}
+
+	for product, pods := range productsToTest {
+		productConfig := quotaConfig.GetProduct(product)
+
+		for pod, label := range pods {
+			var resourceConfig corev1.ResourceRequirements
+			var ok bool
+
+			// in order to simplify logic and data structure one of pods represent a product namespace
+			if pod != "namespace" {
+				resourceConfig, ok = productConfig.GetResourceConfig(pod)
+				if !ok {
+					t.Fatal(fmt.Sprintf("Couldn't retrieve config for %s pod from %s product config", pod, product))
+					return
+				}
+
+				clientPods := &corev1.PodList{}
+				selector, _ := labels.Parse(label)
+				listOpts := []k8sclient.ListOption{
+					k8sclient.InNamespace(pods["namespace"]),
+					k8sclient.MatchingLabelsSelector{
+						Selector: selector,
+					},
+				}
+
+				err = ctx.Client.List(context.TODO(), clientPods, listOpts...)
+				if err != nil {
+					t.Fatal(fmt.Sprintf("failed to get %s pods: %s", pod, err))
+				}
+
+				if !ensurePodMatchesConfig(t, clientPods, &resourceConfig) {
+					t.Fatal(fmt.Sprintf("Found error in resource requirement for %s pod or it's containers", clientPods.Items[0].Name))
+				}
+			}
+
+		}
+	}
+}
+
+func ensurePodMatchesConfig(t TestingTB, pods *corev1.PodList, resourceRequirements *corev1.ResourceRequirements) bool {
+	// all pods will share requests/limits so no point in checking all
+	for _, container := range pods.Items[0].Spec.Containers {
+		if strings.Contains(pods.Items[0].Name, container.Name) {
+			if container.Resources.Limits.Cpu().Cmp(*resourceRequirements.Limits.Cpu()) != 0 &&
+				container.Resources.Limits.Memory().Cmp(*resourceRequirements.Limits.Memory()) != 0 &&
+				container.Resources.Requests.Memory().Cmp(*resourceRequirements.Requests.Memory()) != 0 &&
+				container.Resources.Requests.Cpu().Cmp(*resourceRequirements.Requests.Cpu()) != 0 {
+				t.Error(fmt.Sprintf("mismatch in container %s from %s pod. Does not match quota config", container.Name, pods.Items[0].Name))
+				return false
+			}
+		}
+	}
+	return true
+}


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4639

# What
This PR includes 3 discrete changes which can be identified by their different commits:

1. Adds a function called `addResourceRequests()` to the 3scale reconciler that annotates the `apicast-production`, `apicast-staging`, and `backend-listener` DeploymentConfigs in order to set CPU/memory requests.
2. Adds a new e2e test called `ValidateResourceRequirements` which verifies that every container created in a RHOAM namespace has explicitly set values for CPU/memory requests.
3. Refactors the subscription_controller reconciler to **not** overwrite the `Resources` field in the Subscription's `Config` block with an empty struct `{}`

# Verification steps
## Verify Envoy containers have properly set CPU/memory requests

1. Checkout this PR
2. Provision an OSD cluster
3. Prepare the cluster by running: `INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local`
4. Create the CatalogSource:
```yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/ckyrillo/managed-api-service-index:1.29.0
```
5. Install RHOAM via the OperatorHub in the `redhat-rhoam-operator` Namespace - make sure to check `Automatic` for the `Update approval` (this is needed to force the subscription controller to trigger its reconciler)
6. Create the RHMI CR by running: `INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true LOCAL=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml`
7. Wait for the installation to complete
8. Verify that all of the `envoy-sidecar` Containers in each of the `apicast-production`, `apicast-staging`, `backend-listener` Pods from the `redhat-rhoam-3scale` Namespace have the proper values for CPU/memory requests (`cpu: 190m, memory: 90Mi`)

## Verify new e2e test, `ValidateResourceRequirements`, is passing

1. Nothing to do here as long as prow e2e tests are passing.

## Verify refactored subscription controller is working as expected

1. Verify that the `spec.config.resources` block in the `managed-api-service` Subscription from the `redhat-rhoam-operator` Namespace has the same request values as the `managed-api-service.v1.29.0` [ClusterServiceVersion](https://github.com/integr8ly/integreatly-operator/blob/master/bundles/managed-api-service/1.29.0/manifests/managed-api-service.clusterserviceversion.yaml#L547-L553)
    * Note: Sometimes the subscription's YAML can't be rendered in the UI for some reason. If this happens, run the following command to view the Subscription's contents: `oc get subscription managed-api-service -n redhat-rhoam-operator -o yaml`