### PR TITLE
MGDAPI-5781 Moved PrometheusRules and Probes to new observability namespace

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -272,6 +272,7 @@ rules:
   - get
   - list
   - update
+  - watch
 - apiGroups:
   - noobaa.io
   resources:
@@ -538,24 +539,6 @@ rules:
   - watch
 - apiGroups:
   - monitoring.coreos.com
-  resources:
-  - servicemonitors
-  verbs:
-  - create
-  - get
-- apiGroups:
-  - monitoring.rhobs
-  resources:
-  - prometheusrules
-  verbs:
-  - create
-  - delete
-  - get
-  - list
-  - update
-  - watch
-- apiGroups:
-  - monitoring.rhobs
   resources:
   - servicemonitors
   verbs:

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -184,7 +184,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // Monitoring resources not covered by namespace "admin" permissions
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules;servicemonitors;podmonitors;probes,verbs=get;list;create;update;delete
-// +kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules;servicemonitors;podmonitors;probes,verbs=get;list;create;update;delete
+// +kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules;servicemonitors;podmonitors;probes,verbs=get;list;create;update;delete;watch
 
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles;clusterrolebindings;roles;rolebindings,verbs=*
 
@@ -236,13 +236,9 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;create,namespace=integreatly-operator
 
-// +kubebuilder:rbac:groups=monitoring.rhobs,resources=servicemonitors,verbs=get;create,namespace=integreatly-operator
-
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets,verbs=update;get;patch
 
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=prometheusrules,verbs=get;list;create;update;delete;watch,namespace=integreatly-operator
-
-// +kubebuilder:rbac:groups=monitoring.rhobs,resources=prometheusrules,verbs=get;list;create;update;delete;watch,namespace=integreatly-operator
 
 // +kubebuilder:rbac:groups="",resources=pods;services;endpoints,verbs=get;list;watch,namespace=integreatly-operator
 

--- a/pkg/config/obo.go
+++ b/pkg/config/obo.go
@@ -1,0 +1,9 @@
+package config
+
+const (
+	OboNamespaceSuffix = "-observability"
+)
+
+func GetOboNamespace(installationNamespace string) string {
+	return installationNamespace + OboNamespaceSuffix
+}

--- a/pkg/products/cloudresources/prometheusRules.go
+++ b/pkg/products/cloudresources/prometheusRules.go
@@ -88,7 +88,7 @@ func (r *Reconciler) newAlertsReconciler(ctx context.Context, client k8sclient.C
 		},
 	}
 
-	return addElasticCacheSnapshotNotFoundAlert(ctx, client, logger, installationName, *alertsReconciler, namespace)
+	return addElasticCacheSnapshotNotFoundAlert(ctx, client, logger, installationName, *alertsReconciler, r.installation.Namespace)
 }
 
 func addElasticCacheSnapshotNotFoundAlert(ctx context.Context, client k8sclient.Client, logger l.Logger, installationName string, alertsReconciler resources.AlertReconcilerImpl, ns string) (resources.AlertReconciler, error) {

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -273,7 +273,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, nil
 	}
 
