### PR TITLE
MGDAPI-6408 Update A25 test to pass on OSD v4.16

### DIFF
--- a/test/functional/aws_standalone_vpc.go
+++ b/test/functional/aws_standalone_vpc.go
@@ -512,12 +512,13 @@ func verifyClusterRouteTables(routeTables []*ec2.RouteTable, vpcCidr string, pee
 		clusterRouteTablesError: []error{},
 	}
 
-	// 1 private route per AZ + 1 public route for public cluster
+	// 1 private route table (RT) per AZ + 1 public RT if cluster is public (OSD v4.15-)
+	// 1 private RT per AZ + 1 public RT per AZ if cluster is public (OSD v4.16+)
 	expectedRouteTableCount := len(availableZones)
 	if !privateCluster {
 		expectedRouteTableCount += 1
 	}
-	if len(routeTables) != expectedRouteTableCount {
+	if expectedRouteTableCount <= len(routeTables) && len(routeTables) <= 2*len(availableZones) {
 		errMsg := fmt.Errorf("unexpected number of route tables: %d", len(routeTables))
 		newErr.clusterRouteTablesError = append(newErr.clusterRouteTablesError, errMsg)
 		return newErr


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6408

# What
Update of A25 test to pass on OSD v4.16.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Given the simplicity of the change I think that eye review is sufficient. I ran the test against ROSA STS OSD v4.15 and it passed. Nightly pipelines will show us quickly if there is smt wrong with this.
