### PR TITLE
MGDAPI-5377 alerts-check.sh can be triggered before RHOAM is installed

### DIFF
--- a/scripts/alerts-check.sh
+++ b/scripts/alerts-check.sh
@@ -8,7 +8,23 @@
 # - jq
 # - oc (logged in at the cmd line in order to get the bearer token)
 # VARIABLES
+
+# wait for RHMI CR to appear and have namespace prefix populated
+until oc get RHMIs --all-namespaces -o jsonpath='{.items[0].spec.namespacePrefix}' &> /dev/null
+do
+    echo "Waiting for RHMI CR with namespace prefix set to appear on cluster. Next check to be in 1 minute."
+    sleep 60
+done
+
 NAMESPACE_PREFIX="${NAMESPACE_PREFIX:-$(oc get RHMIs --all-namespaces -o jsonpath='{.items[0].spec.namespacePrefix}')}"
+
+# wait for monitoring route to appear and have host populated
+until oc get route prometheus -n ${NAMESPACE_PREFIX}observability -o=jsonpath='{.spec.host}' &> /dev/null
+do
+    echo "Waiting for Prometheus route in ${NAMESPACE_PREFIX}observability namespace to appear on cluster. Next check to be in 1 minute."
+    sleep 60
+done
+
 RHSSO="rhsso"
 USER_SSO="user-sso"
 THREESCALE="3scale"


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5377

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

It needs to be possible for the script to do its job even if triggered before RHOAM installation starts on the cluster. That way it is possible to use the script to monitor firing/pending alerts during the whole time of RHOAM installation.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

I validated this in Playground:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/trepel/job/rosa-install-alerts-check/7/artifact/alerts-408/
- as you can see the script waited for RHMI CR and Prometheus route as expected (408-alerts-check.log)
- csv files with firing/pending alerts were created as well

If you want to validate manually, run the script against clean cluster (RHOAM not installed, you need to do oc login first). It should keep running. Trigger the RHOAM installation on cluster and once Prometheus is up and running it should start monitoring the alerts. Stop the script (ctrl+c) when RHOAM installation finishes and inspect the created files

`./scripts/alerts-check.sh | tee alert-check.log`


