### PR TITLE
MGDAPI-5089 add grpc support and bump envoy image

### DIFF
--- a/pkg/products/threescale/envoyconfig.go
+++ b/pkg/products/threescale/envoyconfig.go
@@ -6,7 +6,6 @@ import (
 	envoylistenerv3 "github.com/envoyproxy/go-control-plane/envoy/config/listener/v3"
 	envoyratelimitconfigv3 "github.com/envoyproxy/go-control-plane/envoy/config/ratelimit/v3"
 	envoyroutev3 "github.com/envoyproxy/go-control-plane/envoy/config/route/v3"
-	reverseBridge "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/grpc_http1_reverse_bridge/v3"
 	lua "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/lua/v3"
 	envoyratelimitv3 "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/ratelimit/v3"
 	router "github.com/envoyproxy/go-control-plane/envoy/extensions/filters/http/router/v3"
@@ -21,7 +20,7 @@ import (
 
 const (
 	ApicastContainerAddress  = "127.0.0.1"
-	ApicastContainerPort     = 8080
+	ApicastContainerPort     = 8444
 	ApicastClusterName       = "apicast-ratelimit"
 	ApicastNodeID            = "apicast-ratelimit"
 	ApicastEnvoyProxyAddress = "0.0.0.0"
@@ -154,22 +153,6 @@ func getAPICastHTTPFilters() ([]*hcm.HttpFilter, error) {
 		ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: ratelimitSerial},
 	}
 
-	grpcReverseBridgeSerial, err := anypb.New(
-		&reverseBridge.FilterConfig{
-			ContentType:        "application/grpc",
-			WithholdGrpcFrames: false,
-		},
-	)
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert grpc reverse bridge filter for Apicast ratelimit envoy configuration")
-	}
-
-	var tsHTTPGrpcReverseBridgeFilter = hcm.HttpFilter{
-		Name:       "envoy.filters.http.grpc_http1_reverse_bridge",
-		ConfigType: &hcm.HttpFilter_TypedConfig{TypedConfig: grpcReverseBridgeSerial},
-	}
-
 	routerSerial, err := anypb.New(
 		&router.Router{},
 	)
@@ -185,7 +168,6 @@ func getAPICastHTTPFilters() ([]*hcm.HttpFilter, error) {
 
 	httpFilters := []*hcm.HttpFilter{
 		&tsHTTPRateLimitFilter,
-		&tsHTTPGrpcReverseBridgeFilter,
 		&routerFiler,
 	}
 

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.5-6"
+	EnvoyImage      = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.2-3"
 	EnvoyAPIVersion = "v3"
 )
 

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.2.5-6"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.2-3"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5089

# What
Add gRPC support in envoy
Bump envoy image to latest available

# Verification steps
Pre-reqs:
- OSD cluster

Install the current version of RHOAM:
- Navigate to marketplace ns and to CatalogSource CRs
- Create new CR:
```
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/mstoklus/managed-api-service-index:1.34.0
  ```
 - Prepare the cluster for RHOAM installation
 ```
 INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local
 ```
 - Navigate to the OperatorHub under redhat-rhoam-operator ns
 - Find RHOAM
 - Install RHOAM operator under redhat-rhoam-operator ns
 - Create RHMI CR:
 ```
 INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true LOCAL=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml
 ```
 - Wait for installation to complete
 - Update the catalogSource index image to:
 ```
 quay.io/mstoklus/managed-api-service-index:1.35.0
 ```
 - Navigate to installed operator under redhat-rhoam-operator and approve upgrade to 1.35.0
 
 ### Regular 3scale calls are rate limited
 - Navigate to redhat-rhoam-3scale namespace
 - Navigate to routes
 - Find 3scale-admin route and open it
 - Fetch admin password and id from system-seed from 3scale ns
 - Log in to 3scale
 - Follow the wizard to create default service
 - Go to the default service created and into "integration" and "configuration" - fetch the staging call
 - Scale down RHOAM operator
 - Nagivate to the redhat-rhoam-marin3r namespace configmaps
 - In the rate-limiting cm change the value of "max value" to 5
 -  In the deployment of marin3r scale down rate limit pods and scale them back up
 - From your terminal run:
 ```
 curl "<route and user key fetched from 3scale configuration for staging apicast>"
 ```
 - Hit the endpoint 6 times - 5 request should pass through, 6th should be rejected.
 
 ### gRPC verification
 - Download repo: https://github.com/hguerrero/3scale-examples
 - Navigate to the repo/grpc folder
 - Ensure you are oc logged in to your cluster
 - Create new namespace:
 ```
 oc new-project grpc
```
- Apply k8s:
```
oc apply -f k8s/
```
- Change namespace to 3scale:
```
oc project redhat-rhoam-3scale
```
- Apply 3scale resource from k8s:
```
kubectl apply -f threescale/
```
- Navigate again to 3scale admin 3scale route
- Click on gRPC API product
- Click on applications > listing
- Create listing
  - account: john doe
  - App plan - basic gRPC plan
  - sample name and desc
- Navigate to integration > configuration and promote to staging
- In your terminal run (from the 3scale-examples grpc folder:
```
grpcurl -v -insecure -H 'user_key: <user key from 3scale staging configuration>' -proto grpc-helloworld/src/main/proto/helloworld.proto <route from 3scale staging configuration - ensure to add :PORT> helloworld.Greeter/SayHello
```
- Response should look like:
```
Response contents:
{
  "message": "Hello  have a great day!"
}

Response trailers received:
(empty)
Sent 0 requests and received 1 response
```
- Hit it 6 times - we are expecting 5 successful and 1 failed
