### PR TITLE
MGDAPI-3562 update test a25 to be compatible with byovpc clusters

### DIFF
--- a/test/functional/aws_standalone_vpc.go
+++ b/test/functional/aws_standalone_vpc.go
@@ -41,6 +41,7 @@ const (
 	vpcClusterTagKey         = "tag:integreatly.org/clusterID"
 	clusterOwnedTagKeyPrefix = "tag:kubernetes.io/cluster/"
 	clusterOwnedTagValue     = "owned"
+	clusterSharedTagValue    = "shared"
 )
 
 type strategyMap struct {
@@ -165,6 +166,11 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 		t.Fatal("could not get cluster id", err)
 	}
 
+	clusterVpc, err := getClusterVpc(ec2Sess, clusterTag)
+	if err != nil {
+		t.Fatal("failure fetching cluster vpc", err)
+	}
+
 	// get the vpc cidr block
 	expectedCidr, err := getCidrBlockFromStrategyMap(strat)
 	if err != nil {
@@ -179,24 +185,12 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 		}
 
 		// check if the cidr block is in the allowed range
-		err = verifyCidrBlockIsInAllowedRange(standaloneCidr)
-		if err != nil {
+		if err = verifyCidrBlockIsInAllowedRange(standaloneCidr); err != nil {
 			t.Fatalf("cidr block %s is not within the allowed range %s", standaloneCidr, err)
 		}
 
-		// build tag key to retrieve cluster vpc
-		// denoted -> kubernetes.io/cluster/<cluster-id>=owned
-		clusterOwnedVpcKey := fmt.Sprintf("%s%s", clusterOwnedTagKeyPrefix, clusterTag)
-
-		// retrieve the cluster cidr
-		clusterCidr, err := getVpcCidrBlock(ec2Sess, clusterOwnedVpcKey, clusterOwnedTagValue)
-		if err != nil {
-			t.Fatal("could not get cidr block from vpc", err)
-		}
-
 		// check if the cidr blocks overlap
-		err = checkForOverlappingCidrBlocks(standaloneCidr, clusterCidr)
-		if err != nil {
+		if err = checkForOverlappingCidrBlocks(standaloneCidr, *clusterVpc.CidrBlock); err != nil {
 			t.Fatal(err)
 		}
 
@@ -210,18 +204,18 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 	}
 	availableZones := GetClustersAvailableZones(clusterNodes)
 
-	// verify vpc
-	vpc, err := verifyVpc(ec2Sess, clusterTag, expectedCidr, isSTS)
+	err = verifyVpc(clusterVpc, expectedCidr, isSTS)
 	testErrors.vpcError = err.(*networkConfigTestError).vpcError
-
-	// fail immediately if the vpc is nil, since all of the
-	// other network components are associated with it
-	if vpc == nil {
+	if len(testErrors.vpcError) > 0 {
 		t.Fatal(testErrors.Error())
 	}
 
 	// verify subnets
-	subnets, err := verifySubnets(ec2Sess, clusterTag, expectedCidr)
+	clusterSubnets, err := getClusterSubnets(ec2Sess, clusterTag)
+	if err != nil {
+		t.Fatal("failure fetching cluster clusterSubnets", err)
+	}
+	err = verifySubnets(clusterSubnets, expectedCidr)
 	testErrors.subnetsError = err.(*networkConfigTestError).subnetsError
 
 	// verify security groups
@@ -234,7 +228,7 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 
 	// build array list of all vpc private subnets
 	var subnetIDs []*string
-	for _, subnet := range subnets {
+	for _, subnet := range clusterSubnets {
 		subnetIDs = append(subnetIDs, subnet.SubnetId)
 	}
 
@@ -249,7 +243,7 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 	testErrors.cacheSubnetGroupsError = err.(*networkConfigTestError).cacheSubnetGroupsError
 
 	// verify peering connection
-	conn, err := verifyPeeringConnection(ec2Sess, clusterTag, expectedCidr, aws.StringValue(vpc.VpcId))
+	conn, err := verifyPeeringConnection(ec2Sess, clusterTag, expectedCidr, aws.StringValue(clusterVpc.VpcId))
 	testErrors.peeringConnError = err.(*networkConfigTestError).peeringConnError
 
 	// verify standalone vpc route table
@@ -267,78 +261,37 @@ func TestStandaloneVPCExists(t common.TestingTB, testingCtx *common.TestingConte
 }
 
 // verify that the standalone vpc is created
-func verifyVpc(session *ec2.EC2, clusterTag, expectedCidr string, isSTS bool) (*ec2.Vpc, error) {
+func verifyVpc(vpc *ec2.Vpc, expectedCidr string, isSTS bool) error {
 	newErr := &networkConfigTestError{
 		vpcError: []error{},
 	}
-
-	// filter vpcs by integreatly cluster id tag
-	describeVpcs, err := session.DescribeVpcs(&ec2.DescribeVpcsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String(vpcClusterTagKey),
-				Values: []*string{aws.String(clusterTag)},
-			},
-		},
-	})
-	if err != nil {
-		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("could not find vpc: %v", err))
-		return nil, newErr
-	}
-
-	// only one vpc is expected
-	vpcs := describeVpcs.Vpcs
-	if len(vpcs) != 1 {
-		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("expected 1 vpc but found %d", len(vpcs)))
-		return nil, newErr
-	}
-
 	// cidr blocks should match
