### PR TITLE
MGDAPI-6097 - Grafana dashboard is not getting updated when quota cha…

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -30,6 +30,8 @@ const (
 	grafanaConsoleLink           = "grafana-user-console-link"
 	grafanaIcon                  = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjIuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzNyAzNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzcgMzc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRUUwMDAwO30KCS5zdDF7ZmlsbDojRkZGRkZGO30KPC9zdHlsZT4KPGc+Cgk8cGF0aCBkPSJNMjcuNSwwLjVoLTE4Yy00Ljk3LDAtOSw0LjAzLTksOXYxOGMwLDQuOTcsNC4wMyw5LDksOWgxOGM0Ljk3LDAsOS00LjAzLDktOXYtMThDMzYuNSw0LjUzLDMyLjQ3LDAuNSwyNy41LDAuNUwyNy41LDAuNXoiCgkJLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yNSwyMi4zN2MtMC45NSwwLTEuNzUsMC42My0yLjAyLDEuNWgtMS44NVYyMS41YzAtMC4zNS0wLjI4LTAuNjItMC42Mi0wLjYycy0wLjYyLDAuMjgtMC42MiwwLjYydjMKCQkJYzAsMC4zNSwwLjI4LDAuNjIsMC42MiwwLjYyaDIuNDhjMC4yNywwLjg3LDEuMDcsMS41LDIuMDIsMS41YzEuMTcsMCwyLjEyLTAuOTUsMi4xMi0yLjEyUzI2LjE3LDIyLjM3LDI1LDIyLjM3eiBNMjUsMjUuMzcKCQkJYy0wLjQ4LDAtMC44OC0wLjM5LTAuODgtMC44OHMwLjM5LTAuODgsMC44OC0wLjg4czAuODgsMC4zOSwwLjg4LDAuODhTMjUuNDgsMjUuMzcsMjUsMjUuMzd6Ii8+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTIwLjUsMTYuMTJjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJ2LTIuMzhoMS45MWMwLjMyLDAuNzcsMS4wOCwxLjMxLDEuOTYsMS4zMQoJCQljMS4xNywwLDIuMTItMC45NSwyLjEyLTIuMTJzLTAuOTUtMi4xMi0yLjEyLTIuMTJjLTEuMDIsMC0xLjg4LDAuNzMtMi4wOCwxLjY5SDIwLjVjLTAuMzQsMC0wLjYyLDAuMjgtMC42MiwwLjYydjMKCQkJQzE5Ljg3LDE1Ljg1LDIwLjE2LDE2LjEyLDIwLjUsMTYuMTJ6IE0yNSwxMS40M2MwLjQ4LDAsMC44OCwwLjM5LDAuODgsMC44OHMtMC4zOSwwLjg4LTAuODgsMC44OHMtMC44OC0wLjM5LTAuODgtMC44OAoJCQlTMjQuNTIsMTEuNDMsMjUsMTEuNDN6Ii8+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTEyLjEyLDE5Ljk2di0wLjg0aDIuMzhjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJzLTAuMjgtMC42Mi0wLjYyLTAuNjJoLTIuMzh2LTAuOTEKCQkJYzAtMC4zNS0wLjI4LTAuNjItMC42Mi0wLjYyaC0zYy0wLjM0LDAtMC42MiwwLjI4LTAuNjIsMC42MnYzYzAsMC4zNSwwLjI4LDAuNjIsMC42MiwwLjYyaDNDMTEuODQsMjAuNTksMTIuMTIsMjAuMzEsMTIuMTIsMTkuOTYKCQkJeiBNMTAuODcsMTkuMzRIOS4xMnYtMS43NWgxLjc1VjE5LjM0eiIvPgoJCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yOC41LDE2LjM0aC0zYy0wLjM0LDAtMC42MiwwLjI4LTAuNjIsMC42MnYwLjkxSDIyLjVjLTAuMzQsMC0wLjYyLDAuMjgtMC42MiwwLjYyczAuMjgsMC42MiwwLjYyLDAuNjJoMi4zOAoJCQl2MC44NGMwLDAuMzUsMC4yOCwwLjYyLDAuNjIsMC42MmgzYzAuMzQsMCwwLjYyLTAuMjgsMC42Mi0wLjYydi0zQzI5LjEyLDE2LjYyLDI4Ljg0LDE2LjM0LDI4LjUsMTYuMzR6IE0yNy44NywxOS4zNGgtMS43NXYtMS43NQoJCQloMS43NVYxOS4zNHoiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTYuNSwyMC44N2MtMC4zNCwwLTAuNjMsMC4yOC0wLjYzLDAuNjJ2Mi4zOGgtMS44NWMtMC4yNy0wLjg3LTEuMDctMS41LTIuMDItMS41CgkJCWMtMS4xNywwLTIuMTIsMC45NS0yLjEyLDIuMTJzMC45NSwyLjEyLDIuMTIsMi4xMmMwLjk1LDAsMS43NS0wLjYzLDIuMDItMS41aDIuNDhjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJ2LTMKCQkJQzE3LjEyLDIxLjE1LDE2Ljg0LDIwLjg3LDE2LjUsMjAuODd6IE0xMiwyNS4zN2MtMC40OCwwLTAuODgtMC4zOS0wLjg4LTAuODhzMC4zOS0wLjg4LDAuODgtMC44OHMwLjg4LDAuMzksMC44OCwwLjg4CgkJCVMxMi40OCwyNS4zNywxMiwyNS4zN3oiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTYuNSwxMS44N2gtMi40MmMtMC4yLTAuOTctMS4wNi0xLjY5LTIuMDgtMS42OWMtMS4xNywwLTIuMTIsMC45NS0yLjEyLDIuMTJzMC45NSwyLjEyLDIuMTIsMi4xMgoJCQljMC44OCwwLDEuNjQtMC41NCwxLjk2LTEuMzFoMS45MXYyLjM4YzAsMC4zNSwwLjI4LDAuNjIsMC42MywwLjYyczAuNjItMC4yOCwwLjYyLTAuNjJ2LTNDMTcuMTIsMTIuMTUsMTYuODQsMTEuODcsMTYuNSwxMS44N3oKCQkJIE0xMiwxMy4xOGMtMC40OCwwLTAuODgtMC4zOS0wLjg4LTAuODhzMC4zOS0wLjg4LDAuODgtMC44OHMwLjg4LDAuMzksMC44OCwwLjg4UzEyLjQ4LDEzLjE4LDEyLDEzLjE4eiIvPgoJPC9nPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTE4LjUsMjIuNjJjLTIuMjcsMC00LjEzLTEuODUtNC4xMy00LjEyczEuODUtNC4xMiw0LjEzLTQuMTJzNC4xMiwxLjg1LDQuMTIsNC4xMlMyMC43NywyMi42MiwxOC41LDIyLjYyegoJCSBNMTguNSwxNS42MmMtMS41OCwwLTIuODgsMS4yOS0yLjg4LDIuODhzMS4yOSwyLjg4LDIuODgsMi44OHMyLjg4LTEuMjksMi44OC0yLjg4UzIwLjA4LDE1LjYyLDE4LjUsMTUuNjJ6Ii8+CjwvZz4KPC9zdmc+Cg=="
 	gfSecurityAdminUser          = "admin"
+	ratelimitConfigMapName       = "ratelimit-grafana-dashboard"
+	ratelimitCMDataKey           = "ratelimit.json"
 )
 
 type Reconciler struct {
@@ -159,16 +161,21 @@ func (r *Reconciler) ReconcileGrafanaRateLimitDashboardConfigMap(ctx context.Con
 
 	rateLimitConfigMap := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "ratelimit-grafana-dashboard",
+			Name:      ratelimitConfigMapName,
 			Namespace: r.Config.GetNamespace(),
-		},
-		Data: map[string]string{
-			"ratelimit.json": getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota),
 		},
 	}
 
 	_, err := controllerutil.CreateOrUpdate(ctx, client, rateLimitConfigMap, func() error {
+		if rateLimitConfigMap.Data == nil {
+			rateLimitConfigMap.Data = map[string]string{}
+		}
+		ratelimitJsonStr := getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota)
+		if r.isRatelimitJsonChanged(ctx, client, ratelimitJsonStr) {
+			rateLimitConfigMap.Data[ratelimitCMDataKey] = ratelimitJsonStr
+		}
 		return nil
+
 	})
 	if err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
