### PR TITLE
MGDAPI-5783 refactored some of the e2e tests for OBO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -226,7 +226,7 @@ test/e2e/rhoam/prow: export NAMESPACE:= $(NAMESPACE_PREFIX)operator
 test/e2e/rhoam/prow: export INSTALLATION_PREFIX := redhat-rhoam
 test/e2e/rhoam/prow: export INSTALLATION_NAME := rhoam
 test/e2e/rhoam/prow: export INSTALLATION_SHORTHAND := rhoam
-test/e2e/rhoam/prow: IN_PROW = "true"
+test/e2e/rhoam/prow: export IN_PROW = "true"
 test/e2e/rhoam/prow: test/e2e
 
 .PHONY: test/e2e/multitenant-rhoam/prow
@@ -242,12 +242,12 @@ test/e2e/multitenant-rhoam/prow: export NAMESPACE:= $(NAMESPACE_PREFIX)operator
 test/e2e/multitenant-rhoam/prow: export INSTALLATION_PREFIX := sandbox-rhoam
 test/e2e/multitenant-rhoam/prow: export INSTALLATION_NAME := rhoam
 test/e2e/multitenant-rhoam/prow: export INSTALLATION_SHORTHAND := sandbox
-test/e2e/multitenant-rhoam/prow: IN_PROW = "true"
+test/e2e/multitenant-rhoam/prow: export IN_PROW = "true"
 test/e2e/multitenant-rhoam/prow: test/e2e
 
 .PHONY: test/e2e
 test/e2e: export SURF_DEBUG_HEADERS=1
-test/e2e: cluster/deploy
+test/e2e: cluster/deploy test/prepare/ocp/obo
 	go clean -testcache && go test -v ./test/e2e -timeout=120m -ginkgo.v
 
 .PHONY: test/e2e/single
@@ -267,6 +267,15 @@ test/osde2e: export SKIP_FLAKES := $(SKIP_FLAKES)
 test/osde2e:
 	# Run the osde2e tests against an existing cluster. Make sure you have logged in to the cluster.
 	go clean -testcache && go test ./test/osde2e -test.v -ginkgo.v -ginkgo.progress -timeout=120m
+
+.PHONY: test/prepare/ocp/obo
+test/prepare/ocp/obo:
+	# We need to apply these CRDs and create the -observability project on OCP clusters in order to install RHOAM with OBO.
+	# The Probes CRD will be removed in MGDAPI-5780 and the PrometheusRules CRDS will be removed when Phase 2 of the OBO migration is complete.
+	@oc apply -f https://raw.githubusercontent.com/rhobs/observability-operator/main/bundle/manifests/monitoring.rhobs_probes.yaml
+	@oc apply -f https://raw.githubusercontent.com/rhobs/observability-operator/main/bundle/manifests/monitoring.rhobs_prometheusrules.yaml
+	@ - oc new-project $(NAMESPACE)-observability
+	@oc label namespace $(NAMESPACE)-observability monitoring-key=middleware openshift.io/cluster-monitoring="true" --overwrite
 
 ############ E2E TEST COMMANDS ############
 
@@ -426,7 +435,11 @@ cluster/prepare/rbac/dedicated-admins:
 
 .PHONY: cluster/prepare/rhoam-config
 cluster/prepare/rhoam-config:
+ifeq ($(IN_PROW),true)
+	@echo "Not creating rhoam-config ClusterPackage because IN_PROW is set to true"
+else
 	@-oc process -n $(NAMESPACE) CONFIG_IMAGE=$(CONFIG_IMAGE) NAMESPACE=$(NAMESPACE) -f config/hive-config/package.yaml | oc apply -f -
+endif
 
 .PHONY: cluster/cleanup
 cluster/cleanup: kustomize

--- a/test/common/routes_exist.go
+++ b/test/common/routes_exist.go
@@ -50,21 +50,6 @@ var (
 		},
 	}
 
