### PR TITLE
MGDAPI-1787 Update wording in RHOAMApiUsageLevel3ThresholdExceeded

### DIFF
--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -91,7 +91,7 @@ func mapAlertsConfiguration(logger l.Logger, namespace, rateLimitUnit string, ra
 			// Get the complete expression by ANDing the lower and the upper if the
 			// upper limit is set, if not, assign the lower one
 			expr := *lowerExpr
-			upperMessage := "*"
+			upperMessage := "100%"
 			if upperExpr != nil {
 				expr = fmt.Sprintf("%s and %s", expr, *upperExpr)
 				upperMessage = *alertConfig.Threshold.MaxRate


### PR DESCRIPTION
# Issue link
[MGDAPI-1787](https://issues.redhat.com/browse/MGDAPI-1787)

# What
This PR updates wording in RHOAMApiUsageLevel3ThresholdExceeded alert message

# Verification steps

### Provision a cluster

### Checkout this PR

Once the cluster is ready checkout this PR:
`gh pr checkout 3183`

### Install RHOAM via OLM

- Build and push the RHOAM binary
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service INSTALLATION_TYPE=managed-api make image/build/push 
```
- Edit the managed-api-service.clusterserviceversion.yaml to refer to your image
- Build bundle and index images
```
ORG=<Your Quay Org> OLM_TYPE=managed-api-service UPGRADE=false BUNDLE_VERSIONS=1.34.0 make create/olm/bundle
```
- Create a catalog source
Login to the OSD UI and create a catalog source that points to your index image:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
 name: rhmi-operators
 namespace: openshift-marketplace
spec:
 sourceType: grpc
 image: quay.io/<your org>/<OLM_TYPE>-index:<index version>
```
- Prepare the cluster
```
INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local
```
- Create RHMI CR
```
LOCAL=false INSTALLATION_TYPE=managed-api make deploy/integreatly-rhmi-cr.yml
```
- Install RHOAM from OSD Operator Hub

### Check if the `RHOAMApiUsageLevel3ThresholdExceeded` alert message has been updated
- In the OSD UI navigate to the `redhat-rhoam-observability` namespace
- On the left hand side choose Networking -> Routes -> prometheus location URL
- Click on Alerts and find `RHOAMApiUsageLevel3ThresholdExceeded`
- Make sure that `RHOAMApiUsageLevel3ThresholdExceeded` alert message has been updated:
> It should be: " ... service is between 95% and **100%** of the allowable threshold ... "

### Uninstall RHOAM and cleanup/delete the cluster
