### PR TITLE
MGDAPI-5706 - updated access to prometheus pod and changed namespace

### DIFF
--- a/scripts/alerts-check.sh
+++ b/scripts/alerts-check.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # USAGE
-# ./alerts-check.sh <optional sleep in seconds> <optional product-name>
+# ./alerts-check.sh <optional product-name>
 # ^C to break
 # Generates two files one for firing and one for pending alerts
 #
@@ -16,98 +16,159 @@ do
     sleep 60
 done
 
+ROUTE="http://localhost:9090/api/v1/alerts"
 NAMESPACE_PREFIX="${NAMESPACE_PREFIX:-$(oc get RHMIs --all-namespaces -o jsonpath='{.items[0].spec.namespacePrefix}')}"
-
+TOKEN=$(oc whoami --show-token)
 # wait for monitoring route to appear and have host populated
-until oc get route prometheus -n ${NAMESPACE_PREFIX}observability -o=jsonpath='{.spec.host}' &> /dev/null
+# wait for rhoam install to be complete
+until oc exec -n ${NAMESPACE_PREFIX}operator-observability prometheus-rhoam-0 -- wget -qO- --header='Accept: application/json' --header="Authorization: Bearer $TOKEN" --no-check-certificate $ROUTE &> /dev/null && [[ $(oc get rhmi rhoam -n ${NAMESPACE_PREFIX}operator -o json | jq -r '.status.stage') == "complete" ]]
 do
-    echo "Waiting for Prometheus route in ${NAMESPACE_PREFIX}observability namespace to appear on cluster. Next check to be in 1 minute."
+    echo "Waiting for ${NAMESPACE_PREFIX}operator-observability pods to be available and RHOAM installation to be complete. Next check in 1 minute."
     sleep 60
 done
 
-RHSSO="rhsso"
-USER_SSO="user-sso"
-THREESCALE="3scale"
-MONITORING_ROUTE=$(echo "https://$(oc get route prometheus -n ${NAMESPACE_PREFIX}observability -o=jsonpath='{.spec.host}')")/api/v1/alerts
-REPORT_PREFIX=$(date +"%Y-%m-%d-%H-%M")
+OPENSHIFT_MONITORING=$(oc exec -n openshift-monitoring prometheus-k8s-0 -- curl $ROUTE -s -H "Authorization: Bearer $TOKEN")
+RHOAM_MONITORING=$(oc exec -n ${NAMESPACE_PREFIX}operator-observability prometheus-rhoam-0 -- wget -qO- --header='Accept: application/json' --header="Authorization: Bearer $TOKEN" --no-check-certificate $ROUTE)
+# Define an array of monitoring data sources
+declare -A monitoring_sources=(
+  ["rhoam"]=$RHOAM_MONITORING
+  ["openshift"]=$OPENSHIFT_MONITORING
+)
 
-SLEEP_TIME="${1-5}"
-TOKEN=$(oc whoami --show-token)
-PRODUCT_NAME=`echo $2 | grep "3scale\|user-sso\|rhsso\|marin3r"`
+# Define an array of products to report on
+declare -a products=("3scale" "user-sso" "rhsso" "marin3r")
+
+# Define an array of alert states to report on
+declare -a alert_states=("pending" "firing")
 
 # remove tmp files on ctrl-c
-trap "rm tmp-alert-firing-report.csv tmp-alert-pending-report.csv" EXIT
+trap 'find . -name "tmp-*" -delete; for source_name in "${!monitoring_sources[@]}"; do for alert_state in "${alert_states[@]}"; do if [[ -f "tmp-${source_name}-alert-${alert_state}-during-perf-testing-report.csv" ]]; then rm "tmp-${source_name}-alert-${alert_state}-during-perf-testing-report.csv"; fi; done; done' EXIT
 
 # function to check if there are no alerts firing bar deadmansnitch
