### PR TITLE
MGDAPI-5193 Unskip alert tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -464,7 +464,7 @@ deploy/integreatly-rhmi-cr.yml:
 	sed "s/SELF_SIGNED_CERTS/$(SELF_SIGNED_CERTS)/g" | \
 	sed "s/OPERATORS_IN_PRODUCT_NAMESPACE/$(OPERATORS_IN_PRODUCT_NAMESPACE)/g" | \
 	sed "s/USE_CLUSTER_STORAGE/$(USE_CLUSTER_STORAGE)/g" > config/samples/integreatly-rhmi-cr.yml
-	# Workaround until in_prow annotation can be removed from prow
+	# Annotation is used to allow for installation on small Prow cluster and might be used to skip tests failing in Prow
 	yq e -i '.metadata.annotations.in_prow="IN_PROW"' config/samples/integreatly-rhmi-cr.yml
 
 	$(SED_INLINE) "s/IN_PROW/'$(IN_PROW)'/g" config/samples/integreatly-rhmi-cr.yml

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -275,6 +275,20 @@ func isClusterStorage(ctx *TestingContext) (bool, error) {
 	return false, nil
 }
 
+func isInProw(ctx *TestingContext) (bool, error) {
+	rhmi, err := GetRHMI(ctx.Client, true)
+	if err != nil {
+		return false, fmt.Errorf("error getting RHMI CR: %v", err)
+	}
+
+	annotationMap := rhmi.GetObjectMeta().GetAnnotations()
+	isInProw, ok := annotationMap["in_prow"]
+	if ok && isInProw == "true" {
+		return true, nil
+	}
+	return false, nil
+}
+
 // Common function to perform CRUDL and verifying their expected permissions
 func verifyCRUDLPermissions(t TestingTB, openshiftClient *resources.OpenshiftClient, expectedPermission ExpectedPermissions) {
 	// Perform LIST Request


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5193

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

The https://issues.redhat.com/browse/MGDAPI-1404 no longer causes alerts to fire - at least not right after the RHOAM installation so it should be safe to run these tests.

However, the UIBBT alerts are firing in Prow (possibly a limitation of Prow environment). This PR skips the alert tests if running in Prow. Ideal solution would be to ignore the UIBBT alerts if in Prow not skipping the whole tests but this is better than having these tests skipped in non-Prow environment as it is the case now.

For even more context read https://chat.google.com/room/AAAAssKWhTI/h5DeT583XH4

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Eye review only, passing rhoam-e2e should suffice.