### PR TITLE
MGDAPI-5857 - return non-empty result to requeue rhmi controller

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -1009,7 +1009,7 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 				return ctrl.Result{}, err
 			}
 
-			return ctrl.Result{}, err
+			return result, nil
 		}
 		log.Infof("found required secret", l.Fields{"secret": secretName})
 		eventRecorder.Eventf(installation, "Normal", rhmiv1alpha1.EventPreflightCheckPassed,


### PR DESCRIPTION
# Issue link
[MGDAPI-5857](https://issues.redhat.com/browse/MGDAPI-5857)

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
- Fix a [bug](https://github.com/integr8ly/integreatly-operator/pull/3297/commits/e6ac2c59057596332bb43232f05a8dd75aad20de) when rhoam install stucks if pagerduty secret does not exist.
- Update a logic by removing extra `ctrl.Result`s in preflightChecks and handleUninstall functions as we already have `ctrl.Result` in Reconcile function.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- Eye review of the code changes should be sufficient, but if you want you can debug and see if rhoam install does not stuck if pagerduty secret does not exist - don't forget to remove `redhat-rhoam-pagerduty` secret before debugging 
