### PR TITLE
MGDAPI-4603 Fixed S1039 issues caught by gosimple linter

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ issues:
 
 linters-settings:
   gosimple:
-    checks: ["all", -S1004, -S1008, -S1028, -S1039, -S1002, -S1005, -S1031, -S1011, -S1023, -S1025, -S1034, -S1001]
+    checks: ["all", -S1004, -S1008, -S1028, -S1002, -S1005, -S1031, -S1011, -S1023, -S1025, -S1034, -S1001]
   staticcheck:
     checks: ["all", -SA4006, -SA9003, -SA5011, -SA4001, -SA4010, SA1019, -SA1030, -SA6000, -SA4009, -SA4022, -SA5001]
 

--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -121,7 +121,7 @@ func addElasticCacheSnapshotNotFoundAlert(ctx context.Context, client k8sclient.
 		Alert: "RHOAMCloudResourceOperatorElasticCacheSnapshotsNotFound",
 		Annotations: map[string]string{
 			"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-			"message": fmt.Sprintf("Elastic Cache snapshot not found or not available for tagging."),
+			"message": "Elastic Cache snapshot not found or not available for tagging.",
 		},
 		Expr:   intstr.FromString(metricsCheck),
 		Labels: map[string]string{"severity": "warning", "product": installationName},

--- a/pkg/products/marin3r/reconciler.go
+++ b/pkg/products/marin3r/reconciler.go
@@ -185,7 +185,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	r.log.Info("about to start reconciling the discovery service")
 	phase, err = r.reconcileDiscoveryService(ctx, client, productNamespace)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile DiscoveryService cr"), err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile DiscoveryService cr", err)
 		return phase, err
 	}
 
@@ -216,7 +216,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	// Wait for RHSSO postgres to be completed
 	phase, err = resources.WaitForRHSSOPostgresToBeComplete(client, installation.Name, r.ConfigManager.GetOperatorNamespace())
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+		events.HandleError(r.recorder, installation, phase, "Waiting for RHSSO postgres to be completed", err)
 		return phase, err
 	}
 
@@ -240,7 +240,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err = r.reconcileServiceMonitor(ctx, client, productNamespace)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile Prometheus service monitor"), err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile Prometheus service monitor", err)
 		return phase, err
 	}
 

--- a/pkg/products/monitoringcommon/alertmanagerConfig.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig.go
@@ -156,11 +156,11 @@ func ReconcileAlertManagerSecrets(ctx context.Context, serverClient k8sclient.Cl
 		"SMTPToBUAddress":       smtpToBUAddress,
 		"PagerDutyServiceKey":   pagerDutySecret,
 		"DeadMansSnitchURL":     dmsSecret,
-		"Subject":               fmt.Sprintf(`{{template "email.integreatly.subject" . }}`),
+		"Subject":               `{{template "email.integreatly.subject" . }}`,
 		"clusterID":             clusterID,
 		"clusterName":           clusterName,
 		"clusterConsole":        clusterConsoleRoute,
-		"html":                  fmt.Sprintf(`{{ template "email.integreatly.html" . }}`),
+		"html":                  `{{ template "email.integreatly.html" . }}`,
 	})
 
 	templatePath := GetTemplatePath()

--- a/pkg/products/monitoringcommon/alertmanagerConfig_test.go
+++ b/pkg/products/monitoringcommon/alertmanagerConfig_test.go
@@ -169,11 +169,11 @@ func TestReconciler_reconcileAlertManagerSecrets(t *testing.T) {
 		"SMTPToCustomerAddress": mockCustomerAlertingEmailAddress,
 		"SMTPToSREAddress":      mockAlertingEmailAddress,
 		"SMTPToBUAddress":       mockBUAlertingEmailAddress,
-		"Subject":               fmt.Sprintf(`{{template "email.integreatly.subject" . }}`),
+		"Subject":               `{{template "email.integreatly.subject" . }}`,
 		"clusterID":             clusterID,
 		"clusterName":           clusterName,
 		"clusterConsole":        clusterConsoleRoute,
-		"html":                  fmt.Sprintf(`{{ template "email.integreatly.html" . }}`),
+		"html":                  `{{ template "email.integreatly.html" . }}`,
 	})
 
 	templatePath := GetTemplatePath()
