### PR TITLE
MGDAPI-5328 - fix: installation of OO on fresh clusters without cluster logging previously installed

### DIFF
--- a/pkg/products/observability/reconciler_test.go
+++ b/pkg/products/observability/reconciler_test.go
@@ -24,6 +24,7 @@ import (
 	v1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	observability "github.com/redhat-developer/observability-operator/v4/api/v1"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1048,6 +1049,16 @@ func TestReconciler_cleanupClusterLogging(t *testing.T) {
 						ObjectMeta: metav1.ObjectMeta{
 							Name:      "instance",
 							Namespace: clusterLoggingNs,
+						},
+					},
+					&apiextensionv1.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "clusterloggings.logging.openshift.io",
+						},
+					},
+					&apiextensionv1.CustomResourceDefinition{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "clusterlogforwarders.logging.openshift.io",
 						},
 					},
 				),


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5328

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Observaility was failing to install on fresh clusters due to the Cluster Logging CRDs did not exist on the cluster as it was never installed. 

The cleanup logic errors due to this and prevents the installation from completing.

```
failed installation of observability: no matches for kind \"ClusterLogging\" in version \"logging.openshift.io/v1\"
```


# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Verify fresh installation
* Checkout this branch
* On a cluster, ensure none of the cluster logging crds exists
  * Delete if they do exist
```
oc get crds | grep logging
```
* Install RHOAM from this branch
```
export LOCAL=false                                                                                                  
make cluster/prepare/local
make code/run 
```
* Verify installation completes successfully
```
oc get rhmi rhoam -n redhat-rhoam-operator -o jsonpath='{.status.stage}'
```
<img width="561" alt="image" src="https://user-images.githubusercontent.com/24636860/223989336-fe362179-f234-4897-aaf6-82dc0ed619cb.png">

## Verify Upgrade
* Uninstall RHOAM
* Checkout rhoam v1.32.0
```
git checkout tags/rhoam-v1.32.0 -b rhoam-v1.32.0
```
* Install RHOAM
```
export LOCAL=false                                                   
make cluster/prepare/local
make code/run
```
* Once installation completes, stop the operator
* Verify Cluster Logging CRDs exists
```
oc get crds | grep logging
```
<img width="680" alt="image" src="https://user-images.githubusercontent.com/24636860/224022004-367460b2-7fe9-48cf-9a1c-c63c304b35ba.png">

* Checkout this branch
* Watch Cluster logging resources
```
watch "echo "CSV:"; oc get csv -n openshift-logging; echo "Subscription:"; oc get subscriptions -n openshift-logging; echo "Pods:"; oc get pods -n openshift-logging; echo "ClusterLogForwarders:"; oc get clusterlogforwarders -n openshift-logging; echo "ClusterLoggings:"; oc get clusterloggings -n openshift-logging; echo "RHMI"; oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq '.status.stage'"
```
* Re-start Operator
```
export LOCAL=false
make code/rerun 
```
* Verify:
  * Cluster Logging operator subscription is removed
  * Cluster Logging operator csv is removed
  * Cluster Logging pod is removed
  * ClusterLogging CR is removed
  * ClusterLogForwarder CR is removed

<img width="1035" alt="image" src="https://user-images.githubusercontent.com/24636860/224025684-dfb23d39-675f-492b-8b86-46386a796fbf.png">
