### PR TITLE
MGDAPI-6093 bump envoy image

### DIFF
--- a/bundles/managed-api-service/1.39.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.39.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -71,7 +71,7 @@ metadata:
           "observability-origin-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:582fc2d21cb3654f22f3ca50c39966041846e16a1543fc35c6a83948a2fa6c40"
         },
         "marin3r.v0.11.0": {
-          "marin3r.v0.11.0": "quay.io/3scale/marin3r:v0.11.0"
+          "marin3r.v0.12.3": "quay.io/3scale/marin3r:v0.12.3"
         },
         "rhsso-operator.18.0.x": {
           "rhsso-operator.7.6.3-opr-001": "registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:bd83b8c92577ab7f3c4504fde70ac0d272449512fc85e7ff405a69fd2453084f",
@@ -83,7 +83,7 @@ metadata:
           "rhsso_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:5232b24e6d0421057e482a5a85d5deb2c541e94e4f46b2316a92130fe0d0fec1"
         },
         "ratelimit": {
-          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.4-3"
+          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.8-5"
         },
         "limitador": {
           "marin3r-limitador": "quay.io/3scale/limitador:v0.5.1"

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.4-3"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.8-5"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.4-3"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.8-5"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/3scale/limitador:v0.5.1"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6093

# What
Bump envoy image

# Verification steps
- run `make cluster/prepare/local`
- run `make code/run` - RHOAM installation should start
- When installation is completed, navigate to 3scale namespace, click on apicast-production pod, scroll down to find envoy-sidecar container and confirm that the image is registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.8-5
- Cancel `make code/run` to stop rhoam operator
- Navigate to marin3r namespace > configmaps > ratelimig-config cm > change the value of `max_value` to 5
- Navigate to 3scale namespace > secrets > system seed > copy the admin password secret
- Navigate to 3scale namespace > routes > find 3scale-admin route and open it up
- Login with `admin` and password copied from steps above
- Go through the 3scale wizard
- Once in 3scale > click on Dashboard > newly created product > integration > configuration and pull the curl request from Staging env.
- in your terminal curl the endpoint with added `-i` flag `curl -i <endpoint>`. 5 requests should be successful, 6th request should fail with 429 too many requests