@@ -346,11 +346,11 @@ func TestReconciler_reconcileAlertManagerSecrets(t *testing.T) {
 					"SMTPToCustomerAddress": mockCustomerAlertingEmailAddress,
 					"SMTPToSREAddress":      mockAlertingEmailAddress,
 					"SMTPToBUAddress":       mockBUAlertingEmailAddress,
-					"Subject":               fmt.Sprintf(`{{template "email.integreatly.subject" . }}`),
+					"Subject":               `{{template "email.integreatly.subject" . }}`,
 					"clusterID":             clusterID,
 					"clusterName":           clusterName,
 					"clusterConsole":        clusterConsoleRoute,
-					"html":                  fmt.Sprintf(`{{ template "email.integreatly.html" . }}`),
+					"html":                  `{{ template "email.integreatly.html" . }}`,
 				})
 
 				templatePath := GetTemplatePath()

--- a/pkg/products/observability/prometheusRules.go
+++ b/pkg/products/observability/prometheusRules.go
@@ -296,7 +296,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 					Alert: "TestFireCriticalAlert",
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlTestFireAlerts,
-						"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+						"message": "This is occasional Test Fire alert from Team SRE",
 					},
 					Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetNamespace() + "', secret='cj3cssrec'}) > 0"),
 					For:    "10s",
@@ -306,7 +306,7 @@ func (r *Reconciler) newAlertsReconciler(logger l.Logger, installType string) re
 					Alert: "TestFireWarningAlert",
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlTestFireAlerts,
-						"message": fmt.Sprintf("This is occasional Test Fire alert from Team SRE"),
+						"message": "This is occasional Test Fire alert from Team SRE",
 					},
 					Expr:   intstr.FromString("count(kube_secret_info{namespace='" + r.Config.GetNamespace() + "', secret='wj3cssrew'}) > 0"),
 					For:    "10s",

--- a/pkg/products/rhssocommon/reconciler_test.go
+++ b/pkg/products/rhssocommon/reconciler_test.go
@@ -1706,7 +1706,7 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 					Rules: []monitoringv1.Rule{
 						{
 							Alert: "KeycloakInstanceNotAvailable",
-							Expr:  intstr.FromString(fmt.Sprint("testExpression")),
+							Expr:  intstr.FromString("testExpression"),
 						},
 					},
 				},
@@ -1715,7 +1715,7 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 					Rules: []monitoringv1.Rule{
 						{
 							Alert: "test-alert",
-							Expr:  intstr.FromString(fmt.Sprint("testExpression")),
+							Expr:  intstr.FromString("testExpression"),
 						},
 					},
 				},

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -239,7 +239,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	// Wait for RHSSO postgres to be completed
 	phase, err = resources.WaitForRHSSOPostgresToBeComplete(serverClient, installation.Name, r.ConfigManager.GetOperatorNamespace())
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.Recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+		events.HandleError(r.Recorder, installation, phase, "Waiting for RHSSO postgres to be completed", err)
 		return phase, err
 	}
 

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -339,7 +339,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		r.installation.Spec.PriorityClassName,
 	)
 	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
-		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile 3scale-operator csv deployments priority class name"), err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile 3scale-operator csv deployments priority class name", err)
 		return phase, err
 	}
 
@@ -353,7 +353,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		// Wait for RHSSO postgres to be completed
 		phase, err = resources.WaitForRHSSOPostgresToBeComplete(serverClient, installation.Name, r.ConfigManager.GetOperatorNamespace())
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-			events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Waiting for RHSSO postgres to be completed"), err)
+			events.HandleError(r.recorder, installation, phase, "Waiting for RHSSO postgres to be completed", err)
 			return phase, err
 		}
 
@@ -397,7 +397,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err = r.ping3scalePortals(ctx, serverClient, ips)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		errorMessage := fmt.Sprintf("failed pinging 3scale portals through the ingress cluster router")
+		errorMessage := "failed pinging 3scale portals through the ingress cluster router"
 		r.log.Error(errorMessage, err)
 		events.HandleError(r.recorder, installation, phase, errorMessage, err)
 		return phase, err
@@ -515,7 +515,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 
 	phase, err = r.reconcileServiceMonitor(ctx, serverClient, productNamespace)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
-		events.HandleError(r.recorder, installation, phase, fmt.Sprintf("Failed to reconcile 3scale service monitor"), err)
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile 3scale service monitor", err)
 		return phase, err
 	}
 

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -594,7 +594,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	productName := cr.Labels["productName"]
 
 	alertName := "RedisMemoryUsageHigh"
