### PR TITLE
MGDAPI-5874 Addition of PO resources stability e2e

### DIFF
--- a/test/common/tests.go
+++ b/test/common/tests.go
@@ -83,6 +83,7 @@ var (
 				{"Verify prometheus metrics scrapped", TestMetricsScrappedByPrometheus},
 				{"E09 - Verify customer dashboards exist", TestIntegreatlyCustomerDashboardsExist},
 				{"Verify ClusterObjectTemplates ready state", TestClusterObjectTemplateState},
+				{"Verify package operator resource stability", TestPackageOperatorResourceStability},
 			},
 			[]v1alpha1.InstallationType{v1alpha1.InstallationTypeManagedApi, v1alpha1.InstallationTypeMultitenantManagedApi},
 		},

--- a/test/common/verify_po_resource_stability.go
+++ b/test/common/verify_po_resource_stability.go
@@ -1,0 +1,55 @@
+package common
+
+import (
+	goctx "context"
+	"fmt"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"time"
+)
+
+var (
+	threescaleOperatorNs = "redhat-rhoam-3scale-operator"
+	serviceMonitorName   = "threescale-operator-controller-manager-metrics-monitor"
+)
+
+func TestPackageOperatorResourceStability(t TestingTB, ctx *TestingContext) {
+	// Fetch the initial state of the resource
+	resource, err := getServiceMonitor(ctx, threescaleOperatorNs, serviceMonitorName)
+	if err != nil {
+		t.Fatalf("Failed to fetch resource: %v", err)
+	}
+
+	t.Log("Waiting 30 seconds")
+	time.Sleep(30 * time.Second)
+
+	// Update resource, will fail if resource has been modified after fetch
+	err = ctx.Client.Update(goctx.TODO(), resource)
+	if err != nil {
+		t.Fatalf("Failed to update resource: %v", err)
+	}
+
+}
+
+func getServiceMonitor(ctx *TestingContext, nameSpace, serviceName string) (*monitoringv1.ServiceMonitor, error) {
+	// Get the list of service monitors in the namespace
+	listOpts := []k8sclient.ListOption{
+		k8sclient.InNamespace(nameSpace),
+	}
+
+	serviceMonitors := &monitoringv1.ServiceMonitorList{}
+	err := ctx.Client.List(goctx.TODO(), serviceMonitors, listOpts...)
+	if err != nil {
+		return nil, err
+	}
+
+	// Iterate over the service monitors to find the one with the specified name
+	for _, sm := range serviceMonitors.Items {
+		if sm.Name == serviceName {
+			return sm, nil
+		}
+	}
+
+	// If the specific service monitor is not found, return an error
+	return nil, fmt.Errorf("ServiceMonitor %s not found in namespace %s", serviceName, nameSpace)
+}


### PR DESCRIPTION
# Issue link
[MGDAPI-5874](https://issues.redhat.com/browse/MGDAPI-5874)

# What
The addition of a new e2e test for resource stability, this tests checks that resources arent being continuously updated.  Threescale metrics monitor was used in this case.

# Verification steps
1. Checkout this branch 
2.  Install RHOAM
3.  Verify test passes by running 
```
INSTALLATION_TYPE=managed-api TEST="Verify package operator" make test/e2e/single
```
4. Verify test fails by running the command below, but when the `waiting 30 seconds` log shows update the `threescale-operator-controller-manager-metrics-monitor` in the `redhat-rhoam-3scale-operator` namespace. The test should fail
```
INSTALLATION_TYPE=managed-api TEST="Verify package operator" make test/e2e/single
```