### PR TITLE
MGDAPI-5373 Increased duration of RHOAMThreescaleCriticalMetricsMissing alert to 30m

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -345,7 +345,7 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string, ctx
 							"message": "one or more critical metrics have been missing for 10+ minutes",
 						},
 						Expr:   missingMetricsExpr,
-						For:    "15m",
+						For:    "30m",
 						Labels: map[string]string{"severity": "critical"},
 					},
 				},


### PR DESCRIPTION
# Issue link
JIRA: https://issues.redhat.com/browse/MGDAPI-5373

# What
This PR increases the duration that the RHOAMThreescaleCriticalMetricsMissing alert needs to occur before firing from 15 minutes to 30 minutes. This is to reduce toil on CSSRE. 

# Verification steps
Passing the PROW checks should be sufficient verification.
