### PR TITLE
MGDAPI-5299 - fix: OperatorGroup not being updated on namespace change

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -310,6 +310,7 @@ rules:
   - create
   - get
   - list
+  - update
 - apiGroups:
   - operators.coreos.com
   resources:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -175,7 +175,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 // - Namespace update permissions are needed for setting labels
 // +kubebuilder:rbac:groups="",resources=namespaces,verbs=update
 // - Installation of product operators
-// +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources;operatorgroups,verbs=create;list;get
+// +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources;operatorgroups,verbs=create;list;get;update
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=catalogsources,verbs=update,resourceNames=rhmi-registry-cs
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=installplans,verbs=update;get
 // +kubebuilder:rbac:groups=operators.coreos.com,resources=subscriptions,verbs=update;create;delete

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -75,23 +75,20 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	}
 
 	ns := installation.Spec.NamespacePrefix + defaultInstallationNamespace + "-operator"
-	config, err := configManager.ReadGrafana()
+	productConfig, err := configManager.ReadGrafana()
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve grafana config: %w", err)
 	}
-	if config.GetNamespace() == "" {
-		config.SetNamespace(ns)
-		if err := configManager.WriteConfig(config); err != nil {
-			return nil, fmt.Errorf("error writing grafana config : %w", err)
-		}
-	}
-	if config.GetOperatorNamespace() == "" {
-		config.SetOperatorNamespace(config.GetNamespace())
+
+	productConfig.SetNamespace(ns)
+	productConfig.SetOperatorNamespace(productConfig.GetNamespace())
+	if err := configManager.WriteConfig(productConfig); err != nil {
+		return nil, fmt.Errorf("error writing grafana config : %w", err)
 	}
 
 	return &Reconciler{
 		ConfigManager: configManager,
-		Config:        config,
+		Config:        productConfig,
 		installation:  installation,
 		mpm:           mpm,
 		log:           logger,

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -89,6 +89,9 @@ func getBasicConfig() *config.ConfigReadWriterMock {
 				"HOST":      "threescale.openshift-cluster.com",
 			}), nil
 		},
+		WriteConfigFunc: func(config config.ConfigReadable) error {
+			return nil
+		},
 	}
 }
 

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -71,15 +71,15 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		return nil, fmt.Errorf("no product declaration found for RHSSO")
 	}
 
-	config, err := configManager.ReadRHSSO()
+	productConfig, err := configManager.ReadRHSSO()
 	if err != nil {
 		return nil, err
 	}
 
-	rhssocommon.SetNameSpaces(installation, config.RHSSOCommon, defaultOperandNamespace)
+	rhssocommon.SetNameSpaces(installation, productConfig.RHSSOCommon, defaultOperandNamespace)
 
 	return &Reconciler{
-		Config:     config,
+		Config:     productConfig,
 		Log:        logger,
 		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, APIURL, keycloakClientFactory, *productDeclaration),
 	}, nil

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -100,15 +100,15 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 		return nil, fmt.Errorf("no product declaration found for user SSO")
 	}
 
-	config, err := configManager.ReadRHSSOUser()
+	productConfig, err := configManager.ReadRHSSOUser()
 	if err != nil {
 		return nil, err
 	}
 
-	rhssocommon.SetNameSpaces(installation, config.RHSSOCommon, defaultNamespace)
+	rhssocommon.SetNameSpaces(installation, productConfig.RHSSOCommon, defaultNamespace)
 
 	return &Reconciler{
-		Config:     config,
+		Config:     productConfig,
 		Log:        logger,
 		Reconciler: rhssocommon.NewReconciler(configManager, mpm, installation, logger, oauthv1Client, recorder, apiUrl, keycloakClientFactory, *productDeclaration),
 	}, nil

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -5,15 +5,16 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	portaClient "github.com/3scale/3scale-porta-go-client/client"
-	"github.com/integr8ly/integreatly-operator/pkg/addon"
-	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
-	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"net"
 	"net/http"
 	"strconv"
 	"strings"
 	"time"
+
+	portaClient "github.com/3scale/3scale-porta-go-client/client"
+	"github.com/integr8ly/integreatly-operator/pkg/addon"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/k8s"
+	operatorsv1alpha1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 
 	envoyextentionv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/upstreams/http/v3"
 	"github.com/golang/protobuf/ptypes/any"