-	vpc := vpcs[0]
 	foundCidr := aws.StringValue(vpc.CidrBlock)
 	if foundCidr != expectedCidr {
 		errMsg := fmt.Errorf("expected vpc cidr block to match _network cidr block in aws strategy configmap. Expected %s, but got %s", expectedCidr, foundCidr)
 		newErr.vpcError = append(newErr.vpcError, errMsg)
 	}
-
 	if !ec2TagsContains(vpc.Tags, awsManagedTagKey, awsManagedTagValue) {
 		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("vpc does not have expected %s tag", awsManagedTagKey))
 	}
 	if isSTS && !ec2TagsContains(vpc.Tags, awsClusterTypeKey, awsClusterTypeRosaValue) {
 		newErr.vpcError = append(newErr.vpcError, fmt.Errorf("vpc does not have expected %s tag", awsClusterTypeKey))
 	}
-
-	return vpc, newErr
+	return newErr
 }
 
 // verify that the vpc subnets are created
-func verifySubnets(session *ec2.EC2, clusterTag, expectedCidr string) ([]*ec2.Subnet, error) {
+func verifySubnets(subnets []*ec2.Subnet, expectedCidr string) error {
 	newErr := &networkConfigTestError{
 		subnetsError: []error{},
 	}
 
-	// filter subnets by integreatly cluster id tag
-	describeSubnets, err := session.DescribeSubnets(&ec2.DescribeSubnetsInput{
-		Filters: []*ec2.Filter{
-			{
-				Name:   aws.String(vpcClusterTagKey),
-				Values: []*string{aws.String(clusterTag)},
-			},
-		},
-	})
-	if err != nil {
-		errMsg := fmt.Errorf("could not describe subnets: %v", err)
-		newErr.subnetsError = append(newErr.subnetsError, errMsg)
-		return nil, newErr
-	}
-
 	// parse the vpc cidr block from the createStrategy for _network
-	subnets := describeSubnets.Subnets
 	_, cidr, err := net.ParseCIDR(expectedCidr)
 	if err != nil {
 		errMsg := fmt.Errorf("could not parse vpc cidr block: %v", err)
 		newErr.subnetsError = append(newErr.subnetsError, errMsg)
-		return subnets, newErr
+		return newErr
 	}
 	cidrMask, _ := cidr.Mask.Size()
 
@@ -349,7 +302,7 @@ func verifySubnets(session *ec2.EC2, clusterTag, expectedCidr string) ([]*ec2.Su
 		if err != nil {
 			errMsg := fmt.Errorf("could not parse subnet mask for vpc subnets: %v", err)
 			newErr.subnetsError = append(newErr.subnetsError, errMsg)
-			return subnets, newErr
+			return newErr
 		}
 		subnetCidrMask, _ := subnetCidr.Mask.Size()
 		if subnetCidrMask != cidrMask+1 {
@@ -358,7 +311,7 @@ func verifySubnets(session *ec2.EC2, clusterTag, expectedCidr string) ([]*ec2.Su
 		}
 	}
 
-	return subnets, newErr
+	return newErr
 }
 
 // verify vpc security group
@@ -663,8 +616,8 @@ func verifyCidrBlockIsInAllowedRange(cidrBlock string) error {
 		return fmt.Errorf("error parsing cidr %s", cidrBlock)
 	}
 
-	for _, allowedCidrRanges := range allowedCidrRanges {
-		_, cidrRangeNet, err := net.ParseCIDR(allowedCidrRanges)
+	for _, allowedCidrRange := range allowedCidrRanges {
+		_, cidrRangeNet, err := net.ParseCIDR(allowedCidrRange)
 		if err != nil {
 			return fmt.Errorf("error parsing cidr %s", cidrBlock)
 		}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-3562

# What
Updated [test A25](https://github.com/integr8ly/integreatly-operator/blob/52a4634ee77e24ab8cbedfa6943cb2338227e8b4/test/functional/aws_standalone_vpc.go#L132) so it will pass when run against RHOAM installed on BYOVPC cluster

# Verification steps
- Provision an AWS BYOVPC CCS cluster, as well as regular AWS CCS cluster
- Install RHOAM on both clusters
- Run the A25 functional test against both clusters and confirm they both pass
