### PR TITLE
MGDAPI-4706 - csv: add missing permissions

### DIFF
--- a/bundles/managed-api-service/1.30.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.30.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -200,8 +200,10 @@ spec:
                 - services
                 - subscriptions
               verbs:
+                - create
                 - get
                 - list
+                - update
                 - watch
             - apiGroups:
                 - admissionregistration.k8s.io
@@ -240,13 +242,29 @@ spec:
                 - list
                 - watch
             - apiGroups:
+                - apps.3scale.net
+              resources:
+                - apimanagers
+              verbs:
+                - create
+                - get
+                - list
+                - update
+            - apiGroups:
                 - apps.openshift.io
               resources:
                 - deploymentconfigs
               verbs:
                 - get
                 - list
+                - update
                 - watch
+            - apiGroups:
+                - apps.openshift.io
+              resources:
+                - deploymentconfigs/instantiate
+              verbs:
+                - create
             - apiGroups:
                 - config.openshift.io
               resources:
@@ -404,13 +422,21 @@ spec:
               resources:
                 - installplans
               verbs:
+                - get
                 - update
             - apiGroups:
                 - operators.coreos.com
               resources:
                 - subscriptions
               verbs:
+                - create
                 - update
+            - apiGroups:
+                - project.openshift.io
+              resources:
+                - projects
+              verbs:
+                - delete
             - apiGroups:
                 - rbac.authorization.k8s.io
               resources:
@@ -426,6 +452,8 @@ spec:
                 - routes
               verbs:
                 - get
+                - list
+                - update
             - apiGroups:
                 - samples.operator.openshift.io
               resourceNames:


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4706

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Add missing permissions in CSV that is preventing OLM installs working correctly if release scipt is not run

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Prepare cluster
```
INSTALLATION_TYPE=managed-api make cluster/prepare LOCAL=false
```
* Install via OLM using following catalog source:
```
quay.io/kevfan/managed-api-service-index:1.30.0
```
* Deploy RHMI CR
```
make deploy/integreatly-rhmi-cr.yml
```
* Verify installation completes successfully
* Delete RHMI CR
* Verify uninstallation completes successfully