### PR TITLE
MGDAPI-5992 Ignoring firing/pending ErrorBudgetBurn alerts in tests

### DIFF
--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -185,7 +185,7 @@ func getFiringAlerts(t TestingTB, ctx *TestingContext) error {
 
 		// tmp workaround for **ErrorBudgetBurn alerts firing during installation (https://issues.redhat.com/browse/MGDAPI-5992)
 		ignoredAlertsPatterns := []string{
-			"soAvailability2hto1dErrorBudgetBurn",
+			"soAvailability[a-z0-9]+ErrorBudgetBurn",
 		}
 		isIgnored := false
 		for _, ignoredAlertPattern := range ignoredAlertsPatterns {
@@ -334,14 +334,14 @@ func getFiringOrPendingAlerts(t TestingTB, ctx *TestingContext) error {
 
 		// tmp workaround for **ErrorBudgetBurn alerts firing during installation (https://issues.redhat.com/browse/MGDAPI-5992)
 		ignoredAlertsPatterns := []string{
-			"soAvailability2hto1dErrorBudgetBurn",
+			"soAvailability[a-z0-9]+ErrorBudgetBurn",
 		}
 		isIgnored := false
 		for _, ignoredAlertPattern := range ignoredAlertsPatterns {
 			t.Logf("\tPattern ignored: %s", ignoredAlertPattern)
 			matchFound, err := regexp.MatchString(ignoredAlertPattern, alertName)
 			if err == nil && matchFound {
-				t.Logf("\tFiring alert to be ignored: %s", alertName)
+				t.Logf("\tFiring/Pending alert to be ignored: %s", alertName)
 				isIgnored = true
 				continue
 			}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-5992

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Temporary workaround for https://issues.redhat.com/browse/MGDAPI-5992.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Have a cluster with RHOAM installed. In case of no alerts firing the tests should just pass
INSTALLATION_TYPE=managed-api LOCAL=false TEST="Verify Alerts are not firing during or after installation apart from DeadMansSwitch" make test/e2e/single
INSTALLATION_TYPE=managed-api LOCAL=false TEST="C01" make test/e2e/single

I am not sure how to make **ErrorBudgetBurn alerts fire so I recommend to deploy workload-web-app and do some GET requests against the 3scale Product which should make ThreeScaleContainerHighMemory alert to fire. Then run
INSTALLATION_TYPE=managed-api LOCAL=false TEST="Verify Alerts are not firing during or after installation apart from DeadMansSwitch" make test/e2e/single
The tests should fail.

Add "ree[a-zA-Z]+ContainerHigh" into ignoredAlertsPatterns array and run it again. This time the tests should pass.

If you are aware of a simpler way of making some alert fire (without making RHMI CR think that the installation is in progress since that blocks the tests) you can do the verification that way.
