### PR TITLE
MGDAPI-6133 Update test H22 after bumping CRO's default Redis to 6

### DIFF
--- a/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
+++ b/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
@@ -522,7 +522,7 @@ type redisCounter struct {
 func (r *redisCounter) GetCount() (int, error) {
 	keys, err := testcommon.ExecToPodArgs(r.client, r.config,
 		[]string{
-			"/opt/rh/rh-redis32/root/usr/bin/redis-cli",
+			"/opt/rh/rh-redis6/root/usr/bin/redis-cli",
 			"-c",
 			"-h",
 			r.RedisHost,
@@ -555,7 +555,7 @@ func (r *redisCounter) GetCount() (int, error) {
 
 		count, err := testcommon.ExecToPodArgs(r.client, r.config,
 			[]string{
-				"/opt/rh/rh-redis32/root/usr/bin/redis-cli",
+				"/opt/rh/rh-redis6/root/usr/bin/redis-cli",
 				"-c",
 				"-h",
 				r.RedisHost,
@@ -590,7 +590,7 @@ func (r *redisCounter) GetCount() (int, error) {
 func (r *redisCounter) keyIsString(key string) (bool, error) {
 	keyType, err := testcommon.ExecToPodArgs(r.client, r.config,
 		[]string{
-			"/opt/rh/rh-redis32/root/usr/bin/redis-cli",
+			"/opt/rh/rh-redis6/root/usr/bin/redis-cli",
 			"-c",
 			"-h",
 			r.RedisHost,


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-6133](https://issues.redhat.com/browse/MGDAPI-6133)

# What
This PR just updates the `h22-validate-that-rate-limit-service-is-working-as-expected` test to work with Redis 6. 

**NOTE:** This PR should not be merged until this CRO [PR](https://github.com/integr8ly/cloud-resource-operator/pull/695) is merged.

# Verification steps
Re-run the tests on this PR once the CRO PR is merged.
