### PR TITLE
MGDAPI-5835 - Update base ubi images to use ubi9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi8/go-toolset:1.20.12-5 AS builder
+FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -22,7 +22,7 @@ COPY utils/ utils/
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o rhmi-operator main.go
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/rhmi-operator \
     USER_UID=1001 \

--- a/Dockerfile.osde2e
+++ b/Dockerfile.osde2e
@@ -28,7 +28,7 @@ COPY Makefile ./
 # compile test binary
 RUN make test/compile/osde2e
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 COPY --from=builder /go/src/github.com/integr8ly/integreatly-operator/managed-api-test-harness.test managed-api-test-harness.test
 

--- a/Dockerfile.scorecard
+++ b/Dockerfile.scorecard
@@ -19,7 +19,7 @@ COPY test/scorecard ./test/scorecard
 # Build
 RUN GOOS=linux GOARCH=amd64 make scorecard/compile
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 #  kubectl 1.18
 RUN curl -Lso /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/v1.18.0/bin/linux/amd64/kubectl

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ENV OPERATOR=/usr/local/bin/rhmi-operator \
     USER_UID=1001 \


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-5835

# What
Update the ubi8 images to use ubi9 instead.

# Verification steps
- validation done - Local RHOAM installation - completed successfully
