### PR TITLE
MGDAPI-6408 Fix A25 test

### DIFF
--- a/test/functional/aws_standalone_vpc.go
+++ b/test/functional/aws_standalone_vpc.go
@@ -518,7 +518,7 @@ func verifyClusterRouteTables(routeTables []*ec2.RouteTable, vpcCidr string, pee
 	if !privateCluster {
 		expectedRouteTableCount += 1
 	}
-	if expectedRouteTableCount <= len(routeTables) && len(routeTables) <= 2*len(availableZones) {
+	if expectedRouteTableCount > len(routeTables) || len(routeTables) > 2*len(availableZones) {
 		errMsg := fmt.Errorf("unexpected number of route tables: %d", len(routeTables))
 		newErr.clusterRouteTablesError = append(newErr.clusterRouteTablesError, errMsg)
 		return newErr


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6408

# What
Fix bug introduced by me :facepalm:  in https://github.com/integr8ly/integreatly-operator/pull/3475

The condition needs to be converted to its negation.

The test should fail if no. of route tables for multiAZ clusters (having 3 AZs) is *not* in between 4 (incl.)  and 6 (incl.) - exact value depends on the OCP version. The `expectedRouteTableCount` represents the minimum (4) and the `2*len(availableZones)` represents the maximum.
For singleAZ clusters there should be two route tables regardless the OCP version.

# Verification steps
Ideal would be to create three clusters:
OSD v4.16 multiAZ cluster (6 route tables)
OSD v41.5 multiAZ cluster (4 route tables)
OSD v4.16 singleAZ cluster (2 route tables)

Install RHOAM on each and validate that A25 test passes on each. But I feel that this is overkill for such a simple non customer facing change so eye review should suffice. Nightly pipelines reveal if there is a bug with this quickly. 
