### PR TITLE
MGDAPI-5072 - configure snapshotting for GCP

### DIFF
--- a/pkg/resources/constants/croConstants.go
+++ b/pkg/resources/constants/croConstants.go
@@ -9,4 +9,6 @@ const (
 	RHSSOUserProstgresPrefix     = "rhssouser-postgres-"
 	ThreeScaleBlobStoragePrefix  = "threescale-blobstorage-"
 	PostgresApplyImmediately     = true
+	GcpSnapshotFrequency         = "4h"
+	GcpSnapshotRetention         = "1d"
 )

--- a/pkg/resources/rhsso.go
+++ b/pkg/resources/rhsso.go
@@ -35,9 +35,9 @@ const (
 )
 
 // ReconcileRHSSOPostgresCredentials Provisions postgres and creates external database secret based on Installation CR, secret will be nil while the postgres instance is provisioning
-func ReconcileRHSSOPostgresCredentials(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client, name, ns, nsPostfix string) (*crov1.Postgres, error) {
+func ReconcileRHSSOPostgresCredentials(ctx context.Context, installation *integreatlyv1alpha1.RHMI, serverClient k8sclient.Client, name, ns, nsPostfix string, snapshotFrequency, snapshotRetention types.Duration) (*crov1.Postgres, error) {
 	postgresNS := installation.Namespace
-	postgres, err := croUtil.ReconcilePostgres(ctx, serverClient, nsPostfix, installation.Spec.Type, croUtil.TierProduction, name, postgresNS, name, postgresNS, constants.PostgresApplyImmediately, "", "", func(cr metav1.Object) error {
+	postgres, err := croUtil.ReconcilePostgres(ctx, serverClient, nsPostfix, installation.Spec.Type, croUtil.TierProduction, name, postgresNS, name, postgresNS, constants.PostgresApplyImmediately, snapshotFrequency, snapshotRetention, func(cr metav1.Object) error {
 		owner.AddIntegreatlyOwnerAnnotations(cr, installation)
 		return nil
 	})

--- a/pkg/resources/rhsso_test.go
+++ b/pkg/resources/rhsso_test.go
@@ -3,8 +3,9 @@ package resources
 import (
 	"context"
 	"errors"
-	"github.com/integr8ly/integreatly-operator/test/utils"
 	"testing"
+
+	"github.com/integr8ly/integreatly-operator/test/utils"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -15,6 +16,7 @@ import (
 	crov1 "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	croTypes "github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1/types"
 	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -143,7 +145,7 @@ func TestReconcileRHSSOPostgresCredentials(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := ReconcileRHSSOPostgresCredentials(context.TODO(), tt.installation, tt.fakeClient(), tt.postgresName, defaultOperatorNamespace, defaultRHSSONamespace)
+			got, err := ReconcileRHSSOPostgresCredentials(context.TODO(), tt.installation, tt.fakeClient(), tt.postgresName, defaultOperatorNamespace, defaultRHSSONamespace, constants.GcpSnapshotFrequency, constants.GcpSnapshotRetention)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ReconcileRHSSOPostgresCredentials() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
# Issue link
[MGDAPI-5072](https://issues.redhat.com/browse/MGDAPI-5072)

# What
Enable snapshotting for GCP using the SnapshotFrequency and SnapshotRetention on Postgres CR's.


# Verification steps

### Provision a GCP CCS cluster

From the master branch of the [Delorean](https://github.com/integr8ly/delorean) repo create a file in the root of the repo called gcp_service_account.json. Request GCP credentials and add these to this file. Adjust this command to suit your needs, it will generate a config at ocm/cluster.json:
 ```sh
OCM_CLUSTER_NAME=acatterm-ccs OCM_CLUSTER_LIFESPAN=24 COMPUTE_NODES_COUNT=4 BYOC=true CLOUD_PROVIDER=gcp make -f make/ocm.mk ocm/cluster.json
```
Once you have checked the ocm/cluster.json, create the cluster:
```sh
make -f make/ocm.mk ocm/cluster/create
```

### Verify changes


Run RHOAM with these changes:
```
LOCAL=false make cluster/prepare/local
LOCAL=false USE_CLUSTER_STORAGE=false make code/run
```

Expect that the Postgres CR's are all configured with the `Spec.SnapshotFrequency` and `Spec.SnapshotRetention` fields set.

Uninstall should complete successfully removing snapshot CR's.