### PR TITLE
MGDAPI-6046 Changed RHOAM uninstall to make final snapshots of Postgres/Redis

### DIFF
--- a/pkg/resources/utils.go
+++ b/pkg/resources/utils.go
@@ -12,3 +12,12 @@ func IsInProw(inst *integreatlyv1alpha1.RHMI) bool {
 	}
 	return false
 }
+
+func IsSkipFinalDBSnapshots(inst *integreatlyv1alpha1.RHMI) bool {
+	annotationMap := inst.GetObjectMeta().GetAnnotations()
+	skipFinalDBSnapshots, ok := annotationMap["skip_final_db_snapshots"]
+	if ok && skipFinalDBSnapshots == "true" {
+		return true
+	}
+	return false
+}

--- a/pkg/resources/utils_test.go
+++ b/pkg/resources/utils_test.go
@@ -1,0 +1,111 @@
+package resources
+
+import (
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+func TestIsInProw(t *testing.T) {
+	type args struct {
+		inst *integreatlyv1alpha1.RHMI
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "in_prow annotation is true",
+			want: true,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"in_prow": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "in_prow annotation is false",
+			want: false,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"in_prow": "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "in_prow annotation doesn't exist",
+			want: false,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsInProw(tt.args.inst); got != tt.want {
+				t.Errorf("IsInProw() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsSkipFinalDBSnapshots(t *testing.T) {
+	type args struct {
+		inst *integreatlyv1alpha1.RHMI
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "in_prow skip_final_db_snapshots is true",
+			want: true,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"skip_final_db_snapshots": "true",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "skip_final_db_snapshots annotation is false",
+			want: false,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{
+					ObjectMeta: metav1.ObjectMeta{
+						Annotations: map[string]string{
+							"skip_final_db_snapshots": "false",
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "skip_final_db_snapshots annotation doesn't exist",
+			want: false,
+			args: args{
+				inst: &integreatlyv1alpha1.RHMI{},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsSkipFinalDBSnapshots(tt.args.inst); got != tt.want {
+				t.Errorf("IsSkipFinalDBSnapshots() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-6046](https://issues.redhat.com/browse/MGDAPI-6046)

# What
This PR changes the RHOAM uninstallation behavior on CCS clusters using AWS for Postgres and Redis. Previously, when RHOAM was uninstalled, RHOAM (via CRO) would delete the 3 Postgres and 3 Redis DBs without making final snapshots (backups) of them. Therefore if a user accidentally deleted RHOAM on a CCS cluster, there would be no way to recover their DBs.

This PR changes the default behavior to instead make a final snapshot of each of the 3 Postgres and 3 Redis instances before deleting them. This default behavior can be overridden by adding the annotation `skip_final_db_snapshots: 'true'` to the RHMI CR at anytime before deleting it.

This PR also updates the Makefile to set `skip_final_db_snapshots: 'true'` when running `make deploy/integreatly-rhmi-cr.yml` so there shouldn't be any change in the uninstallation behavior for local development and automated testing.

# Verification steps
## Prerequisites
1. Provisioned CCS cluster
2. AWS console access to the account that created the CCS cluster

## Verify final snapshots are created by default
1. Once the cluster has finished provisioning, install RHOAM via addon flow.
2. Patch the CSV with this operator image `quay.io/ckyrillo/managed-api-service:rhoam-v1.38.0`.
3. Set `useClusterStorage: 'false'` in the RHMI .spec
4. Wait for the installation to successfully complete.
5. Trigger the RHOAM uninstallation via addon flow.
6. Login to the AWS [RDS console](https://us-east-1.console.aws.amazon.com/rds/home?region=us-east-1#snapshots-list:tab=manual) (change the region if needed) and verify that there are 3 manual snapshots, 1 for each of the Postgres RDSs. Note: the snapshots may not show up until the RDSs are fully deleted.
7. Login to the AWS [ElastiCache console](https://us-east-1.console.aws.amazon.com/elasticache/home?region=us-east-1#/snapshots) (change the region if needed) and verify that there are 3 manual backups, 1 for each of the Redis instance. Note: the backups may not show up until the Redis DBs are fully deleted.
8. Once you have confirmed all 6 backups are there and RHOAM has finished uninstalling, manually delete the backups. **NOTE:** be careful that you are deleting the correct backups used for this PR verification.

## Verify final snapshots are _not_ created when annotation is set
1. Once RHOAM has fully uninstalled via addon flow, install RHOAM again via addon flow.
2. Patch the CSV with this operator image `quay.io/ckyrillo/managed-api-service:rhoam-v1.38.0`.
3. Add an annotation to the RHMI CR with the key set to `skip_final_db_snapshots` and the value set to `true`.
4. Set `useClusterStorage: 'false'` in the RHMI .spec
5. Wait for the installation to successfully complete.
6. Trigger the RHOAM uninstallation via addon flow.
7. Wait for the uninstallation to successfully complete.
8. Verify that no RDS Snapshots or Elasticache Backups were created during RHOAM uninstallation.

