### PR TITLE
MGDAPI-5764 - Removed all instances of local-rhoam-operator 

### DIFF
--- a/envs/managed-api.env
+++ b/envs/managed-api.env
@@ -8,8 +8,3 @@ export OLM_TYPE ?= managed-api-service
 INSTALLATION_NAME ?= rhoam
 INSTALLATION_SHORTHAND ?= rhoam
 NAMESPACE=$(NAMESPACE_PREFIX)operator
-ifeq ($(LOCAL), true)
-	export INSTALLATION_SHORTHAND:=local-rhoam
-	export NAMESPACE_PREFIX:=local-rhoam-
-	export NAMESPACE:=$(NAMESPACE_PREFIX)operator
-endif

--- a/envs/multitenant-managed-api.env
+++ b/envs/multitenant-managed-api.env
@@ -9,8 +9,4 @@ INSTALLATION_NAME ?= rhoam
 INSTALLATION_SHORTHAND ?= sandbox
 NAMESPACE=$(NAMESPACE_PREFIX)operator
 export CLUSTER_CONFIG:=redhat-sandbox
-ifeq ($(LOCAL), true)
-	export INSTALLATION_SHORTHAND:=local-rhoam
-	export NAMESPACE_PREFIX:=local-rhoam-
-	export NAMESPACE:=$(NAMESPACE_PREFIX)operator
-endif
+

--- a/pkg/products/cloudresources/reconciler_test.go
+++ b/pkg/products/cloudresources/reconciler_test.go
@@ -690,7 +690,7 @@ func TestReconciler_reconcileCloudResourceStrategies(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	const testNamespace = "local-rhoam-operator"
+	const testNamespace = "test-namespace"
 
 	type fields struct {
 		Config        *config.CloudResources


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5764

# What
As part of the migration from OO to OBO, RHOAM will leverage MTBR's PnP functionality to deploy/reoncile ServiceMonitors and Probes (and probably other CRs) when installing RHOAM. Due to some limitations with the PnP's templating, we will need to hardcode the namespace for these CRs. This works fine for "redhat-rhoam-operator", "redhat-rhoami-operator", and "sandbox-rhoam-operator" installations because we have distinct folders/mechanisms for each of those installations. However, we don't have a workaround for "local-rhoam-operator" and so we determined that removing it from the codebase was the best path forward.

# Verification steps
Make sure all instances of local-rhoam-operator have been removed from the integreatly-operator codebase.
