### PR TITLE
MGDAPI-4601 Fix S1008 linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ issues:
 
 linters-settings:
   gosimple:
-    checks: ["all", -S1004, -S1008, -S1005, -S1031, -S1011, -S1025, -S1034, -S1001]
+    checks: ["all", -S1004, -S1005, -S1031, -S1011, -S1025, -S1034, -S1001]
   staticcheck:
     checks: ["all", -SA4006, -SA9003, -SA5011, -SA4001, -SA4010, SA1019, -SA1030, -SA6000, -SA4009, -SA4022, -SA5001]
 

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -643,11 +643,7 @@ func (r *RateLimitServiceReconciler) differentLimitSettings(redisLimits []limita
 	sortByNamespaceAndMaxValue(redisLimits)
 	sortByNamespaceAndMaxValue(currentLimits)
 
-	if !reflect.DeepEqual(redisLimits, currentLimits) {
-		return true
-	}
-
-	return false
+	return !reflect.DeepEqual(redisLimits, currentLimits)
 }
 
 func sortByNamespaceAndMaxValue(elems []limitadorLimit) {

--- a/test/functional/aws_elasticache_resources_exist.go
+++ b/test/functional/aws_elasticache_resources_exist.go
@@ -88,8 +88,5 @@ func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingCon
 
 // helper method for verifying nodes are in different availability zones
 func verifyMultiAZ(member []*elasticache.NodeGroupMember) bool {
-	if member[0].PreferredAvailabilityZone == member[1].PreferredAvailabilityZone {
-		return false
-	}
-	return true
+	return member[0].PreferredAvailabilityZone != member[1].PreferredAvailabilityZone
 }


### PR DESCRIPTION
# Issue link
[MGDAPI-4601](https://issues.redhat.com/browse/MGDAPI-4601)

# What
This PR addresses all issue shown from the gosimple linter with error code S1008

# Verification steps
In this case the code review of the changes should be sufficient, but if you want you could manually verify it by the following verification steps:

- Checkout this PR
- Run `make test/lint`
- Confirm that there are no errors in the output
