### PR TITLE
MGDAPI-5300 Consume GCP maintenance addon parameter in RHOAM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ SMTP_ADDRESS ?= ''
 SMTP_PASS ?= ''
 SMTP_PORT ?= ''
 SMTP_FROM ?= ''
+MAINTENANCE_DAY ?= ''
+MAINTENANCE_HOUR ?= ''
 CRO_ROLE_ARN ?= 'arn:aws:iam::123456789012:role/example'
 THREESCALE_ROLE_ARN ?= 'arn:aws:iam::123456789012:role/example'
 
@@ -394,7 +396,7 @@ cluster/prepare/dms:
 .PHONY: cluster/prepare/addon-params
 cluster/prepare/addon-params:
 	@-oc process -n $(NAMESPACE) QUOTA=$(DEV_QUOTA) DOMAIN=$(CUSTOM_DOMAIN) \
- 		USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) -f config/secrets/addon-params-secret.yaml | oc apply -f -
+ 		USERNAME=$(SMTP_USER) HOST=$(SMTP_ADDRESS) PASSWORD=$(SMTP_PASS) PORT=$(SMTP_PORT) FROM=$(SMTP_FROM) DAY=$(MAINTENANCE_DAY) HOUR=$(MAINTENANCE_HOUR) -f config/secrets/addon-params-secret.yaml | oc apply -f -
 
 .PHONY: cluster/prepare/sts
 cluster/prepare/sts:

--- a/config/secrets/addon-params-secret.yaml
+++ b/config/secrets/addon-params-secret.yaml
@@ -10,6 +10,8 @@ objects:
     stringData:
       addon-managed-api-service: ${QUOTA}
       custom-domain_domain: ${DOMAIN}
+      maintenance-day: ${DAY}
+      maintenance-hour: ${HOUR}
       custom-smtp-username: ${USERNAME}
       custom-smtp-address: ${HOST}
       custom-smtp-password: ${PASSWORD}
@@ -21,6 +23,10 @@ parameters:
     value: "1"
   - name: DOMAIN
     value: ""
+  - name: DAY
+    value: ""
+  - name: HOUR
+    value: ""
   - name: USERNAME
     value: "dummy"
   - name: HOST
@@ -31,3 +37,4 @@ parameters:
     value: "567"
   - name: FROM
     value: "test@example.com"
+

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -704,7 +704,7 @@ func (r *Reconciler) reconcileCloudResourceStrategies(ctx context.Context, clien
 
 	timeConfig := croStrat.NewStrategyTimeConfig(3, 01, day, hour, 00)
 
-	err = croUtil.ReconcileStrategyMaps(context.TODO(), client, timeConfig, croUtil.TierProduction, r.ConfigManager.GetOperatorNamespace())
+	err = croUtil.ReconcileStrategyMaps(ctx, client, timeConfig, croUtil.TierProduction, r.ConfigManager.GetOperatorNamespace())
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to reconcile strategy map: %v", err)
 	}

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -217,12 +217,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
-	maintenanceDay, _, err := addon.GetStringParameter(ctx, client, operatorNamespace, MaintenanceDay)
+	maintenanceDay, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceDay)
 	if err != nil {
 		return phase, err
 	}
 
