### PR TITLE
MGDAPI-4729 - fix: F03 - only check for managed tag for sts clusters

### DIFF
--- a/test/functional/aws_elasticache_resources_exist.go
+++ b/test/functional/aws_elasticache_resources_exist.go
@@ -67,11 +67,15 @@ func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingCon
 		if err != nil {
 			t.Fatalf("failed to get elasticache resource tags: %v", err)
 		}
-		if !elasticacheTagsContains(resp.TagList, awsManagedTagKey, awsManagedTagValue) {
-			testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have %s tag", resourceID, awsManagedTagKey))
-		}
-		if isSTS && !elasticacheTagsContains(resp.TagList, awsClusterTypeKey, awsClusterTypeRosaValue) {
-			testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have %s tag", resourceID, awsClusterTypeKey))
+
+		if isSTS {
+			// Check for managed tag for sts clusters only until https://issues.redhat.com/browse/MGDAPI-4729
+			if !elasticacheTagsContains(resp.TagList, awsManagedTagKey, awsManagedTagValue) {
+				testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have %s tag", resourceID, awsManagedTagKey))
+			}
+			if !elasticacheTagsContains(resp.TagList, awsClusterTypeKey, awsClusterTypeRosaValue) {
+				testErrors = append(testErrors, fmt.Sprintf("elasticache resource %s does not have %s tag", resourceID, awsClusterTypeKey))
+			}
 		}
 	}
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4729

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Only checked for managed tag for elasticache instances for sts clusters

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Ensure F03 passes on non sts ccs install
```
LOCAL=false NAMESPACE=redhat-rhoam-operator TEST=F03 make test/e2e/single
```
<img width="1672" alt="image" src="https://user-images.githubusercontent.com/24636860/207045531-4c49c104-4e75-4809-b9da-34cabe7a928d.png">
