### PR TITLE
MGDAPI-5126 Ensure Kustomize is in path

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -4,7 +4,8 @@ FROM registry.ci.openshift.org/openshift/release:golang-1.18
 ENV OPERATOR_SDK_VERSION=v1.21.0 \
     DELOREAN_VERSION=master \
     GOFLAGS="" \
-    PROMETHEUS_VERSION=2.37.0
+    PROMETHEUS_VERSION=2.37.0 \
+    KUSTOMIZE_VERSION=v4.5.2
 
 RUN set -o pipefail && \
     INSTALL_PKGS="skopeo rsync" && \
@@ -28,6 +29,9 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && make install \
     && chmod -R 0777 $GOPATH \
     && rm -rf $GOPATH/.cache
+
+# install kustomize
+RUN go install sigs.k8s.io/kustomize/kustomize/v4@$KUSTOMIZE_VERSION
 
 # install jq and yq
 RUN wget -O jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 \

--- a/openshift-ci/test/run
+++ b/openshift-ci/test/run
@@ -8,6 +8,7 @@
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'gosec --version'
+docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'kustomize version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'operator-sdk version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'go version'
 docker run --rm --entrypoint=/bin/sh ${IMAGE_NAME} -c 'jq --version'


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5135

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Installing kustomize into the path. This will fix the prow test/scripts failures.

The test script check will fail. These changes need to be merged before prow can make use of the change.


# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

* Build the openshift-ci container image.
`podman build -f openshift-ci/Dockerfile.tools -t openshift-ci`
* Check that kustomize is in the path
`podman run --rm --entrypoint=/bin/sh openshift-ci -c 'which kustomize'`
