### PR TITLE
MGDAPI-5929 - Use correct ingress router to determine IP for 3scale dns alerts

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -181,6 +181,7 @@ const (
 
 type PortalInfo struct {
 	Host        string
+	Ingress     string
 	PortalName  string
 	IsAvailable bool
 }

--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -102,9 +102,25 @@ func TestReconciler_Reconcile3scale(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	openshiftIngress := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "",
+			Namespace: "openshift-ingress",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					corev1.LoadBalancerIngress{
+						IP: "0.0.0.0",
+					},
+				},
+			},
+		},
+	}
 
 	objects := getSuccessfullRHOAMTestPreReqs(integreatlyOperatorNamespace, defaultInstallationNamespace)
 	objects = append(objects, getValidInstallation(integreatlyv1alpha1.InstallationTypeMultitenantManagedApi))
+	objects = append(objects, &openshiftIngress)
 
 	tests := []ThreeScaleTestScenario{
 		{
@@ -2948,6 +2964,21 @@ func TestReconciler_ping3scalePortals(t *testing.T) {
 			},
 		},
 	}
+	openshiftIngress := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "",
+			Namespace: "openshift-ingress",
+		},
+		Status: corev1.ServiceStatus{
+			LoadBalancer: corev1.LoadBalancerStatus{
+				Ingress: []corev1.LoadBalancerIngress{
+					corev1.LoadBalancerIngress{
+						IP: "0.0.0.0",
+					},
+				},
+			},
+		},
+	}
 
 	tests := []struct {
 		name       string
@@ -3150,6 +3181,7 @@ func TestReconciler_ping3scalePortals(t *testing.T) {
 						&masterRoute,
 						&developerRoute,
 						&providerRoute,
+						&openshiftIngress,
 					)
 					return mockClient
 				},
@@ -3177,7 +3209,7 @@ func TestReconciler_ping3scalePortals(t *testing.T) {
 				recorder:      tt.fields.recorder,
 				log:           tt.fields.log,
 			}
-			got, err := r.ping3scalePortals(tt.args.ctx, tt.args.serverClient(), tt.args.ips)
+			got, err := r.ping3scalePortals(tt.args.ctx, tt.args.serverClient())
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ping3scalePortals() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/resources/custom-domain/custom-domain.go
+++ b/pkg/resources/custom-domain/custom-domain.go
@@ -92,10 +92,10 @@ func UpdateErrorAndCustomDomainMetric(installation *v1alpha1.RHMI, active bool, 
 	metrics.SetCustomDomain(active, 0)
 }
 
-func GetIngressRouterService(ctx context.Context, serverClient client.Client) (*v1.Service, error) {
+func GetIngressRouterService(ctx context.Context, serverClient client.Client, svcName string) (*v1.Service, error) {
 	ingressRouterService := &v1.Service{}
 	key := client.ObjectKey{
-		Name:      "router-default",
+		Name:      svcName,
 		Namespace: "openshift-ingress",
 	}
 	err := serverClient.Get(ctx, key, ingressRouterService)

--- a/pkg/resources/custom-domain/custom-domain_test.go
+++ b/pkg/resources/custom-domain/custom-domain_test.go
@@ -427,7 +427,7 @@ func TestGetIngressRouterService(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GetIngressRouterService(tt.args.ctx, tt.args.serverClient())
+			got, err := GetIngressRouterService(tt.args.ctx, tt.args.serverClient(), "router-default")
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetIngressRouterService() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-5929
Use the correct ingress router to determine IP for 3scale dns alerts


# Verification steps
- Check that ***DNSByPass*** alerts are not firing in Custom Domain Rhoam installation
- Regression - check alerts in regular (Not custom domain) Rhoam  installation

- **References**:  
[Configuring custom domain](https://integreatly-operator.readthedocs.io/en/latest/products/custom_domain/)

