### PR TITLE
MGDAPI-5301 update to use different cidr-range param depending on platform type

### DIFF
--- a/pkg/client/sigs_clientset.go
+++ b/pkg/client/sigs_clientset.go
@@ -44,5 +44,8 @@ func NewSigsClientMoqWithScheme(clientScheme *runtime.Scheme, initObjs ...runtim
 		StatusFunc: func() k8sclient.StatusWriter {
 			return sigsClient.Status()
 		},
+		PatchFunc: func(ctx context.Context, obj k8sclient.Object, patch k8sclient.Patch, opts ...k8sclient.PatchOption) error {
+			return sigsClient.Patch(ctx, obj, patch, opts...)
+		},
 	}
 }

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -55,6 +55,8 @@ const (
 	MaintenanceHour              = "maintenance-hour"
 	DefaultMaintenanceDay        = time.Thursday
 	DefaultMaintenanceHour       = 2
+	cidrRangeKeyAws              = "cidr-range"
+	cidrRangeKeyGcp              = "cidr-range-gcp"
 )
 
 var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001"}
@@ -518,7 +520,7 @@ func overrideStrategyConfig(resourceType string, croStrategyConfig *corev1.Confi
 		return fmt.Errorf("failed to unmarshal strategy mapping for resource type %s %w", resourceType, err)
 	}
 
-	for tier, _ := range strategyConfig {
+	for tier := range strategyConfig {
 		deleteStrategyJSON, err := json.Marshal(deleteStrategy)
 		if err != nil {
 			return err
@@ -595,9 +597,9 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 	}
 	switch platformType {
 	case configv1.AWSPlatformType:
-		cidrValueID = "cidr-range"
+		cidrValueID = cidrRangeKeyAws
 	case configv1.GCPPlatformType:
-		cidrValueID = "cidr-range-gcp"
+		cidrValueID = cidrRangeKeyGcp
 	default:
 		return fmt.Errorf("unsupported platform type %s", platformType)
 	}
@@ -648,7 +650,7 @@ func (r *Reconciler) reconcileCIDRValue(ctx context.Context, client k8sclient.Cl
 		network[croUtil.TierProduction].CreateStrategy.CidrBlock = ""
 	}
 
-	for key, _ := range network {
+	for key := range network {
 		network[key].CreateStrategy.CidrBlock = cidrValue
 	}
 


### PR DESCRIPTION
# Issue link
[MGDAPI-5301](https://issues.redhat.com/browse/MGDAPI-5301)

# What
Allowing rhoam to use correct cidr-range param from OCM.

# Verification steps
 - Provision a GCP cluster
   - From the master branch of the Delorean repo create a file in the root of the repo called 
    gcp_service_account.json. Request GCP credentials and add these to this file.
   - Run make -f make/ocm.mk ocm/cluster.json BYOC=true CLOUD_PROVIDER=gcp
   - Edit the cluster.json file to update the name (and remove the expiration timestamp if necessary).
   - Run make ocm/cluster/create
- Prepare the cluster, patching the `addon-managed-api-service-parameters` secret and install RHOAM 
```
LOCAL=false make cluster/prepare/local
echo -n "10.1.0.0/22" | base64 | xargs -I {} oc patch secret addon-managed-api-service-parameters -n redhat-rhoam-operator --type=json -p='[{"op": "replace", "path": /data/cidr-range-gcp, "value": "{}"}]'
LOCAL=false USE_CLUSTER_STORAGE=false make code/run
```
- When installation is complete, check that the GCP strategy configmap has the correct cidr-range address set
```
oc get configmap cloud-resources-gcp-strategies -n redhat-rhoam-operator -o yaml | yq '.data._network' | jq '.production.createStrategy'
```



