### PR TITLE
MGDAPI-5982 Fix e2e tests after ClusterPackage refactor

### DIFF
--- a/test/common/verify_po_resource_stability.go
+++ b/test/common/verify_po_resource_stability.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	serviceMonitorNameNamespace = ThreeScaleOperatorNamespace
+	serviceMonitorNameNamespace = ObservabilityProductNamespace
 	serviceMonitorName          = "threescale-operator-controller-manager-metrics-monitor"
 )
 

--- a/test/common/verify_prometheus_metrics.go
+++ b/test/common/verify_prometheus_metrics.go
@@ -20,28 +20,28 @@ func mangedApiTargets() map[string][]string {
 			"/integreatly-rhsso",
 			"/integreatly-rhssouser",
 		},
-		"serviceMonitor/" + RHSSOProductNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/rhsso-keycloak-service-monitor/0",
 			"/rhsso-keycloak-service-monitor/1",
 		},
-		"serviceMonitor/" + RHSSOOperatorNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/rhsso-operator-metrics/0",
 			"/rhsso-operator-metrics/1",
 		},
-		"serviceMonitor/" + RHSSOUserProductNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/user-sso-keycloak-service-monitor/0",
 			"/user-sso-keycloak-service-monitor/1",
 		},
-		"serviceMonitor/" + RHSSOUserOperatorNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/user-sso-operator-rhsso-operator-metrics/0",
 			"/user-sso-operator-rhsso-operator-metrics/1",
 		},
-		"serviceMonitor/" + CloudResourceOperatorNamespace: {"/cloud-resource-operator-metrics/0"},
-		"serviceMonitor/" + Marin3rProductNamespace:        {"/ratelimit/0"},
-		"serviceMonitor/" + ThreeScaleOperatorNamespace:    {"/threescale-operator-controller-manager-metrics-monitor/0"},
-		"serviceMonitor/" + ThreeScaleProductNamespace:     {"/3scale-service-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace:  {"/openshift-monitoring-federation/0"},
-		"serviceMonitor/" + RHOAMOperatorNamespace:         {"/rhmi-operator-metrics/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/cloud-resource-operator-metrics/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/ratelimit/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/threescale-operator-controller-manager-metrics-monitor/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/3scale-service-monitor/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/openshift-monitoring-federation/0"},
+		"serviceMonitor/" + RHOAMOperatorNamespace:        {"/rhmi-operator-metrics/0"},
 	}
 }
 
@@ -54,20 +54,20 @@ func mtMangedApiTargets() map[string][]string {
 			"/integreatly-grafana",
 			"/integreatly-rhsso",
 		},
-		"serviceMonitor/" + RHSSOProductNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/rhsso-keycloak-service-monitor/0",
 			"/rhsso-keycloak-service-monitor/1",
 		},
-		"serviceMonitor/" + RHSSOOperatorNamespace: {
+		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/rhsso-operator-metrics/0",
 			"/rhsso-operator-metrics/1",
 		},
-		"serviceMonitor/" + CloudResourceOperatorNamespace: {"/cloud-resource-operator-metrics/0"},
-		"serviceMonitor/" + Marin3rProductNamespace:        {"/ratelimit/0"},
-		"serviceMonitor/" + ThreeScaleOperatorNamespace:    {"/threescale-operator-controller-manager-metrics-monitor/0"},
-		"serviceMonitor/" + ThreeScaleProductNamespace:     {"/3scale-service-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace:  {"/openshift-monitoring-federation/0"},
-		"serviceMonitor/" + RHOAMOperatorNamespace:         {"/rhmi-operator-metrics/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/cloud-resource-operator-metrics/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/ratelimit/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/threescale-operator-controller-manager-metrics-monitor/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/3scale-service-monitor/0"},
+		"serviceMonitor/" + ObservabilityProductNamespace: {"/openshift-monitoring-federation/0"},
+		"serviceMonitor/" + RHOAMOperatorNamespace:        {"/rhmi-operator-metrics/0"},
 	}
 }
 


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-5982](https://issues.redhat.com/browse/MGDAPI-5982)

# What
This PR fixes the following e2e tests that broke after refactoring RHOAM's [ClusterPackage](https://gitlab.cee.redhat.com/service/managed-tenants-bundles/-/tree/main/addons/rhoams/package) to reduce the amount of templating we use.

# Verification steps
1. [Provision](https://qaprodauth.console.redhat.com/openshift/create) a cluster
2. Install RHOAM using OLM (CatalogSource) - you can either build your own images or use `quay.io/ckyrillo/managed-api-service-index:1.38.0`. Note: Make sure the RHMI CR has the `IN_PROW` annotation set to `false`.
3. Wait for the installation to complete
4. Verify that the e2e tests are fixed:
```bash
TEST="Verify prometheus metrics scrapped" make test/e2e/single
TEST="Verify package operator resource stability" make test/e2e/single
```

