### PR TITLE
MGDAPI-6243 Update A33 test to work with OSD v4.15

### DIFF
--- a/pkg/resources/cluster/cluster.go
+++ b/pkg/resources/cluster/cluster.go
@@ -108,5 +108,5 @@ func GetClusterVersion(cr *configv1.ClusterVersion) (string, error) {
 	if cr.Status.Desired.Version != "" {
 		return cr.Status.Desired.Version, nil
 	}
-	return "", fmt.Errorf("dedired.version not set in status block")
+	return "", fmt.Errorf("desired.version not set in status block")
 }

--- a/test/common/console_links.go
+++ b/test/common/console_links.go
@@ -9,6 +9,7 @@ import (
 	"github.com/chromedp/cdproto/cdp"
 	"github.com/chromedp/chromedp"
 	rhmiv1alpha1 "github.com/integr8ly/integreatly-operator/apis/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/cluster"
 	"github.com/integr8ly/integreatly-operator/utils"
 )
 
@@ -33,6 +34,15 @@ func TestConsoleLinks(t TestingTB, ctx *TestingContext) {
 		t.Fatal(err)
 	}
 
+	clusterVersionCR, err := cluster.GetClusterVersionCR(context.TODO(), ctx.Client)
+	if err != nil {
+		t.Fatalf("error getting ClusterVersion CR: %w", err)
+	}
+	clusterVersion, err := cluster.GetClusterVersion(clusterVersionCR)
+	if err != nil {
+		t.Fatalf("error getting cluster version from ClusterVersion CR: %w", err)
+	}
+
 	const expectedIcon = "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPCEtLSBHZW5lcmF0b3I6IEFkb2JlIElsbHVzdHJhdG9yIDI1LjIuMCwgU1ZHIEV4cG9ydCBQbHVnLUluIC4gU1ZHIFZlcnNpb246IDYuMDAgQnVpbGQgMCkgIC0tPgo8c3ZnIHZlcnNpb249IjEuMSIgaWQ9IkxheWVyXzEiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyIgeG1sbnM6eGxpbms9Imh0dHA6Ly93d3cudzMub3JnLzE5OTkveGxpbmsiIHg9IjBweCIgeT0iMHB4IgoJIHZpZXdCb3g9IjAgMCAzNyAzNyIgc3R5bGU9ImVuYWJsZS1iYWNrZ3JvdW5kOm5ldyAwIDAgMzcgMzc7IiB4bWw6c3BhY2U9InByZXNlcnZlIj4KPHN0eWxlIHR5cGU9InRleHQvY3NzIj4KCS5zdDB7ZmlsbDojRUUwMDAwO30KCS5zdDF7ZmlsbDojRkZGRkZGO30KPC9zdHlsZT4KPGc+Cgk8cGF0aCBkPSJNMjcuNSwwLjVoLTE4Yy00Ljk3LDAtOSw0LjAzLTksOXYxOGMwLDQuOTcsNC4wMyw5LDksOWgxOGM0Ljk3LDAsOS00LjAzLDktOXYtMThDMzYuNSw0LjUzLDMyLjQ3LDAuNSwyNy41LDAuNUwyNy41LDAuNXoiCgkJLz4KCTxnPgoJCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yNSwyMi4zN2MtMC45NSwwLTEuNzUsMC42My0yLjAyLDEuNWgtMS44NVYyMS41YzAtMC4zNS0wLjI4LTAuNjItMC42Mi0wLjYycy0wLjYyLDAuMjgtMC42MiwwLjYydjMKCQkJYzAsMC4zNSwwLjI4LDAuNjIsMC42MiwwLjYyaDIuNDhjMC4yNywwLjg3LDEuMDcsMS41LDIuMDIsMS41YzEuMTcsMCwyLjEyLTAuOTUsMi4xMi0yLjEyUzI2LjE3LDIyLjM3LDI1LDIyLjM3eiBNMjUsMjUuMzcKCQkJYy0wLjQ4LDAtMC44OC0wLjM5LTAuODgtMC44OHMwLjM5LTAuODgsMC44OC0wLjg4czAuODgsMC4zOSwwLjg4LDAuODhTMjUuNDgsMjUuMzcsMjUsMjUuMzd6Ii8+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTIwLjUsMTYuMTJjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJ2LTIuMzhoMS45MWMwLjMyLDAuNzcsMS4wOCwxLjMxLDEuOTYsMS4zMQoJCQljMS4xNywwLDIuMTItMC45NSwyLjEyLTIuMTJzLTAuOTUtMi4xMi0yLjEyLTIuMTJjLTEuMDIsMC0xLjg4LDAuNzMtMi4wOCwxLjY5SDIwLjVjLTAuMzQsMC0wLjYyLDAuMjgtMC42MiwwLjYydjMKCQkJQzE5Ljg3LDE1Ljg1LDIwLjE2LDE2LjEyLDIwLjUsMTYuMTJ6IE0yNSwxMS40M2MwLjQ4LDAsMC44OCwwLjM5LDAuODgsMC44OHMtMC4zOSwwLjg4LTAuODgsMC44OHMtMC44OC0wLjM5LTAuODgtMC44OAoJCQlTMjQuNTIsMTEuNDMsMjUsMTEuNDN6Ii8+CgkJPHBhdGggY2xhc3M9InN0MCIgZD0iTTEyLjEyLDE5Ljk2di0wLjg0aDIuMzhjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJzLTAuMjgtMC42Mi0wLjYyLTAuNjJoLTIuMzh2LTAuOTEKCQkJYzAtMC4zNS0wLjI4LTAuNjItMC42Mi0wLjYyaC0zYy0wLjM0LDAtMC42MiwwLjI4LTAuNjIsMC42MnYzYzAsMC4zNSwwLjI4LDAuNjIsMC42MiwwLjYyaDNDMTEuODQsMjAuNTksMTIuMTIsMjAuMzEsMTIuMTIsMTkuOTYKCQkJeiBNMTAuODcsMTkuMzRIOS4xMnYtMS43NWgxLjc1VjE5LjM0eiIvPgoJCTxwYXRoIGNsYXNzPSJzdDAiIGQ9Ik0yOC41LDE2LjM0aC0zYy0wLjM0LDAtMC42MiwwLjI4LTAuNjIsMC42MnYwLjkxSDIyLjVjLTAuMzQsMC0wLjYyLDAuMjgtMC42MiwwLjYyczAuMjgsMC42MiwwLjYyLDAuNjJoMi4zOAoJCQl2MC44NGMwLDAuMzUsMC4yOCwwLjYyLDAuNjIsMC42MmgzYzAuMzQsMCwwLjYyLTAuMjgsMC42Mi0wLjYydi0zQzI5LjEyLDE2LjYyLDI4Ljg0LDE2LjM0LDI4LjUsMTYuMzR6IE0yNy44NywxOS4zNGgtMS43NXYtMS43NQoJCQloMS43NVYxOS4zNHoiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTYuNSwyMC44N2MtMC4zNCwwLTAuNjMsMC4yOC0wLjYzLDAuNjJ2Mi4zOGgtMS44NWMtMC4yNy0wLjg3LTEuMDctMS41LTIuMDItMS41CgkJCWMtMS4xNywwLTIuMTIsMC45NS0yLjEyLDIuMTJzMC45NSwyLjEyLDIuMTIsMi4xMmMwLjk1LDAsMS43NS0wLjYzLDIuMDItMS41aDIuNDhjMC4zNCwwLDAuNjItMC4yOCwwLjYyLTAuNjJ2LTMKCQkJQzE3LjEyLDIxLjE1LDE2Ljg0LDIwLjg3LDE2LjUsMjAuODd6IE0xMiwyNS4zN2MtMC40OCwwLTAuODgtMC4zOS0wLjg4LTAuODhzMC4zOS0wLjg4LDAuODgtMC44OHMwLjg4LDAuMzksMC44OCwwLjg4CgkJCVMxMi40OCwyNS4zNywxMiwyNS4zN3oiLz4KCQk8cGF0aCBjbGFzcz0ic3QwIiBkPSJNMTYuNSwxMS44N2gtMi40MmMtMC4yLTAuOTctMS4wNi0xLjY5LTIuMDgtMS42OWMtMS4xNywwLTIuMTIsMC45NS0yLjEyLDIuMTJzMC45NSwyLjEyLDIuMTIsMi4xMgoJCQljMC44OCwwLDEuNjQtMC41NCwxLjk2LTEuMzFoMS45MXYyLjM4YzAsMC4zNSwwLjI4LDAuNjIsMC42MywwLjYyczAuNjItMC4yOCwwLjYyLTAuNjJ2LTNDMTcuMTIsMTIuMTUsMTYuODQsMTEuODcsMTYuNSwxMS44N3oKCQkJIE0xMiwxMy4xOGMtMC40OCwwLTAuODgtMC4zOS0wLjg4LTAuODhzMC4zOS0wLjg4LDAuODgtMC44OHMwLjg4LDAuMzksMC44OCwwLjg4UzEyLjQ4LDEzLjE4LDEyLDEzLjE4eiIvPgoJPC9nPgoJPHBhdGggY2xhc3M9InN0MSIgZD0iTTE4LjUsMjIuNjJjLTIuMjcsMC00LjEzLTEuODUtNC4xMy00LjEyczEuODUtNC4xMiw0LjEzLTQuMTJzNC4xMiwxLjg1LDQuMTIsNC4xMlMyMC43NywyMi42MiwxOC41LDIyLjYyegoJCSBNMTguNSwxNS42MmMtMS41OCwwLTIuODgsMS4yOS0yLjg4LDIuODhzMS4yOSwyLjg4LDIuODgsMi44OHMyLjg4LTEuMjksMi44OC0yLjg4UzIwLjA4LDE1LjYyLDE4LjUsMTUuNjJ6Ii8+CjwvZz4KPC9zdmc+Cg=="
 
 	// Expected console links in the order expected from the Application Launcher
