### PR TITLE
MGDAPI-4655 apply priorityClassName to all rhoam crs

### DIFF
--- a/bundles/managed-api-service/1.30.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.30.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -236,6 +236,16 @@ spec:
                 - apps
               resources:
                 - deployments
+                - replicasets
+                - statefulsets
+              verbs:
+                - get
+                - patch
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - deployments
                 - statefulsets
               verbs:
                 - get
@@ -428,6 +438,7 @@ spec:
                 - delete
                 - get
                 - list
+                - patch
                 - update
             - apiGroups:
                 - operators.coreos.com
@@ -676,15 +687,6 @@ spec:
                 - list
                 - update
                 - watch
-            - apiGroups:
-                - apps
-              resources:
-                - deployments/finalizers
-                - replicasets
-                - statefulsets
-              verbs:
-                - get
-                - update
             - apiGroups:
                 - marin3r.3scale.net
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -108,6 +108,16 @@ rules:
   - apps
   resources:
   - deployments
+  - replicasets
+  - statefulsets
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - apps
+  resources:
+  - deployments
   - statefulsets
   verbs:
   - get
@@ -300,6 +310,7 @@ rules:
   - delete
   - get
   - list
+  - patch
   - update
 - apiGroups:
   - operators.coreos.com
@@ -452,15 +463,6 @@ rules:
   - list
   - update
   - watch
-- apiGroups:
-  - apps
-  resources:
-  - deployments/finalizers
-  - replicasets
-  - statefulsets
-  verbs:
-  - get
-  - update
 - apiGroups:
   - marin3r.3scale.net
   resources:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -232,7 +232,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create,namespace=integreatly-operator
 
-// +kubebuilder:rbac:groups=apps,resources=deployments/finalizers;replicasets;statefulsets,verbs=update;get,namespace=integreatly-operator
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets,verbs=update;get;patch
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;create;update;delete;watch,namespace=integreatly-operator
 
@@ -242,7 +242,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // +kubebuilder:rbac:groups=operator.marin3r.3scale.net,resources=discoveryservices,verbs=get;list;watch;create;update;delete,namespace=integreatly-operator
 
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list;update
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=clusterserviceversions,verbs=get;delete;list;update;patch
 
 // +kubebuilder:rbac:groups=managed.openshift.io,resources=customdomains,verbs=list
 

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -203,6 +203,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileCsvDeploymentsPriority(
+		ctx,
+		client,
+		fmt.Sprintf("cloud-resources.v%s", integreatlyv1alpha1.OperatorVersionCloudResources),
+		r.Config.GetOperatorNamespace(),
+		r.installation.Spec.PriorityClassName,
+	)
+	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile cloud-resources csv deployments priority class name", err)
+		return phase, err
+	}
+
 	phase, err = r.addServiceUpdates(ctx, client, croProviders.RedisResourceType, redisServiceUpdatesToInstall)
 	if err != nil {
 		phase := integreatlyv1alpha1.PhaseFailed

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -154,6 +154,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileCsvDeploymentsPriority(
+		ctx,
+		client,
+		fmt.Sprintf("grafana-operator.v%s", integreatlyv1alpha1.OperatorVersionGrafana),
+		r.Config.GetOperatorNamespace(),
+		r.installation.Spec.PriorityClassName,
+	)
+	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana-operator csv deployments priority class name", err)
+		return phase, err
+	}
+
 	phase, err = r.reconcileComponents(ctx, client)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to create components", err)

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -188,6 +188,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileCsvDeploymentsPriority(
+		ctx,
+		serverClient,
+		fmt.Sprintf("rhsso-operator.%s", "7.6.1-opr-001"),
+		r.Config.GetOperatorNamespace(),
+		installation.Spec.PriorityClassName,
+	)
+	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
+		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile rhsso-operator csv deployments priority class name", err)
+		return phase, err
+	}
+
 	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to handle in progress phase", err)

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -765,8 +765,14 @@ func TestReconciler_fullReconcile(t *testing.T) {
 		{
 			Name:           "test successful reconcile",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, normalRoute, croPostgres, croPostgresSecret, getRHSSOCredentialSeed(), statefulSet, csv, dashboard, prometheusRules),
-			FakeConfig:     basicConfigMock(),
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, normalRoute, croPostgres, croPostgresSecret, getRHSSOCredentialSeed(), statefulSet, csv, dashboard, prometheusRules)
+				mockClient.PatchFunc = func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+					return nil
+				}
+				return mockClient
+			}(),
+			FakeConfig: basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -217,6 +217,18 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileCsvDeploymentsPriority(
+		ctx,
+		serverClient,
+		fmt.Sprintf("rhsso-operator.%s", "7.6.1-opr-001"),
+		r.Config.GetOperatorNamespace(),
+		installation.Spec.PriorityClassName,
+	)
+	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
+		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile user rhsso-operator csv deployments priority class name", err)
+		return phase, err
+	}
+
 	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to handle in progress phase", err)

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -593,8 +593,14 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 		{
 			Name:           "test successful reconcile",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, csv, rhssoPostgres, normalRoute, prometheusRules),
