### PR TITLE
MGDAPI-4763 Ensure a tenant can only create 1 APIManagementTenant CR

### DIFF
--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -355,7 +355,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 						"sop_url": resources.SopApiManagementTenantCRFailed,
 						"message": "An APIManagementTenant CR has failed to reconcile. See the labels for details.",
 					},
-					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready"}`),
+					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready" && provisioningStatus != "won't provision"}`),
 					For:    "10m",
 					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -355,7 +355,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 						"sop_url": resources.SopApiManagementTenantCRFailed,
 						"message": "An APIManagementTenant CR has failed to reconcile. See the labels for details.",
 					},
-					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready"} or tenants_summary{provisioningStatus != "won't provision"}`),
+					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready"} and tenants_summary{provisioningStatus != "won't provision"}`),
 					For:    "10m",
 					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -355,7 +355,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 						"sop_url": resources.SopApiManagementTenantCRFailed,
 						"message": "An APIManagementTenant CR has failed to reconcile. See the labels for details.",
 					},
-					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready" && provisioningStatus != "won't provision"}`),
+					Expr:   intstr.FromString(`tenants_summary{provisioningStatus!="3scale account ready"} or tenants_summary{provisioningStatus != "won't provision"}`),
 					For:    "10m",
 					Labels: map[string]string{"severity": "critical", "product": installationName},
 				},


### PR DESCRIPTION
# Issue link
[https://issues.redhat.com/browse/MGDAPI-4763](url)

# What
Add verification to the controller to ensure that the user does not have an APIManagementTenant CR already in either the dev or stg namespace. If they do add a warning to the second CR informing them that they can not have more than 1 APIManagementTenant CR

# Verification steps

1.  Create cluster
2. Run Operator locally
2.1 `INSTALLATION_TYPE=multitenant-managed-api LOCAL=false make cluster/prepare/local`
2.2 `INSTALLATION_TYPE=multitenant-managed-api LOCAL=false make code/run`
2.3 Command for check RHOAM installation status `oc get rhmi rhoam -n sandbox-rhoam-operator -o yaml`
3. Setup IDP `./scripts/setup-sso-idp.sh`
4. You need to create APIManagementTenant CR with test-user or customer-admin. You need to setup permissions for them with command: `oc adm policy add-cluster-role-to-user cluster-admin customer-admin01`
5. Login with one of the users into cluster 
6. Try create 2 APIManagementTenant CRs in -dev or -stage namespace
7. Ensure that you will get won't provision status if there is user present already and that alert not fire, if this status is present

