### PR TITLE
MGDAPI-6376 add service update for elasticache

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -57,7 +57,7 @@ const (
 	cidrRangeKeyAws              = "cidr-range"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update"}
+var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240501-intel"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}

--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -57,7 +57,7 @@ const (
 	cidrRangeKeyAws              = "cidr-range"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240501-intel"}
+var redisServiceUpdatesToInstall = []string{"elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240225-intel", "elasticache-20240501-intel"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}


### PR DESCRIPTION
# Issue link
<!-- insert a link to the JIRA ticket, GitHub issue or discussion thread -->
MGDAPI-6376  

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->
Add service update for elasticache

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->
- install this branch on a ccs cluster
```bash
INSTALLATION_TYPE=managed-api make cluster/prepare/local
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml
INSTALLATION_TYPE=managed-api make code/run
```
- check the service updates are applied in the aws elasticache ui
![image](https://github.com/integr8ly/integreatly-operator/assets/16667688/574126df-cc75-49cf-a9e3-3aafba38dc2a)

- here is eng long lived where they are not applied
![image](https://github.com/integr8ly/integreatly-operator/assets/16667688/7e4aa558-5d1b-4e1d-b3ba-2713572b4d39)
- this may not be much of a verification as I believe all new redis will get latest the service updates automatically. This verification may not be worth doing. 


