### PR TITLE
MGDAPI-4942 change hive.openshift.io/managed label to rhoam.addon.install/managed

### DIFF
--- a/pkg/addon/operator_run.go
+++ b/pkg/addon/operator_run.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	hiveManagedLabel = "hive.openshift.io/managed"
+	RhoamAddonInstallManagedLabel = "rhoam.addon.install/managed"
 )
 
 // OperatorRunType is used to indicate how the operator is being currently
@@ -121,7 +121,7 @@ func OperatorIsHiveManaged(ctx context.Context, client k8sclient.Client, install
 	}
 
 	labels := ns.GetLabels()
-	value, ok := labels[hiveManagedLabel]
+	value, ok := labels[RhoamAddonInstallManagedLabel]
 	if ok {
 		if value == "true" {
 			logrus.Info("operator is hive managed")

--- a/pkg/addon/operator_run_test.go
+++ b/pkg/addon/operator_run_test.go
@@ -200,7 +200,7 @@ func TestOperatorHiveManaged(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "redhat-rhoam-operator",
 						Labels: map[string]string{
-							"hive.openshift.io/managed": "true",
+							RhoamAddonInstallManagedLabel: "true",
 						},
 					},
 				},
@@ -221,7 +221,7 @@ func TestOperatorHiveManaged(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "redhat-rhoam-operator",
 						Labels: map[string]string{
-							"hive.openshift.io/managed": "false",
+							RhoamAddonInstallManagedLabel: "false",
 						},
 					},
 				},
@@ -260,7 +260,7 @@ func TestOperatorHiveManaged(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "redhat-rhoam-operator",
 						Labels: map[string]string{
-							"hive.openshift.io/managed": "true",
+							RhoamAddonInstallManagedLabel: "true",
 						},
 					},
 				},

--- a/pkg/products/observability/reconciler_test.go
+++ b/pkg/products/observability/reconciler_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	clientMock "github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
@@ -741,7 +742,7 @@ func TestReconciler_deleteObservabilityCR(t *testing.T) {
 						switch obj.(type) {
 						case *corev1.Namespace:
 							obj.(*corev1.Namespace).Labels = map[string]string{
-								"hive.openshift.io/managed": "true",
+								addon.RhoamAddonInstallManagedLabel: "true",
 							}
 							return nil
 						case *corev1.Secret:
@@ -774,7 +775,7 @@ func TestReconciler_deleteObservabilityCR(t *testing.T) {
 					fakeClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
 						switch obj.(type) {
 						case *corev1.Namespace:
-							obj.(*corev1.Namespace).Labels = map[string]string{"hive.openshift.io/managed": "true"}
+							obj.(*corev1.Namespace).Labels = map[string]string{addon.RhoamAddonInstallManagedLabel: "true"}
 							return nil
 						case *corev1.Secret:
 							obj.(*corev1.Secret).Data = map[string][]byte{"SNITCH_URL": []byte("www.example.com")}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4942

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
change rhoam from hive.openshift.io/managed label to rhoam.addon.install/managed

# Verification steps

- build operator image from this branch or use quay.io/austincunningham/managed-api-service:v1.30.0 
- start a rhoam addon install
- from the integreatly-operator repo set the following env var and run the patch-image-csv.sh script
```bash
export VERSION=v1.30.0
export ADDON_VERSION=v1.29.0
export ORG=austincunningham
export USE_CLUSTER_STORAGE=true
./scripts/patch-image-csv.sh
```
- You should see the script complete successfully
```bash
./scripts/patch-image-csv.sh
clusterserviceversion.operators.coreos.com/managed-api-service.v1.29.0 patched
clusterserviceversion.operators.coreos.com/managed-api-service.v1.29.0 patched
Verificaton the CSV has been patched :
    containerImage: quay.io/austincunningham/managed-api-service:v1.30.0
                image: quay.io/austincunningham/managed-api-service:v1.30.0
    message: 'installing: unexpected annotation on deployment. Expected containerImage:quay.io/austincunningham/managed-api-service:v1.30.0,
 
Patching the RHMI CR when its created with useClusterStorage
rhmi.integreatly.org/rhoam patched
Verification USE_CLUSTER_STORAGE is set :
        f:useClusterStorage: {}
  useClusterStorage: "true"

```
- confirm the install finishes
- confirm that the label `rhoam.addon.install/managed: 'true'` is set on the redhat-rhoam-operator Project
![image](https://user-images.githubusercontent.com/16667688/203766257-5788a3aa-5340-4880-aa65-99a1609708f5.png)
- confirm the addon uninstall completes 



<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
