### PR TITLE
MGDAPI-5688 reduce resources required for mcg

### DIFF
--- a/pkg/products/mcg/reconciler.go
+++ b/pkg/products/mcg/reconciler.go
@@ -24,6 +24,7 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
+	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	k8spointer "k8s.io/utils/pointer"
@@ -247,6 +248,24 @@ func (r *Reconciler) ReconcileNoobaa(ctx context.Context, serverClient k8sclient
 				},
 			},
 			Type: noobaav1.StoreTypePVPool,
+		}
+		noobaa.Spec.Endpoints = &noobaav1.EndpointsSpec{
+			MinCount: 1,
+			MaxCount: 2,
+			Resources: &corev1.ResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("200m"), corev1.ResourceMemory: k8sresource.MustParse("250Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("300Mi")},
+			},
+		}
+
+		noobaa.Spec.CoreResources = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("800Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("400m"), corev1.ResourceMemory: k8sresource.MustParse("900Mi")},
+		}
+
+		noobaa.Spec.DBResources = &corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("250m"), corev1.ResourceMemory: k8sresource.MustParse("250Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("300Mi")},
 		}
 		owner.AddIntegreatlyOwnerAnnotations(noobaa, r.installation)
 		return nil

--- a/pkg/products/mcg/reconciler.go
+++ b/pkg/products/mcg/reconciler.go
@@ -24,7 +24,6 @@ import (
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	k8sresource "k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/record"
 	k8spointer "k8s.io/utils/pointer"
@@ -36,8 +35,8 @@ const (
 	DefaultInstallationNamespace  = "mcg"
 	noobaaName                    = "noobaa"
 	noobaaDefaultBucketClass      = noobaaName + "-default-bucket-class"
-	pvpoolStorageSize             = "25Gi"
-	dbStorageSize                 = "16Gi"
+	pvpoolStorageSize             = "16Gi"
+	dbStorageSize                 = "1Gi"
 	defaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 	threescaleBucket              = "3scale-operator-bucket"
 	ThreescaleBucketClaim         = threescaleBucket + "-claim"
@@ -253,19 +252,19 @@ func (r *Reconciler) ReconcileNoobaa(ctx context.Context, serverClient k8sclient
 			MinCount: 1,
 			MaxCount: 2,
 			Resources: &corev1.ResourceRequirements{
-				Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("200m"), corev1.ResourceMemory: k8sresource.MustParse("250Mi")},
-				Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("300Mi")},
+				Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("200m"), corev1.ResourceMemory: resource.MustParse("250Mi")},
+				Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m"), corev1.ResourceMemory: resource.MustParse("300Mi")},
 			},
 		}
 
 		noobaa.Spec.CoreResources = &corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("800Mi")},
-			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("400m"), corev1.ResourceMemory: k8sresource.MustParse("900Mi")},
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m"), corev1.ResourceMemory: resource.MustParse("800Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("400m"), corev1.ResourceMemory: resource.MustParse("900Mi")},
 		}
 
 		noobaa.Spec.DBResources = &corev1.ResourceRequirements{
-			Requests: corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("250m"), corev1.ResourceMemory: k8sresource.MustParse("250Mi")},
-			Limits:   corev1.ResourceList{corev1.ResourceCPU: k8sresource.MustParse("300m"), corev1.ResourceMemory: k8sresource.MustParse("300Mi")},
+			Requests: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m"), corev1.ResourceMemory: resource.MustParse("250Mi")},
+			Limits:   corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("300m"), corev1.ResourceMemory: resource.MustParse("300Mi")},
 		}
 		owner.AddIntegreatlyOwnerAnnotations(noobaa, r.installation)
 		return nil


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5688

# What
MCG had been using default values for memory and cpu requirements. RHOAM does not need these to be so high therefore they were reduced.

# Verification steps
- Install as fresh install on cluster and confirm that the resources allocated to nooba-core, nooba db resources and endpoints are as low as they can be.
