### PR TITLE
MGDAPI-4729 / Modified test to work with nonSts

### DIFF
--- a/test/functional/aws_elasticache_resources_exist.go
+++ b/test/functional/aws_elasticache_resources_exist.go
@@ -51,6 +51,16 @@ func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingCon
 		replicationGroup := foundElasticacheReplicationGroups.ReplicationGroups[0]
 		nodeGroup := replicationGroup.NodeGroups[0]
 
+		cacheClusterID := replicationGroup.MemberClusters[0]
+
+		result, err := elasticacheapi.DescribeCacheClusters(&elasticache.DescribeCacheClustersInput{
+			CacheClusterId: aws.String(*cacheClusterID),
+		})
+		if err != nil {
+			fmt.Println("Failed to describe cache clusters:", err)
+			return
+		}
+
 		// perform checks to verify state is as expected
 		if !verifyMultiAZ(nodeGroup.NodeGroupMembers) {
 			testErrors = append(testErrors, fmt.Errorf("elasticache resource %s multiAZ failure %v", resourceID, err))
@@ -61,22 +71,27 @@ func AWSElasticacheResourcesExistTest(t common.TestingTB, ctx *common.TestingCon
 		if replicationGroup.SnapshotWindow == nil {
 			testErrors = append(testErrors, fmt.Errorf("elasticache resource %s does not have automatic snapshotting enabled", resourceID))
 		}
+		// check cluster arn for non sts
+		var resourceARN string
+
+		if isSTS {
+			resourceARN = *replicationGroup.ARN
+		} else {
+			resourceARN = *result.CacheClusters[0].ARN
+		}
 
 		resp, err := elasticacheapi.ListTagsForResource(&elasticache.ListTagsForResourceInput{
-			ResourceName: replicationGroup.ARN,
+			ResourceName: aws.String(resourceARN),
 		})
 		if err != nil {
 			t.Fatalf("failed to get elasticache resource tags: %v", err)
 		}
 
-		if isSTS {
-			// Check for managed tag for sts clusters only until https://issues.redhat.com/browse/MGDAPI-4729
-			if !elasticacheTagsContains(resp.TagList, awsManagedTagKey, awsManagedTagValue) {
-				testErrors = append(testErrors, fmt.Errorf("elasticache resource %s does not have %s tag", resourceID, awsManagedTagKey))
-			}
-			if !elasticacheTagsContains(resp.TagList, awsClusterTypeKey, awsClusterTypeRosaValue) {
-				testErrors = append(testErrors, fmt.Errorf("elasticache resource %s does not have %s tag", resourceID, awsClusterTypeKey))
-			}
+		if isSTS && !elasticacheTagsContains(resp.TagList, awsClusterTypeKey, awsClusterTypeRosaValue) {
+			testErrors = append(testErrors, fmt.Errorf("elasticache resource %s does not have %s tag", resourceID, awsClusterTypeKey))
+		}
+		if !elasticacheTagsContains(resp.TagList, awsManagedTagKey, awsManagedTagValue) {
+			testErrors = append(testErrors, fmt.Errorf("elasticache resource %s does not have %s tag", resourceID, awsManagedTagKey))
 		}
 	}
 


### PR DESCRIPTION
# Issue link
[MGDAPI-4729](https://issues.redhat.com/browse/MGDAPI-4729)

# What
It wasn't possible to modify the code to tag the replication groups as stated in the JIRA , so after much consideration an agreement was made to just modify the test so that it passes for nonSTS clusters.

# Verification steps
- Spin up a ccs cluster an install rhoam off of master
- Run the test and make sure it passes.

`TEST="F03" INSTALLATION_TYPE=managed-api LOCAL=false DEBUG=true make test/e2e/single`
