### PR TITLE
MGDAPI-5996 Functional test suite timeout increase

### DIFF
--- a/test/functional/suite_test.go
+++ b/test/functional/suite_test.go
@@ -68,7 +68,8 @@ func TestAPIs(t *testing.T) {
 
 	// Fetch the current config
 	suiteConfig, reporterConfig := GinkgoConfiguration()
-	suiteConfig.Timeout = time.Minute * 90
+	// This timeout is slightly less that 3h because that is the default timeout on ci-cd level
+	suiteConfig.Timeout = time.Minute * 170
 	// Update the JUnitReport
 	reporterConfig.JUnitReport = jUnitReportLocation
 	// Pass the updated config to RunSpecs()


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5996

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

In case that there is something wrong with RHOAM installation (e.g. alerts firing or rhmi CR does not say "stage: complete" the tests might take longer than 90 minutes (rough estimate is 100 - 110 minutes in total).  This increases the timeout to 170 minutes to allow for some contingency space. Also on ci-cd level our pipelines have 180 minute timeout for functional test.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Eye review only. Example of the timeout hit:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Nightly/job/managed-api-install-master/573/artifact/test-logs/test-functional/test-functional_integreatly-operator-test-fgnnf.log
- as you can see it timed out during F08 test execution, after this test only three other tests H29, H30, H31 are executed, see e.g. https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Nightly/job/managed-api-install-master/571/artifact/results/2023-08-15-10-26-05/integreatly-operator-test/logs/container.log
