### PR TITLE
MGDAPI-4599 enable unused golangci-lint linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,10 +2,6 @@ output:
   format: tab
   sort-results: true
 
-linters:
-  disable:
-    - unused
-
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/controllers/namespacelabel/namespacelabel_controller.go
+++ b/controllers/namespacelabel/namespacelabel_controller.go
@@ -41,8 +41,6 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
@@ -138,7 +136,6 @@ type NamespaceLabelReconciler struct {
 	Scheme *runtime.Scheme
 
 	operatorNamespace string
-	controller        controller.Controller
 	log               l.Logger
 }
 

--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -784,7 +784,6 @@ func TestReconciler_checkCloudResourcesConfig(t *testing.T) {
 		log           l.Logger
 	}
 	type args struct {
-		ctx          context.Context
 		serverClient k8sclient.Client
 	}
 	scheme, err := utils.NewTestScheme()

--- a/openshift-ci/test/e2e/suite_test.go
+++ b/openshift-ci/test/e2e/suite_test.go
@@ -5,29 +5,15 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
-const (
-	testResultsDirectory = "/test-run-results"
-	jUnitOutputFilename  = "junit-integreatly-operator.xml"
-	addonMetadataName    = "addon-metadata.json"
-	testOutputFileName   = "test-output.txt"
-	testSuiteName        = "integreatly-operator"
-)
-
 // These tests use Ginkgo (BDD-style Go testing framework). Refer to
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
-var cfg *rest.Config
-var k8sClient client.Client
 var testEnv *envtest.Environment
