### PR TITLE
MGDAPI-4920 Updated prepare-release script to not overwrite PROJECT file

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -227,13 +227,6 @@ else
   SED_INLINE=(sed -i)
 fi
 
-# The `projectName` field in the PROJECT file is used by the operator-sdk CLI
-# to generate the CSV. In order to be compatible with both types of CSVs
-# (RHOAM), we need to temporarily set the `projectName` to the desired
-# OLM type, and save the current value in order to reset it when we're done
-current_project_name=$(yq e '.projectName' PROJECT)
-yq e -i ".projectName=\"$OLM_TYPE\"" PROJECT
-
 update_base_csv
 create_or_update_csv
 


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4920

# What
This PR removes a RHMI-specific code snippet from the prepare-release.sh script since it is no longer needed.

# Verification steps

1. Checkout the master branch of integreatly
2. Create a new release of MT RHOAM: `INSTALLATION_TYPE=multitenant-managed-api SEMVER=1.30.0 make release/prepare`
3. Confirm that the`PROJECT` file is modified by running `git status`. The output should look something like this:
![before-change](https://user-images.githubusercontent.com/80267718/201784005-cf229cbd-6e94-4e55-a489-390a50905028.png)
4. Remove the local changes
5. Checkout this PR
6. Create a new release of MT RHOAM: `INSTALLATION_TYPE=multitenant-managed-api SEMVER=1.30.0 make release/prepare`
7. Confirm that the `PROJECT` file is **not** modified by running `git status`. The output should look something like this:
![after-change](https://user-images.githubusercontent.com/80267718/201784450-06cfc8e8-7507-4521-b90c-b9903425dcc8.png)
