### PR TITLE
MGDAPI-5547 Update to PostgresAllocatedStorageMetricName

### DIFF
--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -81,7 +81,7 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 								croResources.DefaultRedisAvailMetricName,
 								croResources.DefaultRedisConnectionMetricName,
 								croResources.DefaultRedisStatusMetricName,
-								croResources.DefaultPostgresAllocatedStorageMetricName,
+								croResources.PostgresAllocatedStorageMetricName,
 							),
 						),
 						For:    "5m",


### PR DESCRIPTION
# Issue link
[MGDAPI-5547](https://issues.redhat.com/browse/MGDAPI-5547)

# What
Update to PostgresAllocatedStorageMetricName as defined in CRO V1.0.0

# Verification steps
In this case the code review should be sufficient, but if you want you could run the following verification steps:

### Provision a cluster

### Checkout this PR

Once the cluster is ready checkout this PR:
`gh pr checkout 3179`

### Install RHOAM via OLM

- Build and push the RHOAM binary
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/build/push 
```
- Edit the managed-api-service.clusterserviceversion.yaml to refer to your image
- Build bundle and index images
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service UPGRADE=false BUNDLE_VERSIONS=1.34.0 make create/olm/bundle
```
- Create a catalog source
Login to the OSD UI and create a catalog source that points to your index image:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
 name: rhmi-operators
 namespace: openshift-marketplace
spec:
 sourceType: grpc
 image: quay.io/<your org>/<OLM_TYPE>-index:<index version>
```
- Prepare the cluster
```
INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local
```
- Create RHMI CR
```
LOCAL=false INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml
```
- Install RHOAM from OSD Operator Hub

### Check if the `cro_postgres_current_allocated_storage` has been added
- In the OSD UI navigate to the `redhat-rhoam-observability` namespace
- On the left hand side choose Networking -> Routes -> prometheus location URL
- Click on Alerts and find `RHOAMCloudResourceOperatorMetricsMissing`
- Make sure that `cro_postgres_current_allocated_storage` has been added

### Uninstall RHOAM and cleanup/delete the cluster
