### PR TITLE
MGDAPI-6160 Bump maxOpenShiftVersion to 4.14

### DIFF
--- a/bundles/managed-api-service/1.39.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.39.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/integreatly/managed-api-service:master
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.13"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     operatorframework.io/suggested-namespace: redhat-rhoam-operator
     operators.operatorframework.io/builder: operator-sdk-v1.21.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
@@ -52,19 +52,19 @@ metadata:
     containerImages: |-
       {
         "3scale-operator.3scale-2.13.1-GA": {
-          "3scale-operator.v0.11.6-mas": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:b4c21ef2d30a86798dd6854b150b09502e19b041d3bac87f2e66e0d53e5b6202",
-          "3scale-rhel7-operator-b4c21ef2d30a86798dd6854b150b09502e19b041d3bac87f2e66e0d53e5b6202-annotation": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:b4c21ef2d30a86798dd6854b150b09502e19b041d3bac87f2e66e0d53e5b6202",
-          "manager": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:b4c21ef2d30a86798dd6854b150b09502e19b041d3bac87f2e66e0d53e5b6202",
-          "backend": "registry.redhat.io/3scale-mas/backend-rhel8@sha256:f7c3bb6abecee08663a3dfb29f6c07c67b781f316fac246ca2dfa35685f81253",
-          "apicast": "registry.redhat.io/3scale-mas/apicast-gateway-rhel8@sha256:bf0433d020c7529d783df56c8d8ba566159ac06402dc19dbcf0cb86225506a29",
-          "system": "registry.redhat.io/3scale-mas/system-rhel7@sha256:46164b56c8993428fabbda15d74065dd29964774ebd0b91c0d955344dcb7c3eb",
-          "zync": "registry.redhat.io/3scale-mas/zync-rhel8@sha256:3f3d9ce5d25cfcd1182cf600150077702b3312d9b6cb557f78e955585b0dee64",
-          "system_memcached": "registry.redhat.io/3scale-mas/memcached-rhel7@sha256:51e78ee68a7fb9364ab5d1ab466f37c535d7485a8fafbaea8069963942252957",
-          "system_postgresql": "registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:6d11943de0765723697c27b784804aeaab572bfd2c838146fbf4eda3c77fa7e1",
-          "system_searchd": "registry.redhat.io/3scale-mas/searchd-rhel7@sha256:0a660658bbeeaf95b04722bee720a99f14216b6bc035a68b4fcb3d36c2d821f2"
+          "3scale-operator.v0.11.8-mas": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:0a6673eae2f0e8d95b919b0243e44d2c0383d13e2e616ac8d3f80742d496d292",
+          "3scale-rhel7-operator-0a6673eae2f0e8d95b919b0243e44d2c0383d13e2e616ac8d3f80742d496d292-annotation": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:0a6673eae2f0e8d95b919b0243e44d2c0383d13e2e616ac8d3f80742d496d292",
+          "manager": "registry.redhat.io/3scale-mas/3scale-rhel7-operator@sha256:0a6673eae2f0e8d95b919b0243e44d2c0383d13e2e616ac8d3f80742d496d292",
+          "backend": "registry.redhat.io/3scale-mas/backend-rhel8@sha256:7d07caf7b6c5a195ba4706e82f3d28c3793afab99b1a6d5a7020547c48534cdc",
+          "apicast": "registry.redhat.io/3scale-mas/apicast-gateway-rhel8@sha256:a03a1ae7f01259192b8d7b4ecee6ddfcdc0cd9e2d24a8c2306accb93ee767135",
+          "system": "registry.redhat.io/3scale-mas/system-rhel7@sha256:b0fd85a4994502a3a2ae9ba6a7610c38af64b6cc897efac12feb4b115a484f77",
+          "zync": "registry.redhat.io/3scale-mas/zync-rhel9@sha256:419eb09d1b165363d5b90df01c1fa10f1f91f03649a8758620ffa49276685feb",
+          "system_memcached": "registry.redhat.io/3scale-mas/memcached-rhel7@sha256:9c2aba45971c924fd55b2aab50ee8e6861a9defd3808b38ff30316727af31f9a",
+          "system_postgresql": "registry.redhat.io/rhscl/postgresql-10-rhel7@sha256:4f807ee6e885e966853f70e1c40bbc179dc1f994b401ac868b7f2b921f9d17a0",
+          "system_searchd": "registry.redhat.io/3scale-mas/searchd-rhel7@sha256:1426e4bd4aa0eb28b479900ffc02621203886280d24997cd11818387ff30d9df"
         },
-        "cloud-resource-operator.v1.1.1": {
-          "cloud-resources.v1.1.0": "quay.io/integreatly/cloud-resource-operator:v1.1.0"
+        "cloud-resource-operator.v1.1.2": {
+          "cloud-resources.v1.1.2": "quay.io/integreatly/cloud-resource-operator:v1.1.2"
         },
         "marin3r.v0.11.0": {
           "marin3r.v0.12.3": "quay.io/3scale/marin3r:v0.12.3"
@@ -88,7 +88,7 @@ metadata:
           "grafana": "registry.redhat.io/rhel9/grafana@sha256:43c8f19a426aea02579dcc1aa818f92666e0d8743b489df074b2fdf465ce29fe"
         },
         "grafana-ose-oauth-proxy": {
-          "grafana-ose-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:62fdde504a8e55669286c525b2d3f224740800843c0a0732d18d5b1024716551"
+          "grafana-ose-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:219bf2d14157acd90298df58bfe77c2e3ed51ce0c743c2e51b3ed54b73dafc14"
         }
       }
   name: managed-api-service.v1.39.0
@@ -639,8 +639,6 @@ spec:
                     command:
                       - rhmi-operator
                     env:
-                      - name: INSTALLATION_TYPE
-                        value: managed-api
                       - name: WATCH_NAMESPACE
                         valueFrom:
                           fieldRef:
@@ -655,6 +653,8 @@ spec:
                         value: "true"
                       - name: LOG_LEVEL
                         value: info
+                      - name: INSTALLATION_TYPE
+                        value: managed-api
                       - name: REBALANCE_PODS
                         value: "true"
                       - name: ALERT_SMTP_FROM

--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.13"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.14"}]'
     support: RHOAM
   name: managed-api-service.v1.39.0
   namespace: placeholder


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-6160](https://issues.redhat.com/browse/MGDAPI-6160)

# What
This PR bumps the `maxOpenShiftVersion` to 4.14 and updates the `containerImages` in the CSV in preparation for the release of v1.39.0 of RHOAM.

# Verification steps
An eye review and passing the PROW checks should be sufficient verification.
