### PR TITLE
[WIP] MGDAPI-5143 Add oc cli to test external image

### DIFF
--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -17,7 +17,9 @@ COPY manifests/ ./manifests
 COPY products ./products
 COPY version ./version
 
-RUN make test/compile/functional
+RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.12.14/openshift-client-linux.tar.gz | tar -zx && \
+    mv oc /usr/local/bin && \
+    make test/compile/functional
 
 FROM quay.io/openshift/origin-cli
 # Install chrome for tests


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5143

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

The test external image needs to have oc installed

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

clone this PR and build the image:
`ORG=<your-quay-org> make image/external/build`

validate the oc cli presence:
`docker run --rm -it --entrypoint=/bin/bash quay.io/<your-quay-org>/integreatly-operator-test-external:latest`
`oc version`
