### PR TITLE
MGDAPI-5136 fixed maintenance window spam bug on fresh install

### DIFF
--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -278,7 +278,7 @@ func (r *SubscriptionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 }
 
 func (r *SubscriptionReconciler) allowDatabaseUpdates(ctx context.Context, installation *integreatlyv1alpha1.RHMI, isServiceAffecting bool) error {
-	if installation.Status.ToVersion != "" && isServiceAffecting {
+	if installation.Status.Version != "" && installation.Status.ToVersion != "" && isServiceAffecting {
 		log.Info("Service affecting and upgrading, setting maintenanceWindow to true")
 		postgresInstances := &crov1alpha1.PostgresList{}
 		if err := r.Client.List(ctx, postgresInstances); err != nil {

--- a/controllers/subscription/subscription_controller_test.go
+++ b/controllers/subscription/subscription_controller_test.go
@@ -365,7 +365,7 @@ func TestAllowDatabaseUpdates(t *testing.T) {
 		ExpectedUpdatesAllowed bool
 	}{
 		{
-			Name: "updates allowed when toVersion is not empty and upgrade is service affecting",
+			Name: "updates allowed when Version is not empty, toVersion is not empty and upgrade is service affecting",
 			RHMI: integreatlyv1alpha1.RHMI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testrhmi",
@@ -373,6 +373,7 @@ func TestAllowDatabaseUpdates(t *testing.T) {
 				},
 				Status: integreatlyv1alpha1.RHMIStatus{
 					ToVersion: "9.9.9",
+					Version:   "8.8.8",
 				},
 			},
 			Fields: fields{
@@ -395,11 +396,14 @@ func TestAllowDatabaseUpdates(t *testing.T) {
 			ExpectedUpdatesAllowed: true,
 		},
 		{
-			Name: "updates not allowed when toVersion is empty and upgrade is service affecting",
+			Name: "updates not allowed when Version is not empty, toVersion is empty and upgrade is service affecting",
 			RHMI: integreatlyv1alpha1.RHMI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testrhmi",
 					Namespace: "testns",
+				},
+				Status: integreatlyv1alpha1.RHMIStatus{
+					Version: "8.8.8",
 				},
 			},
 			Fields: fields{
@@ -422,7 +426,68 @@ func TestAllowDatabaseUpdates(t *testing.T) {
 			ExpectedUpdatesAllowed: false,
 		},
 		{
-			Name: "updates not allowed when toVersion is not empty and upgrade is not service affecting",
+			Name: "updates not allowed when Version is not empty, toVersion is not empty and upgrade is not service affecting",
+			RHMI: integreatlyv1alpha1.RHMI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrhmi",
+					Namespace: "testns",
+				},
+				Status: integreatlyv1alpha1.RHMIStatus{
+					ToVersion: "9.9.9",
+					Version:   "8.8.8",
+				},
+			},
+			Fields: fields{
+				Client: utils.NewTestClient(scheme,
+					&crov1alpha1.Postgres{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testpg",
+							Namespace: "testns",
+						},
+					},
+					&crov1alpha1.Redis{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testredis",
+							Namespace: "testns",
+						},
+					},
+				),
+			},
+			IsServiceAffecting:     false,
+			ExpectedUpdatesAllowed: false,
+		},
+		{
+			Name: "updates not allowed when Version is not empty, toVersion is empty and upgrade is not service affecting",
+			RHMI: integreatlyv1alpha1.RHMI{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testrhmi",
+					Namespace: "testns",
+				},
+				Status: integreatlyv1alpha1.RHMIStatus{
+					Version: "8.8.8",
+				},
+			},
+			Fields: fields{
+				Client: utils.NewTestClient(scheme,
+					&crov1alpha1.Postgres{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testpg",
+							Namespace: "testns",
+						},
+					},
+					&crov1alpha1.Redis{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "testredis",
+							Namespace: "testns",
+						},
+					},
+				),
+			},
+			IsServiceAffecting:     false,
+			ExpectedUpdatesAllowed: false,
+		},
+		{
+			Name: "updates not allowed when Version is empty, toVersion is not empty and upgrade is service affecting",
 			RHMI: integreatlyv1alpha1.RHMI{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "testrhmi",
@@ -448,34 +513,7 @@ func TestAllowDatabaseUpdates(t *testing.T) {
 					},
 				),
 			},
