### PR TITLE
MGDAPI-5222 : Fix custom domain status block not being reconciled.

### DIFF
--- a/controllers/rhmi/bootstrapReconciler_test.go
+++ b/controllers/rhmi/bootstrapReconciler_test.go
@@ -617,8 +617,32 @@ func TestReconciler_retrieveConsoleURLAndSubdomain(t *testing.T) {
 				},
 			},
 			args: args{
-				ctx:          context.TODO(),
-				serverClient: func() k8sclient.Client { return nil },
+				ctx: context.TODO(),
+				serverClient: func() k8sclient.Client {
+					return moqclient.NewSigsClientMoqWithScheme(scheme,
+						&routev1.Route{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "console",
+								Namespace: "openshift-console",
+							},
+							Status: routev1.RouteStatus{
+								Ingress: []routev1.RouteIngress{
+									{
+										Host: "host",
+									},
+								},
+							},
+						},
+						&corev1.Secret{
+							ObjectMeta: v1.ObjectMeta{
+								Name:      "addon-managed-api-service-parameters",
+								Namespace: "test",
+							},
+							Data: map[string][]byte{
+								"custom-domain_domain": []byte("apps.example.com"),
+							},
+						})
+				},
 			},
 			want:    integreatlyv1alpha1.PhaseCompleted,
 			wantErr: false,


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5222

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
If any error happen during the initial reconcile loop the status block for the custom domain may not get set.

Changes here allow the custom domain status block to be reconciled will not reconciling the sub domain route. Understand the linked SOP for why the sub domain route is not reconciled. 

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Install this branch with a custom domain enabled
  * Guide: https://integreatly-operator.readthedocs.io/en/latest/products/custom_domain/
* Expected: Status block for custom domain is added to the rhmi CR. 
  * may take multiply reconcile loops to happen