### PR TITLE
MGDAPI-4906 restore workshop type cloud resource config

### DIFF
--- a/config/configmap/cro-configmaps.yaml
+++ b/config/configmap/cro-configmaps.yaml
@@ -7,3 +7,5 @@ data:
     {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
   multitenant-managed-api: >
     {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}
+  workshop: >
+    {"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}

--- a/controllers/rhmi/bootstrapReconciler.go
+++ b/controllers/rhmi/bootstrapReconciler.go
@@ -278,7 +278,6 @@ func (r *Reconciler) checkCloudResourcesConfig(ctx context.Context, serverClient
 			Namespace: r.installation.Namespace,
 		},
 	}
-
 	if _, err := controllerutil.CreateOrUpdate(ctx, serverClient, cloudConfig, func() error {
 		if cloudConfig.Data == nil {
 			cloudConfig.Data = map[string]string{}
@@ -295,6 +294,7 @@ func (r *Reconciler) checkCloudResourcesConfig(ctx context.Context, serverClient
 			cloudConfig.Data["managed-api"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
 			cloudConfig.Data["multitenant-managed-api"] = `{"blobstorage":"aws", "smtpcredentials":"aws", "redis":"aws", "postgres":"aws"}`
 		}
+		cloudConfig.Data["workshop"] = `{"blobstorage":"openshift", "smtpcredentials":"openshift", "redis":"openshift", "postgres":"openshift"}`
 		return nil
 	}); err != nil {
 		return integreatlyv1alpha1.PhaseInProgress, err

--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -787,7 +787,10 @@ func TestReconciler_checkCloudResourcesConfig(t *testing.T) {
 		ctx          context.Context
 		serverClient k8sclient.Client
 	}
-	scheme, _ := utils.NewTestScheme()
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
 	tests := []struct {
 		name    string
 		fields  fields
@@ -855,7 +858,7 @@ func TestReconciler_checkCloudResourcesConfig(t *testing.T) {
 			args: args{
 				serverClient: func() k8sclient.Client {
 					mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
-					mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj runtime.Object) error {
+					mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj k8sclient.Object) error {
 						return fmt.Errorf("generic error")
 					}
 					return mockClient

--- a/docs/tests/workshop.md
+++ b/docs/tests/workshop.md
@@ -1,0 +1,40 @@
+# Workshop postgres/redis instances
+The workshop type is being used for creating on cluster, throwaway postgres/redis instances for troubleshooting. 
+While this isn't functionality used in production, there are some manual test cases and sops that rely on it.
+
+## Usage
+To create a workshop instance, log in to a cluster and issue one of the following commands:
+
+### Postgres
+```shell
+cat << EOF | oc create -f - -n redhat-rhoam-operator
+  apiVersion: integreatly.org/v1alpha1
+  kind: Postgres
+  metadata:
+    name: throw-away-postgres
+    labels:
+      productName: productName
+  spec:
+    secretRef:
+      name: throw-away-postgres-sec
+    tier: development
+    type: workshop
+EOF
+```
+
+### Redis
+```shell
+cat << EOF | oc create -f - -n redhat-rhoam-operator
+  apiVersion: integreatly.org/v1alpha1
+  kind: Redis
+  metadata:
+    name: throw-away-redis
+    labels:
+      productName: productName
+  spec:
+    secretRef:
+      name: throw-away-redis-sec
+    tier: development
+    type: workshop
+EOF
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -26,6 +26,7 @@ nav:
       - Product tests: tests/product_tests.md
       - Scorecard tests: tests/scorecard_tests.md
       - Testing Alerts: tests/testing_alerts.md
+      - Workshop postgres/redis instances: tests/workshop.md
     - Uninstallation:
       - Local and OLM: uninstallation/local_and_olm.md
       - Addon flow: uninstallation/addon_flow.md


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4906

# What
Add in the workshop type to the cloud-resource-config.
Used for creating on cluster Redis and Postgres for test cases.

# Verification steps
## Local
- Prepare your cluster, run RHOAM locally and await installation complete:
  ```
  LOCAL=false make cluster/prepare/local
  LOCAL=false make deploy/integreatly-rhmi-cr.yml
  LOCAL=false make code/run
  ```
- Create a `workshop` Postgres instance and await its completion:
  ```
  cat << EOF | oc create -f - -n redhat-rhoam-operator                   
    apiVersion: integreatly.org/v1alpha1
    kind: Postgres
    metadata:
      name: throw-away-postgres
      labels:
        productName: productName
    spec:
      secretRef:
        name: throw-away-postgres-sec
      tier: development
      type: workshop
  EOF
  ```
- Proceed with cleanup and await its completion:
  ```
  oc delete postgres throw-away-postgres -n redhat-rhoam-operator
  oc delete rhmi rhoam -n redhat-rhoam-operator
  LOCAL=false make cluster/cleanup
  ```

## OLM
- Install RHOAM through OLM using an index pointing at the latest GitHub tag and await its completion:
  ```
  git switch -d rhoam-v1.29.0
  LOCAL=false make cluster/prepare/local
  LOCAL=false make deploy/integreatly-rhmi-cr.yml
  cat << EOF | oc create -f - -n openshift-marketplace
    apiVersion: operators.coreos.com/v1alpha1
    kind: CatalogSource
    metadata:
      name: rhoam-operators
      namespace: openshift-marketplace
    spec:
      image: 'quay.io/tdimov0/managed-api-service-index:1.29.0'
      sourceType: grpc
  EOF
  ```
- Upgrade RHOAM to a version containing my changes and await its completion:
  ```
  oc patch catalogsource rhoam-operators -n openshift-marketplace --type=json -p='[{"op": "replace", "path": /spec/image, "value": "quay.io/tdimov0/managed-api-service-index:1.30.0"}]'
  ```
- Create a `workshop` Postgres instance and await its completion:
  ```
  cat << EOF | oc create -f - -n redhat-rhoam-operator                   
    apiVersion: integreatly.org/v1alpha1
    kind: Postgres
    metadata:
      name: throw-away-postgres
      labels:
        productName: productName
    spec:
      secretRef:
        name: throw-away-postgres-sec
      tier: development
      type: workshop
  EOF
  ```
- Proceed with cleanup and await its completion:
  ```
  oc delete postgres throw-away-postgres -n redhat-rhoam-operator
  oc delete rhmi rhoam -n redhat-rhoam-operator
  LOCAL=false make cluster/cleanup
  ```