-			IsServiceAffecting:     false,
-			ExpectedUpdatesAllowed: false,
-		},
-		{
-			Name: "updates not allowed when toVersion is empty and upgrade is not service affecting",
-			RHMI: integreatlyv1alpha1.RHMI{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testrhmi",
-					Namespace: "testns",
-				},
-			},
-			Fields: fields{
-				Client: utils.NewTestClient(scheme,
-					&crov1alpha1.Postgres{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "testpg",
-							Namespace: "testns",
-						},
-					},
-					&crov1alpha1.Redis{
-						ObjectMeta: metav1.ObjectMeta{
-							Name:      "testredis",
-							Namespace: "testns",
-						},
-					},
-				),
-			},
-			IsServiceAffecting:     false,
+			IsServiceAffecting:     true,
 			ExpectedUpdatesAllowed: false,
 		},
 	}

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1279,7 +1279,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	backendRedisName := fmt.Sprintf("%s%s", constants.ThreeScaleBackendRedisPrefix, r.installation.Name)
 
 	// If there is a quota change, the quota on the installation spec would not be set to the active quota yet
-	quotaChange := r.installation.Status.Quota != activeQuota
+	quotaChange := isQuotaChanged(r.installation.Status.Quota, activeQuota)
 
 	// if we are on GCP set snaphshot frequency and retention
 	var snapshotFrequency, snapshotRetention types.Duration
@@ -1456,6 +1456,15 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	}
 
 	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func isQuotaChanged(newQuota string, activeQuota string) bool {
+	// During fresh installation, quota is not set until installation completes
+	if newQuota == "" {
+		return false
+	}
+
+	return newQuota != activeQuota
 }
 
 func (r *Reconciler) reconcileOutgoingEmailAddress(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -4737,3 +4737,34 @@ func TestReconciler_deleteConsoleLink(t *testing.T) {
 		})
 	}
 }
+
+func TestIsQuotaChanged(t *testing.T) {
+	tests := []struct {
+		name        string
+		newQuota    string
+		activeQuota string
+		expected    bool
+	}{
+		{
+			name:        "fresh installation",
+			newQuota:    "",
+			activeQuota: "",
+			expected:    false,
+		},
+		{
+			name:        "Changing quotas during install",
+			newQuota:    quota.OneMillionQuotaName,
+			activeQuota: quota.OneHundredThousandQuotaName,
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isQuotaChanged(tt.newQuota, tt.activeQuota)
+			if got != tt.expected {
+				t.Errorf("isQuotaChanged() got = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
[MGDAPI-5136](https://issues.redhat.com/browse/MGDAPI-5136)

# What
Fixes a bug with maintenanceWindow flag cycling on fresh installs of service affecting RHOAM versions. Further investigation still needed to cover upgrade scenarios. 

One problem I stumbled upon was `threescale-backend-redis-rhoam` not going back to 1 after the change like all the 5 other CR's, but going from ~200 to 55 `generation`s in the same time span, the number wasn't increasing with time as I checked on it so it's likely just 3scale reconciling.

# Verification steps
Fresh install:

- Follow [RHOAM OLM Install guide](https://integreatly-operator.readthedocs.io/en/latest/installation_guides/olm_installation) to create a service affecting release based on one of our existing releases (Include the tag in the manifest just like [here](https://github.com/integr8ly/integreatly-operator/blob/master/bundles/managed-api-service/1.32.0/manifests/managed-api-service.clusterserviceversion.yaml#L105)
- Check on the redis and postgres CR's, generation should be a high number ( > 1 )
- Modify the release by including changes from my PR and install it on a fresh cluster
- After RHOAM fully installs check redis and postgres CR's
- `generation` field should be `1` on all of them (except the one mentioned above)