-	observabilityRoutes = []ExpectedRoute{
-		ExpectedRoute{
-			Name:  "alertmanager",
-			isTLS: true,
-		},
-		ExpectedRoute{
-			Name:  "grafana-route",
-			isTLS: true,
-		},
-		ExpectedRoute{
-			Name:  "prometheus",
-			isTLS: true,
-		},
-	}
-
 	rhssoRoutes = []ExpectedRoute{
 		ExpectedRoute{
 			Name:  "keycloak",
@@ -108,7 +93,6 @@ var (
 
 var managedApiExpectedRoutes = map[string][]ExpectedRoute{
 	"3scale":                       threeScaleRoutes,
-	"observability":                observabilityRoutes,
 	"rhsso":                        rhssoRoutes,
 	"user-sso":                     rhoamUserSsoRoutes,
 	"customer-monitoring-operator": customerGrafanaRoutes,
@@ -116,7 +100,6 @@ var managedApiExpectedRoutes = map[string][]ExpectedRoute{
 
 var mtManagedApiExpectedRoutes = map[string][]ExpectedRoute{
 	"3scale":                       threeScaleRoutes,
-	"observability":                observabilityRoutes,
 	"rhsso":                        rhssoRoutes,
 	"customer-monitoring-operator": customerGrafanaRoutes,
 }

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -444,6 +444,18 @@ func GetAWSSpecificTestCases(installType string) []TestCase {
 	return testCases
 }
 
+func GetObservabilityTestCases(installType string) []TestCase {
+	var testCases []TestCase
+	for _, testSuite := range OBSERVABILITY_TESTS {
+		for _, tsInstallType := range testSuite.InstallType {
+			if string(tsInstallType) == installType {
+				testCases = append(testCases, testSuite.TestCases...)
+			}
+		}
+	}
+	return testCases
+}
+
 func writeObjToYAMLFile(obj interface{}, out string) error {
 	data, err := yaml.Marshal(obj)
 	if err != nil {

--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -37,10 +37,8 @@ var (
 			[]TestCase{
 				// Keep test as first on the list, as it ensures that all products are reported as complete
 				{"A01 - Verify that all stages in the integreatly-operator CR report completed", TestIntegreatlyStagesStatus},
-				{"Test RHMI installation CR metric", TestRHMICRMetrics},
 				{"A03 - Verify all namespaces have been created with the correct name", TestNamespaceCreated},
 				{"A05 - Verify product operator version", TestProductOperatorVersions},
-				{"A06 - Verify PVC", TestPVClaims},
 				{"A07 - Verify product versions", TestProductVersions},
 				{"A08 - Verify all products routes are created", TestIntegreatlyRoutesExist},
 				{"A09 - Verify Subscription Install Plan Strategy", TestSubscriptionInstallPlanType},
@@ -51,17 +49,7 @@ var (
 				{"A15 - Verify Stateful Set resources have the expected replicas", TestStatefulSetsExpectedReplicas},
 				{"A26 - Verify Sendgrid Credentials Are Configured Properly", TestSendgridCredentialsAreValid},
 				{"C01 - Verify Alerts are not pending or firing apart from DeadMansSwitch", TestIntegreatlyAlertsPendingOrFiring},
-				{"C04 - Verify Alerts exist", TestIntegreatlyAlertsExist},
-				{"C10B - Verify Prometheus blackbox targets", TestAdditionalBlackboxTargets},
-				{"C08B - Verify alert links to SOPs", TestSOPUrls},
-				{"E01 - Verify Middleware Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
-				{"E02 - Verify that all dashboards are installed and all the graphs are filled with data", TestDashboardsData},
-				{"E03 - Verify middleware dashboards exist", TestIntegreatlyMiddelewareDashboardsExist},
-				{"E05 - Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
 				{"F02 - Verify PodDisruptionBudgets exist", TestIntegreatlyPodDisruptionBudgetsExist},
-				{"Verify servicemonitors are cloned in monitoring namespace and rolebindings are created", TestServiceMonitorsCloneAndRolebindingsExist},
-				{"Verify Alerts are not firing during or after installation apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
-				{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
 				{"A27 + A28 - Verify pod priority class is created and set", TestPriorityClass},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
@@ -76,8 +64,34 @@ var (
 		},
 		{
 			[]TestCase{
-				{"M02B - Verify RHOAM version metric is exposed in Prometheus", TestRhoamVersionMetricExposed},
 				{"Validate resource requirements are set", ValidateResourceRequirements},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
+		},
+	}
+
+	OBSERVABILITY_TESTS = []TestSuite{
+		//Observability related tests are kept separate from HAPPY_PATH because we skip these tests when IN_PROW is true.
+		//This is because the prow checks run on OCP clusters and OCP clusters don't install OBO by default. See MGDAPI-5783.
+		{
+			[]TestCase{
+				{"Test RHMI installation CR metric", TestRHMICRMetrics},
+				{"A06 - Verify PVC", TestPVClaims},
+				{"C04 - Verify Alerts exist", TestIntegreatlyAlertsExist},
+				{"C10B - Verify Prometheus blackbox targets", TestAdditionalBlackboxTargets},
+				{"C08B - Verify alert links to SOPs", TestSOPUrls},
+				{"E01 - Verify Middleware Grafana Route is accessible", TestGrafanaExternalRouteAccessible},
+				{"E02 - Verify that all dashboards are installed and all the graphs are filled with data", TestDashboardsData},
+				{"E03 - Verify middleware dashboards exist", TestIntegreatlyMiddelewareDashboardsExist},
+				{"E05 - Verify Grafana Route returns dashboards", TestGrafanaExternalRouteDashboardExist},
+				{"Verify Alerts are not firing during or after installation apart from DeadMansSwitch", TestIntegreatlyAlertsFiring},
+				{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
+			},
+			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
+		},
+		{
+			[]TestCase{
+				{"M02B - Verify RHOAM version metric is exposed in Prometheus", TestRhoamVersionMetricExposed},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi},
 		},

--- a/test/e2e/integretly_test.go
+++ b/test/e2e/integretly_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/integr8ly/integreatly-operator/test/common"
 	. "github.com/onsi/ginkgo/v2"
+	"strings"
 )
 
 var _ = Describe("integreatly", func() {
@@ -41,10 +42,21 @@ var _ = Describe("integreatly", func() {
 				Type:      fmt.Sprintf("%s Threescale Cluster Scoped", installType),
 				TestCases: common.GetClusterScopedTestCases(installType),
 			},
+		}
+
+		observabilityTests := []common.Tests{
+			{
+				Type:      fmt.Sprintf("%s OBSERVABILITY TESTS", installType),
+				TestCases: common.GetObservabilityTestCases(installType),
+			},
 			{
 				Type:      "FAILURE TESTS",
 				TestCases: common.FAILURE_TESTS,
 			},
+		}
+
+		if strings.Trim(os.Getenv("IN_PROW"), "\"") != "true" {
+			tests = append(tests, observabilityTests...)
 		}
 
 		if os.Getenv("DESTRUCTIVE") == "true" {

--- a/test/functional/integreatly_test.go
+++ b/test/functional/integreatly_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	v1 "github.com/openshift/api/config/v1"
 
@@ -72,6 +73,12 @@ var _ = Describe("integreatly", func() {
 				Type:      "FAILURE TESTS",
 				TestCases: common.FAILURE_TESTS,
 			},
+		}
+		if strings.Trim(os.Getenv("IN_PROW"), "\"") != "true" {
+			tests = append(tests, common.Tests{
+				Type:      fmt.Sprintf("%s OBSERVABILITY TESTS", installType),
+				TestCases: common.GetObservabilityTestCases(installType),
+			})
 		}
 
 		testingContext, err := common.NewTestingContext(restConfig)

--- a/test/osde2e/managed_api_test.go
+++ b/test/osde2e/managed_api_test.go
@@ -30,6 +30,10 @@ var _ = Describe("integreatly", func() {
 				Type:      fmt.Sprintf("%s HAPPY PATH", installType),
 				TestCases: common.GetHappyPathTestCases(installType),
 			},
+			{
+				Type:      fmt.Sprintf("%s OBSERVABILITY TESTS", installType),
+				TestCases: common.GetObservabilityTestCases(installType),
+			},
 		}
 
 		for _, test := range tests {


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-5783](https://issues.redhat.com/browse/MGDAPI-5783)

# What
The e2e prow checks([example](https://github.com/integr8ly/integreatly-operator/pull/3235)) are failing when run on the OBO [feature branch](https://github.com/integr8ly/integreatly-operator/tree/mgdapi-5727-obo) because the prow checks are run on OCP clusters and OCP clusters don't have the package-operator (or OBO) installed by default. In order to get around this, we need to move any tests that rely on any observability components into a new test suite. We will then only run that test suite when the IN_PROW [environment variable](https://github.com/integr8ly/integreatly-operator/blob/mgdapi-5727-obo/Makefile#L17) is set to false. We also want to update the Makefile to only run [cluster/prepare/rhoam-config](https://github.com/integr8ly/integreatly-operator/blob/mgdapi-5727-obo/Makefile#L427-L429) when IN_PROW is set to false.

**NOTE:** the scope of this ticket is not to refactor all tests to be compatible with OBO or remove any/all references to OO in the test suite. The scope of this ticket is just to get majority of the e2e tests working while development on the OBO feature branch continues. A complete refactor of the e2e test suite that removes references to OO will be completed in a followup ticket.

# Verification steps
Assuming the e2e PROW checks pass, the only other verification this PR needs is an eye review.
