### PR TITLE
MGDAPI-5901 - feat: addon instance uninstallation flow

### DIFF
--- a/apis/v1alpha1/rhmi_conditions.go
+++ b/apis/v1alpha1/rhmi_conditions.go
@@ -89,6 +89,15 @@ func (i *RHMI) NonDegradedCondition() metav1.Condition {
 	)
 }
 
+func (i *RHMI) ReadyToBeDeletedCondition() metav1.Condition {
+	return metav1.Condition{
+		Type:    addonv1alpha1.AddonInstanceConditionReadyToBeDeleted.String(),
+		Status:  metav1.ConditionTrue,
+		Reason:  string(addonv1alpha1.AddonInstanceReasonReadyToBeDeleted),
+		Message: "Teardown complete",
+	}
+}
+
 func newRHMICondition(conditionType RHMIConditionType, conditionStatus metav1.ConditionStatus, reason, msg string) metav1.Condition {
 	return metav1.Condition{
 		Type:    conditionType.String(),

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.3
 	github.com/openshift/addon-operator v1.12.0
-	github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482
+	github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a
 	github.com/openshift/custom-domains-operator v0.0.0-20220614181227-281815c251d6

--- a/go.sum
+++ b/go.sum
@@ -941,8 +941,8 @@ github.com/opencontainers/image-spec v1.1.0-rc2 h1:2zx/Stx4Wc5pIPDvIxHXvXtQFW/7X
 github.com/opencontainers/runc v0.0.0-20191031171055-b133feaeeb2e/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/openshift/addon-operator v1.12.0 h1:wm+STSizoMVf1kdAOrtALsq6q6YLxhS04H1f3Jf9cJM=
 github.com/openshift/addon-operator v1.12.0/go.mod h1:s2XyA2qM8K/lNov6uPHSSxAz+BNtwVbCKYZDV+f5Ghk=
-github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482 h1:381Vy6zmXaXXTOblOwoL6yw4oTI2LXxrDTKDkuoQJug=
-github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482/go.mod h1:cDMtOZx741HfmmUMmT09PWM8cOBxEJp3ipUHeHPr8F4=
+github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54 h1:Q8z686tmM4gcKFm0Ftkn+H0FCnGuTQwa8F6AzvyFknw=
+github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54/go.mod h1:cDMtOZx741HfmmUMmT09PWM8cOBxEJp3ipUHeHPr8F4=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1 h1:BleifEWC+NP/YhYHyQlGrDflXZPxawwOzyLUI+nr4jw=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/test/go.mod
+++ b/test/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.9.1
 	github.com/onsi/gomega v1.27.3
 	github.com/openshift-online/ocm-sdk-go v0.1.344
+	github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54
 	github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible
 	github.com/operator-framework/api v0.17.5
 	github.com/pkg/errors v0.9.1
@@ -116,7 +117,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/openshift/addon-operator v1.12.0 // indirect
-	github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482 // indirect
 	github.com/openshift/client-go v0.0.0-20220525160904-9e1acff93e4a // indirect
 	github.com/openshift/cloud-credential-operator v0.0.0-20211102171825-9d7d082fe277 // indirect
 	github.com/openshift/custom-domains-operator v0.0.0-20220614181227-281815c251d6 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -876,8 +876,8 @@ github.com/openshift-online/ocm-sdk-go v0.1.344 h1:Dv2IhoQzR5ONwCoK2j8TYa3e3AXLv
 github.com/openshift-online/ocm-sdk-go v0.1.344/go.mod h1:KYOw8kAKAHyPrJcQoVR82CneQ4ofC02Na4cXXaTq4Nw=
 github.com/openshift/addon-operator v1.12.0 h1:wm+STSizoMVf1kdAOrtALsq6q6YLxhS04H1f3Jf9cJM=
 github.com/openshift/addon-operator v1.12.0/go.mod h1:s2XyA2qM8K/lNov6uPHSSxAz+BNtwVbCKYZDV+f5Ghk=
-github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482 h1:381Vy6zmXaXXTOblOwoL6yw4oTI2LXxrDTKDkuoQJug=
-github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482/go.mod h1:cDMtOZx741HfmmUMmT09PWM8cOBxEJp3ipUHeHPr8F4=
+github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54 h1:Q8z686tmM4gcKFm0Ftkn+H0FCnGuTQwa8F6AzvyFknw=
+github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54/go.mod h1:cDMtOZx741HfmmUMmT09PWM8cOBxEJp3ipUHeHPr8F4=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1 h1:BleifEWC+NP/YhYHyQlGrDflXZPxawwOzyLUI+nr4jw=
 github.com/openshift/api v0.0.0-20210831091943-07e756545ac1/go.mod h1:RsQCVJu4qhUawxxDP7pGlwU3IA4F01wYm3qKEu29Su8=
 github.com/openshift/build-machinery-go v0.0.0-20200819073603-48aa266c95f7/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=

--- a/vendor/github.com/openshift/addon-operator/apis/addons/v1alpha1/addoninstances_types.go
+++ b/vendor/github.com/openshift/addon-operator/apis/addons/v1alpha1/addoninstances_types.go
@@ -9,6 +9,9 @@ import (
 
 // AddonInstanceSpec defines the configuration to consider while taking AddonInstance-related decisions such as HeartbeatTimeouts
 type AddonInstanceSpec struct {
+	// This field indicates whether the addon is marked for deletion.
+	// +optional
+	MarkedForDeletion bool `json:"markedForDeletion"`
 	// The periodic rate at which heartbeats are expected to be received by the AddonInstance object
 	// +kubebuilder:default="10s"
 	HeartbeatUpdatePeriod metav1.Duration `json:"heartbeatUpdatePeriod,omitempty"`
@@ -96,6 +99,9 @@ const (
 	// 'True' or 'False' with additional detail provided thorugh messages
 	// while condition is still 'False'.
 	AddonInstanceConditionInstalled AddonInstanceCondition = "Installed"
+
+	// ReadyToBeDeleted condition indicates whether the addon is ready to be deleted or not.
+	AddonInstanceConditionReadyToBeDeleted AddonInstanceCondition = "ReadyToBeDeleted"
 )
 
 // AddonInstanceHealthyReason is a condition reason used by
@@ -140,6 +146,20 @@ const (
 	// AddonInstanceInstalledReasonBlocked is a status condition
 	// reason used when addon installation is blocked.
 	AddonInstanceInstalledReasonBlocked AddonInstanceInstalledReason = "Blocked"
+)
+
+type AddonInstanceReadyToBeDeleted string
+
+func (r AddonInstanceReadyToBeDeleted) String() string {
+	return string(r)
+}
+
+const (
+	// Addon is ready to be deleted.
+	AddonInstanceReasonReadyToBeDeleted AddonInstanceReadyToBeDeleted = "AddonReadyToBeDeleted"
+
+	// Addon is not yet ready to deleted.
+	AddonInstanceReasonNotReadyToBeDeleted AddonInstanceReadyToBeDeleted = "AddonNotReadyToBeDeleted"
 )
 
 func init() {

--- a/vendor/github.com/openshift/addon-operator/apis/addons/v1alpha1/addons_types.go
+++ b/vendor/github.com/openshift/addon-operator/apis/addons/v1alpha1/addons_types.go
@@ -37,11 +37,16 @@ type AddonSpec struct {
 
 	// Correlation ID for co-relating current AddonCR revision and reported status.
 	// +optional
-	CorrelationID string `json:"correlation_id,omitempty"`
+	CorrelationID string `json:"correlationID,omitempty"`
 
 	// Defines how an Addon is installed.
 	// This field is immutable.
 	Install AddonInstallSpec `json:"install"`
+
+	// Defines whether the addon needs acknowledgment from the underlying
+	// addon's operator before deletion.
+	// +optional
+	DeleteAckRequired bool `json:"deleteAckRequired"`
 
 	// UpgradePolicy enables status reporting via upgrade policies.
 	UpgradePolicy *AddonUpgradePolicy `json:"upgradePolicy,omitempty"`
@@ -240,6 +245,12 @@ const (
 	OLMOwnNamespace AddonInstallType = "OLMOwnNamespace"
 )
 
+// Annotation keys for delete signal from OCM.
+const (
+	DeleteAnnotationFlag  = "addons.managed.openshift.io/delete"
+	DeleteTimeoutDuration = "addons.managed.openshift.io/deletetimeout"
+)
+
 // Addon condition reasons
 
 const (
@@ -293,6 +304,15 @@ const (
 
 	// Addon has successfully been uninstalled.
 	AddonReasonNotInstalled = "AddonNotInstalled"
+
+	// Addon is ready to be deleted.
+	AddonReasonReadyToBeDeleted = "AddonReadyToBeDeleted"
+
+	// Addon is not yet ready to deleted.
+	AddonReasonNotReadyToBeDeleted = "AddonNotReadyToBeDeleted"
+
+	// Addon has timed out waiting for acknowledgement from the underlying addon.
+	AddonReasonDeletionTimedOut = "AddonReasonDeletionTimedOut"
 )
 
 type AddonNamespace struct {
@@ -325,6 +345,13 @@ const (
 	// Installed condition indicates that the addon has been installed successfully
 	// and was available atleast once.
 	Installed = "Installed"
+
+	// ReadyToBeDeleted condition indicates whether the addon is ready to be deleted or not.
+	ReadyToBeDeleted = "ReadyToBeDeleted"
+
+	// DeleteTimeout condition indicates whether an addon has timed out waiting for an delete acknowledgement
+	// from underlying addon.
+	DeleteTimeout = "DeleteTimeout"
 )
 
 // AddonStatus defines the observed state of Addon

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -699,7 +699,7 @@ github.com/onsi/gomega/types
 # github.com/openshift/addon-operator v1.12.0
 ## explicit; go 1.18
 github.com/openshift/addon-operator/pkg/client
-# github.com/openshift/addon-operator/apis v0.0.0-20230505081548-bce54f373482
+# github.com/openshift/addon-operator/apis v0.0.0-20230706051718-4032d89c8b54
 ## explicit; go 1.18
 github.com/openshift/addon-operator/apis/addons/v1alpha1
 # github.com/openshift/api v3.9.1-0.20191031084152-11eee842dafd+incompatible => github.com/openshift/api v0.0.0-20210831091943-07e756545ac1


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
https://issues.redhat.com/browse/MGDAPI-5901

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
* Acccount for addon uninstallation flow by addon instance 
  *  Implementation is based on the changes provided by https://github.com/openshift/addon-operator/pull/358
    * Note: status condition type used to the implementation above was incorrect and will be fixed by https://github.com/openshift/addon-operator/pull/375 which will also provide a client function also that we can later use once released

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
* Checkout this branch
* Install RHOAM
```
export LOCAL=false
make cluster/prepare/local
make code/run
```
* Verify installation completes successfully
* Mark addon instance spec for addon deletion
```
oc patch addoninstance addon-instance -p $'spec:\n markedForDeletion: true' --type merge -n redhat-rhoam-operator
```
* Verify RHMI CR is marked for deletion
* Verify uninstallation completed successfully
* Verify a new status condition is added 
```
watch "oc get addoninstance addon-instance -n redhat-rhoam-operator -o json | jq '.status'"
```
* The following should be added after a successfull uninstall to signal that the addon can be removed in ocm
```
    {
      "lastTransitionTime": "2023-07-06T13:07:43Z",
      "message": "Addon ready to be deleted",
      "observedGeneration": 2,
      "reason": "AddonReadyToBeDeleted",
      "status": "True",
      "type": "addons.managed.openshift.io/ReadyToBeDeleted"
    }
```
