### PR TITLE
MGDAPI-5691 - set Redis size for 100M on GCP

### DIFF
--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -7,6 +7,7 @@ import (
 	threescalev1alpha1 "github.com/3scale/3scale-operator/apis/apps/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
 	"github.com/integr8ly/integreatly-operator/test/resources"
+	configv1 "github.com/openshift/api/config/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
@@ -161,9 +162,15 @@ func setDefaultNumberOfReplicas(defaultNumberOfReplicas int64, threeScaleCompone
 	}
 }
 
-func (t *ThreeScale) GetBackendRedisNodeSize(activeQuota string) string {
+func (t *ThreeScale) GetBackendRedisNodeSize(activeQuota string, platformType configv1.PlatformType) string {
 	if activeQuota == quota.OneHundredMillionQuotaName {
-		return "cache.m5.large"
+		switch platformType {
+		case configv1.AWSPlatformType:
+			return "cache.m5.large"
+		case configv1.GCPPlatformType:
+			// size in GB on GCP
+			return "11"
+		}
 	}
 
 	return ""

--- a/pkg/config/threescale_test.go
+++ b/pkg/config/threescale_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/integr8ly/integreatly-operator/pkg/resources/quota"
+	configv1 "github.com/openshift/api/config/v1"
 )
 
 func TestThreeScale_GetBackendRedisNodeSize(t1 *testing.T) {
@@ -11,7 +12,8 @@ func TestThreeScale_GetBackendRedisNodeSize(t1 *testing.T) {
 		config ProductConfig
 	}
 	type args struct {
-		activeQuota string
+		activeQuota  string
+		platformType configv1.PlatformType
 	}
 	tests := []struct {
 		name   string
@@ -22,16 +24,26 @@ func TestThreeScale_GetBackendRedisNodeSize(t1 *testing.T) {
 		{
 			name: "test empty string is returned when active quota is not 100 M",
 			args: args{
-				activeQuota: quota.OneHundredThousandQuotaName,
+				activeQuota:  quota.OneHundredThousandQuotaName,
+				platformType: configv1.AWSPlatformType,
 			},
 			want: "",
 		},
 		{
-			name: "test cache.m5.large is returned when active quota is 100 M",
+			name: "test cache.m5.large is returned when active quota is 100 M and platformType AWS",
 			args: args{
-				activeQuota: quota.OneHundredMillionQuotaName,
+				activeQuota:  quota.OneHundredMillionQuotaName,
+				platformType: configv1.AWSPlatformType,
 			},
 			want: "cache.m5.large",
+		},
+		{
+			name: "test 11 is returned when active quota is 100 M and platformType GCP",
+			args: args{
+				activeQuota:  quota.OneHundredMillionQuotaName,
+				platformType: configv1.GCPPlatformType,
+			},
+			want: "11",
 		},
 	}
 	for _, tt := range tests {
@@ -39,7 +51,7 @@ func TestThreeScale_GetBackendRedisNodeSize(t1 *testing.T) {
 			t := &ThreeScale{
 				config: tt.fields.config,
 			}
-			if got := t.GetBackendRedisNodeSize(tt.args.activeQuota); got != tt.want {
+			if got := t.GetBackendRedisNodeSize(tt.args.activeQuota, tt.args.platformType); got != tt.want {
 				t1.Errorf("GetBackendRedisNodeSize() = %v, want %v", got, tt.want)
 			}
 		})

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -1289,7 +1289,7 @@ func (r *Reconciler) reconcileExternalDatasources(ctx context.Context, serverCli
 	}
 
 	r.log.Infof("Backend redis config", map[string]interface{}{"quotaChange": quotaChange, "activeQuota": activeQuota})
-	backendRedis, err := croUtil.ReconcileRedis(ctx, serverClient, defaultInstallationNamespace, r.installation.Spec.Type, croUtil.TierProduction, backendRedisName, ns, backendRedisName, ns, r.Config.GetBackendRedisNodeSize(activeQuota), quotaChange, quotaChange, func(cr metav1.Object) error {
+	backendRedis, err := croUtil.ReconcileRedis(ctx, serverClient, defaultInstallationNamespace, r.installation.Spec.Type, croUtil.TierProduction, backendRedisName, ns, backendRedisName, ns, r.Config.GetBackendRedisNodeSize(activeQuota, platformType), quotaChange, quotaChange, func(cr metav1.Object) error {
 		owner.AddIntegreatlyOwnerAnnotations(cr, r.installation)
 		return nil
 	})


### PR DESCRIPTION
# Issue link
[MGDAPI-5691](https://issues.redhat.com/browse/MGDAPI-5691)

# What
Configures the default value for the Redis CR `Spec.Size` on GCP for 100M quota

# Verification steps

Installing RHOAM on a GCP cluster from this branch with 100M quota results in the threescale backend redis CR to have `Spec.Size` set to 11.

<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
