### PR TITLE
MGDAPI-6217 update the timer of the alert

### DIFF
--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -244,7 +244,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 func (r *RHMIReconciler) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	reconcileDelayedMetric := metrics.InstallationControllerReconcileDelayed
 	reconcileDelayedMetric.Set(0) // reset on every reconcile to prevent alert from firing continuously
-	timer := time.AfterFunc(time.Minute*12, func() {
+	timer := time.AfterFunc(time.Minute*30, func() {
 		reconcileDelayedMetric.Set(1)
 	})
 	defer timer.Stop()

--- a/pkg/products/obo/prometheusRules.go
+++ b/pkg/products/obo/prometheusRules.go
@@ -314,7 +314,7 @@ func OboAlertsReconciler(logger l.Logger, installation *integreatlyv1alpha1.RHMI
 					Alert: fmt.Sprintf("%sInstallationControllerReconcileDelayed", strings.ToUpper(installationName)),
 					Annotations: map[string]string{
 						"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-						"message": fmt.Sprintf("The reconcile function of the installation controller in a completed state of %s operator is taking more than 12 minutes to complete", strings.ToUpper(installationName)),
+						"message": fmt.Sprintf("The reconcile function of the installation controller in a completed state of %s operator is taking more than 30 minutes to complete", strings.ToUpper(installationName)),
 					},
 					Expr:   intstr.FromString(installationName + `_version{version=~".+", to_version=""} * on(pod) (installation_controller_reconcile_delayed == 1)`),
 					For:    "1m",


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6217

# What
Increase the time before the RHOAMInstallationControllerReconcileDelayed fires.

# Verification steps
- Install RHOAM from this branch, verify that the RHOAMInstallationControllerReconcileDelayed alert mentions 30mins instead of 12.
- When running rhoam locally, stop the operator and add a sleep of 31minutes here https://github.com/integr8ly/integreatly-operator/blob/master/controllers/rhmi/rhmi_controller.go#L252 and run again. 
- the alert should go into pending or firing after that time.
