### PR TITLE
MGDAPI-5079 - fix: missing permssion for balancing pods

### DIFF
--- a/bundles/managed-api-service/1.31.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.31.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -216,6 +216,7 @@ spec:
                 - pods
               verbs:
                 - create
+                - list
             - apiGroups:
                 - ""
               resourceNames:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -41,6 +41,7 @@ rules:
   - pods
   verbs:
   - create
+  - list
 - apiGroups:
   - ""
   resourceNames:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -216,7 +216,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // +kubebuilder:rbac:groups="*",resources=configmaps;secrets;services;subscriptions,verbs=get;list;watch;create;update
 
 // For accessing limitador api from pod
-// +kubebuilder:rbac:groups="",resources=pods,verbs=create
+// +kubebuilder:rbac:groups="",resources=pods,verbs=create;list
 
 // LimitRanges are used to assign default CPU/Memory requests and limits for containers that don't specify values for compute resources
 // +kubebuilder:rbac:groups="",resources=limitranges,verbs=get;create;update;delete


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5079

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

With https://issues.redhat.com/browse/MGDAPI-4706 some namespaces are now created externally and this change missed a permission for multi az clusters

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Provision multi az cluster
* Install RHOAM
```
make cluster/prepare/local
make code/run
```
* Verify install completes and there's no error on the CR
```
oc get rhmi rhoam -n local-rhoam-operator -o jsonpath={.status.stage}
oc get rhmi rhoam -n local-rhoam-operator -o jsonpath={.status.lastError}
```