### PR TITLE
MGDAPI-5277 Add metrics for critical alerts to CROMissingMetricsalert

### DIFF
--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -74,13 +74,14 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 					{
 						Alert: fmt.Sprintf("%sCloudResourceOperatorMetricsMissing", strings.ToUpper(installationName)),
 						Expr: intstr.FromString(
-							fmt.Sprintf(`(absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s)) == 1 and rhoam_spec{use_cluster_storage="false"}`,
+							fmt.Sprintf(`(absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s) or absent(%s)) == 1 and rhoam_spec{use_cluster_storage="false"}`,
 								croResources.DefaultPostgresAvailMetricName,
 								croResources.DefaultPostgresConnectionMetricName,
 								croResources.DefaultPostgresStatusMetricName,
 								croResources.DefaultRedisAvailMetricName,
 								croResources.DefaultRedisConnectionMetricName,
 								croResources.DefaultRedisStatusMetricName,
+								croResources.DefaultPostgresAllocatedStorageMetricName,
 							),
 						),
 						For:    "5m",


### PR DESCRIPTION
# Issue link
[MGDAPI-5277](https://issues.redhat.com/browse/MGDAPI-5277)

# What
Adding DefaultPostgresAllocatedStorageMetricName to the CRO Missing Metric Alert.

cro_postgres_free_storage_average and cro_redis_memory_usage_percentage_average had already been added.

# Verification steps

### Provision a cluster

### Checkout this PR

Once the cluster is ready checkout this PR:
`gh pr checkout 3168`

### Install RHOAM via OLM

- Build and push the RHOAM binary
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/build/push 
```
- Edit the managed-api-service.clusterserviceversion.yaml to refer to your image
- Build bundle and index images
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service UPGRADE=false BUNDLE_VERSIONS=1.34.0 make create/olm/bundle
```
- Create a catalog source
Login to the OSD UI and create a catalog source that points to your index image:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
 name: rhmi-operators
 namespace: openshift-marketplace
spec:
 sourceType: grpc
 image: quay.io/<your org>/<OLM_TYPE>-index:<index version>
```
- Prepare the cluster
```
INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local
```
- Create RHMI CR
```
LOCAL=false INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml
```
- Install RHOAM from OSD Operator Hub

### Check if the `cro_postgres_current_allocated_storage` has been added
- In the OSD UI navigate to the Observability Operator namespace
- On the left hand side choose Networking -> Routes -> prometheus location URL
- Click on Alerts and find RHOAMCloudResourceOperatorMetricsMissing
- Make sure that cro_postgres_current_allocated_storage has been added

### Uninstall RHOAM and cleanup/delete the cluster