-	maintenanceHour, _, err := addon.GetStringParameter(ctx, client, operatorNamespace, MaintenanceHour)
+	maintenanceHour, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceHour)
 	if err != nil {
 		return phase, err
 	}

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -217,17 +217,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
-	maintenanceDay, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceDay)
-	if err != nil {
-		return phase, err
-	}
-
-	maintenanceHour, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceHour)
-	if err != nil {
-		return phase, err
-	}
-
-	phase, err = r.reconcileCloudResourceStrategies(client, maintenanceDay, maintenanceHour)
+	phase, err = r.reconcileCloudResourceStrategies(ctx, client)
 	if err != nil {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile Cloud Resource strategies", err)
 		return phase, err
@@ -677,25 +667,35 @@ func (r *Reconciler) checkStsCredentialsPresent(client k8sclient.Client, operato
 // as we support different cloud providers this CRO Reconcile Function will ensure the correct infrastructure strategies are provisioned
 //
 // this function was part of the rhmiconfig controller, which has sense been removed.
-func (r *Reconciler) reconcileCloudResourceStrategies(client k8sclient.Client, maintenanceDay, maintenanceHour string) (integreatlyv1alpha1.StatusPhase, error) {
+func (r *Reconciler) reconcileCloudResourceStrategies(ctx context.Context, client k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
 	r.log.Info("reconciling cloud resource maintenance strategies")
+
+	maintenanceDay, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceDay)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to get maintenance day parameter: %v", err)
+	}
 
 	var day time.Weekday
 	if maintenanceDay != "" {
 		parsedDay, err := strconv.ParseInt(maintenanceDay, 0, 64)
 		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, err
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to parse maintenance day parameter: %v", err)
 		}
 		day = time.Weekday(parsedDay)
 	} else {
 		day = DefaultMaintenanceDay
 	}
 
+	maintenanceHour, _, err := addon.GetStringParameter(ctx, client, r.ConfigManager.GetOperatorNamespace(), MaintenanceHour)
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to get maintenance hour parameter: %v", err)
+	}
+
 	var hour int
 	if maintenanceHour != "" {
 		parsedHour, err := strconv.ParseInt(maintenanceHour, 0, 64)
 		if err != nil {
-			return integreatlyv1alpha1.PhaseFailed, err
+			return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to parse maintenance hour parameter: %v", err)
 		}
 		hour = int(parsedHour)
 	} else {
@@ -704,7 +704,7 @@ func (r *Reconciler) reconcileCloudResourceStrategies(client k8sclient.Client, m
 
 	timeConfig := croStrat.NewStrategyTimeConfig(3, 01, day, hour, 00)
 
-	err := croUtil.ReconcileStrategyMaps(context.TODO(), client, timeConfig, croUtil.TierProduction, r.ConfigManager.GetOperatorNamespace())
+	err = croUtil.ReconcileStrategyMaps(context.TODO(), client, timeConfig, croUtil.TierProduction, r.ConfigManager.GetOperatorNamespace())
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failure to reconcile strategy map: %v", err)
 	}

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -421,6 +421,9 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	const testNamespace = "local-rhoam-operator"
+
 	type fields struct {
 		Config        *config.CloudResources
 		ConfigManager config.ConfigReadWriter
@@ -431,10 +434,8 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		recorder      record.EventRecorder
 	}
 	type args struct {
-		client          client.Client
-		maintenanceDay  string
-		maintenanceHour string
-		ctx             context.Context
+		client client.Client
+		ctx    context.Context
 	}
 	tests := []struct {
 		name    string
@@ -446,33 +447,27 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		{
 			name: "success when params are entered in UI",
 			fields: fields{
-				Config: nil,
 				ConfigManager: &config.ConfigReadWriterMock{
 					GetOperatorNamespaceFunc: func() string {
-						return "redhat-rhoam-operator"
+						return testNamespace
 					},
 				},
-				installation: nil,
-				mpm:          nil,
-				log:          getLogger(),
+				log: getLogger(),
 				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
 					WithProductDeclaration(marketplace.ProductDeclaration{}),
 				recorder: nil,
 			},
 			args: args{
-				client: moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.GCPPlatformType,
+				client: moqclient.NewSigsClientMoqWithScheme(scheme,
+					clusterInfrastructure(configv1.GCPPlatformType),
+					addonParamsSecret(testNamespace,
+						map[string][]byte{
+							MaintenanceDay:  []byte("2"),
+							MaintenanceHour: []byte("5"),
 						},
-					},
-				}),
-				maintenanceDay:  "2",
-				maintenanceHour: "5",
-				ctx:             context.TODO(),
+					),
+				),
+				ctx: context.TODO(),
 			},
 			want:    integreatlyv1alpha1.PhaseCompleted,
 			wantErr: false,
@@ -480,33 +475,50 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		{
 			name: "success when params are not entered in UI, use defaults",
 			fields: fields{
-				Config: nil,
 				ConfigManager: &config.ConfigReadWriterMock{
 					GetOperatorNamespaceFunc: func() string {
-						return "redhat-rhoam-operator"
+						return testNamespace
 					},
 				},
-				installation: nil,
-				mpm:          nil,
-				log:          getLogger(),
+				log: getLogger(),
 				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
 					WithProductDeclaration(marketplace.ProductDeclaration{}),
-				recorder: nil,
 			},
 			args: args{
-				client: moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.GCPPlatformType,
+				client: moqclient.NewSigsClientMoqWithScheme(scheme,
+					clusterInfrastructure(configv1.GCPPlatformType),
+					addonParamsSecret(testNamespace,
+						map[string][]byte{
+							MaintenanceDay:  []byte(""),
+							MaintenanceHour: []byte(""),
 						},
+					),
+				),
+				ctx: context.TODO(),
+			},
+			want:    integreatlyv1alpha1.PhaseCompleted,
+			wantErr: false,
+		},
+		{
+			name: "success when params are not in addon params secret (aws), use defaults",
+			fields: fields{
+				ConfigManager: &config.ConfigReadWriterMock{
+					GetOperatorNamespaceFunc: func() string {
+						return testNamespace
 					},
-				}),
-				maintenanceDay:  "",
-				maintenanceHour: "",
-				ctx:             context.TODO(),
+				},
+				log: getLogger(),
+				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
+					WithProductDeclaration(marketplace.ProductDeclaration{}),
+			},
+			args: args{
+				client: moqclient.NewSigsClientMoqWithScheme(scheme,
+					clusterInfrastructure(configv1.AWSPlatformType),
+					addonParamsSecret(testNamespace,
+						map[string][]byte{},
+					),
+				),
+				ctx: context.TODO(),
 			},
 			want:    integreatlyv1alpha1.PhaseCompleted,
 			wantErr: false,
