### PR TITLE
MGDAPI-5315 - fix: 3scale version in products.yaml

### DIFF
--- a/products/products.yaml
+++ b/products/products.yaml
@@ -7,7 +7,7 @@
 # quayScan - decide whether the image should be scanned or not 
 products:
   - name: 3scale-operator
-    version: v2.13.0
+    version: 3scale-2.13.1-GA
     url: "https://github.com/3scale/3scale-operator"
     installType: "rhoam"
     manifestsDir: "integreatly-3scale"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5315

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Fix 3scale version in `products.yaml` to point to correct tag 
* https://github.com/3scale/3scale-operator/tags

Prodsec manifests are also likely missing 3scale dependencies due to this:
```
15:09:13  warning: Could not find remote branch v2.13.0 to clone.
15:09:13  fatal: Remote branch v2.13.0 not found in upstream origin
15:09:13  go: go.mod file not found in current directory or any parent directory; see 'go help modules'
15:09:28  Host key verification failed.
15:09:28  fatal: Could not read from remote repository.
```

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Passing prow checks and eye review is sufficient