### PR TITLE
MGDAPI-5001 bump keycloak-metrics-sbi version

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -285,10 +285,22 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Name:      keycloakName,
 			Namespace: r.Config.GetNamespace(),
 		},
+		Spec: keycloak.KeycloakSpec{
+			KeycloakDeploymentSpec: keycloak.KeycloakDeploymentSpec{
+				Experimental: keycloak.ExperimentalSpec{
+					Env: []corev1.EnvVar{
+						{
+							Name:  "DISABLE_EXTERNAL_ACCESS",
+							Value: "TRUE",
+						},
+					},
+				},
+			},
+		},
 	}
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.1/keycloak-metrics-spi-2.0.1.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar",
 			"https://github.com/integr8ly/authentication-delay-plugin/releases/download/1.0.2/authdelay.jar",
 		}
 		kc.Labels = GetInstanceLabels()

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -3,6 +3,7 @@ package rhssouser
 import (
 	"context"
 	"fmt"
+	corev1 "k8s.io/api/core/v1"
 	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
@@ -321,6 +322,18 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 			Name:      keycloakName,
 			Namespace: r.Config.GetNamespace(),
 		},
+		Spec: keycloak.KeycloakSpec{
+			KeycloakDeploymentSpec: keycloak.KeycloakDeploymentSpec{
+				Experimental: keycloak.ExperimentalSpec{
+					Env: []corev1.EnvVar{
+						{
+							Name:  "DISABLE_EXTERNAL_ACCESS",
+							Value: "TRUE",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	key := k8sclient.ObjectKeyFromObject(kc)
@@ -334,7 +347,7 @@ func (r *Reconciler) reconcileComponents(ctx context.Context, installation *inte
 	or, err := controllerutil.CreateOrUpdate(ctx, serverClient, kc, func() error {
 		owner.AddIntegreatlyOwnerAnnotations(kc, installation)
 		kc.Spec.Extensions = []string{
-			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.0.1/keycloak-metrics-spi-2.0.1.jar",
+			"https://github.com/aerogear/keycloak-metrics-spi/releases/download/2.5.3/keycloak-metrics-spi-2.5.3.jar",
 		}
 		kc.Spec.ExternalDatabase = keycloak.KeycloakExternalDatabase{Enabled: true}
 		kc.Labels = getMasterLabels()


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5001

# What
- Bumped the version of keycloak-metrics-sbi to 2.5.3
- Added this configurations: https://github.com/aerogear/keycloak-metrics-spi#external-access

# Verification steps
- Checkout this branch:
  ```
  gh pr checkout 3058
  ```
- Install RHOAM on an OSD cluster by running the operator locally and wait for it to complete:
  ```
  LOCAL=false make cluster/prepare/local
  LOCAL=false make code/run
  ```
- Verify both keycloak pods in the rhsso and user sso namespaces have the new environment variable set. The output should be 4 identical entries with value `TRUE`:
  ```
  oc get pods -n redhat-rhoam-rhsso -o json | jq '.items[].spec.containers[].env[] | select(.name == "DISABLE_EXTERNAL_ACCESS")'
  oc get pods -n redhat-rhoam-user-sso -o json | jq '.items[].spec.containers[].env[] | select(.name == "DISABLE_EXTERNAL_ACCESS")'
  ```
- Query the metrics endpoint of both Keycloak instances internally and ensure you get metrics back:
  ```
  oc rsh -n redhat-rhoam-user-sso keycloak-0
  curl localhost:8080/auth/realms/master/metrics
  ```
  ```
  oc rsh -n redhat-rhoam-rhsso keycloak-0
  curl localhost:8080/auth/realms/master/metrics
  ```
- Query the metrics endpoint of both Keycloak instances externally and ensure you don't have access to metrics (403 Forbidden):
  ```
  SSO_KEYCLOAK_HOST=$(oc get route keycloak -n redhat-rhoam-user-sso -o json | jq -r '.spec.host')
  curl -I https://$SSO_KEYCLOAK_HOST/auth/realms/master/metrics 
  ```
  ```
  RHSSO_KEYCLOAK_HOST=$(oc get route keycloak -n redhat-rhoam-rhsso -o json | jq -r '.spec.host')
  curl -I https://$RHSSO_KEYCLOAK_HOST/auth/realms/master/metrics 
  ```