### PR TITLE
MGDAPI-4471 - Add support for running the functional test suite externally

### DIFF
--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -1,0 +1,31 @@
+FROM registry.ci.openshift.org/openshift/release:golang-1.18 AS builder
+
+ENV PKG=/go/src/github.com/integr8ly/integreatly-operator/
+WORKDIR ${PKG}
+
+# compile test binary
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY vendor ./vendor
+COPY make ./make
+COPY apis/ apis/
+COPY controllers/ controllers/
+COPY pkg ./pkg
+COPY test ./test
+COPY Makefile ./
+COPY manifests/ ./manifests
+COPY products ./products
+COPY version ./version
+
+RUN make test/compile/functional
+
+FROM quay.io/openshift/origin-cli
+# Install chrome for tests
+COPY test-dependency/*.repo /etc/yum.repos.d/
+COPY build/bin/setup_external.sh ./setup_external.sh
+RUN dnf -y install google-chrome-stable && dnf clean all
+ENV WATCH_NAMESPACE=redhat-rhoam-operator
+RUN mkdir test-run-results
+
+COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
+ENTRYPOINT [ "/bin/bash", "-c", "./setup_external.sh"]

--- a/build/bin/setup_external.sh
+++ b/build/bin/setup_external.sh
@@ -3,7 +3,7 @@
 OUTPUT_DIR=${OUTPUT_DIR:-"test-run-results"}
 mkdir -p ${OUTPUT_DIR}
 oc login ${OPENSHIFT_HOST} -u kubeadmin -p ${OPENSHIFT_PASSWORD}
-SUITE_COMMAND="/integreatly-operator-test-harness.test -test.v -ginkgo.v -ginkgo.progress -ginkgo.no-color --ginkgo.junit-report=${OUTPUT_DIR}/junit-integreatly-operator.xml"
+SUITE_COMMAND="/integreatly-operator-test-harness.test -test.v -ginkgo.v -ginkgo.progress -ginkgo.no-color"
 if [[ ! -z "${RegExpFilter}" ]]; then
     SUITE_COMMAND="${SUITE_COMMAND} -ginkgo.focus ${RegExpFilter}"
 fi

--- a/build/bin/setup_external.sh
+++ b/build/bin/setup_external.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
+OUTPUT_DIR=${OUTPUT_DIR:-"test-run-results"}
+mkdir -p ${OUTPUT_DIR}
 oc login ${OPENSHIFT_HOST} -u kubeadmin -p ${OPENSHIFT_PASSWORD}
-SUITE_COMMAND="/integreatly-operator-test-harness.test -test.v -ginkgo.v -ginkgo.progress -ginkgo.no-color"
+SUITE_COMMAND="/integreatly-operator-test-harness.test -test.v -ginkgo.v -ginkgo.progress -ginkgo.no-color --ginkgo.junit-report=${OUTPUT_DIR}/junit-integreatly-operator.xml"
 if [[ ! -z "${RegExpFilter}" ]]; then
     SUITE_COMMAND="${SUITE_COMMAND} -ginkgo.focus ${RegExpFilter}"
 fi
-$SUITE_COMMAND | tee test-run-results/log.txt
+$SUITE_COMMAND | tee ${OUTPUT_DIR}/log.txt

--- a/build/bin/setup_external.sh
+++ b/build/bin/setup_external.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+oc login ${OPENSHIFT_HOST} -u kubeadmin -p ${OPENSHIFT_PASSWORD}
+SUITE_COMMAND="/integreatly-operator-test-harness.test -test.v -ginkgo.v -ginkgo.progress -ginkgo.no-color"
+if [[ ! -z "${RegExpFilter}" ]]; then
+    SUITE_COMMAND="${SUITE_COMMAND} -ginkgo.focus ${RegExpFilter}"
+fi
+$SUITE_COMMAND | tee test-run-results/log.txt

--- a/make/functional.mk
+++ b/make/functional.mk
@@ -6,6 +6,12 @@ image/functional/build:
 	go mod vendor
 	$(CONTAINER_ENGINE) build --platform=$(CONTAINER_PLATFORM) . -f Dockerfile.functional -t $(INTEGREATLY_OPERATOR_TEST_HARNESS_IMAGE)
 
+.PHONY: image/external/build
+image/external/build:
+	go mod vendor
+	docker build . -f Dockerfile.external 
+
+
 .PHONY: image/functional/push
 image/functional/push:
 	$(CONTAINER_ENGINE) push $(INTEGREATLY_OPERATOR_TEST_HARNESS_IMAGE)

--- a/make/functional.mk
+++ b/make/functional.mk
@@ -1,5 +1,6 @@
 DIR := $(dir $(realpath $(firstword $(MAKEFILE_LIST))))
 INTEGREATLY_OPERATOR_TEST_HARNESS_IMAGE ?= $(REG)/$(ORG)/integreatly-operator-test-harness:latest
+INTEGREATLY_OPERATOR_TEST_EXTERNAL_IMAGE ?= $(REG)/$(ORG)/integreatly-operator-test-external:latest
 
 .PHONY: image/functional/build
 image/functional/build:
@@ -9,7 +10,11 @@ image/functional/build:
 .PHONY: image/external/build
 image/external/build:
 	go mod vendor
-	docker build . -f Dockerfile.external 
+	$(CONTAINER_ENGINE) build --platform=$(CONTAINER_PLATFORM) . -f Dockerfile.external -t $(INTEGREATLY_OPERATOR_TEST_EXTERNAL_IMAGE)
+
+.PHONY: image/external/push
+image/functional/push:
+	$(CONTAINER_ENGINE) push $(INTEGREATLY_OPERATOR_TEST_EXTERNAL_IMAGE)
 
 
 .PHONY: image/functional/push

--- a/make/functional.mk
+++ b/make/functional.mk
@@ -13,7 +13,7 @@ image/external/build:
 	$(CONTAINER_ENGINE) build --platform=$(CONTAINER_PLATFORM) . -f Dockerfile.external -t $(INTEGREATLY_OPERATOR_TEST_EXTERNAL_IMAGE)
 
 .PHONY: image/external/push
-image/functional/push:
+image/external/push:
 	$(CONTAINER_ENGINE) push $(INTEGREATLY_OPERATOR_TEST_EXTERNAL_IMAGE)
 
 

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -2,6 +2,7 @@ package functional
 
 import (
 	"fmt"
+	"os"
 	"testing"
 	"time"
 
@@ -23,8 +24,7 @@ import (
 )
 
 const (
-	testResultsDirectory = "/test-run-results"
-	testSuiteName        = "integreatly-operator"
+	testSuiteName = "integreatly-operator"
 )
 
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
@@ -60,7 +60,10 @@ func TestAPIs(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not get install type %s", err)
 	}
-
+	testResultsDirectory := os.Getenv("OUTPUT_DIR")
+	if len(testResultsDirectory) == 0 {
+		testResultsDirectory = "/test-run-results"
+	}
 	jUnitReportLocation := fmt.Sprintf("%s/%s", testResultsDirectory, utils.JUnitFileName(testSuiteName))
 
 	// Fetch the current config


### PR DESCRIPTION
# Issue link
[MGDAPI-4471](https://issues.redhat.com/browse/MGDAPI-4471)
# What
Repackaged the `Dockerfile.functional` file by changing the base image to include the `oc-cli` and made some other changes resulting in our test suite now being able to be ran from an image independent of delorean

# Verification steps
run `make image/external/build` and take the image hash
have a cluster ready and fill in the `OPENSHIFT_HOST` and `OPENSHIFT_PASSWORD` credentials appropriately
```
docker run  -it \
-e OPENSHIFT_HOST='<openshift api url>' \
-e OPENSHIFT_PASSWORD='<password>' \
-e MULTIAZ=false \
-e DESTRUCTIVE=false \
-e NUMBER_OF_TENANTS='2' \
-e TENANTS_CREATION_TIMEOUT='3' \
-e RegExpFilter=''" \
-e OUTPUT_DIR=test-run-results
-v rhoam-test-run-results:/<same_as_OUTPUT_DIR> \
<image id>
```
I validated it working correctly by first running the same test suite via delorean and comparing the results with this running on my machine and the results were identical, feel free to replicate.