-	alertsReconciler, err := r.newAlertsReconciler(ctx, client, r.log, r.installation.Spec.Type, r.installation.Namespace)
+	alertsReconciler, err := r.newAlertsReconciler(ctx, client, r.log, r.installation.Spec.Type, config.GetOboNamespace(r.installation.Namespace))
 	if err != nil {
 		events.HandleError(r.recorder, installation, phase, "Failed to get new alerts reconciler", err)
 		r.log.Error("Error getting cloud resources alerts reconciler", err)

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -191,7 +191,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
-	alertsReconciler := r.newAlertReconciler(r.log, r.installation.Spec.Type, r.installation.Namespace)
+	alertsReconciler := r.newAlertReconciler(r.log, r.installation.Spec.Type, config.GetOboNamespace(r.installation.Namespace))
 	if phase, err := alertsReconciler.ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana alerts", err)
 		return phase, err

--- a/pkg/products/marin3r/apiUsagePrometheusRules.go
+++ b/pkg/products/marin3r/apiUsagePrometheusRules.go
@@ -18,14 +18,14 @@ var (
 	totalRequestsMetric = "authorized_calls"
 )
 
-func (r *Reconciler) newAlertsReconciler(grafanaDashboardURL string) (resources.AlertReconciler, error) {
+func (r *Reconciler) newAlertsReconciler(grafanaDashboardURL string, namespace string) (resources.AlertReconciler, error) {
 
 	requestsAllowedPerSecond, err := r.getRateLimitInSeconds(r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit)
 	if err != nil {
 		return nil, err
 	}
 
-	alerts, err := mapAlertsConfiguration(r.log, r.installation.Namespace, r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit, requestsAllowedPerSecond, r.AlertsConfig, grafanaDashboardURL, r.installation.Spec.Type)
+	alerts, err := mapAlertsConfiguration(r.log, namespace, r.RateLimitConfig.Unit, r.RateLimitConfig.RequestsPerUnit, requestsAllowedPerSecond, r.AlertsConfig, grafanaDashboardURL, r.installation.Spec.Type)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create alerts from configuration: %w", err)
 	}

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -188,7 +188,7 @@ func TestAlertCreation(t *testing.T) {
 
 			serverClient := tt.serverClient()
 
-			got, err := reconciler.reconcileAlerts(context.TODO(), serverClient, reconciler.installation)
+			got, err := reconciler.reconcileAlerts(context.TODO(), serverClient, reconciler.installation, getBasicInstallation().Name)
 			if tt.wantErr != "" && err.Error() != tt.wantErr {
 				t.Errorf("reconcileAlerts() error = %v, wantErr %v", err.Error(), tt.wantErr)
 				return

--- a/pkg/products/mcg/reconciler.go
+++ b/pkg/products/mcg/reconciler.go
@@ -156,7 +156,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type, r.installation.Namespace)
+	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type, config.GetOboNamespace(r.installation.Namespace))
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/pkg/products/observability/reconciler.go
+++ b/pkg/products/observability/reconciler.go
@@ -238,7 +238,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.newAlertsReconciler(r.log, r.installation.Spec.Type, r.installation.Namespace).ReconcileAlerts(ctx, client)
+	phase, err = r.newAlertsReconciler(r.log, r.installation.Spec.Type, config.GetOboNamespace(r.installation.Namespace)).ReconcileAlerts(ctx, client)
 	r.log.Infof("reconcilePrometheusRule", l.Fields{"phase": phase})
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile alerts", err)

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -245,7 +245,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.newAlertsReconciler(r.Log, r.Installation.Spec.Type, r.Installation.Namespace).ReconcileAlerts(ctx, serverClient)
+	phase, err = r.newAlertsReconciler(r.Log, r.Installation.Spec.Type, config.GetOboNamespace(r.Installation.Namespace)).ReconcileAlerts(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile alerts", err)
 		return phase, err

--- a/pkg/products/rhssocommon/reconciler.go
+++ b/pkg/products/rhssocommon/reconciler.go
@@ -700,7 +700,7 @@ func (r *Reconciler) ExportAlerts(ctx context.Context, apiClient k8sclient.Clien
 	alertToMove := &monv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      productName,
-			Namespace: r.Installation.Namespace,
+			Namespace: config.GetOboNamespace(r.Installation.Namespace),
 		},
 	}
 	opRes, err := controllerutil.CreateOrUpdate(ctx, apiClient, alertToMove, func() error {

--- a/pkg/products/rhssocommon/reconciler_test.go
+++ b/pkg/products/rhssocommon/reconciler_test.go
@@ -1465,17 +1465,17 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 		},
 	}
 
-	prometheusRulesOO := &monv1.PrometheusRule{
+	prometheusRulesOBO := &monv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rhsso",
-			Namespace: "redhat-rhoam-operator",
+			Namespace: config.GetOboNamespace(installation.Namespace),
 		},
 	}
 
-	prometheusRulesOOwithKcExisting := &monv1.PrometheusRule{
+	prometheusRulesOBOwithKcExisting := &monv1.PrometheusRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "rhsso",
-			Namespace: "redhat-rhoam-operator",
+			Namespace: config.GetOboNamespace(installation.Namespace),
 		},
 		Spec: monv1.PrometheusRuleSpec{
 			Groups: []monv1.RuleGroup{
@@ -1512,29 +1512,29 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 		verificationFunction func(*monv1.PrometheusRule) bool
 	}{
 		{
-			name:          "alerting rules correctly mirrored without kc alert when OO groups are nil",
+			name:          "alerting rules correctly mirrored without kc alert when OBO groups are nil",
 			expectedRules: []monv1.Rule{},
 			installation:  installation,
 			configManager: &config.ConfigReadWriterMock{ReadObservabilityFunc: func() (*config.Observability, error) {
 				return config.NewObservability(config.ProductConfig{
-					"NAMESPACE": "redhat-rhoam-operator",
+					"NAMESPACE": config.GetOboNamespace(installation.Namespace),
 				}), nil
 			}},
-			fakeClient:           utils.NewTestClient(scheme, prometheusRulesSSO, prometheusRulesOO),
+			fakeClient:           utils.NewTestClient(scheme, prometheusRulesSSO, prometheusRulesOBO),
 			wantErr:              false,
 			want:                 integreatlyv1alpha1.PhaseCompleted,
 			verificationFunction: kcAlertHasNotBeenMirrored,
 		},
 		{
-			name:          "alerting rules correctly mirrored without kc alert when OO groups are not nil",
+			name:          "alerting rules correctly mirrored without kc alert when OBO groups are not nil",
 			expectedRules: []monv1.Rule{},
 			installation:  installation,
 			configManager: &config.ConfigReadWriterMock{ReadObservabilityFunc: func() (*config.Observability, error) {
 				return config.NewObservability(config.ProductConfig{
-					"NAMESPACE": "redhat-rhoam-operator",
+					"NAMESPACE": config.GetOboNamespace(installation.Namespace),
 				}), nil
 			}},
-			fakeClient:           utils.NewTestClient(scheme, prometheusRulesSSO, prometheusRulesOOwithKcExisting),
+			fakeClient:           utils.NewTestClient(scheme, prometheusRulesSSO, prometheusRulesOBOwithKcExisting),
 			wantErr:              false,
 			want:                 integreatlyv1alpha1.PhaseCompleted,
 			verificationFunction: kcAlertHasNotBeenMirrored,
@@ -1545,10 +1545,10 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 			installation:  installation,
 			configManager: &config.ConfigReadWriterMock{ReadObservabilityFunc: func() (*config.Observability, error) {
 				return config.NewObservability(config.ProductConfig{
-					"NAMESPACE": "redhat-rhoam-operator",
+					"NAMESPACE": config.GetOboNamespace(installation.Namespace),
 				}), nil
 			}},
-			fakeClient: utils.NewTestClient(scheme, prometheusRulesOOwithKcExisting),
+			fakeClient: utils.NewTestClient(scheme, prometheusRulesOBOwithKcExisting),
 			wantErr:    true,
 			want:       integreatlyv1alpha1.PhaseFailed,
 			verificationFunction: func(pr *monv1.PrometheusRule) bool {
@@ -1573,14 +1573,14 @@ func TestReconciler_reconcileExportAlerts(t *testing.T) {
 				t.Errorf("exportAlerts error got = %v, want %v", got, tt.want)
 			}
 
-			// retrieve update OO rules
+			// retrieve update OBO rules
 			observabilityAlert := &monv1.PrometheusRule{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "rhsso",
-					Namespace: "redhat-rhoam-operator",
+					Namespace: config.GetOboNamespace(installation.Namespace),
 				},
 			}
-			err = tt.fakeClient.Get(context.TODO(), k8sclient.ObjectKey{Name: "rhsso", Namespace: "redhat-rhoam-operator"}, observabilityAlert)
+			err = tt.fakeClient.Get(context.TODO(), k8sclient.ObjectKey{Name: "rhsso", Namespace: config.GetOboNamespace(installation.Namespace)}, observabilityAlert)
 			if err != nil && !tt.wantErr {
 				t.Errorf("exportAlerts error- failed to retrieve rhsso rules; got = %v, want %v", got, tt.want)
 			}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -277,7 +277,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	phase, err = r.newAlertsReconciler(r.Log, r.Installation.Spec.Type, r.Installation.Namespace).ReconcileAlerts(ctx, serverClient)
+	phase, err = r.newAlertsReconciler(r.Log, r.Installation.Spec.Type, config.GetOboNamespace(r.Installation.Namespace)).ReconcileAlerts(ctx, serverClient)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile alerts", err)
 		return phase, err

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -275,7 +275,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, nil
 	}
 
-	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type, ctx, serverClient, r.installation.Namespace)
+	alertsReconciler, err := r.newAlertReconciler(r.log, r.installation.Spec.Type, ctx, serverClient, config.GetOboNamespace(r.installation.Namespace))
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}
@@ -539,7 +539,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
-	alertsReconciler = r.newEnvoyAlertReconciler(r.log, r.installation.Spec.Type, r.installation.Namespace)
+	alertsReconciler = r.newEnvoyAlertReconciler(r.log, r.installation.Spec.Type, config.GetOboNamespace(installation.Namespace))
 	if phase, err := alertsReconciler.ReconcileAlerts(ctx, serverClient); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile threescale alerts", err)
 		return phase, err

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -20,6 +20,7 @@ package resources
 import (
 	"context"
 	"fmt"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
 	"strings"
 
 	"github.com/integr8ly/integreatly-operator/pkg/addon"
@@ -180,7 +181,7 @@ func CreateSmtpSecretExists(ctx context.Context, client k8sclient.Client, cr *v1
 		"product":  installationName,
 	}
 
-	ruleNs := cr.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(cr.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlSendGridSmtpSecretExists, alertFor10Mins, alertExp, labels)
 	if err != nil {
 		return v1alpha1.PhaseFailed, fmt.Errorf("failed to create sendgrid smtp exists rule err: %s", err)
@@ -207,7 +208,7 @@ func CreateAddonManagedApiServiceParametersExists(ctx context.Context, client k8
 		"product":  installationName,
 	}
 
-	ruleNs := cr.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(cr.Namespace)
 	_, err = reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlAddonManagedApiServiceParametersExists, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return v1alpha1.PhaseFailed, fmt.Errorf("failed to create addon-managed-api-service-parameters secret exists rule err: %s", err)
@@ -236,7 +237,7 @@ func CreateDeadMansSnitchSecretExists(ctx context.Context, client k8sclient.Clie
 		alertForXMins = alertFor60Mins
 	}
 
-	ruleNs := cr.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(cr.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, SopUrlDeadMansSnitchSecretExists, alertForXMins, alertExp, labels)
 	if err != nil {
 		return v1alpha1.PhaseFailed, fmt.Errorf("failed to create deadmanssnitch exists rule err: %s", err)
@@ -278,7 +279,7 @@ func createPostgresAvailabilityAlert(ctx context.Context, client k8sclient.Clien
 		"product":     installationName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopURL, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -319,7 +320,7 @@ func createPostgresConnectivityAlert(ctx context.Context, client k8sclient.Clien
 		"product":     installationName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopURL, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -350,7 +351,7 @@ func createPostgresResourceStatusPhasePendingAlert(ctx context.Context, client k
 		"product":     installationName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlPostgresResourceStatusPhasePending, alertFor20Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -381,7 +382,7 @@ func createPostgresResourceStatusPhaseFailedAlert(ctx context.Context, client k8
 		"product":     installationName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlPostgresResourceStatusPhaseFailed, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -411,7 +412,7 @@ func createPostgresResourceDeletionStatusFailedAlert(ctx context.Context, client
 		"product":     installationName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlCloudResourceDeletionStatusFailed, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -453,7 +454,7 @@ func reconcilePostgresFreeStorageAlerts(ctx context.Context, client k8sclient.Cl
 	alertExp := intstr.FromString(
 		fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_postgres_free_storage_average{job='%s'})[1h:1m], 5 * 3600) <= 0 and on (instanceID) (cro_postgres_free_storage_average < ((cro_postgres_current_allocated_storage / 100) * 25)))", job))
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopURL, alertFor60Mins, alertExp, labels)
 	if err != nil {
 		return err
@@ -520,7 +521,7 @@ func reconcilePostgresFreeableMemoryAlert(ctx context.Context, client k8sclient.
 	// conversion formula is MiB = bytes / (1024^2)
 	alertExp := intstr.FromString("(cro_postgres_freeable_memory_average) < ((cro_postgres_max_memory / 100 ) * 10)")
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlPostgresFreeableMemoryLow, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return err
@@ -547,7 +548,7 @@ func reconcilePostgresCPUUtilizationAlerts(ctx context.Context, client k8sclient
 
 	alertExp := intstr.FromString("cro_postgres_cpu_utilization_average > 90")
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlPostgresCpuUsageHigh, alertFor15Mins, alertExp, labels)
 	if err != nil {
 		return err
@@ -575,7 +576,7 @@ func createRedisResourceStatusPhasePendingAlert(ctx context.Context, client k8sc
 		"productName": productName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisResourceStatusPhasePending, alertFor20Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -602,7 +603,7 @@ func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, 
 
 	alertExp := intstr.FromString(fmt.Sprintf("cro_redis_memory_usage_percentage_average > %s", alertPercentage))
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor60Mins, alertExp, labels)
 	if err != nil {
 		return err
@@ -668,7 +669,7 @@ func createRedisResourceStatusPhaseFailedAlert(ctx context.Context, client k8scl
 		"productName": productName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisResourceStatusPhaseFailed, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -695,7 +696,7 @@ func createRedisResourceDeletionStatusFailedAlert(ctx context.Context, client k8
 		"productName": productName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlCloudResourceDeletionStatusFailed, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -733,7 +734,7 @@ func createRedisAvailabilityAlert(ctx context.Context, client k8sclient.Client, 
 		"productName": productName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopURL, alertFor5Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -771,7 +772,7 @@ func createRedisConnectivityAlert(ctx context.Context, client k8sclient.Client, 
 		"productName": productName,
 	}
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	pr, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopURL, alertFor60Mins, alertExp, labels)
 	if err != nil {
 		return nil, err
@@ -797,7 +798,7 @@ func CreateRedisCpuUsageAlerts(ctx context.Context, client k8sclient.Client, ins
 
 	alertExp := intstr.FromString(fmt.Sprintf("cro_redis_engine_cpu_utilization_average > %s", alertPercentage))
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisCpuUsageHigh, alertFor15Mins, alertExp, labels)
 	if err != nil {
 		return err
@@ -822,7 +823,7 @@ func CreateRedisServiceMaintenanceAlerts(ctx context.Context, client k8sclient.C
 
 	alertExp := intstr.FromString("cro_redis_service_maintenance{ServiceUpdateType='security-update',UpdateActionStatus!~'complete|waiting-to-start|in-progress|scheduled|stopping',ServiceUpdateSeverity='critical'}")
 
-	ruleNs := inst.Spec.NamespacePrefix + "operator"
+	ruleNs := config.GetOboNamespace(inst.Namespace)
 	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisServiceMaintenanceCritical, alertFor15Mins, alertExp, labels)
 	if err != nil {
 		return err

--- a/pkg/resources/probes.go
+++ b/pkg/resources/probes.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
@@ -33,7 +34,7 @@ func CreatePrometheusProbe(ctx context.Context, client k8sclient.Client, inst *i
 	probe := &monv1.Probe{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
-			Namespace: inst.Namespace,
+			Namespace: config.GetOboNamespace(inst.Namespace),
 		},
 	}
 	owner.AddIntegreatlyOwnerAnnotations(probe, inst)


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-5781](https://issues.redhat.com/browse/MGDAPI-5781)

# What
As part of phase 1 of the OBO migration, the existing PrometheusRules and Probes were moved from `redhat-rhoam-observability`to `redhat-rhoam-operator` #3235 . However, we have since decided that we will create a new [namespace](https://gitlab.cee.redhat.com/fwaters/managed-tenants-bundles/-/blob/mgdapi-5727-obo/addons/rhoams/package/observability/namespace.yaml.gotmpl) called `redhat-rhoam-operator-observability` that we will use to manage all of the OBO components. This namespace is created via MTBR's PnP functionality and isn't created by integreatly-operator.

This PR moves the PrometheusRules and Probes to this new namespace, `redhat-rhoam-operator-observability`.

# Verification steps
1. Provision an **OSD** cluster 
2. Checkout this PR
3. Prepare the cluster for installation
```bash
INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local
```
4.  Create a CatalogSource on the cluster
```bash
cat << EOF | oc create -f - -n openshift-marketplace
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/ckyrillo/managed-api-service-index:1.36.0
EOF
```
5. Login to the cluster UI and install the RHOAM operator via OperatorHub
6. Create an RHMI CR
```bash
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true LOCAL=false IN_PROW=true make deploy/integreatly-rhmi-cr.yml
```
7. Wait for the installation to finish
8. Confirm that the`monitoring.rhobs/v1` PrometheusRules are not in `redhat-rhoam-operator` and are instead in `redhat-rhoam-operator-observability`
9. Confirm that the`monitoring.rhobs/v1` Probes are not in `redhat-rhoam-operator` and are instead in `redhat-rhoam-operator-observability`