@@ -54,12 +64,12 @@ func TestConsoleLinks(t TestingTB, ctx *TestingContext) {
 	consoleUrl := fmt.Sprintf("https://%s", consoleRoute.Spec.Host)
 
 	// test console links for developer user
-	testConsoleLinksForUser(t, consoleUrl, "test-user01", expectedConsoleLinks)
+	testConsoleLinksForUser(t, consoleUrl, "test-user01", expectedConsoleLinks, clusterVersion)
 	// test console links for dedicated admin
-	testConsoleLinksForUser(t, consoleUrl, "customer-admin01", expectedConsoleLinks)
+	testConsoleLinksForUser(t, consoleUrl, "customer-admin01", expectedConsoleLinks, clusterVersion)
 }
 
-func testConsoleLinksForUser(t TestingTB, consoleUrl, userName string, expectedConsoleLinks []ConsoleLinkAssertion) {
+func testConsoleLinksForUser(t TestingTB, consoleUrl, userName string, expectedConsoleLinks []ConsoleLinkAssertion, clusterVersion string) {
 	const applicationLauncherSelector = `button[aria-label="Application launcher"]`
 
 	// Navigate to OSD landing page
@@ -89,18 +99,24 @@ func testConsoleLinksForUser(t TestingTB, consoleUrl, userName string, expectedC
 		// Click the application launcher button
 		chromedp.Click(applicationLauncherSelector),
 		// Assert console links
-		assertConsoleLinksAction(t, expectedConsoleLinks),
+		assertConsoleLinksAction(t, expectedConsoleLinks, clusterVersion),
 	}...)
 
 	ChromeDpTimeOutWithActions(t, 2*time.Minute, actions...)
 }
 
 // assertConsoleLinksAction checks that the console links from
