### PR TITLE
MGDAPI-5446 Apply redis update

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -49,7 +49,7 @@ const (
 	defaultInstallationNamespace = "cloud-resources"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109"}
+var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}


### PR DESCRIPTION
# Issue link
[MGDAPI-5446](https://issues.redhat.com/browse/MGDAPI-5446)

# What
Adding the new service update with id elasticache-20230315-001 to the list of updates CRO should push out during RHOAM upgrade.

# Verification steps
Review of code change.
