### PR TITLE
MGDAPI-4622 Fix S1004 linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -8,7 +8,7 @@ issues:
 
 linters-settings:
   gosimple:
-    checks: ["all", -S1004, -S1005, -S1031, -S1011, -S1025, -S1034, -S1001]
+    checks: ["all", -S1005, -S1031, -S1011, -S1025, -S1034, -S1001]
   staticcheck:
     checks: ["all", -SA4006, -SA9003, -SA5011, -SA4001, -SA4010, SA1019, -SA1030, -SA6000, -SA4009, -SA4022, -SA5001]
 

--- a/pkg/resources/pullSecret_test.go
+++ b/pkg/resources/pullSecret_test.go
@@ -65,7 +65,7 @@ func TestCopyDefaultPullSecretToNameSpace(t *testing.T) {
 				s := &corev1.Secret{}
 				err = c.Get(context.TODO(), k8sclient.ObjectKey{Name: testDestinationSecretName, Namespace: testDestinationNameSpace}, s)
 
-				if bytes.Compare(s.Data["test"], defPullSecret.Data["test"]) != 0 {
+				if !bytes.Equal(s.Data["test"], defPullSecret.Data["test"]) {
 					t.Fatalf("expected data %v, but got %v", defPullSecret.Data["test"], s.Data["test"])
 				}
 			},

--- a/pkg/resources/reconciler_test.go
+++ b/pkg/resources/reconciler_test.go
@@ -368,7 +368,7 @@ func TestReconciler_reconcilePullSecret(t *testing.T) {
 				if err != nil {
 					return err
 				}
-				if bytes.Compare(s.Data["test"], customPullSecret.Data["test"]) != 0 {
+				if !bytes.Equal(s.Data["test"], customPullSecret.Data["test"]) {
 					return fmt.Errorf("expected data %v, but got %v", customPullSecret.Data["test"], s.Data["test"])
 				}
 				return nil


### PR DESCRIPTION
# Issue link
[MGDAPI-4622](https://issues.redhat.com/browse/MGDAPI-4622)

# What
This PR addresses all issue shown from the gosimple linter with error code S1004

# Verification steps
In this case the code review of the changes should be sufficient, but if you want you could manually verify it by the following verification steps:

- Checkout this PR
- Run `make test/lint`
- Confirm that there are no errors in the output
