### PR TITLE
MGDAPI-5249 - ratelimit: bump envoy proxy image

### DIFF
--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.3-6"
+	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.5-6"
 	EnvoyAPIVersion = "v3"
 )
 

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.3-6"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.5-6"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5249

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Bump envoy proxy image for better image grading

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Verifiy Fresh Install
* Checkout this branch
* Install RHOAM
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Verify install complete successfully
* Verify image in used in annotations 
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Run `./test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected


## Verify Upgrade
* Unintall RHAOM
* Checkout master
* Install from master
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Once installation complete, stop the opertor
* Checkout this branch
* Run operator
```
make code/run
```
* Verify apicast / backend-listener pods are redeployed
```
 watch "oc get pods -n redhat-rhoam-3scale | grep -E 'apicast|backend-listener'; echo "RHMI CR Status:"; oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq '.status.stage'"
```
* Verify image in used in annotations
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Run `./test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected

