### PR TITLE
MGDAPI-5890 changes to support 100mln redis bump

### DIFF
--- a/controllers/subscription/subscription_controller.go
+++ b/controllers/subscription/subscription_controller.go
@@ -19,8 +19,11 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/integr8ly/cloud-resource-operator/apis/integreatly/v1alpha1"
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
 	catalogsourceClient "github.com/integr8ly/integreatly-operator/pkg/resources/catalogsource"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	operatorsv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 
@@ -115,9 +118,54 @@ func (r *SubscriptionReconciler) Reconcile(ctx context.Context, request ctrl.Req
 		return ctrl.Result{}, nil
 	}
 
+	// Remove code below post 1.38.0 delivery to production
+	// Temporary code to update backend redis 100mln to specific value
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhoam",
+			Namespace: "redhat-rhoam-operator",
+		},
+	}
+	err := r.Get(context.TODO(), k8sclient.ObjectKey{Name: installation.Name, Namespace: installation.Namespace}, installation)
+	if err != nil {
+		if !k8serr.IsNotFound(err) {
+			return ctrl.Result{}, err
+		}
+	}
+	// Only apply below logic for existing installations, we can't rely on toVersion not present due to possible race condition
+	// between sub and rhmi controller
+	if installation.Status.Version != "" {
+		// Only apply below logic for 100 mln quota installations
+		if installation.Status.Quota == "100 Million" {
+			// at this point, it's safe to assume the backend redis exists
+			backendRedis := &v1alpha1.Redis{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "threescale-backend-redis-rhoam",
+					Namespace: "redhat-rhoam-operator",
+				},
+			}
+
+			err = r.Client.Get(context.TODO(), k8sclient.ObjectKey{Name: backendRedis.Name, Namespace: backendRedis.Namespace}, backendRedis)
+			if err != nil {
+				return ctrl.Result{}, err
+			}
+
+			// Only apply logic if backend redis node size is not cache.m5.xlarge
+			if backendRedis.Spec.Size != "cache.m5.xlarge" {
+				backendRedis.Spec.Size = "cache.m5.xlarge"
+
+				err = r.Client.Update(ctx, backendRedis)
+				if err != nil {
+					return ctrl.Result{}, err
+				}
+			}
+		}
+	}
+	// Remove code above post 1.38.0 delivery to production
+
 	log.Infof("Reconciling subscription", l.Fields{"request": request, "opNS": r.operatorNamespace})
 	subscription := &operatorsv1alpha1.Subscription{}
-	err := r.Get(context.TODO(), request.NamespacedName, subscription)
+	err = r.Get(context.TODO(), request.NamespacedName, subscription)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request. Return and don't requeue

--- a/pkg/config/threescale.go
+++ b/pkg/config/threescale.go
@@ -166,7 +166,7 @@ func (t *ThreeScale) GetBackendRedisNodeSize(activeQuota string, platformType co
 	if activeQuota == quota.OneHundredMillionQuotaName {
 		switch platformType {
 		case configv1.AWSPlatformType:
-			return "cache.m5.large"
+			return "cache.m5.xlarge"
 		case configv1.GCPPlatformType:
 			// size in GB on GCP
 			return "11"

--- a/pkg/config/threescale_test.go
+++ b/pkg/config/threescale_test.go
@@ -35,7 +35,7 @@ func TestThreeScale_GetBackendRedisNodeSize(t1 *testing.T) {
 				activeQuota:  quota.OneHundredMillionQuotaName,
 				platformType: configv1.AWSPlatformType,
 			},
-			want: "cache.m5.large",
+			want: "cache.m5.xlarge",
 		},
 		{
 			name: "test 11 is returned when active quota is 100 M and platformType GCP",


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5890

# What
Bumped 100mln quota redis size to cache.m5.xlarge

# Verification steps
Must be done via OLM on CCS cluster with cluster storage set to false.
## Fresh install
- Via OLM, install 1.38.0 (you can use this index: 'quay.io/mstoklus/managed-api-service-index:1.38.0'
- Confirm that 100mln backend redis is now of cache.m5.xlarge size and that installation does not crash at any point

## Upgrade
- Via OLM, install rhoam 1.37.0 from this index: 'quay.io/mstoklus/managed-api-service-index:1.37.0' (it's matching prod)
- Quota must be 100mln
- Once installation completes, scale down RHOAM operator
- In backend redis CR add:
```
applyImmediately: true
maintenanceWindow: true
```
And change size to:
```
cache.m5.xlarge
```
- Wait for redis to successfully bump the instance on AWS
- Once redis reports completed, remove the applyImmediately flag from redis CR
- Scale back RHOAM
- Confirm that redis cr size has reverted to cache.m5.large but no action is taken on AWS side
- Apply the 1.38.0 index image from above (or build new index using this branch)
- Confirm that Redis CR size got bumped to m5.xlarge and no action is taken on aws side
- Confirm AWS backend worker redis remains at m5.xlarge
