### PR TITLE
MGDAPI-5085 - Add alerting for MCG on GCP

### DIFF
--- a/pkg/products/mcg/prometheusRules.go
+++ b/pkg/products/mcg/prometheusRules.go
@@ -1,17 +1,15 @@
 package mcg
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (r *Reconciler) newAlertReconciler(ctx context.Context, client k8sclient.Client, logger l.Logger, installType string) (resources.AlertReconciler, error) {
+func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string) (resources.AlertReconciler, error) {
 	installationName := resources.InstallationNames[installType]
 
 	observabilityConfig, err := r.ConfigManager.ReadObservability()
@@ -37,7 +35,7 @@ func (r *Reconciler) newAlertReconciler(ctx context.Context, client k8sclient.Cl
 							"sop_url": resources.SopUrlEndpointAvailableAlert,
 							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{namespace='%s', endpoint='noobaa-operator-service'} < 1", r.Config.GetOperatorNamespace())),
+						Expr:   intstr.FromString(fmt.Sprintf("absent(kube_endpoint_address{ready='true',namespace='%s', endpoint='noobaa-operator-service'})", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "critical", "product": installationName},
 					},
@@ -47,7 +45,7 @@ func (r *Reconciler) newAlertReconciler(ctx context.Context, client k8sclient.Cl
 							"sop_url": resources.SopUrlEndpointAvailableAlert,
 							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace=`%s`} < 1", r.Config.GetOperatorNamespace())),
+						Expr:   intstr.FromString(fmt.Sprintf("absent(kube_endpoint_address{ready='true',endpoint='rhmi-registry-cs', namespace=`%s`})", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
 					},
@@ -104,7 +102,7 @@ func (r *Reconciler) newAlertReconciler(ctx context.Context, client k8sclient.Cl
 							"sop_url": resources.SopUrlEndpointAvailableAlert,
 							"message": "MCG s3 endpoint is not available.",
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{namespace='%[1]s', endpoint='s3'} < 1", r.Config.GetOperatorNamespace())),
+						Expr:   intstr.FromString(fmt.Sprintf("absent(kube_endpoint_address{ready='true',namespace='%[1]s', endpoint='s3'})", r.Config.GetOperatorNamespace())),
 						For:    "5m",
 						Labels: map[string]string{"severity": "warning", "product": installationName},
 					},

--- a/pkg/products/mcg/prometheusRules.go
+++ b/pkg/products/mcg/prometheusRules.go
@@ -1,0 +1,135 @@
+package mcg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/integr8ly/integreatly-operator/pkg/resources"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func (r *Reconciler) newAlertReconciler(ctx context.Context, client k8sclient.Client, logger l.Logger, installType string) (resources.AlertReconciler, error) {
+	installationName := resources.InstallationNames[installType]
+
+	observabilityConfig, err := r.ConfigManager.ReadObservability()
+	if err != nil {
+		logger.Warning("failed to get observability config")
+		return nil, err
+	}
+
+	namespace := observabilityConfig.GetNamespace()
+	return &resources.AlertReconcilerImpl{
+		Installation: r.installation,
+		Log:          logger,
+		ProductName:  "mcg",
+		Alerts: []resources.AlertConfiguration{
+			{
+				AlertName: "mcg-operator-ksm-endpoint-alerts",
+				GroupName: "mcg-operator-endpoint.rules",
+				Namespace: namespace,
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "RHOAMMCGOperatorMetricsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{namespace='%s', endpoint='noobaa-operator-service'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical", "product": installationName},
+					},
+					{
+						Alert: "RHOAMMCGOperatorRhmiRegistryCsServiceEndpointDown",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": fmt.Sprintf("No {{  $labels.endpoint  }} endpoints in namespace %s. Expected at least 1.", r.Config.GetOperatorNamespace()),
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{endpoint='rhmi-registry-cs', namespace=`%s`} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+				},
+			},
+			{
+				AlertName: "mcg-ksm-endpoint-alerts",
+				GroupName: "general.rules",
+				Namespace: namespace,
+				Rules: []monitoringv1.Rule{
+					{
+						Alert: "NooBaaCorePod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG noobaa-core has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true',namespace='%[1]s', pod=~'noobaa-core.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running',namespace='%[1]s'}) < 1 OR absent(kube_pod_status_ready{condition='true',namespace='%[1]s',pod=~'noobaa-core.*'})", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaDBPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG noobaa-db has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true',namespace='%[1]s', pod=~'noobaa-db.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running',namespace='%[1]s'}) < 1 OR absent(kube_pod_status_ready{condition='true',namespace='%[1]s',pod=~'noobaa-db.*'})", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaDefaultBackingStorePod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG noobaa-default-backing-store has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true',namespace='%[1]s', pod=~'noobaa-default-backing-store.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running',namespace='%[1]s'}) < 1 OR absent(kube_pod_status_ready{condition='true',namespace='%[1]s',pod=~'noobaa-default-backing-store.*'})", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaEndpointPod",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG noobaa-endpoint has no pods in a ready state.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true',namespace='%[1]s', pod=~'noobaa-endpoint.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running',namespace='%[1]s'}) < 1 OR absent(kube_pod_status_ready{condition='true',namespace='%[1]s',pod=~'noobaa-endpoint.*'})", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaS3Endpoint",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlEndpointAvailableAlert,
+							"message": "MCG s3 endpoint is not available.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("kube_endpoint_address_available{namespace='%[1]s', endpoint='s3'} < 1", r.Config.GetOperatorNamespace())),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaBucketCapacityOver85Percent",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG s3 bucket is over 85% capacity.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("NooBaa_bucket_capacity{namespace='%[1]s', bucket_name=~'%[2]s.*'} > 85", r.Config.GetOperatorNamespace(), threescaleBucket)),
+						For:    "5m",
+						Labels: map[string]string{"severity": "warning", "product": installationName},
+					},
+					{
+						Alert: "NooBaaBucketCapacityOver95Percent",
+						Annotations: map[string]string{
+							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
+							"message": "MCG s3 bucket is over 95% capacity.",
+						},
+						Expr:   intstr.FromString(fmt.Sprintf("NooBaa_bucket_capacity{namespace='%[1]s', bucket_name=~'%[2]s.*'} > 95", r.Config.GetOperatorNamespace(), threescaleBucket)),
+						For:    "5m",
+						Labels: map[string]string{"severity": "critical", "product": installationName},
+					},
+				},
+			},
+		},
+	}, nil
+}

