### PR TITLE
MGDAPI-6432 Bump Envoy image to 2.5.3-8

### DIFF
--- a/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -79,7 +79,7 @@ metadata:
           "rhsso_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:c9634cf64e2b0c3a7e8314b870dba12bb6a370b44545f9347ca577f7a5a13103"
         },
         "ratelimit": {
-          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.9-2"
+          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
         },
         "limitador": {
           "marin3r-limitador": "quay.io/kuadrant/limitador:v1.3.0"

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.9-2"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.3.9-2"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/kuadrant/limitador:v1.3.0"


### PR DESCRIPTION
# Issue Link
JIRA: [MGDAPI-6432](https://issues.redhat.com/browse/MGDAPI-6432)

# What
Bump envoy image from `2.3.9-2` to `2.5.3-8`.

# Verification Steps
1. Prepare the cluster:
```bash
make cluster/prepare/local
```

2. Install RHOAM:
```bash
make code/run
```

3. Wait for the installation to complete:
```bash
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
```

4. Confirm that the `envoy-sidecar` container in the `apicast-production` Pod is running the image `registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8`:
```bash
APICAST_POD=$(oc get pods -n redhat-rhoam-3scale | grep apicast-production | grep Running | head -n 1 | awk '{print $1}')

oc get pod -n redhat-rhoam-3scale ${APICAST_POD} -ojson | jq -r '.spec.containers[] | select(.name == "envoy-sidecar") | .image'
```

5. Cancel `make code/run` in your terminal to stop the rhoam operator.

6. Navigate to the `redhat-rhoam-marin3r` Namespace -> ConfigMaps -> `ratelimit-config` and change the value of `max_value` to `5`.

7. Get the password for the 3scale Admin Portal:
```bash
 oc get secret system-seed -n redhat-rhoam-3scale -ojson | jq -r '.data["ADMIN_PASSWORD"]' | base64 -d
```

8. Navigate to `redhat-rhoam-3scale` Namespace -> Routes -> find the 3scale-admin Route and navigate to it in your browser.

9. Login with `admin` and password copied from step 7.

10. Go through the 3scale wizard to create the example Product and Backend.

11. Once in the 3scale Admin Portal -> Click on the newly created Product -> Integration -> Configuration and copy the curl request from Staging env.

12. In your terminal curl the endpoint with added `-i` flag `curl -i <endpoint>`. The first 5 requests should be successful but the 6th request should fail with 429 too many requests.
