### PR TITLE
MGDAPI-6281 Update A33 test to pass on OSD v4.16

### DIFF
--- a/test/common/console_links.go
+++ b/test/common/console_links.go
@@ -3,6 +3,7 @@ package common
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -112,7 +113,11 @@ func assertConsoleLinksAction(t TestingTB, expectedConsoleLinks []ConsoleLinkAss
 		var sections []*cdp.Node
 
 		sectionSelector := `section[class="pf-c-app-launcher__group"]`
-		if strings.Contains(clusterVersion, "4.15.") {
+		match, err := regexp.MatchString("4\\.1[56789]\\.", clusterVersion)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if match {
 			sectionSelector = `section[class="pf-v5-c-app-launcher__group"]`
 		}
 
@@ -130,7 +135,7 @@ func assertConsoleLinksAction(t TestingTB, expectedConsoleLinks []ConsoleLinkAss
 
 		// Get all the links from this section
 		var links []*cdp.Node
-		err := chromedp.Run(ctx,
+		err = chromedp.Run(ctx,
 			chromedp.Nodes(`a`, &links, chromedp.FromNode(lastElement), chromedp.ByQueryAll),
 		)
 


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->

https://issues.redhat.com/browse/MGDAPI-6281

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

A33 test update so that it pass on OSD v4.16 as well.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

LOCAL=false INSTALLATION_TYPE=managed-api TESTING_IDP_PASSWORD="CHANGEME" TEST="A33" make test/e2e/single
