### PR TITLE
MGDAPI-6431 Update RHSSO image for RHOAM 1.41

### DIFF
--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -75,8 +75,8 @@ var (
 	PreflightFail       PreflightStatus = "failed"
 
 	// Operator image tags
-	OperatorVersionRHSSO          OperatorVersion = "7.6.7-1"
-	OperatorVersionRHSSOUser      OperatorVersion = "7.6.7-1"
+	OperatorVersionRHSSO          OperatorVersion = "7.6.9-3"
+	OperatorVersionRHSSOUser      OperatorVersion = "7.6.9-3"
 	OperatorVersionCloudResources OperatorVersion = "1.1.4"
 	OperatorVersion3Scale         OperatorVersion = "0.11.8-mas"
 	OperatorVersionMarin3r        OperatorVersion = "0.13.1"

--- a/bundles/rhsso-operator/bundles.yaml
+++ b/bundles/rhsso-operator/bundles.yaml
@@ -55,3 +55,13 @@ bundles:
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.6-4
     - name: rhsso-operator.v7.6.7-1
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.7-1
+    - name: rhsso-operator.v7.6.7-4
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.7-4
+    - name: rhsso-operator.v7.6.8-2
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.8-2
+    - name: rhsso-operator.v7.6.8-3
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.8-3
+    - name: rhsso-operator.v7.6.9-2
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-2
+    - name: rhsso-operator.v7.6.9-3
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-3

--- a/manifests/integreatly-rhsso/7.6.7-4/keycloakbackups.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/keycloakbackups.keycloak.org.crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.7-4/keycloakclients.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/keycloakclients.keycloak.org.crd.yaml
@@ -1,0 +1,744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used to group different resource instances with the same type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              serviceAccountClientRoles:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Service account client roles for this client.
+                type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.7-4/keycloakrealms.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/keycloakrealms.keycloak.org.crd.yaml
@@ -1,0 +1,1276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to this resource can be managed by the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource. It can be used to group different resource instances with the same type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviderMappers:
+                    description: A set of Identity Provider Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider Mapper config.
+                          type: object
+                        id:
+                          type: string
+                        identityProviderAlias:
+                          description: Identity Provider Alias.
+                          type: string
+                        identityProviderMapper:
+                          description: Identity Provider Mapper.
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  otpPolicyAlgorithm:
+                    description: OTP Policy Algorithm
+                    type: string
+                  otpPolicyDigits:
+                    description: OTP Policy Digits
+                    format: int32
+                    type: integer
+                  otpPolicyInitialCounter:
+                    description: OTP Policy Initial Counter
+                    format: int32
+                    type: integer
+                  otpPolicyLookAheadWindow:
+                    description: OTP Policy Look Ahead Window
+                    format: int32
+                    type: integer
+                  otpPolicyPeriod:
+                    description: OTP Policy Period
+                    format: int32
+                    type: integer
+                  otpPolicyType:
+                    description: OTP Policy Type
+                    type: string
+                  otpSupportedApplications:
+                    description: OTP Supported Applications
+                    items:
+                      type: string
+                    type: array
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        changedSyncPeriod:
+                          format: int32
+                          type: integer
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap", "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.7-4/keycloaks.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/keycloaks.keycloak.org.crd.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              DisableDefaultServiceMonitor:
+                description: Disables the integration with Application Monitoring Operator. When set to true, the operator doesn't create default PrometheusRule, ServiceMonitor and GrafanaDashboard objects and users will have to create them manually, if needed.
+                type: boolean
+              disableReplicasSyncing:
+                description: Specify whether disabling the syncing of instances from the Keycloak CR to the statefulset replicas should be enabled or disabled. This option could be used when enabling HPA(horizontal pod autoscaler). Defaults to false.
+                type: boolean
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting this field to "reencrypt" will terminate TLS on the Ingress/Route level. Setting this field to "passthrough" will send encrypted traffic to the Pod. If unspecified, defaults to "reencrypt". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: Experimental section
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  podannotations:
+                    additionalProperties:
+                      type: string
+                    description: List of annotations to set in the keycloak pods
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration. This field is deprecated and will be ignored on K8s >=1.25
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for PostgresDeployment.
+                properties:
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.7-4/keycloakusers.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/keycloakusers.keycloak.org.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.7-4/rhsso-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/7.6.7-4/rhsso-operator.clusterserviceversion.yaml
@@ -1,0 +1,400 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Security
+    certified: 'False'
+    containerImage: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:711f12fe68c345c8753b39f68ff0ba71f5c209b9a466ef98feffbcadb531b545
+    createdAt: 2021-08-09 00:00:00
+    description: 'An Operator for installing and managing Red Hat Single Sign-On'
+    repository: 'https://github.com/keycloak/keycloak-operator'
+    support: Red Hat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "Keycloak",
+          "metadata": {
+            "name": "example-keycloak",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "instances": 1,
+            "externalAccess": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakRealm",
+          "metadata": {
+            "name": "example-keycloakrealm"
+          },
+          "spec": {
+            "realm": {
+              "id": "basic",
+              "realm": "basic",
+              "enabled": true,
+              "displayName": "Basic Realm"
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakBackup",
+          "metadata": {
+            "name": "example-keycloakbackup"
+          },
+          "spec": {
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakClient",
+          "metadata": {
+            "name": "client-secret",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            },
+            "client": {
+              "clientId": "client-secret",
+              "secret": "client-secret",
+              "clientAuthenticatorType": "client-secret"
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakUser",
+          "metadata": {
+            "name": "example-realm-user",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "user": {
+              "username": "realm_user",
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "user@example.com",
+              "enabled": true,
+              "emailVerified": false
+            },
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+  name: rhsso-operator.7.6.7-opr-002
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: "Represents a Red Hat Single Sign-On Instance"
+      displayName: "Keycloak"
+      kind: Keycloak
+      name: keycloaks.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Realm"
+      displayName: "KeycloakRealm"
+      kind: KeycloakRealm
+      name: keycloakrealms.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Backup"
+      displayName: "KeycloakBackup"
+      kind: KeycloakBackup
+      name: keycloakbackups.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Client"
+      displayName: "KeycloakClient"
+      kind: KeycloakClient
+      name: keycloakclients.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On User"
+      displayName: "KeycloakUser"
+      kind: KeycloakUser
+      name: keycloakusers.keycloak.org
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK for installing and managing Red Hat Single Sign-On.
+
+    Red Hat Single Sign-On lets you add authentication to applications and secure services with minimum fuss. No need to deal with storing users or authenticating users. It's all available out of the box.
+
+    The operator can deploy and manage Keycloak instances on Kubernetes and OpenShift.
+    The following features are supported:
+
+    * Install Keycloak to a namespace
+    * Import Keycloak Realms
+    * Import Keycloak Clients
+    * Import Keycloak Users
+    * Create scheduled backups of the database
+  displayName: Red Hat Single Sign-On Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: rhsso-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhsso-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhsso-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: PROFILE
+                  value: RHSSO
+                - name: OPERATOR_NAME
+                  value: rhsso-operator
+                - name: SSO_QUARTER
+                  value: 2024_Q1
+                - name: SSO_VER
+                  value: 7.6.7
+                - name: RELATED_IMAGE_RHSSO_OPENJDK
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:2d5d8a9929db09bcd673d1ad52c4a6d2bb4ba1539dd62e9ecc0223c77a825a3d
+                - name: RELATED_IMAGE_RHSSO_OPENJ9
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:2d5d8a9929db09bcd673d1ad52c4a6d2bb4ba1539dd62e9ecc0223c77a825a3d
+                - name: RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:c9634cf64e2b0c3a7e8314b870dba12bb6a370b44545f9347ca577f7a5a13103
+                - name: RELATED_IMAGE_RHSSO_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:c9634cf64e2b0c3a7e8314b870dba12bb6a370b44545f9347ca577f7a5a13103
+                image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:711f12fe68c345c8753b39f68ff0ba71f5c209b9a466ef98feffbcadb531b545
+                imagePullPolicy: Always
+                name: rhsso-operator
+                resources: {}
+              serviceAccountName: rhsso-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          - podmonitors
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - rhsso-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          - keycloakbackups
+          - keycloakbackups/status
+          - keycloakbackups/finalizers
+          - keycloakusers
+          - keycloakusers/status
+          - keycloakusers/finalizers
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhsso-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Keycloak
+  - Identity
+  - Access
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/products/red-hat-single-sign-on
+  - name: Keycloak
+    url: https://www.keycloak.org/
+  maintainers:
+  - email: customerservice@redhat.com
+    name: Red Hat Customer Service
+  maturity: stable
+  provider:
+    name: Red Hat
+  version: 7.6.7-opr-002
+  replaces: rhsso-operator.7.6.7-opr-001
+  skips:
+  - rhsso-operator.7.6.0-opr-001
+  relatedImages:
+  - name: sso7-rhel8-operator-711f12fe68c345c8753b39f68ff0ba71f5c209b9a466ef98feffbcadb531b545-annotation
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:711f12fe68c345c8753b39f68ff0ba71f5c209b9a466ef98feffbcadb531b545
+  - name: rhsso-operator
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:711f12fe68c345c8753b39f68ff0ba71f5c209b9a466ef98feffbcadb531b545
+  - name: rhsso_openjdk
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:2d5d8a9929db09bcd673d1ad52c4a6d2bb4ba1539dd62e9ecc0223c77a825a3d
+  - name: rhsso_openj9
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:2d5d8a9929db09bcd673d1ad52c4a6d2bb4ba1539dd62e9ecc0223c77a825a3d
+  - name: keycloak_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:c9634cf64e2b0c3a7e8314b870dba12bb6a370b44545f9347ca577f7a5a13103
+  - name: rhsso_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:c9634cf64e2b0c3a7e8314b870dba12bb6a370b44545f9347ca577f7a5a13103

--- a/manifests/integreatly-rhsso/7.6.8-2/keycloakbackups.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/keycloakbackups.keycloak.org.crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-2/keycloakclients.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/keycloakclients.keycloak.org.crd.yaml
@@ -1,0 +1,744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used to group different resource instances with the same type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              serviceAccountClientRoles:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Service account client roles for this client.
+                type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-2/keycloakrealms.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/keycloakrealms.keycloak.org.crd.yaml
@@ -1,0 +1,1276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to this resource can be managed by the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource. It can be used to group different resource instances with the same type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviderMappers:
+                    description: A set of Identity Provider Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider Mapper config.
+                          type: object
+                        id:
+                          type: string
+                        identityProviderAlias:
+                          description: Identity Provider Alias.
+                          type: string
+                        identityProviderMapper:
+                          description: Identity Provider Mapper.
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  otpPolicyAlgorithm:
+                    description: OTP Policy Algorithm
+                    type: string
+                  otpPolicyDigits:
+                    description: OTP Policy Digits
+                    format: int32
+                    type: integer
+                  otpPolicyInitialCounter:
+                    description: OTP Policy Initial Counter
+                    format: int32
+                    type: integer
+                  otpPolicyLookAheadWindow:
+                    description: OTP Policy Look Ahead Window
+                    format: int32
+                    type: integer
+                  otpPolicyPeriod:
+                    description: OTP Policy Period
+                    format: int32
+                    type: integer
+                  otpPolicyType:
+                    description: OTP Policy Type
+                    type: string
+                  otpSupportedApplications:
+                    description: OTP Supported Applications
+                    items:
+                      type: string
+                    type: array
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        changedSyncPeriod:
+                          format: int32
+                          type: integer
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap", "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-2/keycloaks.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/keycloaks.keycloak.org.crd.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              DisableDefaultServiceMonitor:
+                description: Disables the integration with Application Monitoring Operator. When set to true, the operator doesn't create default PrometheusRule, ServiceMonitor and GrafanaDashboard objects and users will have to create them manually, if needed.
+                type: boolean
+              disableReplicasSyncing:
+                description: Specify whether disabling the syncing of instances from the Keycloak CR to the statefulset replicas should be enabled or disabled. This option could be used when enabling HPA(horizontal pod autoscaler). Defaults to false.
+                type: boolean
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting this field to "reencrypt" will terminate TLS on the Ingress/Route level. Setting this field to "passthrough" will send encrypted traffic to the Pod. If unspecified, defaults to "reencrypt". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: Experimental section
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  podannotations:
+                    additionalProperties:
+                      type: string
+                    description: List of annotations to set in the keycloak pods
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration. This field is deprecated and will be ignored on K8s >=1.25
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for PostgresDeployment.
+                properties:
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-2/keycloakusers.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/keycloakusers.keycloak.org.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-2/rhsso-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-2/rhsso-operator.clusterserviceversion.yaml
@@ -1,0 +1,400 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Security
+    certified: 'False'
+    containerImage: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:01a275f2d1b252521a8a56038efe6313a7ea7507c04dace10340dfae82b94a7f
+    createdAt: 2021-08-09 00:00:00
+    description: 'An Operator for installing and managing Red Hat Single Sign-On'
+    repository: 'https://github.com/keycloak/keycloak-operator'
+    support: Red Hat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "Keycloak",
+          "metadata": {
+            "name": "example-keycloak",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "instances": 1,
+            "externalAccess": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakRealm",
+          "metadata": {
+            "name": "example-keycloakrealm"
+          },
+          "spec": {
+            "realm": {
+              "id": "basic",
+              "realm": "basic",
+              "enabled": true,
+              "displayName": "Basic Realm"
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakBackup",
+          "metadata": {
+            "name": "example-keycloakbackup"
+          },
+          "spec": {
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakClient",
+          "metadata": {
+            "name": "client-secret",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            },
+            "client": {
+              "clientId": "client-secret",
+              "secret": "client-secret",
+              "clientAuthenticatorType": "client-secret"
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakUser",
+          "metadata": {
+            "name": "example-realm-user",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "user": {
+              "username": "realm_user",
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "user@example.com",
+              "enabled": true,
+              "emailVerified": false
+            },
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+  name: rhsso-operator.7.6.8-opr-001
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: "Represents a Red Hat Single Sign-On Instance"
+      displayName: "Keycloak"
+      kind: Keycloak
+      name: keycloaks.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Realm"
+      displayName: "KeycloakRealm"
+      kind: KeycloakRealm
+      name: keycloakrealms.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Backup"
+      displayName: "KeycloakBackup"
+      kind: KeycloakBackup
+      name: keycloakbackups.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Client"
+      displayName: "KeycloakClient"
+      kind: KeycloakClient
+      name: keycloakclients.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On User"
+      displayName: "KeycloakUser"
+      kind: KeycloakUser
+      name: keycloakusers.keycloak.org
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK for installing and managing Red Hat Single Sign-On.
+
+    Red Hat Single Sign-On lets you add authentication to applications and secure services with minimum fuss. No need to deal with storing users or authenticating users. It's all available out of the box.
+
+    The operator can deploy and manage Keycloak instances on Kubernetes and OpenShift.
+    The following features are supported:
+
+    * Install Keycloak to a namespace
+    * Import Keycloak Realms
+    * Import Keycloak Clients
+    * Import Keycloak Users
+    * Create scheduled backups of the database
+  displayName: Red Hat Single Sign-On Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: rhsso-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhsso-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhsso-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: PROFILE
+                  value: RHSSO
+                - name: OPERATOR_NAME
+                  value: rhsso-operator
+                - name: SSO_QUARTER
+                  value: 2024_Q2
+                - name: SSO_VER
+                  value: 7.6.8
+                - name: RELATED_IMAGE_RHSSO_OPENJDK
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:df944875c5ab7df67e9de6ecb041e569bfcb083472126cfa500ebad4e31c7ba9
+                - name: RELATED_IMAGE_RHSSO_OPENJ9
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:df944875c5ab7df67e9de6ecb041e569bfcb083472126cfa500ebad4e31c7ba9
+                - name: RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:ba1cb1d2b638eaef4a16da9e9f2ce775a64e837bf951a911eac9348f68a30e6a
+                - name: RELATED_IMAGE_RHSSO_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:ba1cb1d2b638eaef4a16da9e9f2ce775a64e837bf951a911eac9348f68a30e6a
+                image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:01a275f2d1b252521a8a56038efe6313a7ea7507c04dace10340dfae82b94a7f
+                imagePullPolicy: Always
+                name: rhsso-operator
+                resources: {}
+              serviceAccountName: rhsso-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          - podmonitors
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - rhsso-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          - keycloakbackups
+          - keycloakbackups/status
+          - keycloakbackups/finalizers
+          - keycloakusers
+          - keycloakusers/status
+          - keycloakusers/finalizers
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhsso-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Keycloak
+  - Identity
+  - Access
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/products/red-hat-single-sign-on
+  - name: Keycloak
+    url: https://www.keycloak.org/
+  maintainers:
+  - email: customerservice@redhat.com
+    name: Red Hat Customer Service
+  maturity: stable
+  provider:
+    name: Red Hat
+  version: 7.6.8-opr-001
+  replaces: rhsso-operator.7.6.7-opr-002
+  skips:
+  - rhsso-operator.7.6.0-opr-001
+  relatedImages:
+  - name: sso7-rhel8-operator-01a275f2d1b252521a8a56038efe6313a7ea7507c04dace10340dfae82b94a7f-annotation
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:01a275f2d1b252521a8a56038efe6313a7ea7507c04dace10340dfae82b94a7f
+  - name: rhsso-operator
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:01a275f2d1b252521a8a56038efe6313a7ea7507c04dace10340dfae82b94a7f
+  - name: rhsso_openjdk
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:df944875c5ab7df67e9de6ecb041e569bfcb083472126cfa500ebad4e31c7ba9
+  - name: rhsso_openj9
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:df944875c5ab7df67e9de6ecb041e569bfcb083472126cfa500ebad4e31c7ba9
+  - name: keycloak_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:ba1cb1d2b638eaef4a16da9e9f2ce775a64e837bf951a911eac9348f68a30e6a
+  - name: rhsso_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:ba1cb1d2b638eaef4a16da9e9f2ce775a64e837bf951a911eac9348f68a30e6a

--- a/manifests/integreatly-rhsso/7.6.8-3/keycloakbackups.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/keycloakbackups.keycloak.org.crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-3/keycloakclients.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/keycloakclients.keycloak.org.crd.yaml
@@ -1,0 +1,744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used to group different resource instances with the same type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              serviceAccountClientRoles:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Service account client roles for this client.
+                type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-3/keycloakrealms.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/keycloakrealms.keycloak.org.crd.yaml
@@ -1,0 +1,1276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to this resource can be managed by the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource. It can be used to group different resource instances with the same type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviderMappers:
+                    description: A set of Identity Provider Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider Mapper config.
+                          type: object
+                        id:
+                          type: string
+                        identityProviderAlias:
+                          description: Identity Provider Alias.
+                          type: string
+                        identityProviderMapper:
+                          description: Identity Provider Mapper.
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  otpPolicyAlgorithm:
+                    description: OTP Policy Algorithm
+                    type: string
+                  otpPolicyDigits:
+                    description: OTP Policy Digits
+                    format: int32
+                    type: integer
+                  otpPolicyInitialCounter:
+                    description: OTP Policy Initial Counter
+                    format: int32
+                    type: integer
+                  otpPolicyLookAheadWindow:
+                    description: OTP Policy Look Ahead Window
+                    format: int32
+                    type: integer
+                  otpPolicyPeriod:
+                    description: OTP Policy Period
+                    format: int32
+                    type: integer
+                  otpPolicyType:
+                    description: OTP Policy Type
+                    type: string
+                  otpSupportedApplications:
+                    description: OTP Supported Applications
+                    items:
+                      type: string
+                    type: array
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        changedSyncPeriod:
+                          format: int32
+                          type: integer
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap", "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-3/keycloaks.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/keycloaks.keycloak.org.crd.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              DisableDefaultServiceMonitor:
+                description: Disables the integration with Application Monitoring Operator. When set to true, the operator doesn't create default PrometheusRule, ServiceMonitor and GrafanaDashboard objects and users will have to create them manually, if needed.
+                type: boolean
+              disableReplicasSyncing:
+                description: Specify whether disabling the syncing of instances from the Keycloak CR to the statefulset replicas should be enabled or disabled. This option could be used when enabling HPA(horizontal pod autoscaler). Defaults to false.
+                type: boolean
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting this field to "reencrypt" will terminate TLS on the Ingress/Route level. Setting this field to "passthrough" will send encrypted traffic to the Pod. If unspecified, defaults to "reencrypt". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: Experimental section
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  podannotations:
+                    additionalProperties:
+                      type: string
+                    description: List of annotations to set in the keycloak pods
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration. This field is deprecated and will be ignored on K8s >=1.25
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for PostgresDeployment.
+                properties:
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-3/keycloakusers.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/keycloakusers.keycloak.org.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.8-3/rhsso-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/7.6.8-3/rhsso-operator.clusterserviceversion.yaml
@@ -1,0 +1,400 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Security
+    certified: 'False'
+    containerImage: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:6356bd8fdcb0fe4dfec346fb3e2bccd8fb3c70e042ec02f4913adfd9642dd344
+    createdAt: 2021-08-09 00:00:00
+    description: 'An Operator for installing and managing Red Hat Single Sign-On'
+    repository: 'https://github.com/keycloak/keycloak-operator'
+    support: Red Hat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "Keycloak",
+          "metadata": {
+            "name": "example-keycloak",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "instances": 1,
+            "externalAccess": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakRealm",
+          "metadata": {
+            "name": "example-keycloakrealm"
+          },
+          "spec": {
+            "realm": {
+              "id": "basic",
+              "realm": "basic",
+              "enabled": true,
+              "displayName": "Basic Realm"
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakBackup",
+          "metadata": {
+            "name": "example-keycloakbackup"
+          },
+          "spec": {
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakClient",
+          "metadata": {
+            "name": "client-secret",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            },
+            "client": {
+              "clientId": "client-secret",
+              "secret": "client-secret",
+              "clientAuthenticatorType": "client-secret"
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakUser",
+          "metadata": {
+            "name": "example-realm-user",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "user": {
+              "username": "realm_user",
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "user@example.com",
+              "enabled": true,
+              "emailVerified": false
+            },
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+  name: rhsso-operator.7.6.8-opr-002
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: "Represents a Red Hat Single Sign-On Instance"
+      displayName: "Keycloak"
+      kind: Keycloak
+      name: keycloaks.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Realm"
+      displayName: "KeycloakRealm"
+      kind: KeycloakRealm
+      name: keycloakrealms.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Backup"
+      displayName: "KeycloakBackup"
+      kind: KeycloakBackup
+      name: keycloakbackups.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Client"
+      displayName: "KeycloakClient"
+      kind: KeycloakClient
+      name: keycloakclients.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On User"
+      displayName: "KeycloakUser"
+      kind: KeycloakUser
+      name: keycloakusers.keycloak.org
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK for installing and managing Red Hat Single Sign-On.
+
+    Red Hat Single Sign-On lets you add authentication to applications and secure services with minimum fuss. No need to deal with storing users or authenticating users. It's all available out of the box.
+
+    The operator can deploy and manage Keycloak instances on Kubernetes and OpenShift.
+    The following features are supported:
+
+    * Install Keycloak to a namespace
+    * Import Keycloak Realms
+    * Import Keycloak Clients
+    * Import Keycloak Users
+    * Create scheduled backups of the database
+  displayName: Red Hat Single Sign-On Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: rhsso-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhsso-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhsso-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: PROFILE
+                  value: RHSSO
+                - name: OPERATOR_NAME
+                  value: rhsso-operator
+                - name: SSO_QUARTER
+                  value: 2024_Q2
+                - name: SSO_VER
+                  value: 7.6.8
+                - name: RELATED_IMAGE_RHSSO_OPENJDK
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:9bcde111cf123b677891051c001e25a0247cde81a2abced635af67792dee2883
+                - name: RELATED_IMAGE_RHSSO_OPENJ9
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:9bcde111cf123b677891051c001e25a0247cde81a2abced635af67792dee2883
+                - name: RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:cc1a09a33bc990c54aa4daa76087c786766e2e3a2a222dff9434f3e90e4c4af6
+                - name: RELATED_IMAGE_RHSSO_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:cc1a09a33bc990c54aa4daa76087c786766e2e3a2a222dff9434f3e90e4c4af6
+                image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:6356bd8fdcb0fe4dfec346fb3e2bccd8fb3c70e042ec02f4913adfd9642dd344
+                imagePullPolicy: Always
+                name: rhsso-operator
+                resources: {}
+              serviceAccountName: rhsso-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          - podmonitors
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - rhsso-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          - keycloakbackups
+          - keycloakbackups/status
+          - keycloakbackups/finalizers
+          - keycloakusers
+          - keycloakusers/status
+          - keycloakusers/finalizers
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhsso-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Keycloak
+  - Identity
+  - Access
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/products/red-hat-single-sign-on
+  - name: Keycloak
+    url: https://www.keycloak.org/
+  maintainers:
+  - email: customerservice@redhat.com
+    name: Red Hat Customer Service
+  maturity: stable
+  provider:
+    name: Red Hat
+  version: 7.6.8-opr-002
+  replaces: rhsso-operator.7.6.8-opr-001
+  skips:
+  - rhsso-operator.7.6.0-opr-001
+  relatedImages:
+  - name: sso7-rhel8-operator-6356bd8fdcb0fe4dfec346fb3e2bccd8fb3c70e042ec02f4913adfd9642dd344-annotation
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:6356bd8fdcb0fe4dfec346fb3e2bccd8fb3c70e042ec02f4913adfd9642dd344
+  - name: rhsso-operator
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:6356bd8fdcb0fe4dfec346fb3e2bccd8fb3c70e042ec02f4913adfd9642dd344
+  - name: rhsso_openjdk
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:9bcde111cf123b677891051c001e25a0247cde81a2abced635af67792dee2883
+  - name: rhsso_openj9
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:9bcde111cf123b677891051c001e25a0247cde81a2abced635af67792dee2883
+  - name: keycloak_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:cc1a09a33bc990c54aa4daa76087c786766e2e3a2a222dff9434f3e90e4c4af6
+  - name: rhsso_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:cc1a09a33bc990c54aa4daa76087c786766e2e3a2a222dff9434f3e90e4c4af6

--- a/manifests/integreatly-rhsso/7.6.9-2/keycloakbackups.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/keycloakbackups.keycloak.org.crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-2/keycloakclients.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/keycloakclients.keycloak.org.crd.yaml
@@ -1,0 +1,744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used to group different resource instances with the same type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              serviceAccountClientRoles:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Service account client roles for this client.
+                type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-2/keycloakrealms.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/keycloakrealms.keycloak.org.crd.yaml
@@ -1,0 +1,1276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to this resource can be managed by the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource. It can be used to group different resource instances with the same type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviderMappers:
+                    description: A set of Identity Provider Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider Mapper config.
+                          type: object
+                        id:
+                          type: string
+                        identityProviderAlias:
+                          description: Identity Provider Alias.
+                          type: string
+                        identityProviderMapper:
+                          description: Identity Provider Mapper.
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  otpPolicyAlgorithm:
+                    description: OTP Policy Algorithm
+                    type: string
+                  otpPolicyDigits:
+                    description: OTP Policy Digits
+                    format: int32
+                    type: integer
+                  otpPolicyInitialCounter:
+                    description: OTP Policy Initial Counter
+                    format: int32
+                    type: integer
+                  otpPolicyLookAheadWindow:
+                    description: OTP Policy Look Ahead Window
+                    format: int32
+                    type: integer
+                  otpPolicyPeriod:
+                    description: OTP Policy Period
+                    format: int32
+                    type: integer
+                  otpPolicyType:
+                    description: OTP Policy Type
+                    type: string
+                  otpSupportedApplications:
+                    description: OTP Supported Applications
+                    items:
+                      type: string
+                    type: array
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        changedSyncPeriod:
+                          format: int32
+                          type: integer
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap", "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-2/keycloaks.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/keycloaks.keycloak.org.crd.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              DisableDefaultServiceMonitor:
+                description: Disables the integration with Application Monitoring Operator. When set to true, the operator doesn't create default PrometheusRule, ServiceMonitor and GrafanaDashboard objects and users will have to create them manually, if needed.
+                type: boolean
+              disableReplicasSyncing:
+                description: Specify whether disabling the syncing of instances from the Keycloak CR to the statefulset replicas should be enabled or disabled. This option could be used when enabling HPA(horizontal pod autoscaler). Defaults to false.
+                type: boolean
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting this field to "reencrypt" will terminate TLS on the Ingress/Route level. Setting this field to "passthrough" will send encrypted traffic to the Pod. If unspecified, defaults to "reencrypt". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: Experimental section
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  podannotations:
+                    additionalProperties:
+                      type: string
+                    description: List of annotations to set in the keycloak pods
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration. This field is deprecated and will be ignored on K8s >=1.25
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for PostgresDeployment.
+                properties:
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-2/keycloakusers.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/keycloakusers.keycloak.org.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-2/rhsso-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-2/rhsso-operator.clusterserviceversion.yaml
@@ -1,0 +1,400 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Security
+    certified: 'False'
+    containerImage: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+    createdAt: 2021-08-09 00:00:00
+    description: 'An Operator for installing and managing Red Hat Single Sign-On'
+    repository: 'https://github.com/keycloak/keycloak-operator'
+    support: Red Hat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "Keycloak",
+          "metadata": {
+            "name": "example-keycloak",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "instances": 1,
+            "externalAccess": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakRealm",
+          "metadata": {
+            "name": "example-keycloakrealm"
+          },
+          "spec": {
+            "realm": {
+              "id": "basic",
+              "realm": "basic",
+              "enabled": true,
+              "displayName": "Basic Realm"
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakBackup",
+          "metadata": {
+            "name": "example-keycloakbackup"
+          },
+          "spec": {
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakClient",
+          "metadata": {
+            "name": "client-secret",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            },
+            "client": {
+              "clientId": "client-secret",
+              "secret": "client-secret",
+              "clientAuthenticatorType": "client-secret"
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakUser",
+          "metadata": {
+            "name": "example-realm-user",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "user": {
+              "username": "realm_user",
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "user@example.com",
+              "enabled": true,
+              "emailVerified": false
+            },
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+  name: rhsso-operator.7.6.9-opr-001
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: "Represents a Red Hat Single Sign-On Instance"
+      displayName: "Keycloak"
+      kind: Keycloak
+      name: keycloaks.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Realm"
+      displayName: "KeycloakRealm"
+      kind: KeycloakRealm
+      name: keycloakrealms.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Backup"
+      displayName: "KeycloakBackup"
+      kind: KeycloakBackup
+      name: keycloakbackups.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Client"
+      displayName: "KeycloakClient"
+      kind: KeycloakClient
+      name: keycloakclients.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On User"
+      displayName: "KeycloakUser"
+      kind: KeycloakUser
+      name: keycloakusers.keycloak.org
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK for installing and managing Red Hat Single Sign-On.
+
+    Red Hat Single Sign-On lets you add authentication to applications and secure services with minimum fuss. No need to deal with storing users or authenticating users. It's all available out of the box.
+
+    The operator can deploy and manage Keycloak instances on Kubernetes and OpenShift.
+    The following features are supported:
+
+    * Install Keycloak to a namespace
+    * Import Keycloak Realms
+    * Import Keycloak Clients
+    * Import Keycloak Users
+    * Create scheduled backups of the database
+  displayName: Red Hat Single Sign-On Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: rhsso-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhsso-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhsso-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: PROFILE
+                  value: RHSSO
+                - name: OPERATOR_NAME
+                  value: rhsso-operator
+                - name: SSO_QUARTER
+                  value: 2024_Q2
+                - name: SSO_VER
+                  value: 7.6.9
+                - name: RELATED_IMAGE_RHSSO_OPENJDK
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:72d69c8661dd62bd4626e2d169b0632b42f1f0c1f7894a165d18bb8e88de7270
+                - name: RELATED_IMAGE_RHSSO_OPENJ9
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:72d69c8661dd62bd4626e2d169b0632b42f1f0c1f7894a165d18bb8e88de7270
+                - name: RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+                - name: RELATED_IMAGE_RHSSO_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+                image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+                imagePullPolicy: Always
+                name: rhsso-operator
+                resources: {}
+              serviceAccountName: rhsso-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          - podmonitors
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - rhsso-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          - keycloakbackups
+          - keycloakbackups/status
+          - keycloakbackups/finalizers
+          - keycloakusers
+          - keycloakusers/status
+          - keycloakusers/finalizers
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhsso-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Keycloak
+  - Identity
+  - Access
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/products/red-hat-single-sign-on
+  - name: Keycloak
+    url: https://www.keycloak.org/
+  maintainers:
+  - email: customerservice@redhat.com
+    name: Red Hat Customer Service
+  maturity: stable
+  provider:
+    name: Red Hat
+  version: 7.6.9-opr-001
+  replaces: rhsso-operator.7.6.8-opr-002
+  skips:
+  - rhsso-operator.7.6.0-opr-001
+  relatedImages:
+  - name: sso7-rhel8-operator-3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60-annotation
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+  - name: rhsso-operator
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+  - name: rhsso_openjdk
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:72d69c8661dd62bd4626e2d169b0632b42f1f0c1f7894a165d18bb8e88de7270
+  - name: rhsso_openj9
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:72d69c8661dd62bd4626e2d169b0632b42f1f0c1f7894a165d18bb8e88de7270
+  - name: keycloak_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+  - name: rhsso_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a

--- a/manifests/integreatly-rhsso/7.6.9-3/keycloakbackups.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/keycloakbackups.keycloak.org.crd.yaml
@@ -1,0 +1,115 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakbackups.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakBackup
+    listKind: KeycloakBackupList
+    plural: keycloakbackups
+    singular: keycloakbackup
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakBackup is the Schema for the keycloakbackups API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakBackupSpec defines the desired state of KeycloakBackup.
+            properties:
+              aws:
+                description: If provided, an automatic database backup will be created on AWS S3 instead of a local Persistent Volume. If this property is not provided - a local Persistent Volume backup will be chosen.
+                properties:
+                  credentialsSecretName:
+                    description: "Provides a secret name used for connecting to AWS S3 Service. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       AWS_S3_BUCKET_NAME: <S3 Bucket Name>       AWS_ACCESS_KEY_ID: <AWS Access Key ID>       AWS_SECRET_ACCESS_KEY: <AWS Secret Key> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  encryptionKeySecretName:
+                    description: "If provided, the database backup will be encrypted. Provides a secret name used for encrypting database data. The secret needs to be in the following form: \n     apiVersion: v1     kind: Secret     metadata:       name: <Secret name>     type: Opaque     stringData:       GPG_PUBLIC_KEY: <GPG Public Key>       GPG_TRUST_MODEL: <GPG Trust Model>       GPG_RECIPIENT: <GPG Recipient> \n For more information, please refer to the Operator documentation."
+                    type: string
+                  schedule:
+                    description: If specified, it will be used as a schedule for creating a CronJob.
+                    type: string
+                type: object
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              restore:
+                description: "Controls automatic restore behavior. Currently not implemented. \n In the future this will be used to trigger automatic restore for a given KeycloakBackup. Each backup will correspond to a single snapshot of the database (stored either in a Persistent Volume or AWS). If a user wants to restore it, all he/she needs to do is to change this flag to true. Potentially, it will be possible to restore a single backup multiple times."
+                type: boolean
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Backup Persistent Volume Claim
+                type: string
+            type: object
+          status:
+            description: KeycloakBackupStatus defines the observed state of KeycloakBackup.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-3/keycloakclients.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/keycloakclients.keycloak.org.crd.yaml
@@ -1,0 +1,744 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakclients.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakClient
+    listKind: KeycloakClientList
+    plural: keycloakclients
+    singular: keycloakclient
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakClient is the Schema for the keycloakclients API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakClientSpec defines the desired state of KeycloakClient.
+            properties:
+              client:
+                description: Keycloak Client REST object.
+                properties:
+                  access:
+                    additionalProperties:
+                      type: boolean
+                    description: Access options.
+                    type: object
+                  adminUrl:
+                    description: Application Admin URL.
+                    type: string
+                  attributes:
+                    additionalProperties:
+                      type: string
+                    description: Client Attributes.
+                    type: object
+                  authenticationFlowBindingOverrides:
+                    additionalProperties:
+                      type: string
+                    description: Authentication Flow Binding Overrides.
+                    type: object
+                  authorizationServicesEnabled:
+                    description: True if fine-grained authorization support is enabled for this client.
+                    type: boolean
+                  authorizationSettings:
+                    description: Authorization settings for this resource server.
+                    properties:
+                      allowRemoteResourceManagement:
+                        description: True if resources should be managed remotely by the resource server.
+                        type: boolean
+                      clientId:
+                        description: Client ID.
+                        type: string
+                      decisionStrategy:
+                        description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                        type: string
+                      id:
+                        description: ID.
+                        type: string
+                      name:
+                        description: Name.
+                        type: string
+                      policies:
+                        description: Policies.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                          properties:
+                            config:
+                              additionalProperties:
+                                type: string
+                              description: Config.
+                              type: object
+                            decisionStrategy:
+                              description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                              type: string
+                            description:
+                              description: A description for this policy.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            logic:
+                              description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                              type: string
+                            name:
+                              description: The name of this policy.
+                              type: string
+                            owner:
+                              description: Owner.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                type: string
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                type: string
+                              type: array
+                            resourcesData:
+                              description: Resources Data.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Scopes.
+                              items:
+                                type: string
+                              type: array
+                            scopesData:
+                              description: Scopes Data.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: Type.
+                              type: string
+                          type: object
+                        type: array
+                      policyEnforcementMode:
+                        description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                        type: string
+                      resources:
+                        description: Resources.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                          properties:
+                            _id:
+                              description: ID.
+                              type: string
+                            attributes:
+                              additionalProperties:
+                                type: string
+                              description: The attributes associated with the resource.
+                              type: object
+                            displayName:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            icon_uri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            name:
+                              description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                              type: string
+                            ownerManagedAccess:
+                              description: True if the access to this resource can be managed by the resource owner.
+                              type: boolean
+                            scopes:
+                              description: The scopes associated with this resource.
+                              items:
+                                x-kubernetes-preserve-unknown-fields: true
+                              type: array
+                            type:
+                              description: The type of this resource. It can be used to group different resource instances with the same type.
+                              type: string
+                            uris:
+                              description: Set of URIs which are protected by resource.
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        type: array
+                      scopes:
+                        description: Authorization Scopes.
+                        items:
+                          description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                          properties:
+                            displayName:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            iconUri:
+                              description: An URI pointing to an icon.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        type: array
+                    type: object
+                  baseUrl:
+                    description: Application base URL.
+                    type: string
+                  bearerOnly:
+                    description: True if a client supports only Bearer Tokens.
+                    type: boolean
+                  clientAuthenticatorType:
+                    description: What Client authentication type to use.
+                    type: string
+                  clientId:
+                    description: Client ID.
+                    type: string
+                  consentRequired:
+                    description: True if Consent Screen is required.
+                    type: boolean
+                  defaultClientScopes:
+                    description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                    items:
+                      type: string
+                    type: array
+                  defaultRoles:
+                    description: Default Client roles.
+                    items:
+                      type: string
+                    type: array
+                  description:
+                    description: Client description.
+                    type: string
+                  directAccessGrantsEnabled:
+                    description: True if Direct Grant is enabled.
+                    type: boolean
+                  enabled:
+                    description: Client enabled flag.
+                    type: boolean
+                  frontchannelLogout:
+                    description: True if this client supports Front Channel logout.
+                    type: boolean
+                  fullScopeAllowed:
+                    description: True if Full Scope is allowed.
+                    type: boolean
+                  id:
+                    description: Client ID. If not specified, automatically generated.
+                    type: string
+                  implicitFlowEnabled:
+                    description: True if Implicit flow is enabled.
+                    type: boolean
+                  name:
+                    description: Client name.
+                    type: string
+                  nodeReRegistrationTimeout:
+                    description: Node registration timeout.
+                    type: integer
+                  notBefore:
+                    description: Not Before setting.
+                    type: integer
+                  optionalClientScopes:
+                    description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                    items:
+                      type: string
+                    type: array
+                  protocol:
+                    description: Protocol used for this Client.
+                    type: string
+                  protocolMappers:
+                    description: Protocol Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config options.
+                          type: object
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        consentText:
+                          description: Text to use for displaying Consent Screen.
+                          type: string
+                        id:
+                          description: Protocol Mapper ID.
+                          type: string
+                        name:
+                          description: Protocol Mapper Name.
+                          type: string
+                        protocol:
+                          description: Protocol to use.
+                          type: string
+                        protocolMapper:
+                          description: Protocol Mapper to use
+                          type: string
+                      type: object
+                    type: array
+                  publicClient:
+                    description: True if this is a public Client.
+                    type: boolean
+                  redirectUris:
+                    description: A list of valid Redirection URLs.
+                    items:
+                      type: string
+                    type: array
+                  rootUrl:
+                    description: Application root URL.
+                    type: string
+                  secret:
+                    description: Client Secret. The Operator will automatically create a Secret based on this value.
+                    type: string
+                  serviceAccountsEnabled:
+                    description: True if Service Accounts are enabled.
+                    type: boolean
+                  standardFlowEnabled:
+                    description: True if Standard flow is enabled.
+                    type: boolean
+                  surrogateAuthRequired:
+                    description: Surrogate Authentication Required option.
+                    type: boolean
+                  useTemplateConfig:
+                    description: True to use a Template Config.
+                    type: boolean
+                  useTemplateMappers:
+                    description: True to use Template Mappers.
+                    type: boolean
+                  useTemplateScope:
+                    description: True to use Template Scope.
+                    type: boolean
+                  webOrigins:
+                    description: A list of valid Web Origins.
+                    items:
+                      type: string
+                    type: array
+                required:
+                - clientId
+                type: object
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              roles:
+                description: Client Roles
+                items:
+                  description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                  properties:
+                    attributes:
+                      additionalProperties:
+                        items:
+                          type: string
+                        type: array
+                      description: Role Attributes
+                      type: object
+                    clientRole:
+                      description: Client Role
+                      type: boolean
+                    composite:
+                      description: Composite
+                      type: boolean
+                    composites:
+                      description: Composites
+                      properties:
+                        client:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Map client => []role
+                          type: object
+                        realm:
+                          description: Realm roles
+                          items:
+                            type: string
+                          type: array
+                      type: object
+                    containerId:
+                      description: Container Id
+                      type: string
+                    description:
+                      description: Description
+                      type: string
+                    id:
+                      description: Id
+                      type: string
+                    name:
+                      description: Name
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - name
+                x-kubernetes-list-type: map
+              scopeMappings:
+                description: Scope Mappings
+                properties:
+                  clientMappings:
+                    additionalProperties:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_clientmappingsrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        mappings:
+                          description: Mappings
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                      type: object
+                    description: Client Mappings
+                    type: object
+                  realmMappings:
+                    description: Realm Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: Role Attributes
+                          type: object
+                        clientRole:
+                          description: Client Role
+                          type: boolean
+                        composite:
+                          description: Composite
+                          type: boolean
+                        composites:
+                          description: Composites
+                          properties:
+                            client:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Map client => []role
+                              type: object
+                            realm:
+                              description: Realm roles
+                              items:
+                                type: string
+                              type: array
+                          type: object
+                        containerId:
+                          description: Container Id
+                          type: string
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: Id
+                          type: string
+                        name:
+                          description: Name
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              serviceAccountClientRoles:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: Service account client roles for this client.
+                type: object
+              serviceAccountRealmRoles:
+                description: Service account realm roles for this client.
+                items:
+                  type: string
+                type: array
+            required:
+            - client
+            - realmSelector
+            type: object
+          status:
+            description: KeycloakClientStatus defines the observed state of KeycloakClient
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-3/keycloakrealms.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/keycloakrealms.keycloak.org.crd.yaml
@@ -1,0 +1,1276 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakrealms.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakRealm
+    listKind: KeycloakRealmList
+    plural: keycloakrealms
+    singular: keycloakrealm
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakRealm is the Schema for the keycloakrealms API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakRealmSpec defines the desired state of KeycloakRealm.
+            properties:
+              instanceSelector:
+                description: Selector for looking up Keycloak Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              realm:
+                description: Keycloak Realm REST object.
+                properties:
+                  accessTokenLifespan:
+                    description: Access Token Lifespan
+                    format: int32
+                    type: integer
+                  accessTokenLifespanForImplicitFlow:
+                    description: Access Token Lifespan For Implicit Flow
+                    format: int32
+                    type: integer
+                  accountTheme:
+                    description: Account Theme
+                    type: string
+                  adminEventsDetailsEnabled:
+                    description: 'Enable admin events details TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminEventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  adminTheme:
+                    description: Admin Console Theme
+                    type: string
+                  authenticationFlows:
+                    description: Authentication flows
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        authenticationExecutions:
+                          description: Authentication executions
+                          items:
+                            properties:
+                              authenticator:
+                                description: Authenticator
+                                type: string
+                              authenticatorConfig:
+                                description: Authenticator Config
+                                type: string
+                              authenticatorFlow:
+                                description: Authenticator flow
+                                type: boolean
+                              flowAlias:
+                                description: Flow Alias
+                                type: string
+                              priority:
+                                description: Priority
+                                format: int32
+                                type: integer
+                              requirement:
+                                description: Requirement [REQUIRED, OPTIONAL, ALTERNATIVE, DISABLED]
+                                type: string
+                              userSetupAllowed:
+                                description: User setup allowed
+                                type: boolean
+                            type: object
+                          type: array
+                        builtIn:
+                          description: Built in
+                          type: boolean
+                        description:
+                          description: Description
+                          type: string
+                        id:
+                          description: ID
+                          type: string
+                        providerId:
+                          description: Provider ID
+                          type: string
+                        topLevel:
+                          description: Top level
+                          type: boolean
+                      required:
+                      - alias
+                      - authenticationExecutions
+                      type: object
+                    type: array
+                  authenticatorConfig:
+                    description: Authenticator config
+                    items:
+                      properties:
+                        alias:
+                          description: Alias
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Config
+                          type: object
+                        id:
+                          description: ID
+                          type: string
+                      required:
+                      - alias
+                      type: object
+                    type: array
+                  bruteForceProtected:
+                    description: Brute Force Detection
+                    type: boolean
+                  clientScopeMappings:
+                    additionalProperties:
+                      items:
+                        description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                        properties:
+                          client:
+                            description: Client
+                            type: string
+                          clientScope:
+                            description: Client Scope
+                            type: string
+                          roles:
+                            description: Roles
+                            items:
+                              type: string
+                            type: array
+                          self:
+                            description: Self
+                            type: string
+                        type: object
+                      type: array
+                    description: Client Scope Mappings
+                    type: object
+                  clientScopes:
+                    description: Client scopes
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          type: object
+                        description:
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                        protocol:
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                      type: object
+                    type: array
+                  clients:
+                    description: A set of Keycloak Clients.
+                    items:
+                      properties:
+                        access:
+                          additionalProperties:
+                            type: boolean
+                          description: Access options.
+                          type: object
+                        adminUrl:
+                          description: Application Admin URL.
+                          type: string
+                        attributes:
+                          additionalProperties:
+                            type: string
+                          description: Client Attributes.
+                          type: object
+                        authenticationFlowBindingOverrides:
+                          additionalProperties:
+                            type: string
+                          description: Authentication Flow Binding Overrides.
+                          type: object
+                        authorizationServicesEnabled:
+                          description: True if fine-grained authorization support is enabled for this client.
+                          type: boolean
+                        authorizationSettings:
+                          description: Authorization settings for this resource server.
+                          properties:
+                            allowRemoteResourceManagement:
+                              description: True if resources should be managed remotely by the resource server.
+                              type: boolean
+                            clientId:
+                              description: Client ID.
+                              type: string
+                            decisionStrategy:
+                              description: The decision strategy dictates how permissions are evaluated and how a final decision is obtained. 'Affirmative' means that at least one permission must evaluate to a positive decision in order to grant access to a resource and its scopes. 'Unanimous' means that all permissions must evaluate to a positive decision in order for the final decision to be also positive.
+                              type: string
+                            id:
+                              description: ID.
+                              type: string
+                            name:
+                              description: Name.
+                              type: string
+                            policies:
+                              description: Policies.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                properties:
+                                  config:
+                                    additionalProperties:
+                                      type: string
+                                    description: Config.
+                                    type: object
+                                  decisionStrategy:
+                                    description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                    type: string
+                                  description:
+                                    description: A description for this policy.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  logic:
+                                    description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                    type: string
+                                  name:
+                                    description: The name of this policy.
+                                    type: string
+                                  owner:
+                                    description: Owner.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      type: string
+                                    type: array
+                                  resourcesData:
+                                    description: Resources Data.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                  scopes:
+                                    description: Scopes.
+                                    items:
+                                      type: string
+                                    type: array
+                                  scopesData:
+                                    description: Scopes Data.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: Type.
+                                    type: string
+                                type: object
+                              type: array
+                            policyEnforcementMode:
+                              description: The policy enforcement mode dictates how policies are enforced when evaluating authorization requests. 'Enforcing' means requests are denied by default even when there is no policy associated with a given resource. 'Permissive' means requests are allowed even when there is no policy associated with a given resource. 'Disabled' completely disables the evaluation of policies and allows access to any resource.
+                              type: string
+                            resources:
+                              description: Resources.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                properties:
+                                  _id:
+                                    description: ID.
+                                    type: string
+                                  attributes:
+                                    additionalProperties:
+                                      type: string
+                                    description: The attributes associated with the resource.
+                                    type: object
+                                  displayName:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  icon_uri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  name:
+                                    description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                    type: string
+                                  ownerManagedAccess:
+                                    description: True if the access to this resource can be managed by the resource owner.
+                                    type: boolean
+                                  scopes:
+                                    description: The scopes associated with this resource.
+                                    items:
+                                      x-kubernetes-preserve-unknown-fields: true
+                                    type: array
+                                  type:
+                                    description: The type of this resource. It can be used to group different resource instances with the same type.
+                                    type: string
+                                  uris:
+                                    description: Set of URIs which are protected by resource.
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              type: array
+                            scopes:
+                              description: Authorization Scopes.
+                              items:
+                                description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_scoperepresentation
+                                properties:
+                                  displayName:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  iconUri:
+                                    description: An URI pointing to an icon.
+                                    type: string
+                                  id:
+                                    description: ID.
+                                    type: string
+                                  name:
+                                    description: A unique name for this scope. The name can be used to uniquely identify a scope, useful when querying for a specific scope.
+                                    type: string
+                                  policies:
+                                    description: Policies.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_policyrepresentation
+                                      properties:
+                                        config:
+                                          additionalProperties:
+                                            type: string
+                                          description: Config.
+                                          type: object
+                                        decisionStrategy:
+                                          description: The decision strategy dictates how the policies associated with a given permission are evaluated and how a final decision is obtained. 'Affirmative' means that at least one policy must evaluate to a positive decision in order for the final decision to be also positive. 'Unanimous' means that all policies must evaluate to a positive decision in order for the final decision to be also positive. 'Consensus' means that the number of positive decisions must be greater than the number of negative decisions. If the number of positive and negative is the same, the final decision will be negative.
+                                          type: string
+                                        description:
+                                          description: A description for this policy.
+                                          type: string
+                                        id:
+                                          description: ID.
+                                          type: string
+                                        logic:
+                                          description: The logic dictates how the policy decision should be made. If 'Positive', the resulting effect (permit or deny) obtained during the evaluation of this policy will be used to perform a decision. If 'Negative', the resulting effect will be negated, in other words, a permit becomes a deny and vice-versa.
+                                          type: string
+                                        name:
+                                          description: The name of this policy.
+                                          type: string
+                                        owner:
+                                          description: Owner.
+                                          type: string
+                                        policies:
+                                          description: Policies.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resources:
+                                          description: Resources.
+                                          items:
+                                            type: string
+                                          type: array
+                                        resourcesData:
+                                          description: Resources Data.
+                                          items:
+                                            description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                            properties:
+                                              _id:
+                                                description: ID.
+                                                type: string
+                                              attributes:
+                                                additionalProperties:
+                                                  type: string
+                                                description: The attributes associated with the resource.
+                                                type: object
+                                              displayName:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              icon_uri:
+                                                description: An URI pointing to an icon.
+                                                type: string
+                                              name:
+                                                description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                                type: string
+                                              ownerManagedAccess:
+                                                description: True if the access to this resource can be managed by the resource owner.
+                                                type: boolean
+                                              scopes:
+                                                description: The scopes associated with this resource.
+                                                items:
+                                                  x-kubernetes-preserve-unknown-fields: true
+                                                type: array
+                                              type:
+                                                description: The type of this resource. It can be used to group different resource instances with the same type.
+                                                type: string
+                                              uris:
+                                                description: Set of URIs which are protected by resource.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            type: object
+                                          type: array
+                                        scopes:
+                                          description: Scopes.
+                                          items:
+                                            type: string
+                                          type: array
+                                        scopesData:
+                                          description: Scopes Data.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: Type.
+                                          type: string
+                                      type: object
+                                    type: array
+                                  resources:
+                                    description: Resources.
+                                    items:
+                                      description: https://www.keycloak.org/docs-api/12.0/rest-api/index.html#_resourcerepresentation
+                                      properties:
+                                        _id:
+                                          description: ID.
+                                          type: string
+                                        attributes:
+                                          additionalProperties:
+                                            type: string
+                                          description: The attributes associated with the resource.
+                                          type: object
+                                        displayName:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        icon_uri:
+                                          description: An URI pointing to an icon.
+                                          type: string
+                                        name:
+                                          description: A unique name for this resource. The name can be used to uniquely identify a resource, useful when querying for a specific resource.
+                                          type: string
+                                        ownerManagedAccess:
+                                          description: True if the access to this resource can be managed by the resource owner.
+                                          type: boolean
+                                        scopes:
+                                          description: The scopes associated with this resource.
+                                          items:
+                                            x-kubernetes-preserve-unknown-fields: true
+                                          type: array
+                                        type:
+                                          description: The type of this resource. It can be used to group different resource instances with the same type.
+                                          type: string
+                                        uris:
+                                          description: Set of URIs which are protected by resource.
+                                          items:
+                                            type: string
+                                          type: array
+                                      type: object
+                                    type: array
+                                type: object
+                              type: array
+                          type: object
+                        baseUrl:
+                          description: Application base URL.
+                          type: string
+                        bearerOnly:
+                          description: True if a client supports only Bearer Tokens.
+                          type: boolean
+                        clientAuthenticatorType:
+                          description: What Client authentication type to use.
+                          type: string
+                        clientId:
+                          description: Client ID.
+                          type: string
+                        consentRequired:
+                          description: True if Consent Screen is required.
+                          type: boolean
+                        defaultClientScopes:
+                          description: A list of default client scopes. Default client scopes are always applied when issuing OpenID Connect tokens or SAML assertions for this client.
+                          items:
+                            type: string
+                          type: array
+                        defaultRoles:
+                          description: Default Client roles.
+                          items:
+                            type: string
+                          type: array
+                        description:
+                          description: Client description.
+                          type: string
+                        directAccessGrantsEnabled:
+                          description: True if Direct Grant is enabled.
+                          type: boolean
+                        enabled:
+                          description: Client enabled flag.
+                          type: boolean
+                        frontchannelLogout:
+                          description: True if this client supports Front Channel logout.
+                          type: boolean
+                        fullScopeAllowed:
+                          description: True if Full Scope is allowed.
+                          type: boolean
+                        id:
+                          description: Client ID. If not specified, automatically generated.
+                          type: string
+                        implicitFlowEnabled:
+                          description: True if Implicit flow is enabled.
+                          type: boolean
+                        name:
+                          description: Client name.
+                          type: string
+                        nodeReRegistrationTimeout:
+                          description: Node registration timeout.
+                          type: integer
+                        notBefore:
+                          description: Not Before setting.
+                          type: integer
+                        optionalClientScopes:
+                          description: A list of optional client scopes. Optional client scopes are applied when issuing tokens for this client, but only when they are requested by the scope parameter in the OpenID Connect authorization request.
+                          items:
+                            type: string
+                          type: array
+                        protocol:
+                          description: Protocol used for this Client.
+                          type: string
+                        protocolMappers:
+                          description: Protocol Mappers.
+                          items:
+                            properties:
+                              config:
+                                additionalProperties:
+                                  type: string
+                                description: Config options.
+                                type: object
+                              consentRequired:
+                                description: True if Consent Screen is required.
+                                type: boolean
+                              consentText:
+                                description: Text to use for displaying Consent Screen.
+                                type: string
+                              id:
+                                description: Protocol Mapper ID.
+                                type: string
+                              name:
+                                description: Protocol Mapper Name.
+                                type: string
+                              protocol:
+                                description: Protocol to use.
+                                type: string
+                              protocolMapper:
+                                description: Protocol Mapper to use
+                                type: string
+                            type: object
+                          type: array
+                        publicClient:
+                          description: True if this is a public Client.
+                          type: boolean
+                        redirectUris:
+                          description: A list of valid Redirection URLs.
+                          items:
+                            type: string
+                          type: array
+                        rootUrl:
+                          description: Application root URL.
+                          type: string
+                        secret:
+                          description: Client Secret. The Operator will automatically create a Secret based on this value.
+                          type: string
+                        serviceAccountsEnabled:
+                          description: True if Service Accounts are enabled.
+                          type: boolean
+                        standardFlowEnabled:
+                          description: True if Standard flow is enabled.
+                          type: boolean
+                        surrogateAuthRequired:
+                          description: Surrogate Authentication Required option.
+                          type: boolean
+                        useTemplateConfig:
+                          description: True to use a Template Config.
+                          type: boolean
+                        useTemplateMappers:
+                          description: True to use Template Mappers.
+                          type: boolean
+                        useTemplateScope:
+                          description: True to use Template Scope.
+                          type: boolean
+                        webOrigins:
+                          description: A list of valid Web Origins.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - clientId
+                      type: object
+                    type: array
+                  defaultDefaultClientScopes:
+                    description: Default client scopes to add to all new clients
+                    items:
+                      type: string
+                    type: array
+                  defaultLocale:
+                    description: Default Locale
+                    type: string
+                  defaultRole:
+                    description: Default role
+                    properties:
+                      attributes:
+                        additionalProperties:
+                          items:
+                            type: string
+                          type: array
+                        description: Role Attributes
+                        type: object
+                      clientRole:
+                        description: Client Role
+                        type: boolean
+                      composite:
+                        description: Composite
+                        type: boolean
+                      composites:
+                        description: Composites
+                        properties:
+                          client:
+                            additionalProperties:
+                              items:
+                                type: string
+                              type: array
+                            description: Map client => []role
+                            type: object
+                          realm:
+                            description: Realm roles
+                            items:
+                              type: string
+                            type: array
+                        type: object
+                      containerId:
+                        description: Container Id
+                        type: string
+                      description:
+                        description: Description
+                        type: string
+                      id:
+                        description: Id
+                        type: string
+                      name:
+                        description: Name
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  displayName:
+                    description: Realm display name.
+                    type: string
+                  displayNameHtml:
+                    description: Realm HTML display name.
+                    type: string
+                  duplicateEmailsAllowed:
+                    description: Duplicate emails
+                    type: boolean
+                  editUsernameAllowed:
+                    description: Edit username
+                    type: boolean
+                  emailTheme:
+                    description: Email Theme
+                    type: string
+                  enabled:
+                    description: Realm enabled flag.
+                    type: boolean
+                  enabledEventTypes:
+                    description: Enabled event types
+                    items:
+                      type: string
+                    type: array
+                  eventsEnabled:
+                    description: 'Enable events recording TODO: change to values and use kubebuilder default annotation once supported'
+                    type: boolean
+                  eventsListeners:
+                    description: A set of Event Listeners.
+                    items:
+                      type: string
+                    type: array
+                  failureFactor:
+                    description: Max Login Failures
+                    format: int32
+                    type: integer
+                  id:
+                    type: string
+                  identityProviderMappers:
+                    description: A set of Identity Provider Mappers.
+                    items:
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider Mapper config.
+                          type: object
+                        id:
+                          type: string
+                        identityProviderAlias:
+                          description: Identity Provider Alias.
+                          type: string
+                        identityProviderMapper:
+                          description: Identity Provider Mapper.
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  identityProviders:
+                    description: A set of Identity Providers.
+                    items:
+                      properties:
+                        addReadTokenRoleOnCreate:
+                          description: Adds Read Token role when creating this Identity Provider.
+                          type: boolean
+                        alias:
+                          description: Identity Provider Alias.
+                          type: string
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: Identity Provider config.
+                          type: object
+                        displayName:
+                          description: Identity Provider Display Name.
+                          type: string
+                        enabled:
+                          description: Identity Provider enabled flag.
+                          type: boolean
+                        firstBrokerLoginFlowAlias:
+                          description: Identity Provider First Broker Login Flow Alias.
+                          type: string
+                        internalId:
+                          description: Identity Provider Internal ID.
+                          type: string
+                        linkOnly:
+                          description: Identity Provider Link Only setting.
+                          type: boolean
+                        postBrokerLoginFlowAlias:
+                          description: Identity Provider Post Broker Login Flow Alias.
+                          type: string
+                        providerId:
+                          description: Identity Provider ID.
+                          type: string
+                        storeToken:
+                          description: Identity Provider Store to Token.
+                          type: boolean
+                        trustEmail:
+                          description: Identity Provider Trust Email.
+                          type: boolean
+                      type: object
+                    type: array
+                  internationalizationEnabled:
+                    description: Internationalization Enabled
+                    type: boolean
+                  loginTheme:
+                    description: Login Theme
+                    type: string
+                  loginWithEmailAllowed:
+                    description: Login with email
+                    type: boolean
+                  maxDeltaTimeSeconds:
+                    description: Failure Reset Time
+                    format: int32
+                    type: integer
+                  maxFailureWaitSeconds:
+                    description: Max Wait
+                    format: int32
+                    type: integer
+                  minimumQuickLoginWaitSeconds:
+                    description: Minimum Quick Login Wait
+                    format: int32
+                    type: integer
+                  otpPolicyAlgorithm:
+                    description: OTP Policy Algorithm
+                    type: string
+                  otpPolicyDigits:
+                    description: OTP Policy Digits
+                    format: int32
+                    type: integer
+                  otpPolicyInitialCounter:
+                    description: OTP Policy Initial Counter
+                    format: int32
+                    type: integer
+                  otpPolicyLookAheadWindow:
+                    description: OTP Policy Look Ahead Window
+                    format: int32
+                    type: integer
+                  otpPolicyPeriod:
+                    description: OTP Policy Period
+                    format: int32
+                    type: integer
+                  otpPolicyType:
+                    description: OTP Policy Type
+                    type: string
+                  otpSupportedApplications:
+                    description: OTP Supported Applications
+                    items:
+                      type: string
+                    type: array
+                  passwordPolicy:
+                    description: Realm Password Policy
+                    type: string
+                  permanentLockout:
+                    description: Permanent Lockout
+                    type: boolean
+                  quickLoginCheckMilliSeconds:
+                    description: Quick Login Check Milli Seconds
+                    format: int64
+                    type: integer
+                  realm:
+                    description: Realm name.
+                    type: string
+                  registrationAllowed:
+                    description: User registration
+                    type: boolean
+                  registrationEmailAsUsername:
+                    description: Email as username
+                    type: boolean
+                  rememberMe:
+                    description: Remember me
+                    type: boolean
+                  resetPasswordAllowed:
+                    description: Forgot password
+                    type: boolean
+                  roles:
+                    description: Roles
+                    properties:
+                      client:
+                        additionalProperties:
+                          items:
+                            description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                            properties:
+                              attributes:
+                                additionalProperties:
+                                  items:
+                                    type: string
+                                  type: array
+                                description: Role Attributes
+                                type: object
+                              clientRole:
+                                description: Client Role
+                                type: boolean
+                              composite:
+                                description: Composite
+                                type: boolean
+                              composites:
+                                description: Composites
+                                properties:
+                                  client:
+                                    additionalProperties:
+                                      items:
+                                        type: string
+                                      type: array
+                                    description: Map client => []role
+                                    type: object
+                                  realm:
+                                    description: Realm roles
+                                    items:
+                                      type: string
+                                    type: array
+                                type: object
+                              containerId:
+                                description: Container Id
+                                type: string
+                              description:
+                                description: Description
+                                type: string
+                              id:
+                                description: Id
+                                type: string
+                              name:
+                                description: Name
+                                type: string
+                            required:
+                            - name
+                            type: object
+                          type: array
+                        description: Client Roles
+                        type: object
+                      realm:
+                        description: Realm Roles
+                        items:
+                          description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_rolerepresentation
+                          properties:
+                            attributes:
+                              additionalProperties:
+                                items:
+                                  type: string
+                                type: array
+                              description: Role Attributes
+                              type: object
+                            clientRole:
+                              description: Client Role
+                              type: boolean
+                            composite:
+                              description: Composite
+                              type: boolean
+                            composites:
+                              description: Composites
+                              properties:
+                                client:
+                                  additionalProperties:
+                                    items:
+                                      type: string
+                                    type: array
+                                  description: Map client => []role
+                                  type: object
+                                realm:
+                                  description: Realm roles
+                                  items:
+                                    type: string
+                                  type: array
+                              type: object
+                            containerId:
+                              description: Container Id
+                              type: string
+                            description:
+                              description: Description
+                              type: string
+                            id:
+                              description: Id
+                              type: string
+                            name:
+                              description: Name
+                              type: string
+                          required:
+                          - name
+                          type: object
+                        type: array
+                    type: object
+                  scopeMappings:
+                    description: Scope Mappings
+                    items:
+                      description: https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_scopemappingrepresentation
+                      properties:
+                        client:
+                          description: Client
+                          type: string
+                        clientScope:
+                          description: Client Scope
+                          type: string
+                        roles:
+                          description: Roles
+                          items:
+                            type: string
+                          type: array
+                        self:
+                          description: Self
+                          type: string
+                      type: object
+                    type: array
+                  smtpServer:
+                    additionalProperties:
+                      type: string
+                    description: Email
+                    type: object
+                  sslRequired:
+                    description: Require SSL
+                    type: string
+                  supportedLocales:
+                    description: Supported Locales
+                    items:
+                      type: string
+                    type: array
+                  userFederationMappers:
+                    description: User federation mappers are extension points triggered by the user federation at various points.
+                    items:
+                      description: https://www.keycloak.org/docs/11.0/server_admin/#_ldap_mappers https://www.keycloak.org/docs-api/11.0/rest-api/index.html#_userfederationmapperrepresentation
+                      properties:
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation mapper config.
+                          type: object
+                        federationMapperType:
+                          type: string
+                        federationProviderDisplayName:
+                          description: The displayName for the user federation provider this mapper applies to.
+                          type: string
+                        id:
+                          type: string
+                        name:
+                          type: string
+                      type: object
+                    type: array
+                  userFederationProviders:
+                    description: Point keycloak to an external user provider to validate credentials or pull in identity information.
+                    items:
+                      description: https://www.keycloak.org/docs-api/10.0/rest-api/index.html#_userfederationproviderrepresentation
+                      properties:
+                        changedSyncPeriod:
+                          format: int32
+                          type: integer
+                        config:
+                          additionalProperties:
+                            type: string
+                          description: User federation provider config.
+                          type: object
+                        displayName:
+                          description: The display name of this provider instance.
+                          type: string
+                        fullSyncPeriod:
+                          format: int32
+                          type: integer
+                        id:
+                          description: The ID of this provider
+                          type: string
+                        priority:
+                          description: The priority of this provider when looking up users or adding a user.
+                          format: int32
+                          type: integer
+                        providerName:
+                          description: The name of the user provider, such as "ldap", "kerberos" or a custom SPI.
+                          type: string
+                      type: object
+                    type: array
+                  userManagedAccessAllowed:
+                    description: User Managed Access Allowed
+                    type: boolean
+                  users:
+                    description: A set of Keycloak Users.
+                    items:
+                      properties:
+                        attributes:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Attributes.
+                          type: object
+                        clientRoles:
+                          additionalProperties:
+                            items:
+                              type: string
+                            type: array
+                          description: A set of Client Roles.
+                          type: object
+                        credentials:
+                          description: A set of Credentials.
+                          items:
+                            properties:
+                              temporary:
+                                description: True if this credential object is temporary.
+                                type: boolean
+                              type:
+                                description: Credential Type.
+                                type: string
+                              value:
+                                description: Credential Value.
+                                type: string
+                            type: object
+                          type: array
+                        email:
+                          description: Email.
+                          type: string
+                        emailVerified:
+                          description: True if email has already been verified.
+                          type: boolean
+                        enabled:
+                          description: User enabled flag.
+                          type: boolean
+                        federatedIdentities:
+                          description: A set of Federated Identities.
+                          items:
+                            properties:
+                              identityProvider:
+                                description: Federated Identity Provider.
+                                type: string
+                              userId:
+                                description: Federated Identity User ID.
+                                type: string
+                              userName:
+                                description: Federated Identity User Name.
+                                type: string
+                            type: object
+                          type: array
+                        firstName:
+                          description: First Name.
+                          type: string
+                        groups:
+                          description: A set of Groups.
+                          items:
+                            type: string
+                          type: array
+                        id:
+                          description: User ID.
+                          type: string
+                        lastName:
+                          description: Last Name.
+                          type: string
+                        realmRoles:
+                          description: A set of Realm Roles.
+                          items:
+                            type: string
+                          type: array
+                        requiredActions:
+                          description: A set of Required Actions.
+                          items:
+                            type: string
+                          type: array
+                        username:
+                          description: User Name.
+                          type: string
+                      type: object
+                    type: array
+                  verifyEmail:
+                    description: Verify email
+                    type: boolean
+                  waitIncrementSeconds:
+                    description: Wait Increment
+                    format: int32
+                    type: integer
+                required:
+                - realm
+                type: object
+              realmOverrides:
+                description: A list of overrides to the default Realm behavior.
+                items:
+                  properties:
+                    forFlow:
+                      description: Flow to be overridden.
+                      type: string
+                    identityProvider:
+                      description: Identity Provider to be overridden.
+                      type: string
+                  required:
+                  - identityProvider
+                  type: object
+                type: array
+                x-kubernetes-list-type: atomic
+              unmanaged:
+                description: When set to true, this KeycloakRealm will be marked as unmanaged and not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            required:
+            - realm
+            type: object
+          status:
+            description: KeycloakRealmStatus defines the observed state of KeycloakRealm
+            properties:
+              loginURL:
+                description: TODO
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ]'
+                type: object
+            required:
+            - loginURL
+            - message
+            - phase
+            - ready
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-3/keycloaks.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/keycloaks.keycloak.org.crd.yaml
@@ -1,0 +1,730 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloaks.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: Keycloak
+    listKind: KeycloakList
+    plural: keycloaks
+    singular: keycloak
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Keycloak is the Schema for the keycloaks API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakSpec defines the desired state of Keycloak.
+            properties:
+              DisableDefaultServiceMonitor:
+                description: Disables the integration with Application Monitoring Operator. When set to true, the operator doesn't create default PrometheusRule, ServiceMonitor and GrafanaDashboard objects and users will have to create them manually, if needed.
+                type: boolean
+              disableReplicasSyncing:
+                description: Specify whether disabling the syncing of instances from the Keycloak CR to the statefulset replicas should be enabled or disabled. This option could be used when enabling HPA(horizontal pod autoscaler). Defaults to false.
+                type: boolean
+              extensions:
+                description: A list of extensions, where each one is a URL to a JAR files that will be deployed in Keycloak.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
+              external:
+                description: Contains configuration for external Keycloak instances. Unmanaged needs to be set to true to use this.
+                properties:
+                  enabled:
+                    description: If set to true, this Keycloak will be treated as an external instance. The unmanaged field also needs to be set to true if this field is true.
+                    type: boolean
+                  url:
+                    description: The URL to use for the keycloak admin API. Needs to be set if external is true.
+                    type: string
+                type: object
+              externalAccess:
+                description: Controls external Ingress/Route settings.
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will create an Ingress or a Route pointing to Keycloak.
+                    type: boolean
+                  host:
+                    description: If set, the Operator will use value of host for Ingress host instead of default value keycloak.local. Using this setting in OpenShift environment will result an error. Only users with special permissions are allowed to modify the hostname.
+                    type: string
+                  tlsTermination:
+                    description: TLS Termination type for the external access. Setting this field to "reencrypt" will terminate TLS on the Ingress/Route level. Setting this field to "passthrough" will send encrypted traffic to the Pod. If unspecified, defaults to "reencrypt". Note, that this setting has no effect on Ingress as Ingress TLS settings are not reconciled by this operator. In other words, Ingress TLS configuration is the same in both cases and it is up to the user to configure TLS section of the Ingress.
+                    type: string
+                type: object
+              externalDatabase:
+                description: "Controls external database settings. Using an external database requires providing a secret containing credentials as well as connection details. Here's an example of such secret: \n     apiVersion: v1     kind: Secret     metadata:         name: keycloak-db-secret         namespace: keycloak     stringData:         POSTGRES_DATABASE: <Database Name>         POSTGRES_EXTERNAL_ADDRESS: <External Database IP or URL (resolvable by K8s)>         POSTGRES_EXTERNAL_PORT: <External Database Port>         # Strongly recommended to use <'Keycloak CR Name'-postgresql>         POSTGRES_HOST: <Database Service Name>         POSTGRES_PASSWORD: <Database Password>         # Required for AWS Backup functionality         POSTGRES_SUPERUSER: true         POSTGRES_USERNAME: <Database Username>      type: Opaque \n Both POSTGRES_EXTERNAL_ADDRESS and POSTGRES_EXTERNAL_PORT are specifically required for creating connection to the external database. The secret name is created using the following convention:       <Custom Resource Name>-db-secret \n For more information, please refer to the Operator documentation."
+                properties:
+                  enabled:
+                    description: If set to true, the Operator will use an external database pointing to Keycloak. The embedded database (externalDatabase.enabled = false) is deprecated.
+                    type: boolean
+                type: object
+              instances:
+                description: Number of Keycloak instances in HA mode. Default is 1.
+                type: integer
+              keycloakDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for KeycloakDeployment.
+                properties:
+                  experimental:
+                    description: Experimental section
+                    properties:
+                      affinity:
+                        description: Affinity settings
+                        properties:
+                          nodeAffinity:
+                            description: Describes node affinity scheduling rules for the pod.
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node matches the corresponding matchExpressions; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: An empty preferred scheduling term matches all objects with implicit weight 0 (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                                  properties:
+                                    preference:
+                                      description: A node selector term, associated with the corresponding weight.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    weight:
+                                      description: Weight associated with matching the corresponding nodeSelectorTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - preference
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to an update), the system may or may not try to eventually evict the pod from its node.
+                                properties:
+                                  nodeSelectorTerms:
+                                    description: Required. A list of node selector terms. The terms are ORed.
+                                    items:
+                                      description: A null or empty node selector term matches no objects. The requirements of them are ANDed. The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                                      properties:
+                                        matchExpressions:
+                                          description: A list of node selector requirements by node's labels.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchFields:
+                                          description: A list of node selector requirements by node's fields.
+                                          items:
+                                            description: A node selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: The label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: Represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                                type: string
+                                              values:
+                                                description: An array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. If the operator is Gt or Lt, the values array must have a single element, which will be interpreted as an integer. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                      type: object
+                                    type: array
+                                required:
+                                - nodeSelectorTerms
+                                type: object
+                            type: object
+                          podAffinity:
+                            description: Describes pod affinity scheduling rules (e.g. co-locate this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                          podAntiAffinity:
+                            description: Describes pod anti-affinity scheduling rules (e.g. avoid putting this pod in the same node, zone, etc. as some other pod(s)).
+                            properties:
+                              preferredDuringSchedulingIgnoredDuringExecution:
+                                description: The scheduler will prefer to schedule pods to nodes that satisfy the anti-affinity expressions specified by this field, but it may choose a node that violates one or more of the expressions. The node that is most preferred is the one with the greatest sum of weights, i.e. for each node that meets all of the scheduling requirements (resource request, requiredDuringScheduling anti-affinity expressions, etc.), compute a sum by iterating through the elements of this field and adding "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the node(s) with the highest sum are the most preferred.
+                                items:
+                                  description: The weights of all of the matched WeightedPodAffinityTerm fields are added per-node to find the most preferred node(s)
+                                  properties:
+                                    podAffinityTerm:
+                                      description: Required. A pod affinity term, associated with the corresponding weight.
+                                      properties:
+                                        labelSelector:
+                                          description: A label query over a set of resources, in this case pods.
+                                          properties:
+                                            matchExpressions:
+                                              description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                              items:
+                                                description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                                properties:
+                                                  key:
+                                                    description: key is the label key that the selector applies to.
+                                                    type: string
+                                                  operator:
+                                                    description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                    type: string
+                                                  values:
+                                                    description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                    items:
+                                                      type: string
+                                                    type: array
+                                                required:
+                                                - key
+                                                - operator
+                                                type: object
+                                              type: array
+                                            matchLabels:
+                                              additionalProperties:
+                                                type: string
+                                              description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                              type: object
+                                          type: object
+                                        namespaces:
+                                          description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                          items:
+                                            type: string
+                                          type: array
+                                        topologyKey:
+                                          description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                          type: string
+                                      required:
+                                      - topologyKey
+                                      type: object
+                                    weight:
+                                      description: weight associated with matching the corresponding podAffinityTerm, in the range 1-100.
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - podAffinityTerm
+                                  - weight
+                                  type: object
+                                type: array
+                              requiredDuringSchedulingIgnoredDuringExecution:
+                                description: If the anti-affinity requirements specified by this field are not met at scheduling time, the pod will not be scheduled onto the node. If the anti-affinity requirements specified by this field cease to be met at some point during pod execution (e.g. due to a pod label update), the system may or may not try to eventually evict the pod from its node. When there are multiple elements, the lists of nodes corresponding to each podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                                items:
+                                  description: Defines a set of pods (namely those matching the labelSelector relative to the given namespace(s)) that this pod should be co-located (affinity) or not co-located (anti-affinity) with, where co-located is defined as running on a node whose value of the label with key <topologyKey> matches that of any node on which a pod of the set of pods is running
+                                  properties:
+                                    labelSelector:
+                                      description: A label query over a set of resources, in this case pods.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                          items:
+                                            description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                    namespaces:
+                                      description: namespaces specifies which namespaces the labelSelector applies to (matches against); null or empty list means "this pod's namespace"
+                                      items:
+                                        type: string
+                                      type: array
+                                    topologyKey:
+                                      description: This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching the labelSelector in the specified namespaces, where co-located is defined as running on a node whose value of the label with key topologyKey matches that of any node on which any of the selected pods is running. Empty topologyKey is not allowed.
+                                      type: string
+                                  required:
+                                  - topologyKey
+                                  type: object
+                                type: array
+                            type: object
+                        type: object
+                      args:
+                        description: Arguments to the entrypoint. Translates into Container CMD.
+                        items:
+                          type: string
+                        type: array
+                      command:
+                        description: Container command. Translates into Container ENTRYPOINT.
+                        items:
+                          type: string
+                        type: array
+                      env:
+                        description: List of environment variables to set in the container.
+                        items:
+                          description: EnvVar represents an environment variable present in a Container.
+                          properties:
+                            name:
+                              description: Name of the environment variable. Must be a C_IDENTIFIER.
+                              type: string
+                            value:
+                              description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                              type: string
+                            valueFrom:
+                              description: Source for the environment variable's value. Cannot be used if value is not empty.
+                              properties:
+                                configMapKeyRef:
+                                  description: Selects a key of a ConfigMap.
+                                  properties:
+                                    key:
+                                      description: The key to select.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the ConfigMap or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                                fieldRef:
+                                  description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                                  properties:
+                                    apiVersion:
+                                      description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                                      type: string
+                                    fieldPath:
+                                      description: Path of the field to select in the specified API version.
+                                      type: string
+                                  required:
+                                  - fieldPath
+                                  type: object
+                                resourceFieldRef:
+                                  description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                                  properties:
+                                    containerName:
+                                      description: 'Container name: required for volumes, optional for env vars'
+                                      type: string
+                                    divisor:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: Specifies the output format of the exposed resources, defaults to "1"
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    resource:
+                                      description: 'Required: resource to select'
+                                      type: string
+                                  required:
+                                  - resource
+                                  type: object
+                                secretKeyRef:
+                                  description: Selects a key of a secret in the pod's namespace
+                                  properties:
+                                    key:
+                                      description: The key of the secret to select from.  Must be a valid secret key.
+                                      type: string
+                                    name:
+                                      description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                                      type: string
+                                    optional:
+                                      description: Specify whether the Secret or its key must be defined
+                                      type: boolean
+                                  required:
+                                  - key
+                                  type: object
+                              type: object
+                          required:
+                          - name
+                          type: object
+                        type: array
+                      serviceAccountName:
+                        description: ServiceAccountName settings
+                        type: string
+                      volumes:
+                        description: Additional volume mounts
+                        properties:
+                          defaultMode:
+                            description: Permissions mode.
+                            format: int32
+                            type: integer
+                          items:
+                            items:
+                              properties:
+                                configMaps:
+                                  description: Allow multiple configmaps to mount to the same directory
+                                  items:
+                                    type: string
+                                  type: array
+                                items:
+                                  description: Mount details
+                                  items:
+                                    description: Maps a string key to a path within a volume.
+                                    properties:
+                                      key:
+                                        description: The key to project.
+                                        type: string
+                                      mode:
+                                        description: 'Optional: mode bits used to set permissions on this file. Must be an octal value between 0000 and 0777 or a decimal value between 0 and 511. YAML accepts both octal and decimal values, JSON requires decimal values for mode bits. If not specified, the volume defaultMode will be used. This might be in conflict with other options that affect the file mode, like fsGroup, and the result can be other mode bits set.'
+                                        format: int32
+                                        type: integer
+                                      path:
+                                        description: The relative path of the file to map the key to. May not be an absolute path. May not contain the path element '..'. May not start with the string '..'.
+                                        type: string
+                                    required:
+                                    - key
+                                    - path
+                                    type: object
+                                  type: array
+                                mountPath:
+                                  description: An absolute path where to mount it
+                                  type: string
+                                name:
+                                  description: Volume name
+                                  type: string
+                                secrets:
+                                  description: Secret mount
+                                  items:
+                                    type: string
+                                  type: array
+                              required:
+                              - mountPath
+                              type: object
+                            type: array
+                        type: object
+                    type: object
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  podannotations:
+                    additionalProperties:
+                      type: string
+                    description: List of annotations to set in the keycloak pods
+                    type: object
+                  podlabels:
+                    additionalProperties:
+                      type: string
+                    description: List of labels to set in the keycloak pods
+                    type: object
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              migration:
+                description: Specify Migration configuration
+                properties:
+                  backups:
+                    description: Set it to config backup policy for migration
+                    properties:
+                      enabled:
+                        description: If set to true, the operator will do database backup before doing migration
+                        type: boolean
+                    type: object
+                  strategy:
+                    description: Specify migration strategy
+                    type: string
+                type: object
+              multiAvailablityZones:
+                description: Specify PodAntiAffinity settings for Keycloak deployment in Multi AZ
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a podAntiAffinity settings for the Keycloak deployment.
+                    type: boolean
+                type: object
+              podDisruptionBudget:
+                description: Specify PodDisruptionBudget configuration. This field is deprecated and will be ignored on K8s >=1.25
+                properties:
+                  enabled:
+                    description: If set to true, the operator will create a PodDistruptionBudget for the Keycloak deployment and set its `maxUnavailable` value to 1.
+                    type: boolean
+                type: object
+              postgresDeploymentSpec:
+                description: Resources (Requests and Limits) and ImagePullPolicy for PostgresDeployment.
+                properties:
+                  imagePullPolicy:
+                    default: Always
+                    description: ImagePullPolicy for the Containers.
+                    enum:
+                    - Always
+                    - Never
+                    - IfNotPresent
+                    type: string
+                  resources:
+                    description: Resources (Requests and Limits) for the Pods.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                type: object
+              profile:
+                description: Profile used for controlling Operator behavior. Default is empty.
+                type: string
+              storageClassName:
+                description: Name of the StorageClass for Postgresql Persistent Volume Claim
+                type: string
+              unmanaged:
+                description: When set to true, this Keycloak will be marked as unmanaged and will not be managed by this operator. It can then be used for targeting purposes.
+                type: boolean
+            type: object
+          status:
+            description: KeycloakStatus defines the observed state of Keycloak.
+            properties:
+              credentialSecret:
+                description: The secret where the admin credentials are to be found.
+                type: string
+              externalURL:
+                description: External URL for accessing Keycloak instance from outside the cluster. Is identical to external.URL if it's specified, otherwise is computed (e.g. from Ingress).
+                type: string
+              internalURL:
+                description: An internal URL (service name) to be used by the admin client.
+                type: string
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+              ready:
+                description: True if all resources are in a ready state and all work is done.
+                type: boolean
+              secondaryResources:
+                additionalProperties:
+                  items:
+                    type: string
+                  type: array
+                description: 'A map of all the secondary resources types and names created for this CR. e.g "Deployment": [ "DeploymentName1", "DeploymentName2" ].'
+                type: object
+              version:
+                description: Version of Keycloak or RHSSO running on the cluster.
+                type: string
+            required:
+            - credentialSecret
+            - internalURL
+            - message
+            - phase
+            - ready
+            - version
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-3/keycloakusers.keycloak.org.crd.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/keycloakusers.keycloak.org.crd.yaml
@@ -1,0 +1,171 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  creationTimestamp: null
+  name: keycloakusers.keycloak.org
+spec:
+  group: keycloak.org
+  names:
+    kind: KeycloakUser
+    listKind: KeycloakUserList
+    plural: keycloakusers
+    singular: keycloakuser
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: KeycloakUser is the Schema for the keycloakusers API.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: KeycloakUserSpec defines the desired state of KeycloakUser.
+            properties:
+              realmSelector:
+                description: Selector for looking up KeycloakRealm Custom Resources.
+                properties:
+                  matchExpressions:
+                    description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                    items:
+                      description: A label selector requirement is a selector that contains values, a key, and an operator that relates the key and values.
+                      properties:
+                        key:
+                          description: key is the label key that the selector applies to.
+                          type: string
+                        operator:
+                          description: operator represents a key's relationship to a set of values. Valid operators are In, NotIn, Exists and DoesNotExist.
+                          type: string
+                        values:
+                          description: values is an array of string values. If the operator is In or NotIn, the values array must be non-empty. If the operator is Exists or DoesNotExist, the values array must be empty. This array is replaced during a strategic merge patch.
+                          items:
+                            type: string
+                          type: array
+                      required:
+                      - key
+                      - operator
+                      type: object
+                    type: array
+                  matchLabels:
+                    additionalProperties:
+                      type: string
+                    description: matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels map is equivalent to an element of matchExpressions, whose key field is "key", the operator is "In", and the values array contains only "value". The requirements are ANDed.
+                    type: object
+                type: object
+              user:
+                description: Keycloak User REST object.
+                properties:
+                  attributes:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Attributes.
+                    type: object
+                  clientRoles:
+                    additionalProperties:
+                      items:
+                        type: string
+                      type: array
+                    description: A set of Client Roles.
+                    type: object
+                  credentials:
+                    description: A set of Credentials.
+                    items:
+                      properties:
+                        temporary:
+                          description: True if this credential object is temporary.
+                          type: boolean
+                        type:
+                          description: Credential Type.
+                          type: string
+                        value:
+                          description: Credential Value.
+                          type: string
+                      type: object
+                    type: array
+                  email:
+                    description: Email.
+                    type: string
+                  emailVerified:
+                    description: True if email has already been verified.
+                    type: boolean
+                  enabled:
+                    description: User enabled flag.
+                    type: boolean
+                  federatedIdentities:
+                    description: A set of Federated Identities.
+                    items:
+                      properties:
+                        identityProvider:
+                          description: Federated Identity Provider.
+                          type: string
+                        userId:
+                          description: Federated Identity User ID.
+                          type: string
+                        userName:
+                          description: Federated Identity User Name.
+                          type: string
+                      type: object
+                    type: array
+                  firstName:
+                    description: First Name.
+                    type: string
+                  groups:
+                    description: A set of Groups.
+                    items:
+                      type: string
+                    type: array
+                  id:
+                    description: User ID.
+                    type: string
+                  lastName:
+                    description: Last Name.
+                    type: string
+                  realmRoles:
+                    description: A set of Realm Roles.
+                    items:
+                      type: string
+                    type: array
+                  requiredActions:
+                    description: A set of Required Actions.
+                    items:
+                      type: string
+                    type: array
+                  username:
+                    description: User Name.
+                    type: string
+                type: object
+            required:
+            - user
+            type: object
+          status:
+            description: KeycloakUserStatus defines the observed state of KeycloakUser.
+            properties:
+              message:
+                description: Human-readable message indicating details about current operator phase or error.
+                type: string
+              phase:
+                description: Current phase of the operator.
+                type: string
+            required:
+            - message
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-rhsso/7.6.9-3/rhsso-operator.clusterserviceversion.yaml
+++ b/manifests/integreatly-rhsso/7.6.9-3/rhsso-operator.clusterserviceversion.yaml
@@ -1,0 +1,400 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    capabilities: Full Lifecycle
+    categories: Security
+    certified: 'False'
+    containerImage: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+    createdAt: 2021-08-09 00:00:00
+    description: 'An Operator for installing and managing Red Hat Single Sign-On'
+    repository: 'https://github.com/keycloak/keycloak-operator'
+    support: Red Hat
+    operators.openshift.io/valid-subscription: '["OpenShift Container Platform", "OpenShift Platform Plus"]'
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "Keycloak",
+          "metadata": {
+            "name": "example-keycloak",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "instances": 1,
+            "externalAccess": {
+              "enabled": true
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakRealm",
+          "metadata": {
+            "name": "example-keycloakrealm"
+          },
+          "spec": {
+            "realm": {
+              "id": "basic",
+              "realm": "basic",
+              "enabled": true,
+              "displayName": "Basic Realm"
+            },
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakBackup",
+          "metadata": {
+            "name": "example-keycloakbackup"
+          },
+          "spec": {
+            "instanceSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakClient",
+          "metadata": {
+            "name": "client-secret",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            },
+            "client": {
+              "clientId": "client-secret",
+              "secret": "client-secret",
+              "clientAuthenticatorType": "client-secret"
+            }
+          }
+        },
+        {
+          "apiVersion": "keycloak.org/v1alpha1",
+          "kind": "KeycloakUser",
+          "metadata": {
+            "name": "example-realm-user",
+            "labels": {
+              "app": "sso"
+            }
+          },
+          "spec": {
+            "user": {
+              "username": "realm_user",
+              "firstName": "John",
+              "lastName": "Doe",
+              "email": "user@example.com",
+              "enabled": true,
+              "emailVerified": false
+            },
+            "realmSelector": {
+              "matchLabels": {
+                "app": "sso"
+              }
+            }
+          }
+        }
+      ]
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/csi: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/cni: "false"
+    features.operators.openshift.io/cnf: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+  name: rhsso-operator.7.6.9-opr-002
+  namespace: placeholder
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.s390x: supported
+    operatorframework.io/arch.ppc64le: supported
+    operatorframework.io/os.linux: supported
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: "Represents a Red Hat Single Sign-On Instance"
+      displayName: "Keycloak"
+      kind: Keycloak
+      name: keycloaks.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Realm"
+      displayName: "KeycloakRealm"
+      kind: KeycloakRealm
+      name: keycloakrealms.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Backup"
+      displayName: "KeycloakBackup"
+      kind: KeycloakBackup
+      name: keycloakbackups.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On Client"
+      displayName: "KeycloakClient"
+      kind: KeycloakClient
+      name: keycloakclients.keycloak.org
+      version: v1alpha1
+    - description: "Represents a Red Hat Single Sign-On User"
+      displayName: "KeycloakUser"
+      kind: KeycloakUser
+      name: keycloakusers.keycloak.org
+      version: v1alpha1
+  description: |
+    A Kubernetes Operator based on the Operator SDK for installing and managing Red Hat Single Sign-On.
+
+    Red Hat Single Sign-On lets you add authentication to applications and secure services with minimum fuss. No need to deal with storing users or authenticating users. It's all available out of the box.
+
+    The operator can deploy and manage Keycloak instances on Kubernetes and OpenShift.
+    The following features are supported:
+
+    * Install Keycloak to a namespace
+    * Import Keycloak Realms
+    * Import Keycloak Clients
+    * Import Keycloak Users
+    * Create scheduled backups of the database
+  displayName: Red Hat Single Sign-On Operator
+  icon:
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAVQAAAC1CAYAAAAA/QcmAAARRElEQVR4nO3dTWgjaWLG8cfuj2n3eKbkpqGHkNmqueSwJJH6kLlkEtVcwkII1pLLHhYkJ7AJ5OC6DCQnqZlDAlmwOqfksLgMCSTsBMuBXSZLQGXYHLJM4nKyl82lS9tZyGZMS/J0tz1utyuHXgvbbX2/Ukny/weCGUuqel1tPXq/ay6O41gAgKHNJ10AAJgVBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgAoAhBCoAGEKgYqxehqFOoqiv13/huqrPzak+N6cvXFfPPU/HQTCyMgKDmovjOE66EJhtcaOhg1JJR76vuNmUJM1Zlm4WCrrleZp3nEvfdxqmp++5aM6ydCOX081cTjdyuVEVH+gZgYqR289k9HJ3t+3zN/N53fI8XctkWj/7slzWQanUNkwvmrdt3cjlOgY0MGoEKkbqoFTS4YMHPb123rY17zg6iSKd1GoDn/N6Nqs3CgXdLBQGPgYwCAIVI3MSRWq+915i55+37Va3wlwqlVg5cHUwKIWR+dL3Ez3/Sa2mwwcP1HScV90HjUai5cHso4aKkWk6zlBNd9PmLEtveJ4WSqWki4IZRaBiJF6Gofbv30+6GJeat20tVirnBsEAE2jyYyQOy+Wki9DWSa2m/fv3dZRwlwRmDzVUjEQjlep5ylOS3qpWdd11ky4GZgQ1VBj3olKZijCVpGdMrYJBBCqMO6pUki5Cz05qNb0Mw6SLgRlBoMK4F1MUqNJ0fQFgshGoMOrsev1pwUYrMIVAhVHTWNujyQ9TGOWHMXGjocbSUtLFGMjbOzvMS8XQqKHCmGnrOz2LZj9MIFBhzLPvfjfpIgzsmGY/DKDJDyOiKNLtr35VNw4Oki7KQOZtW1YfdxIALkMNFUb4vq+DmzeTLsbATmq1vm7NAlyGQIURvu/r46OjpIsxFEb7MSwCFQM7iSIdB4H+ZW1NtVpN3zk40E/u3k26WAN7wcAUhnQ96QJg8r0MQx0HgY5/ccfS4+3tc88fvvtu67+/trenf71zR7/05Mm4izk0RvoxLAalcKmXYajDcrmnjU4+WljQd84MRlnS1IbqEh8HDIEmP845iSJ94bqv9gvd2OhpGelPLozsNyX95pMnemxZIyrl6FBLxTAIVLS8qFS0n8m81qQfRFNSutnUD+7cGb5gY0Q/KoZBoELSq5rZ069/faCNTX67w3LTbzx5om/dvq2jW7eGKd7YPPv006SLgClGoELScBstf/PatY7Pf/L8ud4/PNSPpmAGwOd7e0kXAVOMQIWOfH+ou5O+s7enD7q85qd6NQPgW7dva3+C+1bv/OxnCpmPigERqDCy5d7fWpZ6iclPnj9XutnU31iWXiwsDH1e0/7v3j0F9KNiQAQqjKwQervZ1D/02KRvSvqzZlO/cnAwccH6b8+e6cff/77iRiPpomAKEagYqrl/1vt7e/r7Pkb1zwbrRwsLarz1lpFyDOr49m19vLene599pqbj6KBUIljRFyb2Q/W5OaPH+8GdO/rGgJP6P5Dk3bun39rfH/vOVacLFD6Q9E+/+NmcZel2uayb3B0VPSBQoS9c18jc07OGCdVTvyvpj999V7/x+ee6eXhopmCX2LcsfbPZ1A/P/Oxiya9ns3rT9zXvOCMrB6YfTX6M5NYfv/PkiX58546+MsQxvifp9x4/1juHh8pK+vbSkv7jnXeMzRL437t39dHCgpwLYSpJe/funfv/4+1t7WcyU31XAoweNVToZRhq//79kRz7xcKC/mRuTp88f2782B9I+oqkD2xbbx4f69clXbvefr+f2smJHs/P63u1mn6oV3247fynbeuX2/Qtv7m+ThcALkWgQtJomv1n/ejuXX1rb08/HdkZzOrWWUGo4jI0+SFJWiiVRnr89/f29Nnt2/rzHuerJqnbIgVJerayoiPfH3VRMGWooaLlaS6nF1tbIz/PvmXp46Ojc1v+TZJP797V+z0uQeX20ziLQEVL3GhoP5MxNi+1m6dLS/q7kxP9RbPZsT9znP5wYUF/2UfQc3M/nEWTHy1zqZQWKxXNjWmt/WK9rj9qNvXfCwv65N49/dpYztpev2EqvVoUcTDi7hJMD2qoeM2R7+vZykoi5366tKR/vnZNf7W3p/8a0zktSd++e1e/P+BOU3OWpRQrqiACFW0kGaqnni4taXdxUX/9+HHXaU6DsCT9qWXpD46Ohl6Vxag/JAIVHRz5vp573kCbTo/C06UlRYuL+vejI/3jz3+uptR3LfYDvdoQ+2uLi/rVx4+Nle1mPq83GfW/8ghUdPQyDPWF605MqLbzP7bd8fnU/r4W6/WRnf9aOq232Uf1yiNQ0dVJFOlpLqeXu7tJF2WiccdUMMqPruYdR28FgW7m80kXBZhoBCp6MpdK6U3f1+Lm5timVU0TrgkkAhV9upHLyYoi3VheTrooE4XVUpAIVAzgdAHA4uam5rsMBl0VBCokAhVDuJHL6e0w1K1i8co3eW+4btJFwARglB9GnESRDkolHW1sJF2UsWOlFE5RQ4UR846jN31f1qNHV242wBuel3QRMCGooWIkrkqNdd629XYYai6VSroomAAEKkbqJIr0pe/ry3J54ldbDYL9UHEWgYqxOfJ9HZbLM7Piig1RcBGBirE7iSIdlst6UamMbTNr0whTXIZARaJeVCo6qlT0olKZii6BedvWYqVCMx+XIlAxMV6Gob70fR0HwcR1C8xZlt7wvJHfzBDTjUDFRDqJIh0HgV4EgY6DILGugXnb1s1CQbc8j5F8dEWgYiqcRJFehqGOw/BVDTYMR9ZFcC2d1nXX1RuFAk179IVAxVQ7DoJXYRtFihsNvTyzyfPx9nbb911Lp1s1zuuuq/lUStcyGV1nCSmGQKACgCEsPQUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADCEQAUAQwhUADDketIFAM4Kw/DcIwiCpIsE9IxAHSFTYeA4jhzHMXKsSRNFkXzfVxAECsNQzQF3kIqiSFEUtX1+kGsYhqEaHW4PnclklJrALf3CMJTjOBNZtpkXY2QkGXtYlhUvLy/Hm5ubSf9aRhWLxY6/t6njFIvFvsuWzWY7HrNarfZ9TNPq9Xq8ubkZF4vFOJvNxpZlTUzZriJqqFOi2Wxqa2tLW1tbSqfT8n1fGfbqvLLCMFQul1NtSu/JNasYlJpCu7u7un//vnzfT7ooSEij0SBMJxCBOsVWVlYIVWCCEKhTzvO8joMxAMaHQJ1yzWZTJe7ECUwEBqUSVCwW2z7XaDRaczG7TSXa2NhQuVxmmgyQMAI1Qb3ULBuNhgqFgra2tjq+rlKpqFAodDxOpVJpzffcPXPf+3Q6LcdxlMvllMvljATz2XNd5LqucrnczM9SOF2YEIahoii69Msxm80qk8m0rkk7F/9WunXznM7t7eVYMCjpeVuzTF3mlvaqXq/Htm0PNM+yXq/HxWKxNT+x28OyrLhYLMb1er3v37ffc9m23XWuZ68mZR7qzs5OnM/nu/57tbse6+vrl5al32OZuKboH1d3hEz+Ya+urvYdGDs7O3E6nR7oQ2fbdryzs9Nz+XZ2dgYKEVPXKOlArVarxn7/fD7/WlkI1OnAoNSU6LcZHoahXNc917TvR61Wk+u6lzbZL/J9X/fv37/y8yJN/f4bGxsdu28wuehDnRL9zDc9DdNB18WfajabrVBttw4+CAKtrKwMdZ5xiKKo770VOq3jv8h1XWWzWW1vb/dZssudhqrrukaOhzFJuoo8y2So6ZXP57se6+wa/0Gb+e0e2Wz20nLV6/We+0sHffSqW5N/FI+LfajVatXo8ZeXl3v+WxrFNUX/qKEmqNto62mtqltT0rKs1ghxqVTq2szP5/NyXVeO47R2e+pUs9re3lalUnltFNrzvJ5qwbZtnzvfxVkGs6JdLfV0JN9xHGUyGQVBoCiKtLGx0fF4Z2d2ZLPZc881Go2O1zCdTjONLglJJ/os05hqSmcHXDrVGC3LarsL0fr6esdzXKylPnr0qGu5bNtue75qtdp10KefP89JqKHGcRxvbm62rtf6+nrH2RI7Oztda/idrt8g78NoEagjNI4PtW3brQ/t6Ye53WNtba1jedfW1jq+/9GjRz2/Np1O9zT1qlv3RK8mJVDjOD53nbrp9kVGoE4XmvxTzLIsVSqVVtOuUql0fO1pc7OdTCYjy7LaNuODIGiNPnc6l/RqEK2XJucsNkv72ch6VjcOv6oI1Cll27Yqlcq51UadVs80m019+OGHQ53z7BSqTn2uy8vLM78KqpsoilSpVFqrpC7DCP7sIVCnjGVZ8jxPnue9VrvrZc7oMHo9/lUOijAM5XleT9OnTE2xwuQgUKdMs9lUoVC4tKk87LxTUyaxdprP5/ueLO95Xl+zEXzfn4o5uRgdAjVBcRy/9rNGoyHHcTqGY6lUunSif6f+z3E6XVgwSRzH6btM/fTvVioVwhTshzppUqmUPM/r+JqNjY1LB5cmpWZ4FW/93O3fDFcDgTqBPM+TZVkdX3PZooBugfro0SPFr6bKDfQ4G5QXJ5qftbW1NfL+3EkShmHHxRf5fF7ValX1el1xHGtnZ0fValVra2uybXuMJcWoEagTqJda6vb29ms1wW5N2lwu19P69F5eM85zTbpOXx7FYlG+78t13VYXwun+p57njWza1Cxc12lEoE6oXmqpFwdZcrlcxxrP7u6uXNdtO42n0Wi0PuTdapjdBnhqtZocx2m7qUsQBMpkMjOxBLXTdLWkumG4eWMyCNQJ1UsttVarvfbB6fae3d1dvffee8rlciqXywqCQOVyWYVCQY7j6OHDh61dpjp9KB3HUT6f73iuZrOplZUVpVKpVo0sl8vJcRx9+OGHMxGmUufJ+aVSqW1tMYqikd1gcWtrS47jyPM8lUoleZ4n13UnbrBw5ox9bdYVoi5LF3vRbdNiy7JeW+JpcrepdjvIx/F07TY1yg2md3Z2Or7Otu14dXU1LhaLcbFYjFdXV3v+N2q3hLRerw90PdvtHAYzqKFOuG47UjWbTZXL5XM/q1QqXbsLerWystK2eZ9KpWha6lWzPp1Ot32+Vqvp4cOHevDggR48eKCHDx8OXTtPpVIdBwaRDAJ1whUKha4jweVy+Vyz0nEcBUFgLFQrlUrbpmkul9P6+rqR80yzi19q48DN9iYPgToFeqmlXuw7zWQyiqJo6FpMNptVFEUd+wkLhYKq1aqxAJ9GruuO/YvFdV2trq6O9ZzojECdAr3UUjc2Nl6rRaZSKQVBoPX19b7nO6bTaVWrVQVB0NOKodPZA8VisedgXV1dnalAKBQK2tzc7PlaW5al5eXloc5ZLpe1trZ2pb/MJslcHF+y/hFGdKtZ9tNkC4Kg6wqkbqO4YRjK932FYfjaPeJt224tz8zlckNN92k0Gq2dli5Ovzp7jtPA7/R79XqNuh1nkBFu3/c7jsKfzoxo994gCF67O0E2mz13DRqNRsd+6E7nOKvTNZfUumOA67oTs6JuFhGoAGAITX4AMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBDCFQAMIRABQBD/h+fh1Gb7+ZNngAAAABJRU5ErkJggg==
+    mediatype: image/png
+  install:
+    spec:
+      deployments:
+      - name: rhsso-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhsso-operator
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                name: rhsso-operator
+            spec:
+              containers:
+              - env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: PROFILE
+                  value: RHSSO
+                - name: OPERATOR_NAME
+                  value: rhsso-operator
+                - name: SSO_QUARTER
+                  value: 2024_Q2
+                - name: SSO_VER
+                  value: 7.6.9
+                - name: RELATED_IMAGE_RHSSO_OPENJDK
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:0b926fc9eae775425faa1ab9709a36fdac15afe4bfe523720e17ecf5df45bb28
+                - name: RELATED_IMAGE_RHSSO_OPENJ9
+                  value: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:0b926fc9eae775425faa1ab9709a36fdac15afe4bfe523720e17ecf5df45bb28
+                - name: RELATED_IMAGE_KEYCLOAK_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+                - name: RELATED_IMAGE_RHSSO_INIT_CONTAINER
+                  value: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+                image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+                imagePullPolicy: Always
+                name: rhsso-operator
+                resources: {}
+              serviceAccountName: rhsso-operator
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          - services
+          - services/finalizers
+          - endpoints
+          - persistentvolumeclaims
+          - events
+          - configmaps
+          - secrets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - patch
+          - delete
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - daemonsets
+          - replicasets
+          - statefulsets
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+          - delete
+        - apiGroups:
+          - batch
+          resources:
+          - cronjobs
+          - jobs
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes/custom-host
+          verbs:
+          - create
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - networking.k8s.io
+          resources:
+          - ingresses
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          - prometheusrules
+          - podmonitors
+          verbs:
+          - list
+          - get
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - grafanadashboards
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resourceNames:
+          - rhsso-operator
+          resources:
+          - deployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - get
+          - list
+          - create
+          - update
+          - watch
+        - apiGroups:
+          - keycloak.org
+          resources:
+          - keycloaks
+          - keycloaks/status
+          - keycloaks/finalizers
+          - keycloakrealms
+          - keycloakrealms/status
+          - keycloakrealms/finalizers
+          - keycloakclients
+          - keycloakclients/status
+          - keycloakclients/finalizers
+          - keycloakbackups
+          - keycloakbackups/status
+          - keycloakbackups/finalizers
+          - keycloakusers
+          - keycloakusers/status
+          - keycloakusers/finalizers
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhsso-operator
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
+  keywords:
+  - Keycloak
+  - Identity
+  - Access
+  links:
+  - name: Documentation
+    url: https://access.redhat.com/products/red-hat-single-sign-on
+  - name: Keycloak
+    url: https://www.keycloak.org/
+  maintainers:
+  - email: customerservice@redhat.com
+    name: Red Hat Customer Service
+  maturity: stable
+  provider:
+    name: Red Hat
+  version: 7.6.9-opr-002
+  replaces: rhsso-operator.7.6.9-opr-001
+  skips:
+  - rhsso-operator.7.6.0-opr-001
+  relatedImages:
+  - name: sso7-rhel8-operator-3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60-annotation
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+  - name: rhsso-operator
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:3849757fa1ffe8919928d30f9277906c281a52a9faf8274b78f62b6bad902c60
+  - name: rhsso_openjdk
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:0b926fc9eae775425faa1ab9709a36fdac15afe4bfe523720e17ecf5df45bb28
+  - name: rhsso_openj9
+    image: registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:0b926fc9eae775425faa1ab9709a36fdac15afe4bfe523720e17ecf5df45bb28
+  - name: keycloak_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a
+  - name: rhsso_init_container
+    image: registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:be49c4d5288bdcb3da6bbcf0155314ec3dd3a89b29ccaaafc3345f9f6e86e86a

--- a/manifests/integreatly-rhsso/rhsso.package.yaml
+++ b/manifests/integreatly-rhsso/rhsso.package.yaml
@@ -1,5 +1,5 @@
 channels:
-- currentCSV: rhsso-operator.v7.6.7-1
+- currentCSV: rhsso-operator.v7.6.9-3
   name: stable
 defaultChannel: stable
 packageName: rhsso-operator

--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -177,7 +177,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.ReconcileCsvDeploymentsPriority(
 		ctx,
 		serverClient,
-		fmt.Sprintf("rhsso-operator.%s", "7.6.7-opr-001"),
+		fmt.Sprintf("rhsso-operator.%s", "7.6.9-opr-002"),
 		r.Config.GetOperatorNamespace(),
 		installation.Spec.PriorityClassName,
 	)

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -208,7 +208,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 	phase, err = r.ReconcileCsvDeploymentsPriority(
 		ctx,
 		serverClient,
-		fmt.Sprintf("rhsso-operator.%s", "7.6.7-opr-001"),
+		fmt.Sprintf("rhsso-operator.%s", "7.6.9-opr-002"),
 		r.Config.GetOperatorNamespace(),
 		installation.Spec.PriorityClassName,
 	)

--- a/products/installation-cpaas.yaml
+++ b/products/installation-cpaas.yaml
@@ -75,9 +75,9 @@ products:
     channel: stable
     installFrom: index
     package: rhsso-operator
-    index: quay.io/integreatly/rhsso-index:v7.6.7-1
+    index: quay.io/integreatly/rhsso-index:v7.6.9-3
   rhssouser:
     channel: stable
     installFrom: index
     package: rhsso-operator
-    index: quay.io/integreatly/rhsso-index:v7.6.7-1
+    index: quay.io/integreatly/rhsso-index:v7.6.9-3

--- a/products/installation.yaml
+++ b/products/installation.yaml
@@ -75,9 +75,9 @@ products:
         channel: stable
         installFrom: index
         package: rhsso-operator
-        index: quay.io/integreatly/rhsso-index:v7.6.7-1
+        index: quay.io/integreatly/rhsso-index:v7.6.9-3
     rhssouser:
         channel: stable
         installFrom: index
         package: rhsso-operator
-        index: quay.io/integreatly/rhsso-index:v7.6.7-1
+        index: quay.io/integreatly/rhsso-index:v7.6.9-3


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6431

# What
Update RHSSO image for RHOAM 1.41
New bundle image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-3

**What was done, steps**

-  Created  [preliminary PR](https://github.com/integr8ly/integreatly-operator/pull/3498), where  bundles/rhsso-operator/bundles.yaml  was updated with new bundle(s) (this file is only change, as the goal of those PR - prepare for creation of Index image from master)
- Index Image created: quay.io/integreatly/rhsso-index:v7.6.9-3 
- PL used to create index image: https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/build-product-index/50/

**Notes**:  
- E2E tests of this PR to be rerun after creation of Index image in quay.io/integreatly/rhsso-index repo
- Before creation of Index image in integreatly repository - private image was created and tested as in Verificaiton section below

# Verification
- PL passed:   https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/vmogilev/job/build-product-index/27/.  
      Index created: quay.io/vmogilev_rhmi/rhsso-index:v7.6.9-3

- RHOAM Local installation done using private image quay.io/vmogilev_rhmi/rhsso-index:v7.6.9-3
oc describe pod rhsso-operator-d9f65ccc5-cz457 -n redhat-rhoam-rhsso-operator |grep VER 
      SSO_VER:                                7.6.9
oc describe pod rhsso-operator-d4c574759-kqg82 -n redhat-rhoam-user-sso-operator |grep VER
      SSO_VER:                                7.6.9
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.stage'
complete