### PR TITLE
MGDAPI-5897 update system developer probe logic

### DIFF
--- a/pkg/products/threescale/objects_test.go
+++ b/pkg/products/threescale/objects_test.go
@@ -331,7 +331,7 @@ var threescaleRoute1 = &v1.Route{
 	},
 }
 
-// Have two system-developer routes, the reconcile should pick up on 3scale.
+// Have two system-developer routes, the reconcile should pick up on 3scale + wildcard domain from apim.
 var threescaleRoute2 = &v1.Route{
 	ObjectMeta: metav1.ObjectMeta{
 		Name:      "3scale-system-developer-route",
@@ -341,7 +341,7 @@ var threescaleRoute2 = &v1.Route{
 		},
 	},
 	Spec: v1.RouteSpec{
-		Host: "system-developer",
+		Host: "3scale.apps-somedomain.example.com",
 	},
 	Status: v1.RouteStatus{
 		Ingress: []v1.RouteIngress{
@@ -361,7 +361,7 @@ var threescaleRoute3 = &v1.Route{
 		},
 	},
 	Spec: v1.RouteSpec{
-		Host: "3scale.system-developer",
+		Host: "3scale.apps.example.com",
 	},
 }
 


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5897

# What
Update logic when creating prometheus probe for system-developer

# Verification steps
- Install RHOAM from master locally
- Navigate to routes under 3scale ns
- Copy the contents of 3scale system-developer route
- Create new route using the contents of copied route but change the name of the route so that the first character of the route starts with a letter that's higher in the alphabet than the original route, also, change the host to 3scale.apps-somedomain.<rest of the cluster widlcard domain>
- Wait for RHOAM to reconcile the probe `integreatly-3scale-system-developer` - once it updates it to point to the made up host, confirm UIBBT alert for system-developer access fires.
- Next run RHOAM from this PR and expect the probe to be updated and alert resolved.
