### PR TITLE
MGDAPI-5867 update envoy image

### DIFF
--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.2-3"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.4-3"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.2-3"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.4-3"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"

--- a/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh
+++ b/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-go run test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go -- \
+go run ./scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go -- \
     --namespace-prefix redhat-rhoam- \
     --iterations 10


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5867

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Bump envoy proxy image for better image grading

# Verification steps
<!-- describe verification steps with sufficient level of detail -->
<!-- take into consideration upgrade scenario, RHMI 2.x, etc. -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
## Verifiy Fresh Install
* Checkout this branch
* Install RHOAM
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Verify install complete successfully
* Verify image in used in annotations 
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Open new go workspace in test folder
* Run `./scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected


## Verify Upgrade
* Unintall RHAOM
* Checkout master
* Install from master
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Once installation complete, stop the opertor
* Checkout this branch
* Run operator
```
make code/run
```
* Verify apicast / backend-listener pods are redeployed
```
 watch "oc get pods -n redhat-rhoam-3scale | grep -E 'apicast|backend-listener'; echo "RHMI CR Status:"; oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq '.status.stage'"
```
* Verify image in used in annotations
```
oc get dc apicast-production -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc apicast-staging -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
oc get dc backend-listener -n redhat-rhoam-3scale -o json | jq '.spec.template.metadata.annotations."marin3r.3scale.net/envoy-image"'
```
* Open new go workspace in test folder
* Run `./scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh` to ensure that ratelimiting works as expected

