### PR TITLE
MGDAPI-6131 Requeued if pagerduty secret is missing

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -795,7 +795,7 @@ func (r *RHMIReconciler) preflightChecks(installation *rhmiv1alpha1.RHMI, instal
 				return ctrl.Result{}, err
 			}
 
-			return ctrl.Result{}, err
+			return result, nil
 		}
 		log.Infof("found required secret", l.Fields{"secret": secretName})
 		eventRecorder.Eventf(installation, "Normal", rhmiv1alpha1.EventPreflightCheckPassed,


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-6131

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

If pagerduty secret was missing (e.g. OCM/Hive was slow in creating it for whatever reason) the RHOAM installation got stuck. This fixes is by returing "requeue" result in case of error in getting the secret and in case of non-existence of the secret. This triggers another reconcile(s) later until OCM/Hive creates the secret.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

- Get an OSD cluster and `oc login...` into it
-  Checkout this PR
-  Prepare the cluster for rhoam installation: `make cluster/prepare/local`
- Remove the pagerduty secret from redhat-rhoam-operator namespace:
  - `oc delete secret redhat-rhoam-pagerduty -n redhat-rhoam-operator`
- Remove `cluster/prepare/pagerduty` make target from `code/run` make target in Makefile:
  - https://github.com/integr8ly/integreatly-operator/blob/master/Makefile#L157
- Run the operator locally: `make code/run`
- Watch the RHMI CR and wait for it to report preflight checks failing due to missing pagerduty secret
  - `oc get rhmi rhoam -n redhat-rhoam-operator -o json`
  - `.status.preflightMessage` to contain "Could not find redhat-rhoam-pagerduty secret in redhat-rhoam-operator namespace"
- Create a pagerduty secret: `make cluster/prepare/pagerduty`
- Watch the RHMI CR and wait for preflight checks to pass:
  - `oc get rhmi rhoam -n redhat-rhoam-operator -o json`
  - `.status.preflightMessage` to contain "preflight checks passed"