### PR TITLE
MGDAPI-5281 Improvements to Custom Status Block

### DIFF
--- a/test/common/rhmicr_metrics.go
+++ b/test/common/rhmicr_metrics.go
@@ -51,23 +51,25 @@ func TestRHMICRMetrics(t TestingTB, ctx *TestingContext) {
 	}
 
 	// check if rhmi_info metric labels matches with rhmi installation CR
-	stringRHMIInfo := rhoamInfoMetricPresent.FindString(output)
-	infoLabels := parsePrometheusMetricToMap(stringRHMIInfo, "rhoam_spec")
-
-	doInfoLabelsMatch := true
-	if infoLabels["use_cluster_storage"] != rhmi.Spec.UseClusterStorage ||
-		infoLabels["master_url"] != rhmi.Spec.MasterURL ||
-		infoLabels["installation_type"] != rhmi.Spec.Type ||
-		infoLabels["operator_name"] != rhmi.GetName() ||
-		infoLabels["namespace"] != rhmi.GetNamespace() ||
-		infoLabels["namespace_prefix"] != rhmi.Spec.NamespacePrefix ||
-		infoLabels["operators_in_product_namespace"] != fmt.Sprintf("%t", rhmi.Spec.OperatorsInProductNamespace) ||
-		infoLabels["routing_subdomain"] != rhmi.Spec.RoutingSubdomain ||
-		infoLabels["self_signed_certs"] != fmt.Sprintf("%t", rhmi.Spec.SelfSignedCerts) {
-		doInfoLabelsMatch = false
+	doInfoLabelsMatch := false
+	matches := rhoamInfoMetricPresent.FindAllString(output, -1)
+	for _, match := range matches {
+		infoLabels := parsePrometheusMetricToMap(match, "rhoam_spec")
+		if infoLabels["use_cluster_storage"] == rhmi.Spec.UseClusterStorage &&
+			infoLabels["master_url"] == rhmi.Spec.MasterURL &&
+			infoLabels["installation_type"] == rhmi.Spec.Type &&
+			infoLabels["operator_name"] == rhmi.GetName() &&
+			infoLabels["namespace"] == rhmi.GetNamespace() &&
+			infoLabels["namespace_prefix"] == rhmi.Spec.NamespacePrefix &&
+			infoLabels["operators_in_product_namespace"] == fmt.Sprintf("%t", rhmi.Spec.OperatorsInProductNamespace) &&
+			infoLabels["routing_subdomain"] == rhmi.Spec.RoutingSubdomain &&
+			infoLabels["self_signed_certs"] == fmt.Sprintf("%t", rhmi.Spec.SelfSignedCerts) {
+			doInfoLabelsMatch = true
+			break
+		}
 	}
 	if !doInfoLabelsMatch {
-		t.Fatalf("rhmi_info metric labels do not match with rhmi CR. Labels:\n%v", infoLabels)
+		t.Fatalf("rhmi_info metric labels do not match with rhmi CR. Labels:\n%v", matches)
 	}
 }
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5281

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Ensure if custom domain is configured via the SOP route on a cluster that never had a custom domain initial installed.
This also should apply to if a custom is configured back to the standard route.

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

## Resources
### Indexes
**Current Master:** quay.io/jfitzpat/managed-api-service-index:1.33.0-5281
**Updated Version:** quay.io/jfitzpat/managed-api-service-index:1.34.0-5281 (marked as service affecting for testing)

### Doc's
**SOP:** [Change the Wildcard-domain in an existing RHOAM install](https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/-/blob/master/sops/rhoam/ChangeWildcardDomainRhoam/ChangeWildcardDomainRhoam.md)
**Dev Guide:** [Configuring custom domain](https://integreatly-operator.readthedocs.io/en/latest/products/custom_domain/)

## Verification Setup
* Make a note of the `routingSubDomain` in the RHMI CR. This will be required during the revert verification.
* Install RHOAM using the `Current Master` index with the standard domain.
* Use the `Dev Guide` to configure a custom domain on the cluster. **Do not** follow any steps that change RHOAM resources. 
* Use the `SOP` to update the domain in RHOAM to the custom domain. 
* Wait for installation to become complete. 
* Confirm the following:
  * The RHMI CR has no custom domain block in the status block. 
  * The metric `custom_domain` is missing or is set to false 
  * The metric `rhoam_spec` has two entries

## E2E Verification
* Check out this branch. 
* Run single e2e test `LOCAL=false INSTALLATION_TYPE=managed-api TEST="Test RHMI installation CR metric" make test/e2e/single`
* **Expected:** Test should pass

## Upgrade Verification
* Upgrade RHOAM installation to the `Updated Version`. 
* Wait for upgrade to complete.
* **Expected:**
  * The RHMI CR has custom domain block in the status block. 
  * The metric `custom_domain` is set to True. 
  * There are no firing alerts.

## Revert Verification
* Follow the `SOP` to revert the custom domain back to the standard domain. 
* Allow sometime for the operator to reconcile.
* **Expected:**
  * The custom domain status block is removed for the RHMI Cr status block
  * The metric `custom_domain` is set to false.
  * There are no alerts firing

## For good measure
* Run single e2e test again `LOCAL=false INSTALLATION_TYPE=managed-api TEST="Test RHMI installation CR metric" make test/e2e/single`
* **Expected:** Test should pass