### PR TITLE
MGDAPI-5729 Create MonitoringStack CR in redhat-rhoam-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ include ./make/*.mk
 
 ORG ?= integreatly
 
-CONFIG_IMAGE ?= ''
+CONFIG_IMAGE ?= 'quay.io/integreatly/managed-api-service-config:latest'
 
 REG=quay.io
 SHELL=/bin/bash

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ include ./make/*.mk
 
 ORG ?= integreatly
 
+CONFIG_IMAGE ?= ''
+
 REG=quay.io
 SHELL=/bin/bash
 
@@ -354,7 +356,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd-sandbox | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/addon-params cluster/prepare/delorean cluster/prepare/rbac/dedicated-admins
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/addon-params cluster/prepare/delorean cluster/prepare/rbac/dedicated-admins cluster/prepare/rhoam-config
 	@if [ "$(CREDENTIALS_MODE)" = Manual ]; then \
 		echo "manual mode (sts)"; \
 		$(MAKE) cluster/prepare/sts; \
@@ -422,8 +424,13 @@ endif
 cluster/prepare/rbac/dedicated-admins:
 	@-oc create -f config/rbac/dedicated_admins_rbac.yaml
 
+.PHONY: cluster/prepare/rhoam-config
+cluster/prepare/rhoam-config:
+	@-oc process -n $(NAMESPACE) CONFIG_IMAGE=$(CONFIG_IMAGE) NAMESPACE=$(NAMESPACE) -f config/hive-config/package.yaml | oc apply -f -
+
 .PHONY: cluster/cleanup
 cluster/cleanup: kustomize
+	@-oc delete package rhoam-config -n $(NAMESPACE) --wait
 	@-oc delete rhmis $(INSTALLATION_NAME) -n $(NAMESPACE) --timeout=240s --wait
 	@-oc delete namespace $(NAMESPACE) --timeout=60s --wait
 	@-$(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc delete -f -

--- a/config/hive-config/package.yaml
+++ b/config/hive-config/package.yaml
@@ -1,0 +1,19 @@
+apiVersion: template.openshift.io/v1
+kind: Template
+metadata:
+  name: quota-secret
+objects:
+  - apiVersion: package-operator.run/v1alpha1
+    kind: Package
+    metadata:
+      name: rhoam-config
+      namespace: ${NAMESPACE}
+    spec:
+      image: ${CONFIG_IMAGE}
+      config:
+        addonsv1:
+          targetNamespace: ${NAMESPACE}
+parameters:
+  - name: NAMESPACE
+  - name: CONFIG_IMAGE
+

--- a/config/hive-config/package.yaml
+++ b/config/hive-config/package.yaml
@@ -1,7 +1,7 @@
 apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
-  name: quota-secret
+  name: rhoam-config
 objects:
   - apiVersion: package-operator.run/v1alpha1
     kind: Package


### PR DESCRIPTION
# Issue link
[MGDAPI-5729](https://issues.redhat.com/browse/MGDAPI-5729)
[MGDAPI-5733](https://issues.redhat.com/browse/MGDAPI-5733)

# What
Updating Makefile and adding config file to create Package CR which in turn creates the following via an MTB repo image:
* ClusterRole `rhoam-prometheus-ext`
* ClusterRoleBinding `rhoam-prometheus-ext`
* MonitoringStack `rhoam`
* ServiceMonitor `openshift-monitoring-federation`

# Verification steps
* Provision a cluster
* Prepare the required image:
Checkout this [MR](https://gitlab.cee.redhat.com/service/managed-tenants-bundles/-/merge_requests/974) in the MTB repo and follow steps in the [setup.md file](https://gitlab.cee.redhat.com/service/managed-tenants-bundles/-/merge_requests/974/diffs#d551017d6b0321552069f3dcdc09cd8bae8a5ba7). Alternatively you can use the image I have prepared: quay.io/rh_ee_fwaters/rhoam-config:0.3
* When you reach the `Preparing the cluster` section, navigate to your integreatly operator folder and checkout this PR
```
gh pr checkout 3225
```
* Log into your cluster and run the following command (updating the image url) to prepare the cluster:
```
LOCAL=false CONFIG_IMAGE=<image url> INSTALLATION_TYPE=managed-api make cluster/prepare/local
```
 * Check the OSD UI and ensure that the required CRs (as above) have been created, with the Monitoring Stack and Service Monitor residing in the `redhat-rhoam-operator` namespace.
 * Set up port forwarding in order to check that the metrics added via the service monitor are now available in the prometheus UI.
```
oc port-forward services/prometheus-operated -n redhat-rhoam-operator 9090:9090
```
* Navigate to http://127.0.0.1:9090 in your browser and check that the metrics federated by the service monitor are available.
* Clean up your cluster
```
LOCAL=false INSTALLATION_TYPE=managed-api make cluster/cleanup
```

