### PR TITLE
MGDAPI-4909 make sure to randomize strings, and add a check to re randomize them

### DIFF
--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -727,3 +727,48 @@ func TestReconciler_retrieveAPIServerURL(t *testing.T) {
 		})
 	}
 }
+
+func TestReconciler_generateSecret(t *testing.T) {
+	type fields struct {
+		ConfigManager config.ConfigReadWriter
+		Config        *config.ThreeScale
+		mpm           marketplace.MarketplaceInterface
+		installation  *integreatlyv1alpha1.RHMI
+		Reconciler    *resources.Reconciler
+		recorder      record.EventRecorder
+		log           l.Logger
+	}
+	type args struct {
+		length int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   string
+	}{
+		{
+			name: "Test you get a string of correct length",
+			args: args{
+				length: 32,
+			},
+			want: "V8bHJmLKToT1La4GHkKTVt1NlCECK7W8",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				ConfigManager: tt.fields.ConfigManager,
+				Config:        tt.fields.Config,
+				mpm:           tt.fields.mpm,
+				installation:  tt.fields.installation,
+				Reconciler:    tt.fields.Reconciler,
+				recorder:      tt.fields.recorder,
+				log:           tt.fields.log,
+			}
+			if got := r.generateSecret(tt.args.length); len(got) != len(tt.want) {
+				t.Errorf("generateSecret() = %v, want %v", len(got), len(tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4909

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
make sure randomize strings are generated, and add a check to re randomize them if they already exist

# Verification steps
- Install this branch from local
- once rhoam is installed go to the redhat-rhoam-operator namespace in the UI
- go to the `oauth-client-secrets`
- confirm the secrets are randomized 

![image](https://user-images.githubusercontent.com/16667688/204811640-368190c2-e3a8-44e3-a114-f7e955883d56.png)

- edit the 3scale value to be all the same character
e.g.

![image](https://user-images.githubusercontent.com/16667688/204811918-072cbeb2-be88-426b-b3b9-a10280f3e811.png)

- it should revert to a randomized secret in time. This will handle the secrets in upgrade.  
