### PR TITLE
MGDAPI-3772 introduced env var to allow skip cleanup

### DIFF
--- a/test/common/selfmanaged_apicast.go
+++ b/test/common/selfmanaged_apicast.go
@@ -36,6 +36,7 @@ import (
 	"math/big"
 	"net/http"
 	"net/url"
+	"os"
 	ctrl "sigs.k8s.io/controller-runtime"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	"strconv"
@@ -61,6 +62,7 @@ var (
 	log                 = l.NewLogger()
 	threeScaleNamespace string
 	serviceSystemName   string
+	skipCleanup         = strings.ToLower(os.Getenv("SKIP_CLEANUP"))
 )
 
 func TestSelfmanagedApicast(t TestingTB, testingCtx *TestingContext) {
@@ -126,7 +128,9 @@ func TestSelfmanagedApicast(t TestingTB, testingCtx *TestingContext) {
 	if err != nil {
 		t.Fatalf("Error creating product: %v", err)
 	}
-	defer deleteProduct(threeScaleAdminPortal, token3scale)
+	if skipCleanup != "true" {
+		defer deleteProduct(threeScaleAdminPortal, token3scale)
+	}
 
 	//Add backend usage to product
 	err = addBackendToProduct(threeScaleAdminPortal, token3scale)

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -103,6 +103,7 @@ var (
 				{"C19 - Validate creation of invalid username triggers alert", TestInvalidUserNameAlert},
 				{"H34 - Verify 3scale custom SMTP full config", Test3ScaleCustomSMTPFullConfig},
 				{"H35 - Verify 3scale custom SMTP partial config", Test3ScaleCustomSMTPPartialConfig},
+				{"H24 - Verify selfmanaged Apicast", TestSelfmanagedApicast},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},


### PR DESCRIPTION
# Issue link
[https://issues.redhat.com/browse/MGDAPI-3772](url)

# What
Introduce a way to skip the Product removal call here:
[https://github.com/integr8ly/integreatly-operator/blob/3b24a8d67fb0c2af8ca6502ff7bd593e69ad5bf2/test/common/selfmanaged_apicast.go#L125](url)

E.g. something like:

LOCAL=false INSTALLATION_TYPE=managed-api SKIP_CLEANUP=true TEST=H24 make test/e2e/single

# Verification steps

It is possible to run the H24 tests without Product removal.
Update the H24 test case to use this SKIP_CLEANUP env var

