### PR TITLE
MGDAPI-5834 - bump redis engine 6.2

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -59,7 +59,7 @@ const (
 	cidrRangeKeyGcp              = "cidr-range-gcp"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001"}
+var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}


### PR DESCRIPTION
# Issue link
[MGDAPI-5834](https://issues.redhat.com/browse/MGDAPI-5834)

# What
Add the new service update with id `elasticache-redis-6-2-update` to the list of updates.

# Verification steps

Eye review of the changes should be sufficient, but you can confirm by following the steps:

1. Once the cluster is ready checkout this PR

2. Install RHOAM

3. Deploy the Workload App on the cluster by running the following commands:
3.1 Login to the RHOAM cluster using `oc login` command
3.2 Set `export GRAFANA_DASHBOARD=true` 
3.3 Run this command to deploy the app: `make local/deploy`

4. Check that there is no downtime
4.1 In the OSD UI navigate to the `redhat-rhoam-observability` project
4.2 On the left hand side choose Networking -> Routes -> `grafana-route` location URL
4.3 Click on dashboards icon and choose Manage
4.4 Go to the `Workload App` folder and make sure there is no downtime

Don't forget to undeploy workload-web-app and uninstall rhoam