@@ -514,33 +526,26 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		{
 			name: "error when incorrect values entered for maintenanceDay",
 			fields: fields{
-				Config: nil,
 				ConfigManager: &config.ConfigReadWriterMock{
 					GetOperatorNamespaceFunc: func() string {
-						return "redhat-rhoam-operator"
+						return testNamespace
 					},
 				},
-				installation: nil,
-				mpm:          nil,
-				log:          getLogger(),
+				log: getLogger(),
 				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
 					WithProductDeclaration(marketplace.ProductDeclaration{}),
-				recorder: nil,
 			},
 			args: args{
-				client: moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.GCPPlatformType,
+				client: moqclient.NewSigsClientMoqWithScheme(scheme,
+					clusterInfrastructure(configv1.GCPPlatformType),
+					addonParamsSecret(testNamespace,
+						map[string][]byte{
+							MaintenanceDay:  []byte("Monday"),
+							MaintenanceHour: []byte("2"),
 						},
-					},
-				}),
-				maintenanceDay:  "Monday",
-				maintenanceHour: "2",
-				ctx:             context.TODO(),
+					),
+				),
+				ctx: context.TODO(),
 			},
 			want:    integreatlyv1alpha1.PhaseFailed,
 			wantErr: true,
@@ -548,33 +553,26 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		{
 			name: "error when incorrect values entered for maintenanceHour",
 			fields: fields{
-				Config: nil,
 				ConfigManager: &config.ConfigReadWriterMock{
 					GetOperatorNamespaceFunc: func() string {
-						return "redhat-rhoam-operator"
+						return testNamespace
 					},
 				},
-				installation: nil,
-				mpm:          nil,
-				log:          getLogger(),
+				log: getLogger(),
 				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
 					WithProductDeclaration(marketplace.ProductDeclaration{}),
-				recorder: nil,
 			},
 			args: args{
-				client: moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "cluster",
-					},
-					Status: configv1.InfrastructureStatus{
-						PlatformStatus: &configv1.PlatformStatus{
-							Type: configv1.GCPPlatformType,
+				client: moqclient.NewSigsClientMoqWithScheme(scheme,
+					clusterInfrastructure(configv1.GCPPlatformType),
+					addonParamsSecret(testNamespace,
+						map[string][]byte{
+							MaintenanceDay:  []byte("4"),
+							MaintenanceHour: []byte("Two"),
 						},
-					},
-				}),
-				maintenanceDay:  "4",
-				maintenanceHour: "Two",
-				ctx:             context.TODO(),
+					),
+				),
+				ctx: context.TODO(),
 			},
 			want:    integreatlyv1alpha1.PhaseFailed,
 			wantErr: true,
@@ -582,24 +580,19 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		{
 			name: "failure reconciling strategy map",
 			fields: fields{
-				Config: nil,
 				ConfigManager: &config.ConfigReadWriterMock{
 					GetOperatorNamespaceFunc: func() string {
-						return "redhat-rhoam-operator"
+						return testNamespace
 					},
 				},
-				installation: nil,
-				mpm:          nil,
-				log:          getLogger(),
+				log: getLogger(),
 				Reconciler: resources.NewReconciler(&marketplace.MarketplaceInterfaceMock{}).
 					WithProductDeclaration(marketplace.ProductDeclaration{}),
 				recorder: nil,
 			},
 			args: args{
-				client:          moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{}),
-				maintenanceDay:  "4",
-				maintenanceHour: "2",
-				ctx:             context.TODO(),
+				client: moqclient.NewSigsClientMoqWithScheme(scheme, &configv1.Infrastructure{}),
+				ctx:    context.TODO(),
 			},
 			want:    integreatlyv1alpha1.PhaseFailed,
 			wantErr: true,
@@ -616,7 +609,7 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 				Reconciler:    tt.fields.Reconciler,
 				recorder:      tt.fields.recorder,
 			}
-			got, err := r.reconcileCloudResourceStrategies(tt.args.client, tt.args.maintenanceDay, tt.args.maintenanceHour)
+			got, err := r.reconcileCloudResourceStrategies(tt.args.ctx, tt.args.client)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("reconcileCloudResourceStrategies() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -625,5 +618,29 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 				t.Errorf("reconcileCloudResourceStrategies() got = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func clusterInfrastructure(platformType configv1.PlatformType) *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			PlatformStatus: &configv1.PlatformStatus{
+				Type: platformType,
+			},
+		},
+	}
+}
+
+func addonParamsSecret(namespace string, data map[string][]byte) *corev1.Secret {
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "addon-managed-api-service-parameters",
+			Namespace: namespace,
+		},
+		Data: data,
 	}
 }


### PR DESCRIPTION
# Issue link
[MGDAPI-5300](https://issues.redhat.com/browse/MGDAPI-5300)

# What
Consume new addon parameters from RHOAM that specify maintenance date and time. This includes maintenance day and maintenance hour parameters that will be added as part of [MGDAPI-5301](https://issues.redhat.com/browse/MGDAPI-5301). 

# Verification steps
Code review for this PR but can be tested properly as part of [MGDAPI-5301](https://issues.redhat.com/browse/MGDAPI-5301).
