### PR TITLE
MGDAPI-4456 Fix installation stage watches for J03

### DIFF
--- a/test/common/namespace_restoration.go
+++ b/test/common/namespace_restoration.go
@@ -30,31 +30,9 @@ type StageDeletion struct {
 }
 
 var (
-	commonStages = []StageDeletion{
-		{
-			productStageName: integreatlyv1alpha1.AuthenticationStage,
-			namespaces: []string{
-				RHSSOProductNamespace,
-				RHSSOOperatorNamespace,
-			},
-			removeFinalizers: func(ctx *TestingContext) error {
-				return removeKeyCloakFinalizers(ctx, RHSSOProductNamespace)
-			},
-		},
-		{
-			productStageName: integreatlyv1alpha1.CloudResourcesStage,
-			namespaces: []string{
-				CloudResourceOperatorNamespace,
-			},
-			removeFinalizers: func(ctx *TestingContext) error {
-				return nil
-			},
-		},
-	}
-
 	managedApiStages = []StageDeletion{
 		{
-			productStageName: integreatlyv1alpha1.ProductsStage,
+			productStageName: integreatlyv1alpha1.InstallStage,
 			namespaces: []string{
 				CustomerGrafanaNamespace,
 				Marin3rOperatorNamespace,
@@ -63,53 +41,53 @@ var (
 				RHSSOUserOperatorNamespace,
 				ThreeScaleProductNamespace,
 				ThreeScaleOperatorNamespace,
+				RHSSOProductNamespace,
+				RHSSOOperatorNamespace,
+				CloudResourceOperatorNamespace,
+				ObservabilityOperatorNamespace,
+				ObservabilityProductNamespace,
 			},
 			removeFinalizers: func(ctx *TestingContext) error {
 				if err := removeKeyCloakFinalizers(ctx, RHSSOUserProductNamespace); err != nil {
 					return err
 				}
-
+				if err := removeKeyCloakFinalizers(ctx, RHSSOProductNamespace); err != nil {
+					return err
+				}
+				if err := removeObservabilityFinalizers(ctx, ObservabilityProductNamespace); err != nil {
+					return err
+				}
 				return removeEnvoyConfigRevisionFinalizers(ctx, ThreeScaleProductNamespace)
-			},
-		},
-		{
-			productStageName: integreatlyv1alpha1.ObservabilityStage,
-			namespaces: []string{
-				ObservabilityOperatorNamespace,
-				ObservabilityProductNamespace,
-			},
-			removeFinalizers: func(ctx *TestingContext) error {
-				return removeObservabilityFinalizers(ctx, ObservabilityProductNamespace)
 			},
 		},
 	}
 
 	mtManagedApiStages = []StageDeletion{
 		{
-			productStageName: integreatlyv1alpha1.ProductsStage,
+			productStageName: integreatlyv1alpha1.InstallStage,
 			namespaces: []string{
 				CustomerGrafanaNamespace,
 				Marin3rOperatorNamespace,
 				Marin3rProductNamespace,
 				ThreeScaleProductNamespace,
 				ThreeScaleOperatorNamespace,
+				RHSSOProductNamespace,
+				RHSSOOperatorNamespace,
+				CloudResourceOperatorNamespace,
+				ObservabilityOperatorNamespace,
+				ObservabilityProductNamespace,
 			},
 			removeFinalizers: func(ctx *TestingContext) error {
 				if err := removeKeyCloakFinalizers(ctx, RHSSOUserProductNamespace); err != nil {
 					return err
 				}
-
+				if err := removeKeyCloakFinalizers(ctx, RHSSOProductNamespace); err != nil {
+					return err
+				}
+				if err := removeObservabilityFinalizers(ctx, ObservabilityProductNamespace); err != nil {
+					return err
+				}
 				return removeEnvoyConfigRevisionFinalizers(ctx, ThreeScaleProductNamespace)
-			},
-		},
-		{
-			productStageName: integreatlyv1alpha1.ObservabilityStage,
-			namespaces: []string{
-				ObservabilityOperatorNamespace,
-				ObservabilityProductNamespace,
-			},
-			removeFinalizers: func(ctx *TestingContext) error {
-				return removeObservabilityFinalizers(ctx, ObservabilityProductNamespace)
 			},
 		},
 	}
@@ -334,9 +312,9 @@ func removeEnvoyConfigRevisionFinalizers(ctx *TestingContext, nameSpace string) 
 
 func getStagesForInstallType(installType string) []StageDeletion {
 	if integreatlyv1alpha1.IsRHOAMMultitenant(integreatlyv1alpha1.InstallationType(installType)) {
-		return append(commonStages, mtManagedApiStages...)
+		return mtManagedApiStages
 	} else {
-		return append(commonStages, managedApiStages...)
+		return managedApiStages
 	}
 }
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-4456

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Fix watches on installation stages

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Test on both managed-api and multitenant-managed-api.

* Install the operator for the installation type
* Follow the test case for [J03B](https://github.com/integr8ly/integreatly-operator/blob/master/test-cases/tests/backup-restore/j03b-verify-that-namespaces-get-recreated-by-the-integreatlyoper.md)
* Expected result: test case should pass for insatallation type.

Repeated above steps for each installation type.