### PR TITLE
MGDAPI-5762 - update test cases which refer to workload-web-app

### DIFF
--- a/test-cases/tests/alerts/c05b-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
+++ b/test-cases/tests/alerts/c05b-verify-alerts-are-exposed-and-no-critical-alerts-have-fired.md
@@ -60,10 +60,10 @@ Testcase should not be performed on a cluster that has been used for destructive
    > 2. Create a followup bug JIRA and inform release coordinators. Example JIRA: https://issues.redhat.com/browse/INTLY-9443
    > 3. Request that cluster lifespan be extended to allow time for cluster to be investigated (ask release coordinator).
 
-6. Open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace
+6. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
 ```bash
-echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
 ```
 
 7. Select the **Workload App** dashboard

--- a/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
+++ b/test-cases/tests/multiAZ/p01-measure-downtime-during-down-az.md
@@ -45,7 +45,6 @@ Measure the downtime of the RHOAM components during a AWS Availability Zone fail
    git clone https://github.com/integr8ly/workload-web-app
    cd workload-web-app
    export GRAFANA_DASHBOARD=true
-   export RHOAM=true
    make local/deploy
    oc scale dc workload-web-app --replicas=3 -n workload-web-app
    ```
@@ -181,10 +180,10 @@ Measure the downtime of the RHOAM components during a AWS Availability Zone fail
 
 > Note: the critical 3scale components that _must not_ report any downtime are `apicast-production`, `backend-worker`, and `backend-listener`. On the other hand, the non-critical 3scale components that are ok to experience short downtime (up to 2-3 minutes) are `backend-cron`, `zync-database`, `system-memcache`, `system-sphinx`.
 
-13. Open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace
+13. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
     ```bash
-    echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+    echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
     ```
 
 14. Select the **Workload App** dashboard

--- a/test-cases/tests/products/h21b-verify-all-products-using-the-workloadwebapp.md
+++ b/test-cases/tests/products/h21b-verify-all-products-using-the-workloadwebapp.md
@@ -30,7 +30,7 @@ The [workload-web-app](https://github.com/integr8ly/workload-web-app) will:
    IMPORTANT. Make sure that you don't run `make local/deploy` again, as this will break the monitoring dashboard. If **workload-web-app** namespace exists in the cluster, the workload-web-app has already been deployed.
 
    ```bash
-    export GRAFANA_DASHBOARD=true RHOAM=true
+    export GRAFANA_DASHBOARD=true
     make local/deploy
    ```
 
@@ -42,10 +42,10 @@ The [workload-web-app](https://github.com/integr8ly/workload-web-app) will:
    > THREE_SCALE_URL=https://...
    > ```
 
-4. Open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace
+4. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
    ```bash
-   echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+   echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
    ```
 
 5. Select the **Workload App** dashboard

--- a/test-cases/tests/products/h25-verify-rate-limiting-can-be-disabled-and-reenabled-by-follow.md
+++ b/test-cases/tests/products/h25-verify-rate-limiting-can-be-disabled-and-reenabled-by-follow.md
@@ -39,10 +39,10 @@ This test case should prove that it is possible for SRE to disable/enable rate l
 
 1. Go to https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/blob/master/sops/rhoam/rate-limit/disable.md
 2. Follow and validate the steps in SOP for disabling rate limit service
-3. Open the RHOAM Grafana Console in the `redhat-rhmi-observability` namespace
+3. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
 ```bash
-open "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+open "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
 ```
 
 4. Select the **Workload App** dashboard

--- a/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
+++ b/test-cases/tests/upgrade/n01b-measure-downtime-during-openshift-upgrade.md
@@ -36,7 +36,7 @@ oc login --token=<TOKEN> --server=https://api.<CLUSTER_NAME>.s1.devshift.org:644
    ```
    git clone https://github.com/integr8ly/workload-web-app
    cd workload-web-app
-   export GRAFANA_DASHBOARD=true RHOAM=true
+   export GRAFANA_DASHBOARD=true
    make local/deploy
    ```
 
@@ -103,10 +103,10 @@ CLUSTER_ID=$(ocm get clusters --parameter search="name like '%$CLUSTER_NAME%'" |
 
 > Note: the critical 3scale components that _must not_ report any downtime are `apicast-production`, `backend-worker`, and `backend-listener`. On the other hand, the non-critical 3scale components that are ok to experience short downtime (up to 2-3 minutes) are `backend-cron`, `zync-database`, `system-memcache`, `system-sphinx`.
 
-9. Open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace
+9. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
 ```bash
-echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
 ```
 
 10. Select the **Workload App** dashboard

--- a/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
+++ b/test-cases/tests/upgrade/n10-verify-quota-feature-upgrade.md
@@ -43,7 +43,7 @@ Measure the downtime of the RHOAM components during Quota change. Verify quota i
    ```
    git clone https://github.com/integr8ly/workload-web-app
    cd workload-web-app
-   export GRAFANA_DASHBOARD=true RHOAM=true
+   export GRAFANA_DASHBOARD=true
    make local/deploy
    ```
 
@@ -51,10 +51,10 @@ Measure the downtime of the RHOAM components during Quota change. Verify quota i
 
    There should be no errors in the command output and product (3scale, SSO) URLS should not be blank. Alternatively, you can check the `Environment` tab in workload-webapp namespace in OpenShift console.
 
-3. Open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace
+3. Open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
 ```bash
-echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
 ```
 
 4. Select the **Workload App** dashboard
@@ -110,12 +110,12 @@ EOF
 ocm get /api/clusters_mgmt/v1/clusters/$CLUSTER_ID/addons/managed-api-service
 ```
 
-6. After Quota change is done, open the RHOAM Grafana Console in the `redhat-rhoam-observability` namespace again
+6. After Quota change is done, open the RHOAM Grafana Console in the `redhat-rhoam-customer-monitoring-operator` namespace
 
 > Quota change is done when `toQuota` disappears from RHMI `rhoam` CR and `quota` is set to the expected value. Quota change takes ~1 minute.
 
 ```bash
-echo "https://$(oc get route grafana-route -n redhat-rhoam-observability -o=jsonpath='{.spec.host}')"
+echo "https://$(oc get route grafana-route -n redhat-rhoam-customer-monitoring-operator -o=jsonpath='{.spec.host}')"
 ```
 
 7. Select the **Workload App** dashboard


### PR DESCRIPTION
# Issue link
[MGDAPI-5762](https://issues.redhat.com/browse/MGDAPI-5762)

# What
Update test cases which refers to the workload-web-app as it was moved to another namespace: from `redhat-rhoam-observability` to `redhat-rhoam-customer-monitoring-operator`

# Verification steps
Eye review of the code changes
