### PR TITLE
MGDAPI-6050 Fixed Verify ClusterObjectTemplates e2e test

### DIFF
--- a/pkg/products/obo/clusterPackage.go
+++ b/pkg/products/obo/clusterPackage.go
@@ -39,7 +39,7 @@ func GetOboClusterPackageLabel(client k8sclient.Client) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("package-operator.run/package=%s", clusterPackageName), nil
+	return fmt.Sprintf("package-operator.run/instance=%s", clusterPackageName), nil
 }
 
 func getClusterPackageName() (string, error) {


### PR DESCRIPTION
# Issue link
[MGDAPI-6050](https://issues.redhat.com/browse/MGDAPI-6050)

# What
It looks like the package-operator slightly changed the name of the labels it applies to ClusterObjectTemplates from `package-operator.run/package=` to `package-operator.run/instance=`. This was causing the `Verify ClusterObjectTemplates ready state` test to fail. This PR updates the label selector to address that.

# Verification steps
N/A - Passing the prow checks should be sufficient verification.
