### PR TITLE
MGDAPI-5092 Fixed F01 test after switching from Postgres 13.4 to 13.8

### DIFF
--- a/test/functional/aws_rds_resources_exist.go
+++ b/test/functional/aws_rds_resources_exist.go
@@ -56,5 +56,5 @@ func verifyRDSInstanceConfig(instance rds.DBInstance, isSTS bool) bool {
 	// and the rosa cluster type is present, and the rest of the config is expected
 	return rdsTagsContains(instance.TagList, awsManagedTagKey, awsManagedTagValue) &&
 		(!isSTS || rdsTagsContains(instance.TagList, awsClusterTypeKey, awsClusterTypeRosaValue)) &&
-		*instance.MultiAZ && *instance.DeletionProtection && *instance.StorageEncrypted && !*instance.AutoMinorVersionUpgrade && *instance.EngineVersion == "13.4"
+		*instance.MultiAZ && *instance.DeletionProtection && *instance.StorageEncrypted && !*instance.AutoMinorVersionUpgrade && *instance.EngineVersion == "13.8"
 }


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-5092

# What
Updates the `verifyRDSInstanceConfig()` function to check that the Postgres RDS engine is `13.8` instead of `13.4` following changes made in this [CRO PR](https://github.com/integr8ly/cloud-resource-operator/pull/621)

# Verification steps

- Eye review and passing the e2e prow checks should be sufficient
