### PR TITLE
MGDAPI-4847 add logic to override wildcard domain in apimanger cr

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -693,7 +693,14 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, serverClient k8scl
 			Enabled: true,
 		}
 		apim.Spec.APIManagerCommonSpec.ResourceRequirementsEnabled = &resourceRequirements
-		apim.Spec.WildcardDomain = r.installation.Spec.RoutingSubdomain
+		/** RHOAM will only update the WildcardDomain for the following cases,
+		* - Fresh installs without customDomain set
+		* - Fresh installs with customDomain set
+		* The wildcardDomain will be editable for other cases installs. See MGDAPI-4974
+		**/
+		if apim.Spec.WildcardDomain == "" {
+			apim.Spec.WildcardDomain = r.installation.Spec.RoutingSubdomain
+		}
 		apim.Spec.ExternalComponents = &threescalev1.ExternalComponentsSpec{
 			System: &threescalev1.ExternalSystemComponents{
 				Redis:    &ExternalComponentsTrue,


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4974

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
add the ability to overwrite the wildcard domain in the apimanager CR

# Verification steps
- Run this branch against a cluster locally
- Wait for the install to finish
- Edit the apimanager CR in the redhat-rhoam-3scale NS
```yaml
spec:
  wildcardDomain: <change this to anything doesn't have to be a valid domain> 
```
- The change should remain 
