### PR TITLE
MGDAPI-4706 - increase permissions for when ns is created by hive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -326,6 +326,10 @@ create/rhsso-operator/index:
 
 .PHONY: cluster/prepare/project
 cluster/prepare/project:
+	@ - oc new-project $(NAMESPACE_PREFIX)cloud-resources-operator
+	@oc label namespace $(NAMESPACE_PREFIX)cloud-resources-operator monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
+	@ - oc new-project $(NAMESPACE_PREFIX)3scale
+	@oc label namespace $(NAMESPACE_PREFIX)3scale monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 	@ - oc new-project $(NAMESPACE)
 	@oc label namespace $(NAMESPACE) monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 	@oc project $(NAMESPACE)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -72,8 +72,10 @@ rules:
   - services
   - subscriptions
   verbs:
+  - create
   - get
   - list
+  - update
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
@@ -112,13 +114,29 @@ rules:
   - list
   - watch
 - apiGroups:
+  - apps.3scale.net
+  resources:
+  - apimanagers
+  verbs:
+  - create
+  - get
+  - list
+  - update
+- apiGroups:
   - apps.openshift.io
   resources:
   - deploymentconfigs
   verbs:
   - get
   - list
+  - update
   - watch
+- apiGroups:
+  - apps.openshift.io
+  resources:
+  - deploymentconfigs/instantiate
+  verbs:
+  - create
 - apiGroups:
   - config.openshift.io
   resources:
@@ -276,13 +294,21 @@ rules:
   resources:
   - installplans
   verbs:
+  - get
   - update
 - apiGroups:
   - operators.coreos.com
   resources:
   - subscriptions
   verbs:
+  - create
   - update
+- apiGroups:
+  - project.openshift.io
+  resources:
+  - projects
+  verbs:
+  - delete
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
@@ -298,6 +324,8 @@ rules:
   - routes
   verbs:
   - get
+  - list
+  - update
 - apiGroups:
   - samples.operator.openshift.io
   resourceNames:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -144,13 +144,15 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // We are using ProjectRequests API to create namespaces where we automatically become admins
 // +kubebuilder:rbac:groups="";project.openshift.io,resources=projectrequests,verbs=create
 
+// +kubebuilder:rbac:groups=project.openshift.io,resources=projects,verbs=delete
+
 // Preflight check for existing installations of products
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=list;get;watch
 // +kubebuilder:rbac:groups=apps,resources=deployments;statefulsets,verbs=list;get;watch
-// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=list;get;watch
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs,verbs=list;get;watch;update
 
 // We need to get console route for solution explorer
-// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get
+// +kubebuilder:rbac:groups=route.openshift.io,resources=routes,verbs=get;list;update
 
 // Reconciling Fuse templates and image streams
 // +kubebuilder:rbac:groups=template.openshift.io,resources=templates,verbs=get;create;update;delete
@@ -174,8 +176,8 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // - Installation of product operators
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources;operatorgroups,verbs=create;list;get
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=update,resourceNames=rhmi-registry-cs
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=update
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=update
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=update;get
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=update;create
 
 // Monitoring resources not covered by namespace "admin" permissions
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors;podmonitors,verbs=get;list;create;update;delete
@@ -210,7 +212,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups=observability.redhat.com,resources=observabilities,verbs=*
 
 // Required for multitenant installations of RHOAM because the RHOAM operator is cluster scoped in these installations
-// +kubebuilder:rbac:groups="*",resources=configmaps;secrets;services;subscriptions,verbs=get;list;watch
+// +kubebuilder:rbac:groups="*",resources=configmaps;secrets;services;subscriptions,verbs=get;list;watch;create;update
 
 // For accessing limitador api from pod
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create
@@ -244,6 +246,10 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups=managed.openshift.io,resources=customdomains,verbs=list
 
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials,verbs=get;list;watch
+
+// +kubebuilder:rbac:groups=apps.3scale.net,resources=apimanagers,verbs=get;create;update;list
+
+// +kubebuilder:rbac:groups=apps.openshift.io,resources=deploymentconfigs/instantiate,verbs=create
 
 func (r *RHMIReconciler) Reconcile(request ctrl.Request) (ctrl.Result, error) {
 	_ = context.Background()


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4706

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
We want to have the CRO and 3scale namespaces to be created by Hive to speed up the sync sts secrets and subsequently the install itself.

However, the permission scope needs to be expanded when the namespace is externally created rather than by the Operator.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch and install operator
```
make cluster/prepare/local
make code/run
```
* Verify installation is successful
* Delete the RHMI CR and verify uninstall is successfull
* Prow e2e test for RHOAM and Multitenant is successfull