### PR TITLE
MGDAPI-5242 - extend route timeout to 75s

### DIFF
--- a/pkg/products/threescale/envoyconfig.go
+++ b/pkg/products/threescale/envoyconfig.go
@@ -275,6 +275,7 @@ virtualHosts:
 		prefix: /
 		route:
 		cluster: apicast-ratelimit
+		timeout: 75s
 		rateLimits:
 		- actions:
 			- genericKey:
@@ -297,6 +298,9 @@ func getAPICastVirtualHosts(installation *integreatlyv1alpha1.RHMI, clusterName 
 					Route: &envoyroutev3.RouteAction{
 						ClusterSpecifier: &envoyroutev3.RouteAction_Cluster{
 							Cluster: clusterName,
+						},
+						Timeout: &duration.Duration{
+							Seconds: 75,
 						},
 						RateLimits: getRateLimitsPerInstallType(installation),
 					},
@@ -328,6 +332,7 @@ virtual_hosts:
 			prefix: "/"
 		route:
 			cluster: backend-listener-ratelimit
+			timeout: 75s
 			rate_limits:
 **/
 func getBackendListenerVitualHosts(clusterName string) []*envoyroutev3.VirtualHost {
@@ -347,6 +352,9 @@ func getBackendListenerVitualHosts(clusterName string) []*envoyroutev3.VirtualHo
 						Route: &envoyroutev3.RouteAction{
 							ClusterSpecifier: &envoyroutev3.RouteAction_Cluster{
 								Cluster: clusterName,
+							},
+							Timeout: &duration.Duration{
+								Seconds: 75,
 							},
 							RateLimits: []*envoyroutev3.RateLimit{&tsRatelimitDescriptor},
 						},


### PR DESCRIPTION
# Issue link
[MGDAPI-5242](https://issues.redhat.com/browse/MGDAPI-5242)

# What
Updated the [route timeout](https://www.envoyproxy.io/docs/envoy/latest/faq/configuration/timeouts#route-timeouts) to 75s to match the [APIcast](https://github.com/3scale/APIcast/blob/master/doc/parameters.md#http_keepalive_timeout) `HTTP_KEEPALIVE_TIMEOUT`.

# Verification steps

- Deploy RHOAM from master with a backend configured with the base URL set to https://reqres.in:443/
- Perform a CURL request to the end point with a delay > 15s and notice that the requests timeout

```
time curl -kv "https://api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org/api/users?delay=29&user_key=<REDACTED>"

*   Trying 52.205.155.224:443...
* Connected to api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org (52.205.155.224) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-0-0][CF-SSL] TLSv1.0 (OUT), TLS header, Certificate Status (22):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS handshake, Client hello (1):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Certificate Status (22):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Server hello (2):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Certificate (11):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, CERT verify (15):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=api.acatterm.icod.s1.devshift.org
*  start date: Feb 27 09:38:43 2023 GMT
*  expire date: May 28 09:38:42 2023 GMT
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Supplemental data (23):
> GET /api/users?delay=29&user_key=0c75dbb906b0a4ea0b1689a8e8478b0c HTTP/1.1
> Host: api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org
> User-Agent: curl/7.87.0
> Accept: */*
>
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 504 Gateway Timeout
< content-length: 24
< content-type: text/plain
< date: Mon, 27 Feb 2023 16:06:27 GMT
< server: envoy
< set-cookie: 3a1bd5846f96b160cf166a6b811833cb=990292bf67a2b3fcd92dc0f7b1635f90; path=/; HttpOnly; Secure; SameSite=None
<
* Connection #0 to host api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org left intact
upstream request timeout
curl -kv   0.02s user 0.01s system 0% cpu 15.384 total
```
- Deploy from this branch and perform the same curl request and expect the request to succeed:

```
*   Trying 23.23.78.197:443...
* Connected to api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org (23.23.78.197) port 443 (#0)
* ALPN: offers h2
* ALPN: offers http/1.1
* [CONN-0-0][CF-SSL] TLSv1.0 (OUT), TLS header, Certificate Status (22):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS handshake, Client hello (1):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Certificate Status (22):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Server hello (2):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Encrypted Extensions (8):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Certificate (11):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, CERT verify (15):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Finished (20):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS change cipher, Change cipher spec (1):
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / TLS_AES_128_GCM_SHA256
* ALPN: server did not agree on a protocol. Uses default.
* Server certificate:
*  subject: CN=api.acatterm.icod.s1.devshift.org
*  start date: Feb 27 09:38:43 2023 GMT
*  expire date: May 28 09:38:42 2023 GMT
*  issuer: C=US; O=Let's Encrypt; CN=R3
*  SSL certificate verify result: unable to get local issuer certificate (20), continuing anyway.
* [CONN-0-0][CF-SSL] TLSv1.2 (OUT), TLS header, Supplemental data (23):
> GET /api/users?delay=29&user_key=0c75dbb906b0a4ea0b1689a8e8478b0c HTTP/1.1
> Host: api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org
> User-Agent: curl/7.87.0
> Accept: */*
>
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* [CONN-0-0][CF-SSL] TLSv1.3 (IN), TLS handshake, Newsession Ticket (4):
* old SSL session ID is stale, removing
* [CONN-0-0][CF-SSL] TLSv1.2 (IN), TLS header, Supplemental data (23):
* Mark bundle as not supporting multiuse
< HTTP/1.1 200 OK
< server: envoy
< date: Mon, 27 Feb 2023 16:11:51 GMT
< content-type: application/json; charset=utf-8
< content-length: 996
< x-powered-by: Express
< access-control-allow-origin: *
< etag: W/"3e4-2RLXvr5wTg9YQ6aH95CkYoFNuO8"
< via: 1.1 vegur
< cf-cache-status: DYNAMIC
< report-to: {"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v3?s=IzHG5OJ%2BFY8H0kmxU75NEsMZqFD61uxba%2Fl1FGpxSrKAEHTlsQpx2AA3UptlaQoTrvUabUrnoTwMBVpmvBB8f184PT6oPst1jJuf%2B%2BGLrGioA4UAd6yJS87G6Q%3D%3D"}],"group":"cf-nel","max_age":604800}
< nel: {"success_fraction":0,"report_to":"cf-nel","max_age":604800}
< cf-ray: 7a02322b69e93b4e-IAD
< x-envoy-upstream-service-time: 29281
< set-cookie: 3a1bd5846f96b160cf166a6b811833cb=8a891415d3b8b650cf52f553e09163e0; path=/; HttpOnly; Secure; SameSite=None
< cache-control: private
<
* Connection #0 to host api-3scale-apicast-staging.apps.acatterm.icod.s1.devshift.org left intact
{"page":1,"per_page":6,"total":12,"total_pages":2,"data":[{"id":1,"email":"george.bluth@reqres.in","first_name":"George","last_name":"Bluth","avatar":"https://reqres.in/img/faces/1-image.jpg"},{"id":2,"email":"janet.weaver@reqres.in","first_name":"Janet","last_name":"Weaver","avatar":"https://reqres.in/img/faces/2-image.jpg"},{"id":3,"email":"emma.wong@reqres.in","first_name":"Emma","last_name":"Wong","avatar":"https://reqres.in/img/faces/3-image.jpg"},{"id":4,"email":"eve.holt@reqres.in","first_name":"Eve","last_name":"Holt","avatar":"https://reqres.in/img/faces/4-image.jpg"},{"id":5,"email":"charles.morris@reqres.in","first_name":"Charles","last_name":"Morris","avatar":"https://reqres.in/img/faces/5-image.jpg"},{"id":6,"email":"tracey.ramos@reqres.in","first_name":"Tracey","last_name":"Ramos","avatar":"https://reqres.in/img/faces/6-image.jpg"}],"support":{"url":"https://reqres.in/#support-heading","text":"To keep ReqRes free, contributions towards server costs are appreciated!"}}
curl -kv   0.01s user 0.01s system 0% cpu 29.615 total
```