### PR TITLE
MGDAPI-5000 : Set Outgoing email address

### DIFF
--- a/bundles/managed-api-service/1.31.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.31.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -219,6 +219,12 @@ spec:
                 - list
             - apiGroups:
                 - ""
+              resources:
+                - pods/exec
+              verbs:
+                - create
+            - apiGroups:
+                - ""
               resourceNames:
                 - grafana-datasources
               resources:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -44,6 +44,12 @@ rules:
   - list
 - apiGroups:
   - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+- apiGroups:
+  - ""
   resourceNames:
   - grafana-datasources
   resources:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -215,8 +215,9 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // Required for multitenant installations of RHOAM because the RHOAM operator is cluster scoped in these installations
 // +kubebuilder:rbac:groups="*",resources=configmaps;secrets;services;subscriptions,verbs=get;list;watch;create;update
 
-// For accessing limitador api from pod
+// For accessing limitador api and rails console from pod
 // +kubebuilder:rbac:groups="",resources=pods,verbs=create;list
+// +kubebuilder:rbac:groups="",resources=pods/exec,verbs=create
 
 // LimitRanges are used to assign default CPU/Memory requests and limits for containers that don't specify values for compute resources
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;create;update;delete

--- a/pkg/products/threescale/clients_test.go
+++ b/pkg/products/threescale/clients_test.go
@@ -3,6 +3,7 @@ package threescale
 import (
 	"context"
 	"fmt"
+	portaClient "github.com/3scale/3scale-porta-go-client/client"
 	"github.com/integr8ly/integreatly-operator/pkg/products/monitoringcommon"
 	"math/rand"
 	"net/http"
@@ -226,6 +227,9 @@ func getThreeScaleClient() *ThreeScaleInterfaceMock {
 			return nil
 		},
 		DeleteTenantFunc: func(accessToken string, id int) error {
+			return nil
+		},
+		UpdateTenantFunc: func(id int64, params portaClient.Params, portaClientMoqParam *portaClient.ThreeScaleClient) error {
 			return nil
 		},
 	}

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -961,7 +961,6 @@ func getSuccessfullRHOAMTestPreReqs(integreatlyOperatorNamespace, threeScaleInst
 			},
 		},
 		&v1.RouteList{
-
 			Items: []v1.Route{
 				{ObjectMeta: metav1.ObjectMeta{Name: "master", Namespace: "3scale"},
 					Spec: v1.RouteSpec{Host: "master.apps.example.com"}},

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -179,6 +179,22 @@ var systemApp = appsv1.DeploymentConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "system-app",
 	},
+	Spec: appsv1.DeploymentConfigSpec{
+		Template: &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "SUPPORT_EMAIL",
+								Value: "wrong@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
+	},
 	Status: appsv1.DeploymentConfigStatus{
 		LatestVersion: 1,
 	},
@@ -187,6 +203,22 @@ var systemApp = appsv1.DeploymentConfig{
 var systemSidekiq = appsv1.DeploymentConfig{
 	ObjectMeta: metav1.ObjectMeta{
 		Name: "system-sidekiq",
+	},
+	Spec: appsv1.DeploymentConfigSpec{
+		Template: &corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Env: []corev1.EnvVar{
+							{
+								Name:  "SUPPORT_EMAIL",
+								Value: "wrong@example.com",
+							},
+						},
+					},
+				},
+			},
+		},
 	},
 	Status: appsv1.DeploymentConfigStatus{
 		LatestVersion: 1,
@@ -953,6 +985,22 @@ func getSuccessfullRHOAMTestPreReqs(integreatlyOperatorNamespace, threeScaleInst
 					"tenant": "true",
 				},
 				Name: "test_user",
+			},
+		},
+		&corev1.PodList{
+			Items: []corev1.Pod{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "system-app-1-abcde",
+						Namespace: "3scale",
+						Labels: map[string]string{
+							"deploymentConfig": "system-app",
+						},
+					},
+					Status: corev1.PodStatus{
+						Phase: "Running",
+					},
+				},
 			},
 		},
 	)

--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -960,6 +960,13 @@ func getSuccessfullRHOAMTestPreReqs(integreatlyOperatorNamespace, threeScaleInst
 				Host: "backend-3scale.apps",
 			},
 		},
+		&v1.RouteList{
+
+			Items: []v1.Route{
+				{ObjectMeta: metav1.ObjectMeta{Name: "master", Namespace: "3scale"},
+					Spec: v1.RouteSpec{Host: "master.apps.example.com"}},
+			},
+		},
 		&corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "apicast-staging",

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -442,15 +442,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.syncInvitationEmail(ctx, serverClient)
-	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		if err != nil {
-			r.log.Warning("Failed to syncInvitationEmail: " + err.Error())
-			events.HandleError(r.recorder, installation, phase, "Failed to syncInvitationEmail", err)
-		}
-		return phase, err
-	}
-
 	phase, err = r.reconcileRHSSOIntegration(ctx, serverClient)
 	r.log.Infof("reconcileRHSSOIntegration", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
@@ -576,6 +567,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	r.log.Infof("changesDeploymentConfigsEnvVar", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to change deployment config envvars", err)
+		return phase, err
+	}
+
+	phase, err = r.syncInvitationEmail(ctx, serverClient)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		if err != nil {
+			r.log.Warning("Failed to syncInvitationEmail: " + err.Error())
+			events.HandleError(r.recorder, installation, phase, "Failed to syncInvitationEmail", err)
+		}
 		return phase, err
 	}
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1500,7 +1500,7 @@ func (r *Reconciler) getOAuthClientName() string {
 	return r.installation.Spec.NamespacePrefix + string(r.Config.GetProductName())
 }
 
