### PR TITLE
MGDAPI-4847 - bump: oauth proxy image

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -319,7 +319,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, client k8sclient.C
 			BaseImage: fmt.Sprintf("%s:%s", constants.GrafanaImage, constants.GrafanaVersion),
 			Containers: []v1.Container{
 				{Name: "grafana-proxy",
-					Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1",
+					Image: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:24802df1766a74114169d3d151036e3eaf725124bc52ab86c8f24469b2781ca7",
 					VolumeMounts: []v1.VolumeMount{
 						{MountPath: "/etc/tls/private",
 							Name:     "secret-grafana-k8s-tls",

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -9,7 +9,7 @@ additionalImages:
   - name: observability-grafana-plugins-init
     url: "quay.io/grafana-operator/grafana_plugins_init:0.0.6"
   - name: observability-origin-oauth-proxy
-    url: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:9a5ee95f8e99a63a4ad0e8b01683ac03c75337bbbe3d504d199a97f9921eb0c1"
+    url: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:24802df1766a74114169d3d151036e3eaf725124bc52ab86c8f24469b2781ca7"
   - name: observability-prometheus-operator
     url: "quay.io/prometheus-operator/prometheus-operator@sha256:066fce4a6b7392f07f7179b59ed4448bacc0767277637de99809449637be924b"
   - name: rhsso-operator


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4847

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Bump oauth proxy image to latest available

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
* Verify customer grafana is still acessible using latest image