### PR TITLE
MGDAPI-4920 Updated prepare release script to also move bundle.Dockefile for MT RHOAM

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -253,10 +253,8 @@ if [[ "${OLM_TYPE}" == "multitenant-managed-api-service" ]]; then
  update_smtp_from
 fi
 
-# Move bundle.Dockerfile to the bundle folder for standard RHOAM
-if [[ "${OLM_TYPE}" == "managed-api-service" ]]; then
-  mv bundle.Dockerfile bundles/$OLM_TYPE/$VERSION
-fi
+# Move bundle.Dockerfile to the bundle folder
+mv bundle.Dockerfile bundles/$OLM_TYPE/$VERSION
 
 # Ensure code is formatted correctly
 "${GOFMT[@]}" -w `find . -type f -name '*.go' -not -path "./vendor/*"`


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4920

# What
This PR reverts a previous change to the `prepare-release.sh` script. Before the script supported mulitenant RHOAM, it would move the generated `bundle.Dockerfile` to `bundles/$OLM_TYPE/$VERSION` directory regardless of the `OLM_TYPE`. However when the script was refactored for MT RHOAM, it was changed to only move the `bundle.Dockerfile` when the `OLM_TYPE` was `managed-api-service`. This conditional isn't necessary and so we can include the bundle.Dockerfile in the `bundles/multitenant-managed-api-service/$VERSION` folder from now on. We don't need to retroactively add the `bundle.Dockerfile` into the existing multitenant bundle directories - adding it for future bundles is all we need.

# Verification steps
1. Checkout the master branch of integreatly
2. Create a new release of MT RHOAM: `INSTALLATION_TYPE=multitenant-managed-api SEMVER=1.30.0 make release/prepare`
3. Confirm that the`bundle.Dockefile` file is **not** in the `bundles/multitenant-managed-api-service/1.30.0/` folder
4. Remove the local changes
5. Checkout this PR
6. Create a new release of MT RHOAM: `INSTALLATION_TYPE=multitenant-managed-api SEMVER=1.30.0 make release/prepare`
7. Confirm that the`bundle.Dockefile` file **is** in the `bundles/multitenant-managed-api-service/1.30.0/` folder