-func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileOpenshiftUsers(ctx context.Context, _ *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("Reconciling openshift users to 3scale")
 
 	rhssoConfig, err := r.ConfigManager.ReadRHSSO()
@@ -2887,7 +2887,7 @@ func (r *Reconciler) reconcileRouteEditRole(ctx context.Context, client k8sclien
 	return integreatlyv1alpha1.PhaseCompleted, nil
 }
 
-func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, inst *integreatlyv1alpha1.RHMI, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileSubscription(ctx context.Context, serverClient k8sclient.Client, _ *integreatlyv1alpha1.RHMI, productNamespace string, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
 	target := marketplace.Target{
 		SubscriptionName: constants.ThreeScaleSubscriptionName,
 		Namespace:        operatorNamespace,
@@ -3354,7 +3354,7 @@ func (r *Reconciler) getBackendListenerRoute(ctx context.Context, serverClient k
 	return backendRoute, nil
 }
 
-func (r *Reconciler) addSSOReadyAnnotationToUser(ctx context.Context, client k8sclient.Client, name string) error {
+func (r *Reconciler) addSSOReadyAnnotationToUser(_ context.Context, client k8sclient.Client, name string) error {
 	// Get the User CR to annotate
 	userToAnnotate := &usersv1.User{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -424,7 +424,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.reconcileDcEnvarEmailAddress(ctx, serverClient, "system-app", updateSystemAppAddresses)
+	phase, err = r.reconcileDcEnvarEmailAddress(ctx, serverClient, systemAppDCName, updateSystemAppAddresses)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		if err != nil {
 			r.log.Warning("Failed to reconcileDcEnvarEmailAddress: " + err.Error())
@@ -3666,7 +3666,7 @@ func (r *Reconciler) syncInvitationEmail(ctx context.Context, serverClient k8scl
 	pods := &corev1.PodList{}
 	listOpts := []k8sclient.ListOption{
 		k8sclient.InNamespace(ns),
-		k8sclient.MatchingLabels(map[string]string{"deploymentConfig": "system-app"}),
+		k8sclient.MatchingLabels(map[string]string{"deploymentConfig": systemAppDCName}),
 	}
 	err = serverClient.List(ctx, pods, listOpts...)
 	if err != nil {
@@ -3675,7 +3675,7 @@ func (r *Reconciler) syncInvitationEmail(ctx context.Context, serverClient k8scl
 	}
 
 	for _, pod := range pods.Items {
-		if pod.Status.Phase == "Running" {
+		if pod.Status.Phase == corev1.PodRunning {
 			podname = pod.ObjectMeta.Name
 			break
 		}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -5,19 +5,15 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	portaClient "github.com/3scale/3scale-porta-go-client/client"
 	"github.com/integr8ly/integreatly-operator/pkg/addon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
 	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	portaClient "github.com/3scale/3scale-porta-go-client/client"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
-
-	"github.com/integr8ly/integreatly-operator/pkg/addon"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
-	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	envoyextentionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes/any"
@@ -3033,7 +3029,7 @@ func (r *Reconciler) changesDeploymentConfigsEnvVar(ctx context.Context, serverC
 
 			// Have to use the index when iterating here because when using range go creates a copy of the variable
 			// so any update will be applied to the copy
-			for envVarName, _ := range envVars {
+			for envVarName := range envVars {
 				foundEnv := false
 				envVarValue := envVars[envVarName]
 

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/integr8ly/integreatly-operator/pkg/resources/sts"
 	openshiftappsv1 "github.com/openshift/api/apps/v1"
 	cloudcredentialv1 "github.com/openshift/api/operator/v1"
+	fakeappsv1Client "github.com/openshift/client-go/apps/clientset/versioned/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -3395,6 +3396,488 @@ func TestReconciler_createStsS3Secret(t *testing.T) {
 			}
 			if err := r.createStsS3Secret(tt.args.ctx, tt.args.serverClient, tt.args.credSec, tt.args.blobStorageSec); (err != nil) != tt.wantErr {
 				t.Errorf("createStsS3Secret() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestReconciler_reconcileSystemAppSupportEmailAddress(t *testing.T) {
+	type fields struct {
+		ConfigManager config.ConfigReadWriter
+		Config        *config.ThreeScale
+		mpm           marketplace.MarketplaceInterface
+		installation  *integreatlyv1alpha1.RHMI
+		tsClient      ThreeScaleInterface
+		appsv1Client  appsv1Client.AppsV1Interface
+		oauthv1Client oauthClient.OauthV1Interface
+		Reconciler    *resources.Reconciler
+		extraParams   map[string]string
+		recorder      record.EventRecorder
+		log           l.Logger
+	}
+	type args struct {
+		ctx          context.Context
+		serverClient k8sclient.Client
+		dcName       string
+		updateFn     func(dc *openshiftappsv1.DeploymentConfig, value string) bool
+	}
+
+	tests := []struct {
+		name        string
+		fields      fields
+		args        args
+		want        integreatlyv1alpha1.StatusPhase
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "Error getting Observability config",
+			want:        integreatlyv1alpha1.PhaseFailed,
+			wantErr:     true,
+			errContains: "some error",
+			args: args{
+				ctx:          context.TODO(),
+				serverClient: fake.NewClientBuilder().Build(),
+			},
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					ReadObservabilityFunc: func() (*config.Observability, error) {
+						return &config.Observability{
+							Config: config.ProductConfig{
+								"NAMESPACE": "namespace",
+							},
+						}, fmt.Errorf("some error")
+					}},
+			},
+		},
+		{
+			name:        "Error getting existing SMTP from Address",
+			want:        integreatlyv1alpha1.PhaseFailed,
+			wantErr:     true,
+			errContains: "cannot unmarshal !!str",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: fake.NewClientBuilder().WithRuntimeObjects(&corev1.Secret{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "alertmanager-application-monitoring",
+						Namespace: "namespace",
+					},
+					Data: map[string][]byte{
+						"alertmanager.yaml": []byte("|\nglobal: foo"),
+					},
+				}).Build(),
+			},
+			fields: fields{
+				installation: &integreatlyv1alpha1.RHMI{},
+				log:          getLogger(),
+				ConfigManager: &config.ConfigReadWriterMock{
+					ReadObservabilityFunc: func() (*config.Observability, error) {
+						return &config.Observability{
+							Config: config.ProductConfig{
+								"NAMESPACE": "namespace",
+							},
+						}, nil
+					}},
+			},
+		},
+		{
+			name:        "Error Getting deployment config",
+			want:        integreatlyv1alpha1.PhaseFailed,
+			wantErr:     true,
+			errContains: "\"system-app\" not found",
+			args: args{
+				ctx:          context.TODO(),
+				dcName:       "system-app",
+				serverClient: fake.NewClientBuilder().Build(),
+			},
+			fields: fields{
+				installation: &integreatlyv1alpha1.RHMI{},
+				log:          getLogger(),
+				ConfigManager: &config.ConfigReadWriterMock{
+					ReadObservabilityFunc: func() (*config.Observability, error) {
+						return &config.Observability{
+							Config: config.ProductConfig{
+								"NAMESPACE": "namespace",
+							},
+						}, nil
+					},
+				},
+				Config: config.NewThreeScale(config.ProductConfig{
+					"NAMESPACE": defaultInstallationNamespace,
+				}),
+
+				appsv1Client: fakeappsv1Client.NewSimpleClientset([]runtime.Object{}...).AppsV1(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &Reconciler{
+				ConfigManager: tt.fields.ConfigManager,
+				Config:        tt.fields.Config,
+				mpm:           tt.fields.mpm,
+				installation:  tt.fields.installation,
+				tsClient:      tt.fields.tsClient,
+				appsv1Client:  tt.fields.appsv1Client,
+				oauthv1Client: tt.fields.oauthv1Client,
+				Reconciler:    tt.fields.Reconciler,
+				extraParams:   tt.fields.extraParams,
+				recorder:      tt.fields.recorder,
+				log:           tt.fields.log,
+			}
+			t.Setenv("ALERT_SMTP_FROM", "envar@smtp.com")
+			got, err := r.reconcileDcEnvarEmailAddress(tt.args.ctx, tt.args.serverClient, tt.args.dcName, tt.args.updateFn)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("reconcileDcEnvarEmailAddress() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("reconcileDcEnvarEmailAddress() got = %v, want %v", got, tt.want)
+			}
+
+			if tt.wantErr && !strings.Contains(err.Error(), tt.errContains) {
+				t.Errorf("reconcileDcEnvarEmailAddress()\nerror message = %v\nshould contain = %v", err, tt.errContains)
+			}
+		})
+	}
+}
+
+func Test_updateContainerSupportEmail(t *testing.T) {
+	type args struct {
+		dc                      *openshiftappsv1.DeploymentConfig
+		existingSMTPFromAddress string
+		envar                   string
+	}
+	tests := []struct {
+		name          string
+		args          args
+		want          bool
+		expectedFinds int
+	}{
+		{
+			name:          "No container is updated",
+			want:          false,
+			expectedFinds: 1,
+			args: args{
+				envar:                   "SUPPORT_EMAIL",
+				existingSMTPFromAddress: "test@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "test@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "One container has envar added",
+			want:          true,
+			expectedFinds: 1,
+			args: args{
+				envar:                   "SUPPORT_EMAIL",
+				existingSMTPFromAddress: "test@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "Other Envar",
+												Value: "test@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "One container has envar updated",
+			want:          true,
+			expectedFinds: 1,
+			args: args{
+				envar:                   "SUPPORT_EMAIL",
+				existingSMTPFromAddress: "test@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "wrong@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:          "Multi container: One no update, One envar added, One envar updated",
+			want:          true,
+			expectedFinds: 3,
+			args: args{
+				envar:                   "SUPPORT_EMAIL",
+				existingSMTPFromAddress: "test@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "test@example.com",
+											},
+										},
+									},
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "Other Envar",
+												Value: "test@example.com",
+											},
+										},
+									},
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "wrong@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updateContainerSupportEmail(tt.args.dc, tt.args.existingSMTPFromAddress, tt.args.envar); got != tt.want {
+				t.Errorf("updateContainerSupportEmail() = %v, want %v", got, tt.want)
+			}
+
+			finds := 0
+			for _, container := range tt.args.dc.Spec.Template.Spec.Containers {
+				for _, envar := range container.Env {
+					if envar.Name == "SUPPORT_EMAIL" {
+						if envar.Value != tt.args.existingSMTPFromAddress {
+							t.Errorf("DeploymentConfig not updated as expected, \nFound: %v,\nExpected value to have: %v", envar, tt.args.existingSMTPFromAddress)
+						}
+						finds++
+					}
+				}
+			}
+
+			if finds != tt.expectedFinds {
+				t.Errorf("updateContainerSupportEmail() = %v, want %v", finds, tt.expectedFinds)
+			}
+
+		})
+	}
+}
+
+func Test_updateSystemAppAddresses(t *testing.T) {
+	type args struct {
+		dc    *openshiftappsv1.DeploymentConfig
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "DC was updated",
+			want: true,
+			args: args{
+				value: "update@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "test@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "DC was not updated",
+			want: false,
+			args: args{
+				value: "no-update@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "no-update@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updateSystemAppAddresses(tt.args.dc, tt.args.value); got != tt.want {
+				t.Errorf("updateSystemAppAddresses() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_updateSystemSidekiqAddresses(t *testing.T) {
+	type args struct {
+		dc    *openshiftappsv1.DeploymentConfig
+		value string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "None are updated",
+			want: false,
+			args: args{
+				value: "no-update@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "no-update@example.com",
+											},
+											{
+												Name:  "NOTIFICATION_EMAIL",
+												Value: "no-update@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "SUPPORT_EMAIL updated",
+			want: true,
+			args: args{
+				value: "no-update@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "test@example.com",
+											},
+											{
+												Name:  "NOTIFICATION_EMAIL",
+												Value: "no-update@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "NOTIFICATION_EMAIL updated",
+			want: true,
+			args: args{
+				value: "no-update@example.com",
+				dc: &openshiftappsv1.DeploymentConfig{
+					Spec: openshiftappsv1.DeploymentConfigSpec{
+						Template: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Env: []corev1.EnvVar{
+											{
+												Name:  "SUPPORT_EMAIL",
+												Value: "no-update@example.com",
+											},
+											{
+												Name:  "NOTIFICATION_EMAIL",
+												Value: "test@example.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := updateSystemSidekiqAddresses(tt.args.dc, tt.args.value); got != tt.want {
+				t.Errorf("updateSystemSidekiqAddresses() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strings"
 	"testing"
 

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -409,6 +409,12 @@ func TestReconciler_Reconcile3scale(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error creating new reconciler %s: %v", constants.ThreeScaleSubscriptionName, err)
 			}
+
+			r.podExecutor = &resources.PodExecutorInterfaceMock{
+				ExecuteRemoteContainerCommandFunc: func(ns string, podName string, container string, command []string) (string, string, error) {
+					return "ok", "", nil
+				}}
+
 			got, err := r.Reconcile(context.TODO(), tt.args.installation, tt.args.productStatus, tt.fields.sigsClient, tt.args.productConfig, tt.args.uninstall)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Reconcile() error = %v, wantErr %v", err, tt.wantErr)

--- a/pkg/products/threescale/three_scale_client.go
+++ b/pkg/products/threescale/three_scale_client.go
@@ -6,6 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
+	"github.com/3scale/3scale-porta-go-client/client"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -28,6 +29,7 @@ type ThreeScaleInterface interface {
 	SetUserAsMember(userID int, accessToken string) (*http.Response, error)
 	SetFromEmailAddress(emailAddress string, accessToken string) (*http.Response, error)
 	UpdateUser(userID int, username string, email string, accessToken string) (*http.Response, error)
+	UpdateTenant(id int64, params client.Params, portaClient *client.ThreeScaleClient) error
 
 	CreateAccount(accessToken, orgName, username string) (string, error)
 	CreateBackend(accessToken, name, privateEndpoint string) (int, error)
@@ -800,6 +802,15 @@ func (tsc *threeScaleClient) makeRequest(method, path string, parameters map[str
 func (tsc *threeScaleClient) makeRequestToMaster(method, path string, parameters map[string]interface{}) (*http.Response, error) {
 	url := fmt.Sprintf("https://master.%s/%s", tsc.wildCardDomain, path)
 	return makeRequest(url, method, parameters, tsc)
+}
+
+func (tsc *threeScaleClient) UpdateTenant(id int64, params client.Params, portaClient *client.ThreeScaleClient) error {
+
+	_, err := portaClient.UpdateTenant(id, params)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 func xmlFromResponse(res *http.Response, xpath string) (string, error) {

--- a/pkg/products/threescale/three_scale_moq.go
+++ b/pkg/products/threescale/three_scale_moq.go
@@ -4,6 +4,7 @@
 package threescale
 
 import (
+	portaClient "github.com/3scale/3scale-porta-go-client/client"
 	"net/http"
 	"sync"
 )
@@ -114,6 +115,9 @@ var _ ThreeScaleInterface = &ThreeScaleInterfaceMock{}
 // 			SetUserAsMemberFunc: func(userID int, accessToken string) (*http.Response, error) {
 // 				panic("mock out the SetUserAsMember method")
 // 			},
+// 			UpdateTenantFunc: func(id int64, params portaClient.Params, portaClientMoqParam *portaClient.ThreeScaleClient) error {
+// 				panic("mock out the UpdateTenant method")
+// 			},
 // 			UpdateUserFunc: func(userID int, username string, email string, accessToken string) (*http.Response, error) {
 // 				panic("mock out the UpdateUser method")
 // 			},
@@ -219,6 +223,9 @@ type ThreeScaleInterfaceMock struct {
 
 	// SetUserAsMemberFunc mocks the SetUserAsMember method.
 	SetUserAsMemberFunc func(userID int, accessToken string) (*http.Response, error)
+
+	// UpdateTenantFunc mocks the UpdateTenant method.
+	UpdateTenantFunc func(id int64, params portaClient.Params, portaClientMoqParam *portaClient.ThreeScaleClient) error
 
 	// UpdateUserFunc mocks the UpdateUser method.
 	UpdateUserFunc func(userID int, username string, email string, accessToken string) (*http.Response, error)
@@ -493,6 +500,15 @@ type ThreeScaleInterfaceMock struct {
 			// AccessToken is the accessToken argument value.
 			AccessToken string
 		}
+		// UpdateTenant holds details about calls to the UpdateTenant method.
+		UpdateTenant []struct {
+			// ID is the id argument value.
+			ID int64
+			// Params is the params argument value.
+			Params portaClient.Params
+			// PortaClientMoqParam is the portaClientMoqParam argument value.
+			PortaClientMoqParam *portaClient.ThreeScaleClient
+		}
 		// UpdateUser holds details about calls to the UpdateUser method.
 		UpdateUser []struct {
 			// UserID is the userID argument value.
@@ -537,6 +553,7 @@ type ThreeScaleInterfaceMock struct {
 	lockSetNamespace                    sync.RWMutex
 	lockSetUserAsAdmin                  sync.RWMutex
 	lockSetUserAsMember                 sync.RWMutex
+	lockUpdateTenant                    sync.RWMutex
 	lockUpdateUser                      sync.RWMutex
 }
 
@@ -1745,6 +1762,45 @@ func (mock *ThreeScaleInterfaceMock) SetUserAsMemberCalls() []struct {
 	mock.lockSetUserAsMember.RLock()
 	calls = mock.calls.SetUserAsMember
 	mock.lockSetUserAsMember.RUnlock()
+	return calls
+}
+
+// UpdateTenant calls UpdateTenantFunc.
+func (mock *ThreeScaleInterfaceMock) UpdateTenant(id int64, params portaClient.Params, portaClientMoqParam *portaClient.ThreeScaleClient) error {
+	if mock.UpdateTenantFunc == nil {
+		panic("ThreeScaleInterfaceMock.UpdateTenantFunc: method is nil but ThreeScaleInterface.UpdateTenant was just called")
+	}
+	callInfo := struct {
+		ID                  int64
+		Params              portaClient.Params
+		PortaClientMoqParam *portaClient.ThreeScaleClient
+	}{
+		ID:                  id,
+		Params:              params,
+		PortaClientMoqParam: portaClientMoqParam,
+	}
+	mock.lockUpdateTenant.Lock()
+	mock.calls.UpdateTenant = append(mock.calls.UpdateTenant, callInfo)
+	mock.lockUpdateTenant.Unlock()
+	return mock.UpdateTenantFunc(id, params, portaClientMoqParam)
+}
+
+// UpdateTenantCalls gets all the calls that were made to UpdateTenant.
+// Check the length with:
+//     len(mockedThreeScaleInterface.UpdateTenantCalls())
+func (mock *ThreeScaleInterfaceMock) UpdateTenantCalls() []struct {
+	ID                  int64
+	Params              portaClient.Params
+	PortaClientMoqParam *portaClient.ThreeScaleClient
+} {
+	var calls []struct {
+		ID                  int64
+		Params              portaClient.Params
+		PortaClientMoqParam *portaClient.ThreeScaleClient
+	}
+	mock.lockUpdateTenant.RLock()
+	calls = mock.calls.UpdateTenant
+	mock.lockUpdateTenant.RUnlock()
 	return calls
 }
 

--- a/pkg/resources/podHelper.go
+++ b/pkg/resources/podHelper.go
@@ -15,6 +15,7 @@ import (
 //go:generate moq -out pod_executor_moq.go . PodExecutorInterface
 type PodExecutorInterface interface {
 	ExecuteRemoteCommand(ns string, podName string, command []string) (string, string, error)
+	ExecuteRemoteContainerCommand(ns string, podName string, container string, command []string) (string, string, error)
 }
 
 type PodExecutor struct {
@@ -46,6 +47,49 @@ func (p PodExecutor) ExecuteRemoteCommand(ns string, podName string, command []s
 		Stderr:  true,
 		TTY:     true,
 		//Container: container,
+	}
+	req.VersionedParams(
+		option,
+		scheme.ParameterCodec,
+	)
+	exec, err := remotecommand.NewSPDYExecutor(restConfig, "POST", req.URL())
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	buf := &bytes.Buffer{}
+	errBuf := &bytes.Buffer{}
+
+	p.Log.Infof("Executing", l.Fields{"command": command, "pod": podName})
+
+	err = exec.Stream(remotecommand.StreamOptions{
+		Stdout: buf,
+		Stderr: errBuf,
+	})
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed executing command %s on %s/%s", command, ns, podName)
+	}
+
+	return buf.String(), errBuf.String(), nil
+}
+
+// ExecuteRemoteContainerCommand exec command on specific pod and wait the command's output.
+func (p PodExecutor) ExecuteRemoteContainerCommand(ns string, podName string, container string, command []string) (string, string, error) {
+
+	kubeClient, restConfig, err := getClient()
+	if err != nil {
+		return "", "", errors.Wrapf(err, "Failed to get client")
+	}
+
+	req := kubeClient.CoreV1().RESTClient().Post().Resource("pods").Name(podName).
+		Namespace(ns).SubResource("exec")
+	option := &v1.PodExecOptions{
+		Command:   command,
+		Stdin:     false,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       true,
+		Container: container,
 	}
 	req.VersionedParams(
 		option,

--- a/pkg/resources/pod_executor_moq.go
+++ b/pkg/resources/pod_executor_moq.go
@@ -20,6 +20,9 @@ var _ PodExecutorInterface = &PodExecutorInterfaceMock{}
 // 			ExecuteRemoteCommandFunc: func(ns string, podName string, command []string) (string, string, error) {
 // 				panic("mock out the ExecuteRemoteCommand method")
 // 			},
+// 			ExecuteRemoteContainerCommandFunc: func(ns string, podName string, container string, command []string) (string, string, error) {
+// 				panic("mock out the ExecuteRemoteContainerCommand method")
+// 			},
 // 		}
 //
 // 		// use mockedPodExecutorInterface in code that requires PodExecutorInterface
@@ -29,6 +32,9 @@ var _ PodExecutorInterface = &PodExecutorInterfaceMock{}
 type PodExecutorInterfaceMock struct {
 	// ExecuteRemoteCommandFunc mocks the ExecuteRemoteCommand method.
 	ExecuteRemoteCommandFunc func(ns string, podName string, command []string) (string, string, error)
+
+	// ExecuteRemoteContainerCommandFunc mocks the ExecuteRemoteContainerCommand method.
+	ExecuteRemoteContainerCommandFunc func(ns string, podName string, container string, command []string) (string, string, error)
 
 	// calls tracks calls to the methods.
 	calls struct {
@@ -41,8 +47,20 @@ type PodExecutorInterfaceMock struct {
 			// Command is the command argument value.
 			Command []string
 		}
+		// ExecuteRemoteContainerCommand holds details about calls to the ExecuteRemoteContainerCommand method.
+		ExecuteRemoteContainerCommand []struct {
+			// Ns is the ns argument value.
+			Ns string
+			// PodName is the podName argument value.
+			PodName string
+			// Container is the container argument value.
+			Container string
+			// Command is the command argument value.
+			Command []string
+		}
 	}
-	lockExecuteRemoteCommand sync.RWMutex
+	lockExecuteRemoteCommand          sync.RWMutex
+	lockExecuteRemoteContainerCommand sync.RWMutex
 }
 
 // ExecuteRemoteCommand calls ExecuteRemoteCommandFunc.
@@ -81,5 +99,48 @@ func (mock *PodExecutorInterfaceMock) ExecuteRemoteCommandCalls() []struct {
 	mock.lockExecuteRemoteCommand.RLock()
 	calls = mock.calls.ExecuteRemoteCommand
 	mock.lockExecuteRemoteCommand.RUnlock()
+	return calls
+}
+
+// ExecuteRemoteContainerCommand calls ExecuteRemoteContainerCommandFunc.
+func (mock *PodExecutorInterfaceMock) ExecuteRemoteContainerCommand(ns string, podName string, container string, command []string) (string, string, error) {
+	if mock.ExecuteRemoteContainerCommandFunc == nil {
+		panic("PodExecutorInterfaceMock.ExecuteRemoteContainerCommandFunc: method is nil but PodExecutorInterface.ExecuteRemoteContainerCommand was just called")
+	}
+	callInfo := struct {
+		Ns        string
+		PodName   string
+		Container string
+		Command   []string
+	}{
+		Ns:        ns,
+		PodName:   podName,
+		Container: container,
+		Command:   command,
+	}
+	mock.lockExecuteRemoteContainerCommand.Lock()
+	mock.calls.ExecuteRemoteContainerCommand = append(mock.calls.ExecuteRemoteContainerCommand, callInfo)
+	mock.lockExecuteRemoteContainerCommand.Unlock()
+	return mock.ExecuteRemoteContainerCommandFunc(ns, podName, container, command)
+}
+
+// ExecuteRemoteContainerCommandCalls gets all the calls that were made to ExecuteRemoteContainerCommand.
+// Check the length with:
+//     len(mockedPodExecutorInterface.ExecuteRemoteContainerCommandCalls())
+func (mock *PodExecutorInterfaceMock) ExecuteRemoteContainerCommandCalls() []struct {
+	Ns        string
+	PodName   string
+	Container string
+	Command   []string
+} {
+	var calls []struct {
+		Ns        string
+		PodName   string
+		Container string
+		Command   []string
+	}
+	mock.lockExecuteRemoteContainerCommand.RLock()
+	calls = mock.calls.ExecuteRemoteContainerCommand
+	mock.lockExecuteRemoteContainerCommand.RUnlock()
 	return calls
 }

--- a/pkg/resources/smtp.go
+++ b/pkg/resources/smtp.go
@@ -3,6 +3,11 @@ package resources
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/custom-smtp"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"os"
 
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
@@ -42,4 +47,47 @@ func GetExistingSMTPFromAddress(ctx context.Context, client k8sclient.Client, ns
 		return "", fmt.Errorf("failed to find smtp_from in alert manager config map")
 	}
 	return smtpFrom, nil
+}
+
+// GetSMTPFromAddress returns the correct from address depending on how the operator is configured
+// For addon installs returns the address stated in the alertmanger.yaml or the address configured by the custom SMTP feature in ocm
+// For sandbox it returns the default hardcoded value of: test@rhmw.io
+func GetSMTPFromAddress(ctx context.Context, serverClient k8sclient.Client, log logger.Logger, installation *v1alpha1.RHMI, namespace string) (string, error) {
+
+	if installation == nil {
+		return "", fmt.Errorf("nil pointer passed for installation")
+	}
+
+	if v1alpha1.IsRHOAMMultitenant(v1alpha1.InstallationType(installation.Spec.Type)) {
+		return "test@rhmw.io", nil
+	}
+
+	var existingSMTPFromAddress string
+	var err error
+
+	if installation.Status.CustomSmtp != nil && installation.Status.CustomSmtp.Enabled {
+		existingSMTPFromAddress, err = custom_smtp.GetFromAddress(ctx, serverClient, installation.Namespace)
+
+		if err != nil {
+			log.Error("error getting smtp_from address from custom smtp secret", err)
+			return "", err
+		}
+	} else {
+		existingSMTPFromAddress, err = GetExistingSMTPFromAddress(ctx, serverClient, namespace)
+
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				log.Error("Error getting smtp_from address from secret alertmanager-application-monitoring", err)
+				return "", err
+			}
+			log.Warning("failure finding secret alertmanager-application-monitoring: " + err.Error())
+		}
+	}
+
+	if existingSMTPFromAddress == "" {
+		log.Warning("Couldn't find SMTP in a secret, retrieving it from the envar")
+		existingSMTPFromAddress = os.Getenv(v1alpha1.EnvKeyAlertSMTPFrom)
+	}
+
+	return existingSMTPFromAddress, nil
 }

--- a/pkg/resources/smtp_test.go
+++ b/pkg/resources/smtp_test.go
@@ -2,9 +2,9 @@ package resources
 
 import (
 	"context"
-	"testing"
 	"github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"testing"
 
 	"github.com/integr8ly/integreatly-operator/test/utils"
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +12,6 @@ import (
 	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"strings"
-
 )
 
 func TestGetExistingSMTPFromAddress(t *testing.T) {


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5000

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Set outgoing email address as oulined in the following guide. https://access.redhat.com/solutions/4112341

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

* Install this branch, pre-built index: quay.io/jfitzpat/managed-api-service-index:1.32.0-5000
* Set up extra tenants after the install, [guide](https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/-/blob/master/sops/3scale_create_tenants.md)
* Follow the [knowledge article](https://access.redhat.com/solutions/4112341) 
* Check what the current value for the email is.
* Change the current email to something else. 
** The reonciler should revert all email address to the initial values. 
* Make sure to check the UI for the extra tenants