-	ruleName := fmt.Sprintf("redis-memory-usage-high")
+	ruleName := "redis-memory-usage-high"
 	alertDescription := "Redis Memory for instance {{ $labels.instanceID }} is 90 percent or higher for the last hour. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
 	labels := map[string]string{
 		"severity":    "warning",
@@ -613,7 +613,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	job := "operator-metrics-service"
 
 	alertName = "RedisMemoryUsageMaxIn4Hours"
-	ruleName = fmt.Sprintf("redis-memory-usage-will-max-in-4-hours")
+	ruleName = "redis-memory-usage-will-max-in-4-hours"
 	alertDescription = "Redis Memory Usage is predicted to max with in four hours for instance {{ $labels.instanceID }}. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
 	labels = map[string]string{
 		"severity":    "warning",
@@ -630,7 +630,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 	}
 
 	alertName = "RedisMemoryUsageMaxIn4Days"
-	ruleName = fmt.Sprintf("redis-memory-usage-max-fill-in-4-days")
+	ruleName = "redis-memory-usage-max-fill-in-4-days"
 	alertDescription = "Redis Memory Usage is predicted to max in four days for instance {{ $labels.instanceID }}. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
 	labels = map[string]string{
 		"severity":    "warning",
@@ -789,7 +789,7 @@ func CreateRedisCpuUsageAlerts(ctx context.Context, client k8sclient.Client, ins
 	}
 	productName := cr.Labels["productName"]
 	alertName := "RedisCpuUsageHigh"
-	ruleName := fmt.Sprintf("redis-cpu-usage-high")
+	ruleName := "redis-cpu-usage-high"
 	alertDescription := "Redis Cpu for instance {{ $labels.instanceID }} is 90 percent or higher for the last hour. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
 	labels := map[string]string{
 		"severity":    "warning",
@@ -814,14 +814,14 @@ func CreateRedisServiceMaintenanceAlerts(ctx context.Context, client k8sclient.C
 	}
 	productName := cr.Labels["productName"]
 	alertName := "RedisServiceMaintenanceCritical"
-	ruleName := fmt.Sprintf("redis-service-maintenance-critical")
+	ruleName := "redis-service-maintenance-critical"
 	alertDescription := "Redis service maintenance update is available, this is a critical security update for instance {{ $labels.instanceID }}. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
 	labels := map[string]string{
 		"severity":    "warning",
 		"productName": productName,
 	}
 
-	alertExp := intstr.FromString(fmt.Sprintf("cro_redis_service_maintenance{ServiceUpdateType='security-update',UpdateActionStatus!~'complete|waiting-to-start|in-progress|scheduled|stopping',ServiceUpdateSeverity='critical'}"))
+	alertExp := intstr.FromString("cro_redis_service_maintenance{ServiceUpdateType='security-update',UpdateActionStatus!~'complete|waiting-to-start|in-progress|scheduled|stopping',ServiceUpdateSeverity='critical'}")
 
 	ruleNs := inst.Spec.NamespacePrefix + "observability"
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisServiceMaintenanceCritical, alertFor15Mins, alertExp, labels)

--- a/test/functional/aws_elasticache_resources_exist.go
+++ b/test/functional/aws_elasticache_resources_exist.go
@@ -44,7 +44,7 @@ func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingCon
 			continue
 		}
 		if len(foundElasticacheReplicationGroups.ReplicationGroups[0].NodeGroups) > 1 {
-			testErrors = append(testErrors, fmt.Sprintf("insufficient number of nodes in elasticache group"))
+			testErrors = append(testErrors, "insufficient number of nodes in elasticache group")
 			continue
 		}
 		replicationGroup := foundElasticacheReplicationGroups.ReplicationGroups[0]

--- a/test/osde2e/pre-test.go
+++ b/test/osde2e/pre-test.go
@@ -41,13 +41,13 @@ func PreTest(t common.TestingTB, ctx *common.TestingContext) {
 
 		// Patch RHMI CR CR with cluster storage
 		if rhmi.Spec.UseClusterStorage == "false" || rhmi.Spec.UseClusterStorage == "" {
-			rhmiCR := fmt.Sprintf(`{
+			rhmiCR := `{
 				"apiVersion": "integreatly.org/v1alpha1",
 				"kind": "RHMI",
 				"spec": {
 					"useClusterStorage" : "true"
 				}
-			}`)
+			}`
 
 			rhmiCRBytes := []byte(rhmiCR)
 


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-4603

# What
This PR fixes the existing S1039("unnecessary use of fmt.Sprintf") errors that were previously not checked by the gosimple linter and enables the linter to check for these errors going forward.

# Verification steps
An eye review of the changes and passing prow checks should be sufficient verification but if you want to manually verify:

- Checkout this PR
- Run `make test/lint` and confirm there are no errors in the output
