### PR TITLE
MGDAPI-4918 Allow for specifying testing-idp password via env var

### DIFF
--- a/test/common/3Scale_user_promotion.go
+++ b/test/common/3Scale_user_promotion.go
@@ -64,7 +64,7 @@ func Test3ScaleUserPromotion(t TestingTB, ctx *TestingContext) {
 		t.Fatal(err)
 	}
 
-	err = loginToThreeScale(t, host, dedicatedAdminUser, DefaultPassword, TestingIDPRealm, httpClient)
+	err = loginToThreeScale(t, host, dedicatedAdminUser, TestingIdpPassword, TestingIDPRealm, httpClient)
 	if err != nil {
 		t.Fatalf("Failed to log into 3Scale: %v", err)
 	}
@@ -121,7 +121,7 @@ func loginTo3ScaleAsDeveloper(t TestingTB, user string, host string, ctx *Testin
 		t.Fatal(err)
 	}
 
-	err = loginToThreeScale(t, host, user, DefaultPassword, TestingIDPRealm, httpClient)
+	err = loginToThreeScale(t, host, user, TestingIdpPassword, TestingIDPRealm, httpClient)
 	if err != nil {
 		t.Fatalf("Failed to log into 3Scale: %v", err)
 	}

--- a/test/common/3scale_crudl.go
+++ b/test/common/3scale_crudl.go
@@ -54,7 +54,7 @@ func Test3ScaleCrudlPermissions(t TestingTB, ctx *TestingContext) {
 
 	// Login to 3Scale
 	By("Login to 3Scale and become admin")
-	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
+	err = loginToThreeScale(t, host, threescaleLoginUser, TestingIdpPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
 		t.Fatalf("Failed to log into 3Scale: %v", err)
 	}

--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -480,7 +480,7 @@ func sendTestEmail(ctx *TestingContext, t TestingTB) {
 	tsClient := resources.NewThreeScaleAPIClient(host, keycloakHost, redirectURL, ctx.HttpClient, ctx.Client, t)
 
 	// Login to 3Scale
-	err = loginToThreeScale(t, host, threescaleLoginUser, DefaultPassword, "testing-idp", ctx.HttpClient)
+	err = loginToThreeScale(t, host, threescaleLoginUser, TestingIdpPassword, "testing-idp", ctx.HttpClient)
 	if err != nil {
 		t.Fatalf("[%s] error ocurred: %v", getTimeStampPrefix(), err)
 	}

--- a/test/common/alerts_invalid_username.go
+++ b/test/common/alerts_invalid_username.go
@@ -132,7 +132,7 @@ func pollOpenshiftUserLogin(t TestingTB, ctx *TestingContext, masterURL, userNam
 			return false, nil
 		}
 
-		if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), userName, DefaultPassword, tempHttpClient, TestingIDPRealm, t); err != nil {
+		if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), userName, TestingIdpPassword, tempHttpClient, TestingIDPRealm, t); err != nil {
 			t.Logf("Error trying to sign in as %s to openshift : %v", userName, err)
 			return false, nil
 		}

--- a/test/common/authdelay_first_broker_login.go
+++ b/test/common/authdelay_first_broker_login.go
@@ -66,7 +66,7 @@ func TestAuthDelayFirstBrokerLogin(t TestingTB, ctx *TestingContext) {
 		t.Fatal(err)
 	}
 
-	err = loginToThreeScale(t, tsHost, testUser.UserName, DefaultPassword, TestingIDPRealm, httpClient)
+	err = loginToThreeScale(t, tsHost, testUser.UserName, TestingIdpPassword, TestingIDPRealm, httpClient)
 	if err != nil {
 		t.Fatalf("[%s] error logging in to three scale: %v ", getTimeStampPrefix(), err)
 	}

