### PR TITLE
MGDAPI-4549 : Add filter for active tenants to dns bypass metrics

### DIFF
--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -219,7 +219,7 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 				},
 			}, nil
 		},
-		ListTenantAccountsFunc: func(accessToken string, page int) ([]AccountDetail, error) {
+		ListTenantAccountsFunc: func(accessToken string, page int, filterFn func(ac AccountDetail) bool) ([]AccountDetail, error) {
 			return accounts, nil
 		},
 		DeleteTenantsFunc: func(accessToken string, accounts []AccountDetail) error {

--- a/pkg/products/threescale/filters.go
+++ b/pkg/products/threescale/filters.go
@@ -7,10 +7,10 @@ import (
 
 type TenantAccountsFilter struct {
 	providers  []AccountDetail
-	developers []developerAccounts
+	developers []developerRoute
 }
 
-type developerAccounts struct {
+type developerRoute struct {
 	Url   string
 	State string
 }
@@ -18,7 +18,7 @@ type developerAccounts struct {
 func NewTenantAccountsFilter(accounts []AccountDetail) TenantAccountsFilter {
 	f := TenantAccountsFilter{}
 	f.setProviders(accounts)
-	f.generateDeveloperAccounts(accounts)
+	f.generateDeveloperRoutes(accounts)
 
 	return f
 }
@@ -41,10 +41,10 @@ func (f *TenantAccountsFilter) Developer(r v1.Route) bool {
 	return false
 }
 
-func (f *TenantAccountsFilter) generateDeveloperAccounts(accounts []AccountDetail) {
+func (f *TenantAccountsFilter) generateDeveloperRoutes(accounts []AccountDetail) {
 	for _, account := range accounts {
 		if strings.Contains(account.AdminBaseURL, "-admin.") {
-			d := developerAccounts{}
+			d := developerRoute{}
 			d.State = account.State
 			search := "-admin."
 			i := strings.LastIndex(account.AdminBaseURL, search)

--- a/pkg/products/threescale/filters.go
+++ b/pkg/products/threescale/filters.go
@@ -1,0 +1,61 @@
+package threescale
+
+import (
+	"github.com/openshift/api/route/v1"
+	"strings"
+)
+
+type TenantAccountsFilter struct {
+	providers  []AccountDetail
+	developers []developerAccounts
+}
+
+type developerAccounts struct {
+	Url   string
+	State string
+}
+
+func NewTenantAccountsFilter(accounts []AccountDetail) TenantAccountsFilter {
+	f := TenantAccountsFilter{}
+	f.setProviders(accounts)
+	f.generateDeveloperAccounts(accounts)
+
+	return f
+}
+
+func (f *TenantAccountsFilter) Provider(r v1.Route) bool {
+	for _, account := range f.providers {
+		if strings.HasSuffix(account.AdminBaseURL, r.Spec.Host) {
+			return account.State == "approved"
+		}
+	}
+	return false
+}
+
+func (f *TenantAccountsFilter) Developer(r v1.Route) bool {
+	for _, account := range f.developers {
+		if strings.HasSuffix(account.Url, r.Spec.Host) {
+			return account.State == "approved"
+		}
+	}
+	return false
+}
+
+func (f *TenantAccountsFilter) generateDeveloperAccounts(accounts []AccountDetail) {
+	for _, account := range accounts {
+		if strings.Contains(account.AdminBaseURL, "-admin.") {
+			d := developerAccounts{}
+			d.State = account.State
+			search := "-admin."
+			i := strings.LastIndex(account.AdminBaseURL, search)
+
+			d.Url = account.AdminBaseURL[:i] + strings.Replace(account.AdminBaseURL[i:], search, ".", 1)
+			f.developers = append(f.developers, d)
+
+		}
+	}
+}
+
+func (f *TenantAccountsFilter) setProviders(accounts []AccountDetail) {
+	f.providers = accounts
+}

--- a/pkg/products/threescale/filters_test.go
+++ b/pkg/products/threescale/filters_test.go
@@ -1,0 +1,426 @@
+package threescale
+
+import (
+	v1 "github.com/openshift/api/route/v1"
+	"reflect"
+	"testing"
+)
+
+func TestNewTenantAccountsFilter(t *testing.T) {
+	type args struct {
+		accounts []AccountDetail
+	}
+	tests := []struct {
+		name string
+		args args
+		want TenantAccountsFilter
+	}{
+		{
+			name: "Accounts is nil",
+			args: args{accounts: nil},
+			want: TenantAccountsFilter{providers: nil, developers: nil},
+		},
+		{
+			name: "Accounts have 3 routes of which 2 are admin",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "test1-example.com",
+				},
+				{
+					Id:           1,
+					State:        "approved",
+					AdminBaseURL: "test2-admin.example.com",
+				},
+				{
+					Id:           2,
+					State:        "approved",
+					AdminBaseURL: "test3-admin.example.com",
+				},
+			}},
+			want: TenantAccountsFilter{
+				providers: []AccountDetail{
+					{
+						Id:           0,
+						State:        "approved",
+						AdminBaseURL: "test1-example.com",
+					},
+					{
+						Id:           1,
+						State:        "approved",
+						AdminBaseURL: "test2-admin.example.com",
+					},
+					{
+						Id:           2,
+						State:        "approved",
+						AdminBaseURL: "test3-admin.example.com",
+					},
+				},
+				developers: []developerAccounts{
+					{
+						Url:   "test2.example.com",
+						State: "approved",
+					},
+					{
+						Url:   "test3.example.com",
+						State: "approved",
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewTenantAccountsFilter(tt.args.accounts); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("NewTenantAccountsFilter()\nGot: %v \nWant %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTenantAccountsFilter_SetAccounts(t *testing.T) {
+
+	type args struct {
+		accounts []AccountDetail
+	}
+	tests := []struct {
+		name string
+		args args
+		want []AccountDetail
+	}{
+		{
+			name: "AccountDetail assigned to inner providers correctly",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:   0,
+					Name: "Mock 01",
+				},
+			}},
+			want: []AccountDetail{
+				{
+					Id:   0,
+					Name: "Mock 01",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &TenantAccountsFilter{}
+			f.setProviders(tt.args.accounts)
+
+			if !reflect.DeepEqual(tt.want, f.providers) {
+				t.Errorf("Returned Account Details does not macth input. \nWant: %v \nGot: %v", tt.want, f.providers)
+			}
+
+		})
+	}
+}
+
+func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
+	type args struct {
+		accounts []AccountDetail
+	}
+	tests := []struct {
+		name string
+		args args
+		want []developerAccounts
+	}{
+		{
+			name: "All accounts are admin",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "3scale-admin.example.com",
+				},
+				{
+					Id:           1,
+					State:        "approved",
+					AdminBaseURL: "test-admin.example.com",
+				},
+			}},
+			want: []developerAccounts{
+				{
+					Url:   "3scale.example.com",
+					State: "approved",
+				},
+				{
+					Url:   "test.example.com",
+					State: "approved",
+				},
+			},
+		},
+		{
+			name: "One out of two accounts are admin",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "3scale-admin.example.com",
+				},
+				{
+					Id:           1,
+					State:        "approved",
+					AdminBaseURL: "test.example.com",
+				},
+			}},
+			want: []developerAccounts{
+				{
+					Url:   "3scale.example.com",
+					State: "approved",
+				},
+			},
+		},
+		{
+			name: "Multiply admin sections in URL",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:           1,
+					AdminBaseURL: "x-admin.dev-admin.example.com",
+				},
+			}},
+			want: []developerAccounts{
+				{
+					Url: "x-admin.dev.example.com",
+				},
+			},
+		},
+		{
+			name: "Input list has no admin urls",
+			args: args{accounts: []AccountDetail{
+				{
+					Id:           1,
+					State:        "approved",
+					AdminBaseURL: "test.example.com",
+				},
+			}},
+			want: nil,
+		},
+		{
+			name: "Input list is nil",
+			args: args{accounts: nil},
+			want: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &TenantAccountsFilter{}
+			f.generateDeveloperAccounts(tt.args.accounts)
+
+			if !reflect.DeepEqual(tt.want, f.developers) {
+				t.Errorf("developers list not as expected. \nWant: %s \nGot: %s", tt.want, f.developers)
+			}
+
+		})
+	}
+}
+
+func TestTenantAccountsFilter_Developer(t *testing.T) {
+	type fields struct {
+		developers []developerAccounts
+	}
+	type args struct {
+		r v1.Route
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Url exist and is approved",
+			fields: fields{developers: []developerAccounts{
+				{
+					Url:   "dummy.example.com",
+					State: "approved",
+				},
+				{
+					Url:   "3scale.example.com",
+					State: "approved",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale.example.com",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Url exist but not approved",
+			fields: fields{developers: []developerAccounts{
+				{
+					Url:   "dummy.example.com",
+					State: "approved",
+				},
+				{
+					Url:   "3scale.example.com",
+					State: "not approved",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Url does not exist",
+			fields: fields{developers: []developerAccounts{
+				{
+					Url:   "dummy.example.com",
+					State: "approved",
+				},
+				{
+					Url:   "dummy2.example.com",
+					State: "approved",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "Developer list is nil",
+			fields: fields{developers: nil},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &TenantAccountsFilter{
+				developers: tt.fields.developers,
+			}
+			if got := f.Developer(tt.args.r); got != tt.want {
+				t.Errorf("Developer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTenantAccountsFilter_Provider(t *testing.T) {
+	type fields struct {
+		providers []AccountDetail
+	}
+	type args struct {
+		r v1.Route
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "Url exists and is approved",
+			fields: fields{providers: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "dummy-admin.example.com",
+				},
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "3scale-admin.example.com",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale-admin.example.com",
+					},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Url exists and is not approved",
+			fields: fields{providers: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "dummy-admin.example.com",
+				},
+				{
+					Id:           0,
+					State:        "not approved",
+					AdminBaseURL: "3scale-admin.example.com",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale-admin.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Url does not exist",
+			fields: fields{providers: []AccountDetail{
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "dummy-admin.example.com",
+				},
+				{
+					Id:           0,
+					State:        "approved",
+					AdminBaseURL: "dummy2-admin.example.com",
+				},
+			}},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale-admin.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+		{
+			name:   "providers list is nil",
+			fields: fields{providers: nil},
+			args: args{
+				r: v1.Route{
+					Spec: v1.RouteSpec{
+						Host: "3scale-admin.example.com",
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &TenantAccountsFilter{
+				providers: tt.fields.providers,
+			}
+			if got := f.Provider(tt.args.r); got != tt.want {
+				t.Errorf("Provider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/products/threescale/filters_test.go
+++ b/pkg/products/threescale/filters_test.go
@@ -57,7 +57,7 @@ func TestNewTenantAccountsFilter(t *testing.T) {
 						AdminBaseURL: "test3-admin.example.com",
 					},
 				},
-				developers: []developerAccounts{
+				developers: []developerRoute{
 					{
 						Url:   "test2.example.com",
 						State: "approved",
@@ -125,7 +125,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		want []developerAccounts
+		want []developerRoute
 	}{
 		{
 			name: "All accounts are admin",
@@ -141,7 +141,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 					AdminBaseURL: "test-admin.example.com",
 				},
 			}},
-			want: []developerAccounts{
+			want: []developerRoute{
 				{
 					Url:   "3scale.example.com",
 					State: "approved",
@@ -166,7 +166,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 					AdminBaseURL: "test.example.com",
 				},
 			}},
-			want: []developerAccounts{
+			want: []developerRoute{
 				{
 					Url:   "3scale.example.com",
 					State: "approved",
@@ -181,7 +181,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 					AdminBaseURL: "x-admin.dev-admin.example.com",
 				},
 			}},
-			want: []developerAccounts{
+			want: []developerRoute{
 				{
 					Url: "x-admin.dev.example.com",
 				},
@@ -207,7 +207,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			f := &TenantAccountsFilter{}
-			f.generateDeveloperAccounts(tt.args.accounts)
+			f.generateDeveloperRoutes(tt.args.accounts)
 
 			if !reflect.DeepEqual(tt.want, f.developers) {
 				t.Errorf("developers list not as expected. \nWant: %s \nGot: %s", tt.want, f.developers)
@@ -219,7 +219,7 @@ func TestTenantAccountsFilter_GenerateDeveloperAccounts(t *testing.T) {
 
 func TestTenantAccountsFilter_Developer(t *testing.T) {
 	type fields struct {
-		developers []developerAccounts
+		developers []developerRoute
 	}
 	type args struct {
 		r v1.Route
@@ -232,7 +232,7 @@ func TestTenantAccountsFilter_Developer(t *testing.T) {
 	}{
 		{
 			name: "Url exist and is approved",
-			fields: fields{developers: []developerAccounts{
+			fields: fields{developers: []developerRoute{
 				{
 					Url:   "dummy.example.com",
 					State: "approved",
@@ -253,7 +253,7 @@ func TestTenantAccountsFilter_Developer(t *testing.T) {
 		},
 		{
 			name: "Url exist but not approved",
-			fields: fields{developers: []developerAccounts{
+			fields: fields{developers: []developerRoute{
 				{
 					Url:   "dummy.example.com",
 					State: "approved",
@@ -274,7 +274,7 @@ func TestTenantAccountsFilter_Developer(t *testing.T) {
 		},
 		{
 			name: "Url does not exist",
-			fields: fields{developers: []developerAccounts{
+			fields: fields{developers: []developerRoute{
 				{
 					Url:   "dummy.example.com",
 					State: "approved",

--- a/pkg/products/threescale/three_scale_moq.go
+++ b/pkg/products/threescale/three_scale_moq.go
@@ -96,7 +96,7 @@ var _ ThreeScaleInterface = &ThreeScaleInterfaceMock{}
 // 			IsAuthProviderAddedFunc: func(accessToken string, authProviderName string, account AccountDetail) (bool, error) {
 // 				panic("mock out the IsAuthProviderAdded method")
 // 			},
-// 			ListTenantAccountsFunc: func(accessToken string, page int) ([]AccountDetail, error) {
+// 			ListTenantAccountsFunc: func(accessToken string, page int, filterFn func(ac AccountDetail) bool) ([]AccountDetail, error) {
 // 				panic("mock out the ListTenantAccounts method")
 // 			},
 // 			PromoteProxyFunc: func(accessToken string, serviceID string, env string, to string) (string, error) {
@@ -203,7 +203,7 @@ type ThreeScaleInterfaceMock struct {
 	IsAuthProviderAddedFunc func(accessToken string, authProviderName string, account AccountDetail) (bool, error)
 
 	// ListTenantAccountsFunc mocks the ListTenantAccounts method.
-	ListTenantAccountsFunc func(accessToken string, page int) ([]AccountDetail, error)
+	ListTenantAccountsFunc func(accessToken string, page int, filterFn func(ac AccountDetail) bool) ([]AccountDetail, error)
 
 	// PromoteProxyFunc mocks the PromoteProxy method.
 	PromoteProxyFunc func(accessToken string, serviceID string, env string, to string) (string, error)
@@ -453,6 +453,8 @@ type ThreeScaleInterfaceMock struct {
 			AccessToken string
 			// Page is the page argument value.
 			Page int
+			// FilterFn is the filterFn argument value.
+			FilterFn func(ac AccountDetail) bool
 		}
 		// PromoteProxy holds details about calls to the PromoteProxy method.
 		PromoteProxy []struct {
@@ -1529,21 +1531,23 @@ func (mock *ThreeScaleInterfaceMock) IsAuthProviderAddedCalls() []struct {
 }
 
 // ListTenantAccounts calls ListTenantAccountsFunc.
-func (mock *ThreeScaleInterfaceMock) ListTenantAccounts(accessToken string, page int) ([]AccountDetail, error) {
+func (mock *ThreeScaleInterfaceMock) ListTenantAccounts(accessToken string, page int, filterFn func(ac AccountDetail) bool) ([]AccountDetail, error) {
 	if mock.ListTenantAccountsFunc == nil {
 		panic("ThreeScaleInterfaceMock.ListTenantAccountsFunc: method is nil but ThreeScaleInterface.ListTenantAccounts was just called")
 	}
 	callInfo := struct {
 		AccessToken string
 		Page        int
+		FilterFn    func(ac AccountDetail) bool
 	}{
 		AccessToken: accessToken,
 		Page:        page,
+		FilterFn:    filterFn,
 	}
 	mock.lockListTenantAccounts.Lock()
 	mock.calls.ListTenantAccounts = append(mock.calls.ListTenantAccounts, callInfo)
 	mock.lockListTenantAccounts.Unlock()
-	return mock.ListTenantAccountsFunc(accessToken, page)
+	return mock.ListTenantAccountsFunc(accessToken, page, filterFn)
 }
 
 // ListTenantAccountsCalls gets all the calls that were made to ListTenantAccounts.
@@ -1552,10 +1556,12 @@ func (mock *ThreeScaleInterfaceMock) ListTenantAccounts(accessToken string, page
 func (mock *ThreeScaleInterfaceMock) ListTenantAccountsCalls() []struct {
 	AccessToken string
 	Page        int
+	FilterFn    func(ac AccountDetail) bool
 } {
 	var calls []struct {
 		AccessToken string
 		Page        int
+		FilterFn    func(ac AccountDetail) bool
 	}
 	mock.lockListTenantAccounts.RLock()
 	calls = mock.calls.ListTenantAccounts


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4549

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
This add a filter to ensure that the routes used for the dns bypass alerts are from an active tenant. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Install master version
* Install the current master of the operator via OLM. Index: quay.io/jfitzpat/managed-api-service-index:1.30.0-4549
* Create muitly tenants in 3scale.
* Check the routes in the 3scale namespace. If the system-provider and system-developer routes for the created tenants are listed above the default routes. In 3scale UI delete the tenants belonging to the routes.
* Expected: alerts for DnsBypassThreeScaleDeveloperUI or DnsBypassThreeScaleSystemAdminUI shoud start firing.
* Allow alert to go into a firing state before moving onto the upgrade verification

## Upgrade to these changes
* Use index quay.io/jfitzpat/managed-api-service-index:1.31.0-4549
* Allow upgrade to finish
* Expected: dns bypass alerts will stop firing.