--- a/pkg/products/mcg/reconciler.go
+++ b/pkg/products/mcg/reconciler.go
@@ -40,6 +40,7 @@ const (
 	defaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 	threescaleBucket              = "3scale-operator-bucket"
 	ThreescaleBucketClaim         = threescaleBucket + "-claim"
+	S3RouteName                   = "s3"
 )
 
 type Reconciler struct {
@@ -152,6 +153,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	r.log.Infof("ReconcileObjectBucketClaim", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile ObjectBucketClaim", err)
+		return phase, err
+	}
+
+	alertsReconciler, err := r.newAlertReconciler(ctx, serverClient, r.log, r.installation.Spec.Type)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, err
+	}
+	if phase, err := alertsReconciler.ReconcileAlerts(ctx, serverClient); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile mcg alerts", err)
 		return phase, err
 	}
 

--- a/pkg/products/mcg/reconciler.go
+++ b/pkg/products/mcg/reconciler.go
@@ -156,7 +156,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	alertsReconciler, err := r.newAlertReconciler(ctx, serverClient, r.log, r.installation.Spec.Type)
+	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type)
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -82,7 +82,6 @@ const (
 	s3CredentialsSecretName        = "s3-credentials"
 	s3BucketRegion                 = "global"
 	s3PathStyle                    = "true"
-	s3RouteName                    = "s3"
 	externalRedisSecretName        = "system-redis"
 	externalBackendRedisSecretName = "backend-redis"
 	externalPostgresSecretName     = "system-database"
@@ -1171,7 +1170,7 @@ func (r *Reconciler) createMCGS3Secret(ctx context.Context, serverClient k8sclie
 
 	// Retrieve s3 route
 	s3Route := &routev1.Route{}
-	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: s3RouteName, Namespace: mcgNamespace}, s3Route)
+	err = serverClient.Get(ctx, k8sclient.ObjectKey{Name: mcg.S3RouteName, Namespace: mcgNamespace}, s3Route)
 	if err != nil {
 		return fmt.Errorf("failed to get s3 route: %w", err)
 	}

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -786,7 +786,7 @@ func TestReconciler_reconcileComponents(t *testing.T) {
 					},
 					&routev1.Route{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      s3RouteName,
+							Name:      mcg.S3RouteName,
 							Namespace: mcg.DefaultInstallationNamespace + "-operator",
 						},
 					}),
@@ -3509,7 +3509,7 @@ func TestReconciler_createMCGS3Secret(t *testing.T) {
 
 	s3Route := &routev1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      s3RouteName,
+			Name:      mcg.S3RouteName,
 			Namespace: mcg.DefaultInstallationNamespace + "-operator",
 		},
 	}


### PR DESCRIPTION
# Issue link
[MGDAPI-5085](https://issues.redhat.com/browse/MGDAPI-5085)

# What
Add alerts for various MCG resources - requires rebase once #3052 is merged.

# Verification steps
Provision a GCP CCS cluster - if you do not have an access key,  request one from myself - place in root of delorean repo and run:
```
OCM_CLUSTER_NAME=acatterm-ccs OCM_CLUSTER_LIFESPAN=24 COMPUTE_NODES_COUNT=4 BYOC=true CLOUD_PROVIDER=gcp make -f make/ocm.mk ocm/cluster.json
make -f make/ocm.mk ocm/cluster/create
```

Once provisioned we can deploy RHOAM from this branch:
```
LOCAL=false make cluster/prepare/local
LOCAL=false USE_CLUSTER_STORAGE=true make code/run
```

Navigate to alerting in `redhat-rhoam-observability` namespace:
Networking -> Routes -> Prometheus (location) -> Alerts

Verify that the alerts are listed and are not firing.

* `RHOAMMCGOperatorMetricsServiceEndpointDown`
* `RHOAMMCGOperatorRhmiRegistryCsServiceEndpointDown`
* `NooBaaCorePod`
* `NooBaaDBPod`
* `NooBaaDefaultBackingStorePod`
* `NooBaaEndpointPod`
* `NooBaaS3Endpoint`
* `NooBaaBucketCapacityOver85Percent`
* `NooBaaBucketCapacityOver95Percent`

Scale down:
* deployments/noobaa-operator
* deployments/noobaa-endpoint
* statefulsets/noobaa-core
* statefulsets/noobaa-db-pg

Delete:
* pods/noobaa-default-backing-store-noobaa-pod-*

After a few minutes, the following alerts should be firing:
* `RHOAMMCGOperatorMetricsServiceEndpointDown`
* `NooBaaCorePod`
* `NooBaaDBPod`
* `NooBaaDefaultBackingStorePod`
* `NooBaaEndpointPod`
* `NooBaaS3Endpoint`

Scaling the all of the deployments back up again should result in the alerts to stop.
