### PR TITLE
MGDAPI-6099 - Delete grafana Operator alerts

### DIFF
--- a/pkg/products/grafana/prometheusRules.go
+++ b/pkg/products/grafana/prometheusRules.go
@@ -1,16 +1,20 @@
 package grafana
 
 import (
+	"context"
 	"fmt"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
 	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string, namespace string) resources.AlertReconciler {
 	installationName := resources.InstallationNames[installType]
-	alertNamePrefix := "customer-monitoring-"
+	alertNamePrefix := "customer-monitoring-po-"
 
 	return &resources.AlertReconcilerImpl{
 		Installation: r.installation,
@@ -36,7 +40,7 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string, nam
 			},
 			{
 				AlertName: alertNamePrefix + "ksm-grafana-alerts",
-				GroupName: "general.rules",
+				GroupName: "grafana-general.rules",
 				Namespace: namespace,
 				Rules: []monv1.Rule{
 					{
@@ -53,4 +57,29 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string, nam
 			},
 		},
 	}
+}
+
+func (r *Reconciler) removeGrafanaOperatorAlerts(installType string, ctx context.Context, apiClient k8sclient.Client) error {
+	oboNamespace := "redhat-" + resources.InstallationNames[installType] + "-operator-observability"
+	prometheusRule := &monv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customer-monitoring-ksm-grafana-alerts",
+			Namespace: oboNamespace,
+		},
+	}
+	err := apiClient.Delete(ctx, prometheusRule)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return err
+	}
+	prometheusRule = &monv1.PrometheusRule{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "customer-monitoring-ksm-endpoint-alerts",
+			Namespace: oboNamespace,
+		},
+	}
+	err = apiClient.Delete(ctx, prometheusRule)
+	if err != nil && !k8serr.IsNotFound(err) {
+		return err
+	}
+	return nil
 }

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -140,6 +140,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		}
 	}
 
+	err = r.removeGrafanaOperatorAlerts(r.installation.Spec.Type, ctx, client)
+	if err != nil {
+		r.log.Error("Error removing obsolete Grafana Operator alerts: ", err)
+	}
 	alertsReconciler := r.newAlertReconciler(r.log, r.installation.Spec.Type, productNamespace)
 	if phase, err := alertsReconciler.ReconcileAlerts(ctx, client); err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.recorder, installation, phase, "Failed to reconcile grafana alerts", err)

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -123,13 +123,13 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			},
 		},
 		{
-			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-ksm-endpoint-alerts.yaml",
+			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-po-ksm-endpoint-alerts.yaml",
 			Rules: []string{
 				"GrafanaServiceEndpointDown",
 			},
 		},
 		{
-			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-ksm-grafana-alerts.yaml",
+			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-po-ksm-grafana-alerts.yaml",
 			Rules: []string{
 				"GrafanaServicePod",
 			},
@@ -218,13 +218,13 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			},
 		},
 		{
-			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-ksm-endpoint-alerts.yaml",
+			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-po-ksm-endpoint-alerts.yaml",
 			Rules: []string{
 				"GrafanaServiceEndpointDown",
 			},
 		},
 		{
-			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-ksm-grafana-alerts.yaml",
+			File: CustomerGrafanaNamespacePrefix + "customer-monitoring-po-ksm-grafana-alerts.yaml",
 			Rules: []string{
 				"GrafanaServicePod",
 			},


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6099

# What
Grafana Operator Alerts remains in from previous release during Upgrade process.
These Alerts are not firing, but impact on Pipeline Functional tests - C04 failed.
Grafana Operator Alerts need to be deleted.

# Verification steps
- Rhoam Upgrade process to be used to verify PR, Upgrade from 1.38.0 to 1.39.0 (this branch)
- Pipeline `test-pr-upgrade` can be used, or manual process (the process is not provided here)
- CatalogSource files for testing with Images for 1.38.0 and 1.39.0, that were used for PR testing in development - attached.
[catalogsource-Rhoam_1.39.0.yaml.txt](https://github.com/integr8ly/integreatly-operator/files/13216714/catalogsource-Rhoam_1.39.0.yaml.txt)
[catalogsource-Rhoam_1.38.yaml.txt](https://github.com/integr8ly/integreatly-operator/files/13216715/catalogsource-Rhoam_1.38.yaml.txt)

