### PR TITLE
MGDAPI-5512 - refactor: remove conversion of cro_postgres_max_memory metric to bytes

### DIFF
--- a/pkg/products/monitoringcommon/dashboards/croResources.go
+++ b/pkg/products/monitoringcommon/dashboards/croResources.go
@@ -397,7 +397,7 @@ const MonitoringGrafanaDBCROResourcesJSON = `{
           "pluginVersion": "7.1.1",
           "targets": [
             {
-              "expr": "cro_postgres_max_memory*1048576",
+              "expr": "cro_postgres_max_memory",
               "format": "table",
               "instant": true,
               "interval": "",

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -517,9 +517,8 @@ func reconcilePostgresFreeableMemoryAlert(ctx context.Context, client k8sclient.
 	}
 
 	// checking if the percentage of freeable memory is less than 10% of the max memory
-	// cro_postgres_max_memory is in MiB so cro_postgres_freeable_memory_average needs to be converted from bytes to MiB
 	// conversion formula is MiB = bytes / (1024^2)
-	alertExp := intstr.FromString("(cro_postgres_freeable_memory_average / (1024*1024)) < ((cro_postgres_max_memory / 100 ) * 10)")
+	alertExp := intstr.FromString("(cro_postgres_freeable_memory_average) < ((cro_postgres_max_memory / 100 ) * 10)")
 
 	ruleNs := inst.Spec.NamespacePrefix + "observability"
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlPostgresFreeableMemoryLow, alertFor5Mins, alertExp, labels)


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5512

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
There is a discrepency is metric value for `cro_postgres_max_memory` which causes an alert to be fired for only GCP installs. This is due to the AWS provider uses MiB whereas GCP provider uses bytes for this metric.

https://github.com/integr8ly/cloud-resource-operator/pull/677 handles the conversion to bytes for the `cro_postgres_max_memory` metric for the AWS provider. This will use bytes as the standard for this metric.

With this change, there is no longer a need to handle conversion of this metric in alerts or dashboards

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Code review and passing prow checks should be sufficient