### PR TITLE
MGDAPI-5996 Added oc into external test image

### DIFF
--- a/Dockerfile.external
+++ b/Dockerfile.external
@@ -28,13 +28,15 @@ COPY Makefile ./
 # compile test binary
 RUN make test/compile/functional
 
-FROM registry.redhat.io/openshift4/ose-cli:v4.13
+FROM registry.access.redhat.com/ubi8/ubi:latest
 # Install chrome for tests
 COPY test-dependency/*.repo /etc/yum.repos.d/
 COPY build/bin/setup_external.sh ./setup_external.sh
 RUN dnf -y install google-chrome-stable && dnf clean all
 ENV WATCH_NAMESPACE=redhat-rhoam-operator
-RUN mkdir test-run-results
+RUN mkdir test-run-results && \
+    curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.12.28/openshift-client-linux.tar.gz | tar -zx && \
+    mv oc /usr/local/bin
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/integreatly-operator-test-harness.test integreatly-operator-test-harness.test
 ENTRYPOINT [ "/bin/bash", "-c", "./setup_external.sh"]


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5996

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

When the image is built via openshift/release it is built from `os` which is ubi8 image so I just updated the Dockerfile.external to use the same FROM image. However, `oc` must be added since this new FROM image does not have it.

See
https://github.com/openshift/release/blob/master/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml#L44-L50

and

https://github.com/openshift/release/blob/master/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml#L6-L9 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Have a cluster with RHOAM installed. Build and push the image from this PR and run some tests using the external image:
ORG=yourQuayOrg make image/external/build
ORG=yourQuayOrg make image/external/push
podman run -it -e OPENSHIFT_HOST='https://api.test-237-tr1457.mf29.s1.devshift.org:6443' -e OPENSHIFT_PASSWORD='redacted' -e MULTIAZ=false -e DESTRUCTIVE=false -e NUMBER_OF_TENANTS='2' -e TENANTS_CREATION_TIMEOUT='3' -e RegExpFilter='A01' -e OUTPUT_DIR=a01-test-run-result -v "$(pwd)/a01-test-run-result:/a01-test-run-result:Z" quay.io/yourQuayOrg/integreatly-operator-test-external:latest

I did all this (ran just A01 test) so eye review might suffice:

```
podman run -it -e OPENSHIFT_HOST='https://api.test-237-tr1457.mf29.s1.devshift.org:6443' -e OPENSHIFT_PASSWORD='redacted' -e MULTIAZ=false -e DESTRUCTIVE=false -e NUMBER_OF_TENANTS='2' -e TENANTS_CREATION_TIMEOUT='3' -e RegExpFilter='A01' -e OUTPUT_DIR=a01-test-run-result -v "$(pwd)/a01-test-run-result:/a01-test-run-result:Z" quay.io/trepel/integreatly-operator-test-external:latest
Login successful.

You have access to 115 projects, the list has been suppressed. You can list all projects with 'oc projects'

Using project "default".
Welcome! See 'oc help' to get started.
INFO[0000] calling reset on all prometheus gauge vectors  custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /
========================================
Random Seed: 1692777634

Will run 1 of 60 specs
------------------------------
[BeforeSuite] 
/go/src/github.com/integr8ly/integreatly-operator/test/functional/suite_test.go:78
  STEP: bootstrapping test environment @ 08/23/23 08:00:41.484
[BeforeSuite] PASSED [0.010 seconds]
------------------------------
SSSSSSS
------------------------------
integreatly managed-api HAPPY PATH A01 - Verify that all stages in the integreatly-operator CR report completed
/go/src/github.com/integr8ly/integreatly-operator/test/functional/integreatly_test.go:148
• [5.516 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
[AfterSuite] 
/go/src/github.com/integr8ly/integreatly-operator/test/functional/suite_test.go:107
  STEP: tearing down the test environment @ 08/23/23 08:00:47.012
[AfterSuite] PASSED [0.001 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.004 seconds]
------------------------------

Ran 1 of 60 Specs in 5.530 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 59 Skipped
```
