### PR TITLE
MGDAPI-5143 Update oc in test external image

### DIFF
--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -28,7 +28,7 @@ COPY Makefile ./
 # compile test binary
 RUN make test/compile/functional
 
-FROM quay.io/openshift/origin-cli
+FROM registry.redhat.io/openshift4/ose-cli:v4.13
 # Install chrome for tests
 COPY test-dependency/*.repo /etc/yum.repos.d/
 COPY build/bin/setup_external.sh ./setup_external.sh


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5143

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
ROSA private link pipeline uses the test external image to run tests. It was discovered that `oc` is not there - or to be more precise a rather old `oc` is there.

Here's the update so that a newer version of oc is used.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
ORG=yourOrg make image/external/build
podman run --rm -it --entrypoint=/bin/bash quay.io/yourOrg/integreatly-operator-test-external:latest
oc version

Output should be
Client Version: 4.13.0-202304190216.p0.g92b1a3d.assembly.stream-92b1a3d
Kustomize Version: v4.5.7

Optional - you can actually run the tests against the cluster:
```
rm -rf  ./test-run-result
mkdir test-run-result
# update the host, password, and quay org
podman run -it -e OPENSHIFT_HOST='https://api.cluster.s1.devshift.org:6443' -e OPENSHIFT_PASSWORD='kubeadminPassword' -e MULTIAZ=false -e DESTRUCTIVE=false -e NUMBER_OF_TENANTS='2' -e TENANTS_CREATION_TIMEOUT='3' -e RegExpFilter='C01' -e OUTPUT_DIR=test-run-result -v "$(pwd)/test-run-result:/test-run-result:Z" quay.io/yourOrg/integreatly-operator-test-external:latest
```
