### PR TITLE
MGDAPI-4713 use csv_succeeded instead of csv_abnormal metric

### DIFF
--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -262,9 +262,9 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 				{
 					Alert: "RHOAMCSVRequirementsNotMet",
 					Annotations: map[string]string{
-						"message": "RequirementsNotMet for CSV '{{$labels.name}}' in namespace '{{$labels.namespace}}'. Phase is {{$labels.phase}}",
+						"message": "RequirementsNotMet for CSV '{{$labels.name}}' in namespace '{{$labels.exported_namespace}}'. Phase is not succeeded",
 					},
-					Expr:   intstr.FromString(fmt.Sprintf("csv_abnormal{phase=~'Pending|Failed',exported_namespace=~'%s.*'}", r.Config.GetNamespacePrefix())),
+					Expr:   intstr.FromString(fmt.Sprintf(`csv_succeeded{exported_namespace=~"%s.*"} != 1`, r.Config.GetNamespacePrefix())),
 					For:    "15m",
 					Labels: map[string]string{"severity": "warning", "product": installationName},
 				},


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4713

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
- Provision an OSD cluster
- Prepare the cluster and install RHOAM from the latest stable version `v1.28.0`:
```
git checkout tags/rhoam-v1.28.0 -b rhoam-v1.28.0

make cluster/prepare/local LOCAL=false

cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/tdimov0/managed-api-service-index:1.28.0
EOF

make deploy/integreatly-rhmi-cr.yml LOCAL=false
```
- Install the RHOAM operator from Operator Hub
- Installation should complete successfully and no alerts should be firing
- Patch the catalog source to point at `1.29.0` and upgrade RHOAM:
```
oc patch catalogsource rhoam-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": /spec/image, "value": "quay.io/tdimov0/managed-api-service-index:1.29.0"}]'
```
- After the upgrade completes, verify there are no alerts firing
- Scale down the RHOAM operator:
```
oc patch deployment rhmi-operator -n redhat-rhoam-operator --type=json -p='[{"op": "replace", "path": /spec/replicas, "value": 0}]'
```
- Delete the operator group for the observability-operator namespace to trigger a CSV error:
```
oc delete operatorgroup rhmi-registry-og -n redhat-rhoam-observability-operator
```
- Verify that the `RHOAMCSVRequirementsNotMet` alert is firing in relation to the observability-operator
