### PR TITLE
MGDAPI-6421 Use root to support base image build via podman v4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Build the manager binary
 FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
 
+# this is required for podman
+USER root
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6421

# What

The ticket is about CRO but same is true for RHOAM base image build. This is the same fix as was done for CRO:
https://github.com/integr8ly/cloud-resource-operator/pull/827

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Have a podman v4 (I validated with v4.9.4 because our ci-cd pipeline uses that version) installed. Then execute:
`ORG=your-quay-org INSTALLATION_TYPE=managed-api TAG=test CONTAINER_ENGINE=podman make image/build/push`

or simply

`podman build --tag quay.io/your-org/managed-api-service:test -f ./Dockerfile .`

I validated this PR via pipeline. It failed due to missing cluster but building base operator image, bundle, index, and test harness image went ok:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-rosa-autoscale-upgrade/20/consoleFull