### PR TITLE
MGDAPI-5759 - remove namespaces with make cluster/cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -426,6 +426,8 @@ cluster/prepare/rbac/dedicated-admins:
 cluster/cleanup: kustomize
 	@-oc delete rhmis $(INSTALLATION_NAME) -n $(NAMESPACE) --timeout=240s --wait
 	@-oc delete namespace $(NAMESPACE) --timeout=60s --wait
+	@-oc delete namespace $(NAMESPACE_PREFIX)cloud-resources-operator --timeout=60s --wait
+	@-oc delete namespace $(NAMESPACE_PREFIX)3scale --timeout=60s --wait
 	@-$(KUSTOMIZE) build config/rbac-$(INSTALLATION_SHORTHAND) | oc delete -f -
 
 .PHONY: cluster/cleanup/serviceaccount


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
[MGDAPI-5759](https://issues.redhat.com/browse/MGDAPI-5759)

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Remove the 3scale and CRO namespaces using the `make cluster/cleanup` command.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

- Checkout this PR
- Provision a cluster
- Log in to the cluster `ocm_cluster_login`
- Prepare the cluster 
```
LOCAL=false make cluster/prepare/local
```
Here you can see that the namespaces were created:
![image](https://github.com/integr8ly/integreatly-operator/assets/72521959/92f317ac-d1e1-422a-9ac2-2e8c4db7e16c)


- Clean up the cluster
```
LOCAL=false make cluster/cleanup
```
- Make sure `redhat-rhoam-3scale` and ` redhat-rhoan-cloud-resources-operator` namespaces were deleted:
![image](https://github.com/integr8ly/integreatly-operator/assets/72521959/f34b516b-ab27-48c2-8f04-8dfc174c7a77)
- Delete the cluster