-			FakeConfig:     basicConfigMock(),
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, csv, rhssoPostgres, normalRoute, prometheusRules)
+				mockClient.PatchFunc = func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+					return nil
+				}
+				return mockClient
+			}(),
+			FakeConfig: basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 
@@ -632,8 +638,14 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 		{
 			Name:           "test waiting for RHSSO postgres",
 			ExpectedStatus: integreatlyv1alpha1.PhaseInProgress,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, csv, rhssoPostgresInProgress),
-			FakeConfig:     basicConfigMock(),
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, csv, rhssoPostgresInProgress)
+				mockClient.PatchFunc = func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+					return nil
+				}
+				return mockClient
+			}(),
+			FakeConfig: basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 
@@ -931,8 +943,14 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 		{
 			Name:           "RHOAM - test successful reconcile",
 			ExpectedStatus: integreatlyv1alpha1.PhaseCompleted,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, ssoAlert, csv, rhssoPostgres),
-			FakeConfig:     basicConfigMock(),
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, ssoAlert, csv, rhssoPostgres)
+				mockClient.PatchFunc = func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+					return nil
+				}
+				return mockClient
+			}(),
+			FakeConfig: basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 
@@ -970,8 +988,14 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 		{
 			Name:           "RHOAM - test in progress if no rhsso prom rules are present",
 			ExpectedStatus: integreatlyv1alpha1.PhaseAwaitingComponents,
-			FakeClient:     moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, ssoAlertNoGroups, csv),
-			FakeConfig:     basicConfigMock(),
+			FakeClient: func() k8sclient.Client {
+				mockClient := moqclient.NewSigsClientMoqWithScheme(scheme, getKcr(keycloak.KeycloakRealmStatus{Phase: keycloak.PhaseReconciling}, masterRealmName, "user-sso"), kc, secret, ns, operatorNS, githubOauthSecret, oauthClientSecrets, installation, edgeRoute, group, croPostgresSecret, croPostgres, getRHSSOCredentialSeed(), statefulSet, ssoAlertNoGroups, csv)
+				mockClient.PatchFunc = func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+					return nil
+				}
+				return mockClient
+			}(),
+			FakeConfig: basicConfigMock(),
 			FakeMPM: &marketplace.MarketplaceInterfaceMock{
 				InstallOperatorFunc: func(ctx context.Context, serverClient k8sclient.Client, t marketplace.Target, operatorGroupNamespaces []string, approvalStrategy operatorsv1alpha1.Approval, catalogSourceReconciler marketplace.CatalogSourceReconciler) error {
 

--- a/pkg/resources/k8s/objectQueries_test.go
+++ b/pkg/resources/k8s/objectQueries_test.go
@@ -1,0 +1,164 @@
+package k8s
+
+import (
+	"context"
+	"fmt"
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/test/utils"
+	k8sappsv1 "k8s.io/api/apps/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"testing"
+)
+
+func TestPatchIfExists(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+	type args struct {
+		ctx          context.Context
+		serverClient client.Client
+		fn           controllerutil.MutateFn
+		obj          client.Object
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    integreatlyv1alpha1.StatusPhase
+		wantErr bool
+	}{
+		{
+			name: "success patching an existing cr",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fakeclient.NewFakeClientWithScheme(scheme, &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				}),
+				fn: func() error {
+					return nil
+				},
+				obj: &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "failure fetching a cr that needs to be patched",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: &moqclient.SigsClientInterfaceMock{
+					GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return fmt.Errorf("generic error")
+					},
+				},
+				fn: func() error {
+					return nil
+				},
+				obj: &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "failure fetching a cr that needs to be patched (not found)",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: &moqclient.SigsClientInterfaceMock{
+					GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return k8serr.NewNotFound(schema.GroupResource{}, "generic")
+					},
+				},
+				fn: func() error {
+					return nil
+				},
+				obj: &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseInProgress,
+			wantErr: false,
+		},
+		{
+			name: "failure patching an existing cr during mutate function",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: &moqclient.SigsClientInterfaceMock{
+					GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return nil
+					},
+				},
+				fn: func() error {
+					return fmt.Errorf("generic error")
+				},
+				obj: &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+		{
+			name: "failure patching an existing cr",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: &moqclient.SigsClientInterfaceMock{
+					GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return nil
+					},
+					PatchFunc: func(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+						return fmt.Errorf("generic error")
+					},
+				},
+				fn: func() error {
+					return nil
+				},
+				obj: &k8sappsv1.Deployment{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "deploymentName",
+						Namespace: "deploymentNamespace",
+					},
+				},
+			},
+			want:    integreatlyv1alpha1.PhaseFailed,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := PatchIfExists(tt.args.ctx, tt.args.serverClient, tt.args.fn, tt.args.obj)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("PatchIfExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("PatchIfExists() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4655

# What
The priority field for the rhmi-operator pod is currently set to 0 (the lowest possible value). This means that if there weren't enough free resources on a cluster, the rhmi-operator pod would be one of the first things to be scaled down in order to free up resources.

Audited the relevant pods created by RHOAM and standardized their priority values where needed.

# Verification steps
- Provision an OSD cluster
- Prepare the cluster and install RHOAM from the latest stable version `v1.29.0`:
```
git checkout tags/rhoam-v1.29.0 -b rhoam-v1.29.0

make cluster/prepare/local LOCAL=false

cat << EOF | oc create -f -
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/tdimov0/managed-api-service-index:1.29.0
EOF

make deploy/integreatly-rhmi-cr.yml LOCAL=false
```
- Install the RHOAM operator from Operator Hub
- Wait until the RHOAM installation completes successfully
- Patch the catalog source to point at `1.30.0` and upgrade RHOAM:
```
oc patch catalogsource rhoam-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": /spec/image, "value": "quay.io/tdimov0/managed-api-service-index:1.30.0"}]'
```
- Wait until the upgrade completes and verify that the resources below have a `priorityClassName` field set to the corresponding value in column **PriorityClassName**.  

**NOTE**: Italic **PriorityClassName** value means the resource was standardized as part of this task. Non-italic value means the resource already had a **PriorityClassName** set.  
The entries with missing priority can be on-cluster postgres or redis instances. This scenario can happen when a cluster is ran with `useClusterStorage: true`. Thread link: https://chat.google.com/room/AAAAssKWhTI/Bj2d-wNKOVY

## Deployments
 **Namespace**                             | **Name**                                  | **PriorityClassName**                 
-------------------------------------------|-------------------------------------------|---------------------------------------
 redhat-rhoam-3scale                       | marin3r-instance                          | *rhoam-pod-priority*                  
 redhat-rhoam-3scale-operator              | threescale-operator-controller-manager-v2 | *rhoam-pod-priority*                  
 redhat-rhoam-cloud-resources-operator     | cloud-resource-operator                   | *rhoam-pod-priority*                  
 redhat-rhoam-customer-monitoring-operator | grafana-operator-controller-manager       | *rhoam-pod-priority*                  
 redhat-rhoam-customer-monitoring-operator | grafana-deployment                        | rhoam-pod-priority                    
 redhat-rhoam-marin3r                      | ratelimit                                 | rhoam-pod-priority                    
 redhat-rhoam-marin3r-operator             | marin3r-controller-webhook                | *rhoam-pod-priority*                  
 redhat-rhoam-marin3r-operator             | marin3r-controller-manager                | *rhoam-pod-priority*                  
 redhat-rhoam-observability                | prometheus-operator                       | observability-operator-priority-class 
 redhat-rhoam-observability                | grafana-operator                          | observability-operator-priority-class 
 redhat-rhoam-observability                | grafana-deployment                        | observability-operator-priority-class 
 redhat-rhoam-observability-operator       | observability-operator-controller-manager | observability-operator-priority-class 
 redhat-rhoam-operator                     | threescale-redis-rhoam                    | -                                     
 redhat-rhoam-operator                     | threescale-postgres-rhoam                 | -                                     
 redhat-rhoam-operator                     | threescale-backend-redis-rhoam            | -                                     
 redhat-rhoam-operator                     | rhssouser-postgres-rhoam                  | -                  
 redhat-rhoam-operator                     | rhsso-postgres-rhoam                      | -                                     
 redhat-rhoam-operator                     | rhmi-operator                             | rhoam-pod-priority                    
 redhat-rhoam-operator                     | ratelimit-service-redis-rhoam             | -                                     
 redhat-rhoam-rhsso-operator               | rhsso-operator                            | *rhoam-pod-priority*                  
 redhat-rhoam-user-sso-operator            | rhsso-operator                            | *rhoam-pod-priority*                  

## DeploymentConfigs
 **Namespace**       | **Name**           | **PriorityClassName** 
---------------------|--------------------|-----------------------
 redhat-rhoam-3scale | zync-que           | rhoam-pod-priority    
 redhat-rhoam-3scale | zync-database      | rhoam-pod-priority    
 redhat-rhoam-3scale | zync               | rhoam-pod-priority    
 redhat-rhoam-3scale | system-sphinx      | rhoam-pod-priority    
 redhat-rhoam-3scale | system-sidekiq     | rhoam-pod-priority    
 redhat-rhoam-3scale | system-memcache    | rhoam-pod-priority    
 redhat-rhoam-3scale | system-app         | rhoam-pod-priority    
 redhat-rhoam-3scale | backend-worker     | rhoam-pod-priority    
 redhat-rhoam-3scale | backend-listener   | rhoam-pod-priority    
 redhat-rhoam-3scale | backend-cron       | rhoam-pod-priority    
 redhat-rhoam-3scale | apicast-staging    | rhoam-pod-priority    
 redhat-rhoam-3scale | apicast-production | rhoam-pod-priority    

## StatefulSets
 **Namespace**              | **Name**                  | **PriorityClassName**                 
----------------------------|---------------------------|---------------------------------------
 redhat-rhoam-observability | prometheus-prometheus     | observability-operator-priority-class 
 redhat-rhoam-observability | alertmanager-alertmanager | observability-operator-priority-class 
 redhat-rhoam-rhsso         | keycloak                  | rhoam-pod-priority                    
 redhat-rhoam-user-sso      | keycloak                  | rhoam-pod-priority                    

