### PR TITLE
MGDAPI-5232 : Fix route selection based on route prefix to route labels

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -3724,14 +3724,16 @@ func (r *Reconciler) reconcileTenantOutgoingEmailAddress(ctx context.Context, se
 		return fmt.Errorf("failed to get 3scale route list during portaClient creation, error: %v", err)
 	}
 	for _, route := range routes.Items {
-		if strings.Contains(route.Spec.Host, "master.apps") {
+		routeLabels := route.GetLabels()
+		value, exists := routeLabels["zync.3scale.net/route-to"]
+		if exists && value == "system-master" {
 			admRoute = route
 			found = true
 			break
 		}
 	}
 	if !found {
-		return fmt.Errorf("failed to get 3scale route during portaClient creation, error: %v", err)
+		return fmt.Errorf("failed to get 3scale route during portaClient creation")
 	}
 
 	adminPortal, err := portaClient.NewAdminPortal("https", admRoute.Spec.Host, 443)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5232

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Selection of master route was based on the URL containing `apps`. This may not be the case when using a custom domain.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Install this branch using a custom domain that **DOES NOT** start with `apps.`
  * custom domain guide: https://integreatly-operator.readthedocs.io/en/latest/products/custom_domain/
* Expected: 
  * In the rhmi CR the `routingSubdomain` will equal the custom domain
  * Install will go to a complete state
  * The custom domain status block will be missing from the rhmi CR. This PR does not include the changes from https://github.com/integr8ly/integreatly-operator/pull/3109

# Images
**operator:** quay.io/jfitzpat/managed-api-service:rhoam-v1.33.0-5232
 **index:** quay.io/jfitzpat/managed-api-service-index:1.33.0-5232