-function CHECK_NO_ALERTS(){
-    if [[ $(curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE | jq -r '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt, .labels.severity ] | @csv' | wc -l  | xargs ) == 1 ]] ; then
-      echo Only alert firing is DeadMansSwitch
-      date
-    else
-      echo "============================================================================"
-      echo Following alerts are Firing at :
-      date
-      cat ${REPORT_PREFIX}${PRODUCT_NAME}-alert-firing-report.csv
-      echo "============================================================================"
-      echo Following alerts are Pending :
-      date
-      cat ${REPORT_PREFIX}${PRODUCT_NAME}-alert-pending-report.csv
-      echo "============================================================================"
-    fi
+function CHECK_NO_ALERTS() {
+  # Extract firing alerts from OpenShift monitoring
+  openshift_alerts=$(echo "$OPENSHIFT_MONITORING" | jq -r '.data.alerts[] | select(.state == "firing") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
 
-    sleep $SLEEP_TIME
-    if [[ $? != 0 ]]; then
-        sleep 5
-    fi
+  # Extract firing alerts from RHOAM monitoring
+  rhoam_alerts=$(echo "$RHOAM_MONITORING" | jq -r '.data.alerts[] | select(.state == "firing") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
+
+  # Extract pending alerts from OpenShift monitoring
+  openshift_alerts_pending=$(echo "$OPENSHIFT_MONITORING" | jq -r '.data.alerts[] | select(.state == "pending") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
+
+  # Extract pending alerts from RHOAM monitoring
+  rhoam_alerts_pending=$(echo "$RHOAM_MONITORING" | jq -r '.data.alerts[] | select(.state == "pending") | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv')
+
+  # Combine and sort the alerts
+  all_alerts=$(echo -e "${openshift_alerts}\n${rhoam_alerts}" | sort)
+
+  all_alerts_pending=$(echo -e "${openshift_alerts_pending}\n${rhoam_alerts_pending}" | sort)
+
+  # Check if there are no firing alerts
+  if [[ $(echo "$all_alerts" | wc -l | xargs) == 1 ]]; then
+    echo Only alert firing is DeadMansSwitch
+    date
+    sleep 5
+  elif [[ $(echo "$rhoam_alerts" | wc -l | xargs) == 1 ]] && [[ $(echo "$openshift_alerts" | wc -l | xargs) != 1 ]]; then
+    echo "============================================================================"
+    date
+    echo "Only alert firing is DeadMansSwitch for ${NAMESPACE_PREFIX}operator-observability"
+    echo "$rhoam_alerts"
+    echo "----------------------------------------------------------------------------"
+    echo "Following alerts are firing for openshift-monitoring:"
+    echo "$openshift_alerts"
+    echo "============================================================================"
+    echo "Following alerts are pending for openshift-monitoring:"
+    echo "$openshift_alerts_pending"
+    echo "============================================================================"
+  elif [[ $(echo "$rhoam_alerts" | wc -l | xargs) != 1 ]] && [[ $(echo "$openshift_alerts" | wc -l | xargs) == 1 ]]; then
+    echo "============================================================================"
+    date
+    echo Only alert firing is DeadMansSwitch for openshift-monitoring
+    echo "$openshift_alerts"
+    echo "----------------------------------------------------------------------------"
+    echo "Following alerts are firing for ${NAMESPACE_PREFIX}operator-observability:"
+    echo "$rhoam_alerts"
+    echo "============================================================================"
+    echo "Following alerts are pending for ${NAMESPACE_PREFIX}operator-observability:"
+    echo "$rhoam_alerts_pending"
+    echo "============================================================================"
+  else
+    echo "============================================================================"
+    echo "Following alerts are firing:"
+    date
+    echo "$all_alerts"
+    echo "============================================================================"
+    echo "Following alerts are pending:"
+    date
+    echo "$all_alerts_pending"
+    echo "============================================================================"
+  fi
+
+  sleep 5
+
 }
 
-# If product name not passed in then run for all products
-if [[ -z "$PRODUCT_NAME" ]]; then
-  while :; do
-    # generate a report
-    curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-    | jq -r '.data.alerts[]| select(.state=="pending") | [.labels.alertname, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-pending-report.csv
+for product_name in "${products[@]}"; do
+  if [[ "$1" != "$product_name" ]] && [[ "$1" != "" ]]; then
+    continue
+  fi
 
-    curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-    | jq -r '.data.alerts[]| select(.state=="firing") | [.labels.alertname, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-firing-report.csv
+  # Loop over each monitoring source
+  for source_name in "${!monitoring_sources[@]}"; do
+    source_data="${monitoring_sources[$source_name]}"
 
-    # sort command to remove duplicate alert
-    sort -t',' -k 1,1 -u tmp-alert-firing-report.csv > ${REPORT_PREFIX}-alert-firing-report.csv
-    #sort -t, -k1 -u alert-firing-report.csv > alert-firing-report.csv
-    sort -t, -k1 -u tmp-alert-pending-report.csv > ${REPORT_PREFIX}-alert-pending-report.csv
-    CHECK_NO_ALERTS
+    # Loop over each alert state to report on
+    for alert_state in "${alert_states[@]}"; do
+      # Generate a report for the current product, alert state, and monitoring source
+      if [ $product_name == "rh-sso" ] || [ $product_name == "user-sso" ]; then
+        echo "$source_data" |
+          jq -r --arg state "$alert_state" --arg product "$product_name" '.data.alerts[] | select(.state==$state and (.labels.namespace==$product or .labels.namespace==($product+"-operator") or .labels.productName==$product or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt] | @csv' >>"tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv"
+      elif [ $product_name == "3scale" ]; then
+        echo "$source_data" |
+          jq -r --arg state "$alert_state" --arg product "$product_name" '.data.alerts[] | select(.state==$state and (.labels.namespace==$product or .labels.namespace==($product+"-operator") or .labels.productName==$product or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt] | @csv' >>"tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv"
+      else
+        echo "$source_data" |
+          jq -r --arg state "$alert_state" --arg product "$product_name" '.data.alerts[] | select(.state==$state and (.labels.namespace==$product or .labels.namespace==($product+"-operator") or .labels.productName==$product)) | [.labels.alertname, .labels.namespace, .state, .activeAt] | @csv' >>"tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv"
+      fi
+
+      # Generate a report for the current product, alert state, and monitoring source and make sure it's not empty
+      report_data=$(echo "$source_data" | jq -r --arg state "$alert_state" --arg product "$product_name" '.data.alerts[] | select(.state==$state and (.labels.namespace==$product or .labels.namespace==($product+"-operator") or .labels.productName==$product or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt] | @csv')
+      echo "$report_data" >>"tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv"
+      
+      file="tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv"
+      # Check if file is empty
+      if [ ! -n "$(cat "$file")" ]; then
+        echo "File $file is empty, removing it"
+        rm "$file"
+      else
+        # Sort the report to remove duplicates
+        sort -t',' -k 1,1 -u "tmp-${source_name}-alert-${alert_state}-${product_name}-during-perf-testing-report.csv" -o "${product_name}-alert-${alert_state}-during-perf-testing-report.csv"
+      fi
+
+    done
   done
-fi
 
-# Check the alerts in product namespaces
-if [ -z "$PRODUCT_NAME" ]; then
-  echo Error command line either no args or args excepted for individual products alerts listed below
-  echo - "3scale"
-  echo - "user-sso"
-  echo - "rhsso"
-  echo - "marin3r"
-else
-  echo "Check $PRODUCT_NAME product namespace and operator namespace for alerts"
+  CHECK_NO_ALERTS
+done
+
+#If no args are passed in then run for all products
+if (($# == 0)); then
   while :; do
-    if [ $PRODUCT_NAME == $RHSSO ] || [ $PRODUCT_NAME == $USER_SSO ]; then
-      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-pending-report.csv
-      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("Keycloak.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-firing-report.csv
-    elif [ $PRODUCT_NAME == $THREESCALE ]; then
-     curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-     | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-pending-report.csv
-     curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-     | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'" or (.labels.alertname|test("ThreeScale.+")))) | [.labels.alertname, .labels.namespace, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-firing-report.csv
-   else
-      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="pending") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt ] | @csv'>> tmp-alert-pending-report.csv
-      curl -s -H "Authorization: Bearer $TOKEN" $MONITORING_ROUTE \
-      | jq -r '.data.alerts[]| select((.state=="firing") and (.labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'" or .labels.namespace=="'$NAMESPACE_PREFIX''$PRODUCT_NAME'-operator" or .labels.productName=="'$PRODUCT_NAME'")) | [.labels.alertname, .labels.namespace, .state, .activeAt, .labels.severity ] | @csv'>> tmp-alert-firing-report.csv
-    fi
-    # sort command to remove duplicate alert
-    sort -t, -k1 -u tmp-alert-pending-report.csv > ${REPORT_PREFIX}${PRODUCT_NAME}-alert-pending-report.csv
-    sort -t, -k1 -u tmp-alert-firing-report.csv > ${REPORT_PREFIX}${PRODUCT_NAME}-alert-firing-report.csv
+
+    # Loop over each monitoring source
+    for source_name in "${!monitoring_sources[@]}"; do
+      source_data="${monitoring_sources[$source_name]}"
+
+      # Loop over each alert state to report on
+      for alert_state in "${alert_states[@]}"; do
+        # Generate a report for the current alert state and monitoring source
+        echo "$source_data" |
+          jq -r --arg state "$alert_state" '.data.alerts[] | select(.state==$state) | [.labels.alertname, .state, .activeAt, .labels.severity] | @csv' >>"tmp-${source_name}-alert-${alert_state}-during-perf-testing-report.csv"
+
+        # Sort the report to remove duplicates
+        sort -t',' -k 1,1 -u "tmp-${source_name}-alert-${alert_state}-during-perf-testing-report.csv" -o "${source_name}-alert-${alert_state}-during-perf-testing-report.csv"
+      done
+    done
 
     CHECK_NO_ALERTS
   done

--- a/scripts/monitoringupgradetest.sh
+++ b/scripts/monitoringupgradetest.sh
@@ -43,12 +43,12 @@ done
 # The time is noted and stored for use later
 while true
 do
-  ooPrometheus=$(oc get statefulset prometheus-prometheus -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
+  ooPrometheus=$(oc get statefulset prometheus-rhoam -n redhat-rhoam-operator-observability -o yaml | yq e '.status.readyReplicas' -)
   if [ "$ooPrometheus" -ge 1 ]; then
     echo "Prometheus reporting 1 replica ready"
-    ooAlertManager=$(oc get statefulset alertmanager-alertmanager -n redhat-rhoam-observability -o yaml | yq e '.status.readyReplicas' -)
+    ooAlertManager=$(oc get statefulset alertmanager-rhoam -n redhat-rhoam-operator-observability -o yaml | yq e '.status.readyReplicas' -)
     if [ "$ooAlertManager" -ge 1 ]; then
-      echo "AlertManager reporting 1 replica ready"
+      echo "AlertManager reporting 2 replica ready"
       date +"%T"
       END=$(date +%s);
       break


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5706

# What
- Changed scripts to access prometheus api endpoints without using a route.
- Modified scripts to access `redhat-rhoam-operator-observability` namespace instead of the depreciated `redhat-rhoam-observability` namespace.
 

# Verification steps
- Create a cluster
- Once cluster is created sign into it and run these commands: 
1. `INSTALLATION_TYPE=managed-api LOCAL=false make cluster/prepare/local`

## Running *alert-check.sh*
- run the script `scripts/alert-check.sh `
- `INSTALLATION_TYPE=managed-api LOCAL=false  make code/run  ` , wait for install to complete.
- THe script should be waiting and only complete once rhoam install is finished.
- Scale down a resource causing an alert to fire eg. *3scale*
- Make sure it generates all the necessary csv files corresponding to the firing/pending alerts
- It is also possible to check individual products by running eg. `scripts/alert-check.sh  3scale`

This should be the output along with a csv file listing all the alerts:
![image](https://github.com/integr8ly/integreatly-operator/assets/59964862/262d2844-d8dc-40e9-9eca-df6beba3311c)


## Running *capture-resource-metrics.sh*
- Create necessary files following the instructions on the top of the file.
- run `scripts/capture_resource_metrics.sh`

The output should be a list of metrics generated in the terminal

**Note** if you get an error such as:
`wget: server returned error: HTTP/1.1 400 Bad Request`
1. Make sure your cluster login hasn't timed out.
2. Try removing the timestamp files and creating them again making sure you create the start time first.

## Running *monitoringupgradetest.sh*
- Create an OLM upgrade scenario
- Before triggering the upgrade run the script `scripts/monitoringupgradetest.sh`
- Make sure there are no errors