-var installType string
-var err error
 
 func TestAPIs(t *testing.T) {
 	RegisterFailHandler(Fail)
@@ -39,7 +25,7 @@ func TestAPIs(t *testing.T) {
 		AttachControlPlaneOutput: true,
 	}
 	var err error
-	cfg, err = testEnv.Start()
+	_, err = testEnv.Start()
 	if err != nil {
 		t.Fatalf("could not get start test environment %s", err)
 	}

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -52,7 +52,6 @@ type Reconciler struct {
 	installation  *integreatlyv1alpha1.RHMI
 	mpm           marketplace.MarketplaceInterface
 	log           l.Logger
-	extraParams   map[string]string
 	recorder      record.EventRecorder
 }
 

--- a/pkg/products/marin3r/rateLimitService_test.go
+++ b/pkg/products/marin3r/rateLimitService_test.go
@@ -896,9 +896,8 @@ func TestRateLimitServiceReconciler_deleteRedisLimitsUsingObservabilityOperator(
 		ConfigManager   config.ConfigReadWriter
 	}
 	type args struct {
-		ctx             context.Context
-		client          k8sclient.Client
-		limitadorClient *LimitadorClient
+		ctx    context.Context
+		client k8sclient.Client
 	}
 	tests := []struct {
 		name    string

--- a/pkg/products/monitoringspec/reconciler_test.go
+++ b/pkg/products/monitoringspec/reconciler_test.go
@@ -155,16 +155,6 @@ func createRole(name, namespace string) *rbac.Role {
 	}
 	return role
 }
-func basicConfigMock() *config.ConfigReadWriterMock {
-	return &config.ConfigReadWriterMock{
-		ReadMonitoringSpecFunc: func() (ready *config.MonitoringSpec, e error) {
-			return config.NewMonitoringSpec(config.ProductConfig{}), nil
-		},
-		WriteConfigFunc: func(config config.ConfigReadable) error {
-			return nil
-		},
-	}
-}
 
 func setupRecorder() record.EventRecorder {
 	return record.NewFakeRecorder(50)

--- a/pkg/products/observability/reconciler_test.go
+++ b/pkg/products/observability/reconciler_test.go
@@ -129,11 +129,6 @@ func TestReconciler_GetPreflightObject(t *testing.T) {
 		Reconciler    *resources.Reconciler
 		ConfigManager config.ConfigReadWriter
 		Config        *config.Observability
-		installation  *v1alpha1.RHMI
-		mpm           marketplace.MarketplaceInterface
-		log           logger.Logger
-		extraParams   map[string]string
-		recorder      record.EventRecorder
 	}
 	type args struct {
 		ns string

--- a/pkg/products/rhssocommon/reconciler.go
+++ b/pkg/products/rhssocommon/reconciler.go
@@ -40,7 +40,6 @@ import (
 
 var (
 	idpAlias        = "openshift-v4"
-	manifestPackage = "integreatly-rhsso"
 	podMonitorName  = "keycloak-pod-monitor"
 	keycloakPDBName = "keycloak"
 )

--- a/pkg/products/rhssocommon/reconciler_test.go
+++ b/pkg/products/rhssocommon/reconciler_test.go
@@ -1871,40 +1871,6 @@ func kcAlertHasNotBeenMirrored(existingRules *monitoringv1.PrometheusRule) bool 
 	return true
 }
 
-func kcAlertHasNotBeenRemovedorUpdated(existingRules *monitoringv1.PrometheusRule) bool {
-	var alert1exists = false
-	var alert2exists = false
-	var alertKCexists = false
-	var expressionUpdated = false
-
-	for _, alertRuleGroups := range existingRules.Spec.Groups {
-		for _, alert := range alertRuleGroups.Rules {
-			if alert.Alert == "testAlert1" {
-				alert1exists = true
-			}
-		}
-		for _, alert := range alertRuleGroups.Rules {
-			if alert.Alert == "testAlert2" {
-				alert2exists = true
-			}
-		}
-		for _, alert := range alertRuleGroups.Rules {
-			if alert.Alert == "KeycloakInstanceNotAvailable" {
-				if alert.Expr.StrVal != "testExpression" {
-					expressionUpdated = true
-				}
-				alertKCexists = true
-			}
-		}
-	}
-
-	if !alert1exists || !alert2exists || !alertKCexists || expressionUpdated {
-		return false
-	}
-
-	return true
-}
-
 func TestReconciler_ReconcilePodDisruptionBudget(t *testing.T) {
 	scheme, err := utils.NewTestScheme()
 	if err != nil {

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -16,7 +16,6 @@ import (
 	croTypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
-	userHelper "github.com/integr8ly/integreatly-operator/pkg/resources/user"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -184,22 +183,6 @@ func TestReconciler_config(t *testing.T) {
 				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
 			}
 		})
-	}
-}
-
-func getUser(name string) userHelper.MultiTenantUser {
-	return userHelper.MultiTenantUser{
-		Username:   name,
-		TenantName: name,
-		Email:      "asdf@bla.com",
-		UID:        "123",
-	}
-}
-
-func getAddedUsers() []userHelper.MultiTenantUser {
-	return []userHelper.MultiTenantUser{
-		getUser("user1"),
-		getUser("user2"),
 	}
 }
 

--- a/pkg/products/threescale/asserts_test.go
+++ b/pkg/products/threescale/asserts_test.go
@@ -19,10 +19,6 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (t ThreeScaleTestScenario) assertNoop() error {
-	return nil
-}
-
 func (t ThreeScaleTestScenario) assertInstallationSuccessful() error {
 	ctx := context.TODO()
 	accessToken := "test123"

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -9,14 +9,12 @@ import (
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	crotypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
-	"github.com/integr8ly/integreatly-operator/pkg/config"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
-	cloudcredentialv1 "github.com/openshift/api/operator/v1"
-	customdomainv1alpha1 "github.com/openshift/custom-domains-operator/api/v1alpha1"
-
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	keycloak "github.com/integr8ly/keycloak-client/apis/keycloak/v1alpha1"
+	cloudcredentialv1 "github.com/openshift/api/operator/v1"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhsso"
 	appsv1 "github.com/openshift/api/apps/v1"
@@ -763,19 +761,6 @@ var clusterVersion = &v12.ClusterVersion{
 				Verified:       false,
 			},
 		},
-	},
-}
-
-var customDomainCR = &customdomainv1alpha1.CustomDomain{
-	ObjectMeta: metav1.ObjectMeta{
-		Name:      "customDomain",
-		Namespace: "ns",
-	},
-	Spec: customdomainv1alpha1.CustomDomainSpec{
-		Domain: "apps.example.com",
-	},
-	Status: customdomainv1alpha1.CustomDomainStatus{
-		State: customdomainv1alpha1.CustomDomainStateReady,
 	},
 }
 

--- a/pkg/resources/cluster_test.go
+++ b/pkg/resources/cluster_test.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/test/utils"
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,7 +15,6 @@ import (
 type ClusterVersionTestScenario struct {
 	Name           string
 	FakeSigsClient k8sclient.Client
-	logger         l.Logger
 	ExpectedError  string
 	ExpectedValue  bool
 }

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -22,13 +22,6 @@ const (
 	EnvoyAPIVersion = "v3"
 )
 
-type container struct {
-	namespace          string
-	dcName             string
-	envoyNodeID        string
-	envoyContainerPort int32
-}
-
 type envoyProxyServer struct {
 	ctx    context.Context
 	client k8sclient.Client

--- a/pkg/resources/user/userHelper.go
+++ b/pkg/resources/user/userHelper.go
@@ -9,8 +9,6 @@ import (
 	"regexp"
 	"strings"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	keycloak "github.com/integr8ly/keycloak-client/apis/keycloak/v1alpha1"
 	v1 "github.com/openshift/api/config/v1"
 	usersv1 "github.com/openshift/api/user/v1"
@@ -184,36 +182,6 @@ func getIdentity(name string, identities *usersv1.IdentityList) *usersv1.Identit
 		}
 	}
 	return nil
-}
-
-func getUsersFromAdminGroups(ctx context.Context, serverClient k8sclient.Client, excludeGroups []string) (*usersv1.UserList, error) {
-	adminGroups := &usersv1.GroupList{}
-	err := serverClient.List(ctx, adminGroups)
-	if err != nil {
-		return nil, errors.Wrap(err, "could not list users")
-	}
-
-	adminUsers := &usersv1.UserList{}
-	for _, adminGroup := range adminGroups.Items {
-		if excludeGroup(excludeGroups, adminGroup.Name) {
-			for _, user := range adminGroup.Users {
-				adminUsers.Items = append(adminUsers.Items, usersv1.User{
-					ObjectMeta: metav1.ObjectMeta{Name: user}},
-				)
-			}
-		}
-	}
-
-	return adminUsers, nil
-}
-
-func excludeGroup(groups []string, group string) bool {
-	for _, gr := range groups {
-		if group == gr {
-			return true
-		}
-	}
-	return false
 }
 
 func GetIdentitiesByProviderName(ctx context.Context, serverClient k8sclient.Client, providerName string) (*usersv1.IdentityList, error) {

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -37,22 +37,21 @@ const (
 )
 
 var (
-	r1, _                         = rand.Int(rand.Reader, big.NewInt(200))
-	smtpReplicas            int32 = 1
-	threescaleLoginUserSMTP       = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
-	emailAddress                  = fmt.Sprintf("test%v@test.com", r1.Int64())
-	serviceIP                     = ""
-	emailUsername                 = "dummy"
-	emailPassword                 = "dummy"
-	emailPort                     = "1587"
-	originalHost                  = ""
-	originalPassword              = ""
-	originalPort                  = ""
-	originalUsername              = ""
-	original3scalePassword        = ""
-	original3scalePort            = ""
-	original3scaleHost            = ""
-	original3scaleUsername        = ""
+	r1, _                        = rand.Int(rand.Reader, big.NewInt(200))
+	smtpReplicas           int32 = 1
+	emailAddress                 = fmt.Sprintf("test%v@test.com", r1.Int64())
+	serviceIP                    = ""
+	emailUsername                = "dummy"
+	emailPassword                = "dummy"
+	emailPort                    = "1587"
+	originalHost                 = ""
+	originalPassword             = ""
+	originalPort                 = ""
+	originalUsername             = ""
+	original3scalePassword       = ""
+	original3scalePort           = ""
+	original3scaleHost           = ""
+	original3scaleUsername       = ""
 )
 
 //Test3ScaleSMTPConfig to confirm 3scale can send an email

--- a/test/common/grafana_routes.go
+++ b/test/common/grafana_routes.go
@@ -21,11 +21,6 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-var (
-	grafanaCredsUsername = fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
-	grafanaCredsPassword = DefaultPassword
-)
-
 func TestCustomerGrafanaExternalRouteAccessible(t TestingTB, ctx *TestingContext) {
 	if os.Getenv("SKIP_FLAKES") == "true" {
 		// https://issues.redhat.com/browse/MGDAPI-555

--- a/test/common/namespace_restoration.go
+++ b/test/common/namespace_restoration.go
@@ -301,48 +301,6 @@ func removeKeyCloakUserFinalizers(ctx *TestingContext, nameSpace string) error {
 	return err
 }
 
-// Remove finalizers from Monitoring resources in a target namespace
-func removeMonitoringFinalizers(ctx *TestingContext, nameSpace string) error {
-
-	err := removeBlackBoxTargetFinalizers(ctx, nameSpace)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// Poll removal of all finalizers from BlackBoxTargets from a namespace
-func removeBlackBoxTargetFinalizers(ctx *TestingContext, nameSpace string) error {
-	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {
-		blackBoxes := &integreatlyv1alpha1.BlackboxTargetList{}
-
-		err = ctx.Client.List(goctx.TODO(), blackBoxes, &k8sclient.ListOptions{
-			Namespace: nameSpace,
-		})
-
-		if err != nil {
-			return false, err
-		}
-
-		for i := range blackBoxes.Items {
-			blackBox := blackBoxes.Items[i]
-			_, err = controllerutil.CreateOrUpdate(goctx.TODO(), ctx.Client, &blackBox, func() error {
-				blackBox.Finalizers = []string{}
-				return nil
-			})
-
-			if err != nil {
-				return false, err
-			}
-		}
-
-		return true, nil
-	})
-
-	return err
-}
-
 // Poll removal of all finalizers from EnvoyConfigRevisions from a namespace
 func removeEnvoyConfigRevisionFinalizers(ctx *TestingContext, nameSpace string) error {
 	err := wait.Poll(finalizerDeletionRetryInterval, finalizerDeletionTimeout, func() (done bool, err error) {

--- a/test/common/rhmicr_metrics.go
+++ b/test/common/rhmicr_metrics.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"strings"
 
-	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -106,11 +105,4 @@ func parsePrometheusMetricToMap(metric, metricName string) map[string]string {
 		parsedStrings[value[0]] = strings.ReplaceAll(value[1], "\"", "")
 	}
 	return parsedStrings
-}
-
-func sanitizeForPrometheusLabel(productName integreatlyv1alpha1.ProductName) string {
-	if productName == integreatlyv1alpha1.Product3Scale {
-		productName = "threescale"
-	}
-	return fmt.Sprintf("%s_status", strings.ReplaceAll(string(productName), "-", "_"))
 }

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -74,17 +74,6 @@ var (
 		},
 	}
 
-	userSsoRoutes = []ExpectedRoute{
-		ExpectedRoute{
-			Name:  "keycloak",
-			isTLS: true,
-		},
-		ExpectedRoute{
-			Name:  "keycloak-edge",
-			isTLS: true,
-		},
-	}
-
 	rhoamUserSsoRoutes = []ExpectedRoute{
 		ExpectedRoute{
 			Name:  "keycloak",

--- a/test/common/scale_up_replicas_rhsso.go
+++ b/test/common/scale_up_replicas_rhsso.go
@@ -16,7 +16,6 @@ import (
 
 var (
 	rhssoName     = "rhsso"
-	userSSOName   = "rhssouser"
 	requestURLSSO = "/apis/keycloak.org/v1alpha1"
 	kindSSO       = "Keycloaks"
 )

--- a/test/common/validate_resource_requirements.go
+++ b/test/common/validate_resource_requirements.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
-	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -44,7 +43,6 @@ var (
 			"namespace":         Marin3rProductNamespace,
 		},
 	}
-	testLog = l.NewLoggerWithContext(l.Fields{l.ProductLogContext: "TeST"}).Logger
 )
 
 func ValidateResourceRequirements(t TestingTB, ctx *TestingContext) {

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -34,15 +34,10 @@ import (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
-var k8sClient client.Client
 var testEnv *envtest.Environment
 var installType string
 var err error
 var retryInterval = time.Second * 30
-var cloudResourcesStageTimeout = time.Minute * 10
-var monitoringStageTimeout = time.Minute * 10
-var authenticationStageTimeout = time.Minute * 30
-var productsStageTimout = time.Minute * 30
 var deploymentTimeout = time.Minute * 25
 var installStageTimeout = time.Minute * 40
 var failed = false

--- a/test/functional/multiaz_pod_distribution.go
+++ b/test/functional/multiaz_pod_distribution.go
@@ -3,7 +3,6 @@ package functional
 import (
 	goctx "context"
 	"fmt"
-	"math"
 	"os"
 	"strings"
 
@@ -18,7 +17,6 @@ var (
 		common.RHSSOProductNamespace,
 		common.ThreeScaleProductNamespace,
 	}
-	availableZones = map[string]bool{}
 )
 
 type podDistribution struct {
@@ -36,8 +34,6 @@ func TestMultiAZPodDistribution(t common.TestingTB, ctx *common.TestingContext) 
 	if err != nil {
 		t.Fatalf("error listing nodes: %s", err)
 	}
-
-	availableZones = GetClustersAvailableZones(nodes)
 
 	// If "NAMESPACES_TO_CHECK" env var contains a list of namespaces, use that instead of the predefined list
 	namespacesFromEnvVar := os.Getenv("NAMESPACES_TO_CHECK")
@@ -142,21 +138,4 @@ func testCorrectPodDistribution(dist map[string]*podDistribution) []string {
 	}
 	return testErrors
 
-}
-
-// Takes the total number of pods belonging to the pod owner
-// and calculates the minimal and maximal amount of pods that should be running
-// per zone to meet the criteria for uniform pod distribution across the zones
-// Examples:
-// - 5 pods, 3 zones => 5/3 => min 1, max 2 pods per zone
-// - 4 pods, 2 zones => 4/2 => min 2, max 2 pods per zone
-func getAllowedNumberOfPodsPerZone(podsTotal int) (min int, max int) {
-	if podsTotal%len(availableZones) == 0 {
-		min = podsTotal / len(availableZones)
-		max = min
-		return
-	}
-	min = int(math.Floor(float64(podsTotal) / float64(len(availableZones))))
-	max = min + 1
-	return
 }

--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -11,7 +11,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,7 +30,6 @@ const (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
-var k8sClient client.Client
 var testEnv *envtest.Environment
 var installType string
 var err error

--- a/test/osde2e/suite_test.go
+++ b/test/osde2e/suite_test.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -31,7 +30,6 @@ const (
 // http://onsi.github.io/ginkgo/ to learn more about Ginkgo.
 
 var cfg *rest.Config
-var k8sClient client.Client
 var testEnv *envtest.Environment
 var installType string
 var err error

--- a/test/resources/oauth_proxy_auth.go
+++ b/test/resources/oauth_proxy_auth.go
@@ -3,7 +3,6 @@ package resources
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -235,15 +234,6 @@ func ProxyOAuth(client *http.Client, host string, username string, password stri
 	}
 
 	return client, nil
-}
-
-func verifyRedirect(redirectUrl, host string) error {
-	if redirectUrl != host {
-		return errors.New(fmt.Sprintf("redirect host does not match product host: %v / %v",
-			redirectUrl,
-			host))
-	}
-	return nil
 }
 
 // Submit permission approval form


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-4599

# What
Enabled the `unused` golangci-lint linter and fixed all existing errors found by it.

# Verification steps
Verify all prow checks are passing