-func assertConsoleLinksAction(t TestingTB, expectedConsoleLinks []ConsoleLinkAssertion) chromedp.ActionFunc {
+func assertConsoleLinksAction(t TestingTB, expectedConsoleLinks []ConsoleLinkAssertion, clusterVersion string) chromedp.ActionFunc {
 	return func(ctx context.Context) error {
 		// Get all the sections from the dropdown as there could be multiple depending on developer user and dedicated admin
 		var sections []*cdp.Node
-		if err := chromedp.Run(ctx, chromedp.Nodes(`section[class="pf-c-app-launcher__group"]`, &sections, chromedp.ByQueryAll)); err != nil {
+
+		sectionSelector := `section[class="pf-c-app-launcher__group"]`
+		if strings.Contains(clusterVersion, "4.15.") {
+			sectionSelector = `section[class="pf-v5-c-app-launcher__group"]`
+		}
+
+		if err := chromedp.Run(ctx, chromedp.Nodes(sectionSelector, &sections, chromedp.ByQueryAll)); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-6243

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

Change of section class in OSD v4.15 broke the test so the test now has to determine the cluster version first and populate the sectionSelector with proper value based on the cluster version. 

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Install RHOAM twice -> on OSD v4.15.0-rc.5 and OSD v4.14.10 (latest 4.14 at the time of writing this)
Run the A33 against both clusters, it should pass for each

```
LOCAL=false INSTALLATION_TYPE=managed-api TESTING_IDP_PASSWORD="HIDDEN" TEST=A33 make test/e2e/single
```

