### PR TITLE
MGDAPI-5125 - revert release-prepare kustomize change

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -32,16 +32,10 @@ fi
 
 # Optional environment variable to set a different Kustomize path. If this
 # variable is not set, it will use the one from the $PATH or try a default Kustomize path
-if [[ -n $KUSTOMIZE_PATH ]]; then
-  KUSTOMIZE=$KUSTOMIZE_PATH
+if [[ -z $KUSTOMIZE_PATH ]]; then
+  KUSTOMIZE="/usr/local/bin/kustomize"
 else
-  if command -v kustomize >/dev/null 2>&1; then
-    echo "kustomize on path found"
-    KUSTOMIZE=$(which kustomize)
-  else
-    echo "Kustomize not found on path: defaulting to /usr/local/bin/kustomize"
-    KUSTOMIZE="/usr/local/bin/kustomize"
-  fi
+  KUSTOMIZE=$(which kustomize)
 fi
 
 echo "Using kustomize path: $KUSTOMIZE"


### PR DESCRIPTION
# Issue link
MGDAPI-5125

# What
Reverted the change to finding kustomize as release pipeline is failing on `which`

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