@@ -349,4 +356,27 @@ func generateRandomBytes(n int) []byte {
 func RandStringRunes(s int) string {
 	b := generateRandomBytes(s)
 	return base64.URLEncoding.EncodeToString(b)
+}
+
+func (r *Reconciler) isRatelimitJsonChanged(ctx context.Context, client k8sclient.Client, newRateLimitJsonStr string) bool {
+	log := l.NewLogger()
+
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      ratelimitConfigMapName,
+		Namespace: r.Config.GetNamespace(),
+	}, configMap); err != nil {
+		log.Error("can't get ratelimit config map "+ratelimitConfigMapName, err)
+		return false
+	}
+
+	ratelimitJsonStr, ok := configMap.Data[ratelimitCMDataKey]
+	if !ok {
+		fmt.Printf(ratelimitCMDataKey + " key not found in " + ratelimitConfigMapName + ", updating config map...")
+		return true
+	}
+	if ratelimitJsonStr == newRateLimitJsonStr {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6097

# What
Fix in CreateOrUpdate() to update Grafana Dashboard when quota changed.

# Verification steps
- run Rhoam
```
CONFIG_IMAGE=quay.io/vmogilev_rhmi/managed-api-service-config:MGDAPI-5991-s1 make cluster/prepare/local
LOCAL=false USE_CLUSTER_STORAGE=true INSTALLATION_TYPE=managed-api make code/run
```
- Open Grafana Ratelimit Dashboard and see that default/Initial Quota is 100K
- Change Quota:  
Edit secret `addon-managed-api-service-parameters` in `redhat-rhoam-operator` ns and check that Quota changed in Grafana Dashboard
```
$ echo -n "10" | base64
MTA=

Set this value in secret:
$ oc edit secret addon-managed-api-service-parameters -n redhat-rhoam-operator

apiVersion: v1
data:
  addon-managed-api-service: MTA=
  custom-domain_domain: ""

```
![Screenshot from 2023-10-25 12-36-34](https://github.com/integr8ly/integreatly-operator/assets/56625811/ae06f258-eb33-45c6-bb9e-2275631cbb17)

