### PR TITLE
Increase limits for marin3r and observability operator in Multi Tenant RHOAM

### DIFF
--- a/pkg/products/marin3r/multitenantChanges.go
+++ b/pkg/products/marin3r/multitenantChanges.go
@@ -1,0 +1,95 @@
+package marin3r
+
+import (
+	"context"
+	"fmt"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+type csvUpdater struct {
+	ctx       context.Context
+	client    k8sclient.Client
+	namespace string
+	log       l.Logger
+	csv       *operatorsv1alpha1.ClusterServiceVersion
+}
+
+func newCsvUpdater(ctx context.Context, client k8sclient.Client, namespace string, log l.Logger) csvUpdater {
+	return csvUpdater{ctx: ctx, client: client, namespace: namespace, log: log}
+}
+
+func (f *csvUpdater) findCsv() error {
+	csvPrefix := "marin3r"
+	csvList := &operatorsv1alpha1.ClusterServiceVersionList{}
+	listOptions := &k8sclient.ListOptions{
+		Namespace: f.namespace,
+	}
+
+	f.log.Infof("finding marin3r CSV", l.Fields{"namespace": f.namespace, "csv prefix": csvPrefix})
+	err := f.client.List(f.ctx, csvList, listOptions)
+	if err != nil {
+		f.log.Errorf("failed to list CSVs", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	for i, csv := range csvList.Items {
+		if strings.HasPrefix(csv.Name, csvPrefix) {
+			f.csv = &csvList.Items[i]
+			return nil
+		}
+	}
+
+	err = fmt.Errorf("failed to find marin3r CSV")
+	f.log.Errorf("failed to find marin3r CSV", l.Fields{"namespace": f.namespace, "csv prefix": csvPrefix}, err)
+	return err
+}
+
+func (f *csvUpdater) setManagerResources() error {
+	if f.csv == nil {
+		err := fmt.Errorf("csvUpdater.csv is not set, run csvUpdater.findCsv()")
+		f.log.Errorf("failed setting manager resources", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	f.log.Infof("setting manager resources", l.Fields{"csv": f.csv.Name, "namespace": f.namespace})
+	memoryLimit := "800Mi"
+	deploymentName := "marin3r-controller-manager"
+	containerName := "manager"
+
+	for i, spec := range f.csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		if spec.Name == deploymentName {
+			for j, container := range spec.Spec.Template.Spec.Containers {
+				if container.Name == containerName {
+					cpu := container.Resources.Limits.Cpu().DeepCopy()
+					limits := corev1.ResourceList{corev1.ResourceCPU: cpu, corev1.ResourceMemory: resource.MustParse(memoryLimit)}
+					f.csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Spec.Template.Spec.Containers[j].Resources.Limits = limits
+					return nil
+				}
+			}
+		}
+	}
+	err := fmt.Errorf("unable to find manager container to update")
+	f.log.Errorf("failed setting manager resources", l.Fields{"csv": f.csv.Name, "namespace": f.namespace}, err)
+	return err
+}
+
+func (f *csvUpdater) updateCSV() error {
+	if f.csv == nil {
+		err := fmt.Errorf("csvUpdater.csv is not set, run csvUpdater.findCsv()")
+		f.log.Errorf("failed updating csv", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	f.log.Infof("updating csv", l.Fields{"csv": f.csv.Name, "namespace": f.namespace})
+	err := f.client.Update(f.ctx, f.csv)
+	if err != nil {
+		f.log.Errorf("failed updating csv", l.Fields{"csv": f.csv.Name, "namespace": f.namespace}, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/products/marin3r/multitenantChanges_test.go
+++ b/pkg/products/marin3r/multitenantChanges_test.go
@@ -1,0 +1,346 @@
+package marin3r
+
+import (
+	"context"
+	"errors"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/utils"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+)
+
+func Test_csvUpdater_findCsv(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:        "failed to list csv",
+			wantErr:     true,
+			expectedErr: "list function failure",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: func() client.Client {
+					mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+					mockClient.ListFunc = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						return errors.New("list function failure")
+					}
+					return mockClient
+				}(),
+			},
+		},
+		{
+			name:        "failed to find csv",
+			wantErr:     true,
+			expectedErr: "failed to find marin3r CSV",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersionList{
+						Items: []operatorsv1alpha1.ClusterServiceVersion{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "some other csv", Namespace: "local-test"},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name:    "successfully find csv",
+			wantErr: false,
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersionList{
+						Items: []operatorsv1alpha1.ClusterServiceVersion{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "some other csv", Namespace: "local-test"},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "marin3r-sample-csv", Namespace: "local-test"},
+							},
+						},
+					}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			err := f.findCsv()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("findCsv() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("findCsv() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_csvUpdater_setManagerResources(t *testing.T) {
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:        "function ran before csv is set",
+			wantErr:     true,
+			expectedErr: "csvUpdater.csv is not set",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+			},
+		},
+		{
+			name:        "manager container not updated",
+			wantErr:     true,
+			expectedErr: "unable to find manager container",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+				},
+			},
+		},
+		{
+			name:    "csv updated successfully",
+			wantErr: false,
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+							StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+								DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+									{
+										Name: "marin3r-controller-manager",
+										Spec: appsv1.DeploymentSpec{
+											Template: corev1.PodTemplateSpec{
+												Spec: corev1.PodSpec{
+													Containers: []corev1.Container{
+														{Name: "manager"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			err := f.setManagerResources()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("setManagerResources() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("setManagerResources() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_csvUpdater_updateCSV(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+		fetchCsv    bool
+	}{
+		{
+			name:        "function ran before csv is set",
+			wantErr:     true,
+			expectedErr: "csvUpdater.csv is not set",
+			fields: fields{
+				log:    getLogger(),
+				ctx:    context.TODO(),
+				client: utils.NewTestClient(scheme),
+			},
+		},
+		{
+			name:        "fail to update csv",
+			wantErr:     true,
+			expectedErr: "\"test-csv\" not found",
+			fields: fields{
+				log:    getLogger(),
+				ctx:    context.TODO(),
+				client: utils.NewTestClient(scheme),
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+				},
+			},
+		},
+		{
+			name:     "successfully updated csv",
+			wantErr:  false,
+			fetchCsv: true,
+			fields: fields{
+				log: getLogger(),
+				ctx: context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-csv",
+							Namespace: "test-local",
+						},
+					}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			if tt.fetchCsv {
+				csv := &operatorsv1alpha1.ClusterServiceVersion{}
+				err = f.client.Get(f.ctx, client.ObjectKey{
+					Name:      "test-csv",
+					Namespace: "test-local",
+				}, csv)
+
+				if err != nil {
+					t.Errorf("\"updateCSV() unexpected error = %v", err)
+				}
+				f.csv = csv
+			}
+			err = f.updateCSV()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("updateCSV() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("updateCSV() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_newCsvUpdater(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+	}
+	tests := []struct {
+		name string
+		args args
+		want csvUpdater
+	}{
+		{
+			name: "happy path",
+			args: args{
+				ctx:       context.TODO(),
+				client:    nil,
+				namespace: "test-namespace",
+				log:       getLogger(),
+			},
+			want: csvUpdater{
+				ctx:       context.TODO(),
+				client:    nil,
+				namespace: "test-namespace",
+				log:       getLogger(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newCsvUpdater(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.log); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newCsvUpdater() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/products/observability/multitenantChanges.go
+++ b/pkg/products/observability/multitenantChanges.go
@@ -1,0 +1,100 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+)
+
+type csvUpdater struct {
+	ctx       context.Context
+	client    k8sclient.Client
+	namespace string
+	log       l.Logger
+	csv       *operatorsv1alpha1.ClusterServiceVersion
+}
+
+func newCsvUpdater(ctx context.Context, client k8sclient.Client, namespace string, log l.Logger) csvUpdater {
+	return csvUpdater{ctx: ctx, client: client, namespace: namespace, log: log}
+}
+
+func (f *csvUpdater) findCsv() error {
+	csvPrefix := "observability-operator"
+	ownedNamed := "observabilities.observability.redhat.com"
+	csvList := &operatorsv1alpha1.ClusterServiceVersionList{}
+	listOptions := &k8sclient.ListOptions{
+		Namespace: f.namespace,
+	}
+
+	f.log.Infof("finding observability CSV", l.Fields{"namespace": f.namespace, "csv prefix": csvPrefix})
+	err := f.client.List(f.ctx, csvList, listOptions)
+	if err != nil {
+		f.log.Errorf("failed to list CSVs", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	for i, csv := range csvList.Items {
+		if strings.HasPrefix(csv.Name, csvPrefix) {
+			for _, item := range csv.Spec.CustomResourceDefinitions.Owned {
+				if item.Name == ownedNamed {
+					f.csv = &csvList.Items[i]
+					return nil
+				}
+			}
+		}
+	}
+
+	err = fmt.Errorf("failed to find observability CSV")
+	f.log.Errorf("failed to find observability CSV", l.Fields{"namespace": f.namespace, "csv prefix": csvPrefix}, err)
+	return err
+}
+
+func (f *csvUpdater) setManagerResources() error {
+	if f.csv == nil {
+		err := fmt.Errorf("csvUpdater.csv is not set, run csvUpdater.findCsv()")
+		f.log.Errorf("failed setting manager resources", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	f.log.Infof("setting manager resources", l.Fields{"csv": f.csv.Name, "namespace": f.namespace})
+	memoryLimit := "1000Mi"
+	deploymentName := "observability-operator-controller-manager"
+	containerName := "manager"
+
+	for i, spec := range f.csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs {
+		if spec.Name == deploymentName {
+			for j, container := range spec.Spec.Template.Spec.Containers {
+				if container.Name == containerName {
+					cpu := container.Resources.Limits.Cpu().DeepCopy()
+					limits := corev1.ResourceList{corev1.ResourceCPU: cpu, corev1.ResourceMemory: resource.MustParse(memoryLimit)}
+					f.csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs[i].Spec.Template.Spec.Containers[j].Resources.Limits = limits
+					return nil
+				}
+			}
+		}
+	}
+	err := fmt.Errorf("unable to find manager container to update")
+	f.log.Errorf("failed setting manager resources", l.Fields{"csv": f.csv.Name, "namespace": f.namespace}, err)
+	return err
+}
+
+func (f *csvUpdater) updateCSV() error {
+	if f.csv == nil {
+		err := fmt.Errorf("csvUpdater.csv is not set, run csvUpdater.findCsv()")
+		f.log.Errorf("failed updating csv", l.Fields{"namespace": f.namespace}, err)
+		return err
+	}
+
+	f.log.Infof("updating csv", l.Fields{"csv": f.csv.Name, "namespace": f.namespace})
+	err := f.client.Update(f.ctx, f.csv)
+	if err != nil {
+		f.log.Errorf("failed updating csv", l.Fields{"csv": f.csv.Name, "namespace": f.namespace}, err)
+		return err
+	}
+	return nil
+}

--- a/pkg/products/observability/multitenantChanges_test.go
+++ b/pkg/products/observability/multitenantChanges_test.go
@@ -1,0 +1,358 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/utils"
+	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"reflect"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"testing"
+)
+
+func Test_csvUpdater_findCsv(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:        "failed to list csv",
+			wantErr:     true,
+			expectedErr: "list function failure",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: func() client.Client {
+					mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+					mockClient.ListFunc = func(ctx context.Context, list client.ObjectList, opts ...client.ListOption) error {
+						return errors.New("list function failure")
+					}
+					return mockClient
+				}(),
+			},
+		},
+		{
+			name:        "failed to find csv",
+			wantErr:     true,
+			expectedErr: "failed to find observability CSV",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersionList{
+						Items: []operatorsv1alpha1.ClusterServiceVersion{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "some other csv", Namespace: "local-test"},
+							},
+						},
+					}),
+			},
+		},
+		{
+			name:    "successfully find csv",
+			wantErr: false,
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				ctx:       context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersionList{
+						Items: []operatorsv1alpha1.ClusterServiceVersion{
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "some other csv", Namespace: "local-test"},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "observability-operator-bad-sample-csv", Namespace: "local-test"},
+							},
+							{
+								ObjectMeta: metav1.ObjectMeta{Name: "observability-operator-good-sample-csv", Namespace: "local-test"},
+								Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+									CustomResourceDefinitions: operatorsv1alpha1.CustomResourceDefinitions{
+										Owned: []operatorsv1alpha1.CRDDescription{
+											{
+												Name: "observabilities.observability.redhat.com",
+											},
+										},
+									},
+								},
+							},
+						},
+					}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			err := f.findCsv()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("findCsv() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("findCsv() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_csvUpdater_setManagerResources(t *testing.T) {
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+	}{
+		{
+			name:        "function ran before csv is set",
+			wantErr:     true,
+			expectedErr: "csvUpdater.csv is not set",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+			},
+		},
+		{
+			name:        "manager container not updated",
+			wantErr:     true,
+			expectedErr: "unable to find manager container",
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+				},
+			},
+		},
+		{
+			name:    "csv updated successfully",
+			wantErr: false,
+			fields: fields{
+				log:       getLogger(),
+				namespace: "local-test",
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+					Spec: operatorsv1alpha1.ClusterServiceVersionSpec{
+						InstallStrategy: operatorsv1alpha1.NamedInstallStrategy{
+							StrategySpec: operatorsv1alpha1.StrategyDetailsDeployment{
+								DeploymentSpecs: []operatorsv1alpha1.StrategyDeploymentSpec{
+									{
+										Name: "observability-operator-controller-manager",
+										Spec: appsv1.DeploymentSpec{
+											Template: corev1.PodTemplateSpec{
+												Spec: corev1.PodSpec{
+													Containers: []corev1.Container{
+														{Name: "manager"},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			err := f.setManagerResources()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("setManagerResources() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("setManagerResources() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_csvUpdater_updateCSV(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type fields struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+		csv       *operatorsv1alpha1.ClusterServiceVersion
+	}
+	tests := []struct {
+		name        string
+		fields      fields
+		wantErr     bool
+		expectedErr string
+		fetchCsv    bool
+	}{
+		{
+			name:        "function ran before csv is set",
+			wantErr:     true,
+			expectedErr: "csvUpdater.csv is not set",
+			fields: fields{
+				log:    getLogger(),
+				ctx:    context.TODO(),
+				client: utils.NewTestClient(scheme),
+			},
+		},
+		{
+			name:        "fail to update csv",
+			wantErr:     true,
+			expectedErr: "\"test-csv\" not found",
+			fields: fields{
+				log:    getLogger(),
+				ctx:    context.TODO(),
+				client: utils.NewTestClient(scheme),
+				csv: &operatorsv1alpha1.ClusterServiceVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-csv",
+						Namespace: "test-local",
+					},
+				},
+			},
+		},
+		{
+			name:     "successfully updated csv",
+			wantErr:  false,
+			fetchCsv: true,
+			fields: fields{
+				log: getLogger(),
+				ctx: context.TODO(),
+				client: utils.NewTestClient(scheme,
+					&operatorsv1alpha1.ClusterServiceVersion{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "test-csv",
+							Namespace: "test-local",
+						},
+					}),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			f := &csvUpdater{
+				ctx:       tt.fields.ctx,
+				client:    tt.fields.client,
+				namespace: tt.fields.namespace,
+				log:       tt.fields.log,
+				csv:       tt.fields.csv,
+			}
+
+			if tt.fetchCsv {
+				csv := &operatorsv1alpha1.ClusterServiceVersion{}
+				err = f.client.Get(f.ctx, client.ObjectKey{
+					Name:      "test-csv",
+					Namespace: "test-local",
+				}, csv)
+
+				if err != nil {
+					t.Errorf("\"updateCSV() unexpected error = %v", err)
+				}
+				f.csv = csv
+			}
+			err = f.updateCSV()
+			if err != nil {
+				if !tt.wantErr {
+					t.Errorf("updateCSV() error = %v, wantErr %v", err, tt.wantErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("updateCSV() error = %v, should contain: %v", err, tt.expectedErr)
+				}
+			}
+		})
+	}
+}
+
+func Test_newCsvUpdater(t *testing.T) {
+	type args struct {
+		ctx       context.Context
+		client    client.Client
+		namespace string
+		log       logger.Logger
+	}
+	tests := []struct {
+		name string
+		args args
+		want csvUpdater
+	}{
+		{
+			name: "happy path",
+			args: args{
+				ctx:       context.TODO(),
+				client:    nil,
+				namespace: "test-namespace",
+				log:       getLogger(),
+			},
+			want: csvUpdater{
+				ctx:       context.TODO(),
+				client:    nil,
+				namespace: "test-namespace",
+				log:       getLogger(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newCsvUpdater(tt.args.ctx, tt.args.client, tt.args.namespace, tt.args.log); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("newCsvUpdater() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5758

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Increase the memory limits on marin3r and observability operator in Multi Tenant RHOAM

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

* Install the current version of Multi tenanted RHAOM
* Record the memory limits on the operator for marin3r and observability. (Command below can be used to do this outside the UI)
* Run the operator version from this branch.
* Check the resource memory limits for both again.
* Expected the limits should increase.
    * marin3r goes to 800Mi
    * observability goes to 1000Mi

Check marin3r resources
```
kubectl get pods $(kubectl get pod -l 'control-plane=controller-manager' -n sandbox-rhoam-marin3r-operator --no-headers=true | awk '{print $1}') -o jsonpath='{range .spec.containers[*]}{"Container Name: "}{.name}{"\n"}{"Memory: "}{.resources.limits.memory}{"\n"}{end}' -n sandbox-rhoam-marin3r-operator
```

Check observability operator resources
```
kubectl get pods $(kubectl get pod -l 'control-plane=controller-manager' -n sandbox-rhoam-observability-operator --no-headers=true | awk '{print $1}') -o jsonpath='{range .spec.containers[*]}{"Container Name: "}{.name}{"\n"}{"memory: "}{.resources.limits.memory}{"\n"}{end}' -n sandbox-rhoam-observability-operator
```