--- a/test/common/multitenancy.go
+++ b/test/common/multitenancy.go
@@ -245,7 +245,7 @@ func loginUsersTo3scale(t TestingTB, ctx *TestingContext, rhmi *integreatlyv1alp
 
 			// login tenant to 3scale
 			if !isThreeScaleLoggedIn {
-				err := loginToThreeScale(t, host, testUser, DefaultPassword, TestingIDPRealm, tenantClient)
+				err := loginToThreeScale(t, host, testUser, TestingIdpPassword, TestingIDPRealm, tenantClient)
 				if err != nil {
 					t.Log(fmt.Sprintf("User failed to login to 3scale %s", testUser))
 					return false, nil
@@ -967,7 +967,7 @@ func validateTestUser(ctx *TestingContext, rhmi *integreatlyv1alpha1.RHMI, usern
 }
 
 func loginToCluster(t TestingTB, tenantClient *http.Client, masterURL, testUser string) error {
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, DefaultPassword, tenantClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, TestingIdpPassword, tenantClient, TestingIDPRealm, t); err != nil {
 		return err
 	}
 	return nil

--- a/test/common/multitenancy_performance.go
+++ b/test/common/multitenancy_performance.go
@@ -65,7 +65,7 @@ func loginUsersToCluster(t TestingTB, ctx *TestingContext, rhmi *integreatlyv1al
 			// login to cluster
 			if !isClusterLoggedIn {
 				err = resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", rhmi.Spec.MasterURL),
-					testUser, DefaultPassword, tenantClient, TestingIDPRealm, t)
+					testUser, TestingIdpPassword, tenantClient, TestingIDPRealm, t)
 				if err != nil {
 					return false, nil
 				} else {

--- a/test/common/network_policy_access_ns_to_svc.go
+++ b/test/common/network_policy_access_ns_to_svc.go
@@ -42,7 +42,7 @@ func TestNetworkPolicyAccessNSToSVC(t TestingTB, ctx *TestingContext) {
 	masterURL := rhmi.Spec.MasterURL
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), dedicatedAdminUsername, TestingIdpPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/product_login.go
+++ b/test/common/product_login.go
@@ -201,7 +201,7 @@ func loginToRHSSOActions(t TestingTB, rhssoConsoleUrl string, userName string) [
 		chromedp.Navigate(rhssoConsoleUrl),
 		chromedp.WaitVisible(`#kc-page-title`), // Wait for redirect to kc login page
 		chromedp.SendKeys(`//input[@name="username"]`, userName),
-		chromedp.SendKeys(`//input[@name="password"]`, DefaultPassword),
+		chromedp.SendKeys(`//input[@name="password"]`, TestingIdpPassword),
 		chromedp.Submit(`#kc-form-login`),
 		chromedp.WaitVisible(`#input-error`), // Wait to expect login error
 		chromedp.ActionFunc(func(ctx context.Context) error {
@@ -234,7 +234,7 @@ func chromeDPLoginIDPActions(userName string) []chromedp.Action {
 		chromedp.WaitVisible(`html[data-test-id="login"]`), // Wait to allow page to redirect to oauth page
 		chromedp.Click(`a[title="Log in with testing-idp"]`),
 		chromedp.SendKeys(`//input[@name="username"]`, userName),
-		chromedp.SendKeys(`//input[@name="password"]`, DefaultPassword),
+		chromedp.SendKeys(`//input[@name="password"]`, TestingIdpPassword),
 		chromedp.Submit(`#kc-form-login`),
 	}
 }

--- a/test/common/selfmanaged_apicast.go
+++ b/test/common/selfmanaged_apicast.go
@@ -981,7 +981,7 @@ func customerLogin(t TestingTB, ctx *TestingContext, installation *integreatlyv1
 	}
 	err = wait.Poll(pollingTime, tenantReadyTimeout, func() (done bool, err error) {
 		err = resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", installation.Spec.MasterURL),
-			customerAdminUsername, DefaultPassword, httpClient, TestingIDPRealm, t)
+			customerAdminUsername, TestingIdpPassword, httpClient, TestingIDPRealm, t)
 		if err != nil {
 			return false, nil
 		}

--- a/test/common/testing_idp.go
+++ b/test/common/testing_idp.go
@@ -8,6 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 
 	"github.com/integr8ly/integreatly-operator/test/resources"
+	"github.com/integr8ly/integreatly-operator/test/utils"
 	"github.com/integr8ly/keycloak-client/apis/keycloak/v1alpha1"
 	v12 "github.com/openshift/api/authorization/v1"
 	configv1 "github.com/openshift/api/config/v1"
@@ -30,7 +31,7 @@ const (
 	defaultNumberOfDedicatedAdmins = 2
 	defaultSecret                  = "rhmiForeva"
 	DefaultTestUserName            = "test-user"
-	DefaultPassword                = "Password1"
+	defaultPassword                = "Password1"
 	clusterOauthName               = "cluster"
 )
 
@@ -39,6 +40,7 @@ var (
 	keycloakClientNamespace      = RHSSOProductNamespace
 	clusterOauthClientSecretName = fmt.Sprintf("idp-%s", TestingIDPRealm)
 	idpCAName                    = fmt.Sprintf("idp-ca-%s", TestingIDPRealm)
+	TestingIdpPassword           = utils.GetIdpPassword(defaultPassword)
 )
 
 type TestUser struct {
@@ -132,7 +134,7 @@ func createTestingIDP(t TestingTB, ctx context.Context, client dynclient.Client,
 		}
 
 		dedicatedAdminUsername := fmt.Sprintf("%s%02d", defaultDedicatedAdminName, defaultNumberOfDedicatedAdmins)
-		authErr := resources.DoAuthOpenshiftUser(fmt.Sprintf("https://%s/auth/login", masterURL), dedicatedAdminUsername, DefaultPassword, tempHTTPClient, TestingIDPRealm, t)
+		authErr := resources.DoAuthOpenshiftUser(fmt.Sprintf("https://%s/auth/login", masterURL), dedicatedAdminUsername, TestingIdpPassword, tempHTTPClient, TestingIDPRealm, t)
 		if authErr != nil {
 			t.Logf("Error while checking IDP is setup, retrying: %+v", authErr)
 			return false, nil
@@ -405,7 +407,7 @@ func createOrUpdateKeycloakUserCR(ctx context.Context, client dynclient.Client, 
 					Credentials: []v1alpha1.KeycloakCredential{
 						{
 							Type:  "password",
-							Value: DefaultPassword,
+							Value: TestingIdpPassword,
 						},
 					},
 				},

--- a/test/common/user_dedicated_admin_permissions.go
+++ b/test/common/user_dedicated_admin_permissions.go
@@ -62,7 +62,7 @@ func TestDedicatedAdminUserPermissions(t TestingTB, ctx *TestingContext) {
 	}
 
 	// get dedicated admin token
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), customerAdminUsername, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), customerAdminUsername, TestingIdpPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 

--- a/test/common/user_rhmi_developer_permissions.go
+++ b/test/common/user_rhmi_developer_permissions.go
@@ -50,7 +50,7 @@ func TestRHMIDeveloperUserPermissions(t TestingTB, ctx *TestingContext) {
 	t.Log("retrieved openshift-Oauth route")
 
 	// get rhmi developer user tokens
-	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, DefaultPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
+	if err := resources.DoAuthOpenshiftUser(fmt.Sprintf("%s/auth/login", masterURL), testUser, TestingIdpPassword, ctx.HttpClient, TestingIDPRealm, t); err != nil {
 		t.Fatalf("error occured trying to get token : %v", err)
 	}
 	t.Log("retrieved rhmi developer user tokens")

--- a/test/common/users_create_realm_sso.go
+++ b/test/common/users_create_realm_sso.go
@@ -71,7 +71,7 @@ func createRealmInUserSSOActions(t TestingTB, userSSOConsoleUrl, userName string
 		chromedp.WaitVisible(`html[data-test-id="login"]`), // Wait to allow page to redirect to oauth page
 		chromedp.Click(`a[title="Log in with testing-idp"]`),
 		chromedp.SendKeys(`//input[@name="username"]`, userName),
-		chromedp.SendKeys(`//input[@name="password"]`, DefaultPassword),
+		chromedp.SendKeys(`//input[@name="password"]`, TestingIdpPassword),
 		chromedp.Submit(`#kc-form-login`),
 		chromedp.WaitVisible(`div[data-ng-controller="RealmTabCtrl"]`),
 		chromedp.Click(`#view > div.col-sm-3.col-md-2.col-sm-pull-9.col-md-pull-10.sidebar-pf.sidebar-pf-left > div.realm-selector > h2:nth-child(1) > i`),

--- a/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/h24-verify-selfmanaged-apicast-and-custom-policy.go
+++ b/test/scripts/products/h24-verify-selfmanaged-apicast-and-custom-policy/h24-verify-selfmanaged-apicast-and-custom-policy.go
@@ -495,7 +495,7 @@ func customerLogin(interactiveMode bool) error {
 		command = "oc login --token=" + token
 	} else {
 		customerAdminUsername := fmt.Sprintf("%v%02d", defaultDedicatedAdminName, 1)
-		command = "oc login -u " + customerAdminUsername + " -p " + testcommon.DefaultPassword
+		command = "oc login -u " + customerAdminUsername + " -p " + testcommon.TestingIdpPassword
 	}
 	err = runShellCommand(command)
 	if err != nil {

--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -24,3 +24,12 @@ func SpecDescription(spec string) string {
 	}
 	return spec
 }
+
+// GetIdpPassword Allow specifying Testing IDP password via env var.
+func GetIdpPassword(defaultPassword string) string {
+	idpPassword := os.Getenv("TESTING_IDP_PASSWORD")
+	if len(idpPassword) > 0 {
+		return idpPassword
+	}
+	return defaultPassword
+}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-4918

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Populate Testing IDP password from env var preferably and only use DefaultPassword as a fallback if env var is not defined.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

- Install RHOAM and do "oc login" into the cluster
- "export TESTING_IDP_PASSWORD=yourpassword"
- "PASSWORD=$TESTING_IDP_PASSWORD DEDICATED_ADMIN_PASSWORD=$TESTING_IDP_PASSWORD ./scripts/setup-sso-idp.sh"

Execute some of the affected tests:
H07; H03; H11; H34; H35; C19; A16; "Verify Network Policy allows cross NS access to SVC"; B01B; H24; B04; B03; B08B;

Example:
 TESTING_IDP_PASSWORD=yourpassword INSTALLATION_TYPE=managed-api LOCAL=false TEST="A16" make test/e2e/single

Note that H03, H07 might fail since they are a bit flaky.