@@ -133,20 +134,18 @@ func NewReconciler(configManager config.ConfigReadWriter, installation *integrea
 	if err != nil {
 		return nil, fmt.Errorf("could not retrieve threescale config: %w", err)
 	}
-	if threescaleConfig.GetNamespace() == "" {
-		threescaleConfig.SetNamespace(ns)
-		if err := configManager.WriteConfig(threescaleConfig); err != nil {
-			return nil, fmt.Errorf("error writing threescale config : %w", err)
-		}
-	}
-	if threescaleConfig.GetOperatorNamespace() == "" {
-		if installation.Spec.OperatorsInProductNamespace {
-			threescaleConfig.SetOperatorNamespace(threescaleConfig.GetNamespace())
-		} else {
-			threescaleConfig.SetOperatorNamespace(threescaleConfig.GetNamespace() + "-operator")
-		}
+
+	threescaleConfig.SetNamespace(ns)
+	if installation.Spec.OperatorsInProductNamespace {
+		threescaleConfig.SetOperatorNamespace(threescaleConfig.GetNamespace())
+	} else {
+		threescaleConfig.SetOperatorNamespace(threescaleConfig.GetNamespace() + "-operator")
 	}
 	threescaleConfig.SetBlackboxTargetPathForAdminUI("/p/login/")
+
+	if err := configManager.WriteConfig(threescaleConfig); err != nil {
+		return nil, fmt.Errorf("error writing threescale config : %w", err)
+	}
 
 	return &Reconciler{
 		ConfigManager: configManager,

--- a/pkg/resources/marketplace/manager_test.go
+++ b/pkg/resources/marketplace/manager_test.go
@@ -1,0 +1,88 @@
+package marketplace
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/test/utils"
+	v1 "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestManager_reconcileOperatorGroup(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type args struct {
+		ctx                     context.Context
+		serverClient            client.Client
+		t                       Target
+		operatorGroupNamespaces []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{
+		{
+			name: "test operator group is created",
+			args: args{
+				ctx:          context.TODO(),
+				serverClient: utils.NewTestClient(scheme),
+				t: Target{
+					Namespace:        "ns",
+					SubscriptionName: "subName",
+				},
+				operatorGroupNamespaces: []string{"ns"},
+			},
+		},
+		{
+			name: "test operator group is updated",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: utils.NewTestClient(scheme, &v1.OperatorGroup{
+					TypeMeta: metav1.TypeMeta{},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      OperatorGroupName,
+						Namespace: "ns",
+					},
+					Spec: v1.OperatorGroupSpec{
+						TargetNamespaces: []string{"ns"},
+					},
+				}),
+				t: Target{
+					Namespace:        "ns",
+					SubscriptionName: "subName",
+				},
+				operatorGroupNamespaces: []string{"updated"},
+			},
+		},
+		{
+			name: "test operator group error",
+			args: args{
+				ctx: context.TODO(),
+				serverClient: &moqclient.SigsClientInterfaceMock{
+					GetFunc: func(ctx context.Context, key types.NamespacedName, obj client.Object) error {
+						return fmt.Errorf("error")
+					},
+				},
+				t: Target{},
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Manager{}
+			if err := m.reconcileOperatorGroup(tt.args.ctx, tt.args.serverClient, tt.args.t, tt.args.operatorGroupNamespaces); (err != nil) != tt.wantErr {
+				t.Errorf("createOperatorGroup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5299

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
* Ensure namespace and operator namespace is correctly written to config 
* Allow operator group to be updatable

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Verify installation completes successfully
* Add `test` as an addition namespace to the targetNamespaces to the `rhmi-registry-og` OperatorGroup in the `edhat-rhoam-customer-monitoring-operator` namespace
<img width="468" alt="image" src="https://user-images.githubusercontent.com/24636860/222508019-2d88ff7e-9983-4401-a6a0-d3cb95de5a62.png">

* Verify it is reconciled back
* Change the `grafana.Namespace` value to `test` in the `redhat-rhoam-installation-config` config map in the `redhat-rhoam-operate`namespace 
<img width="811" alt="image" src="https://user-images.githubusercontent.com/24636860/222508531-580255e1-c532-4677-a9e5-b9b10e068767.png">

* Verify it is reconciled back