### PR TITLE
MGDAPI-6446 add kc bundles

### DIFF
--- a/bundles/rhsso-operator/bundles.yaml
+++ b/bundles/rhsso-operator/bundles.yaml
@@ -65,3 +65,9 @@ bundles:
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-2
     - name: rhsso-operator.v7.6.9-3
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-3
+    - name: rhsso-operator.v7.6.9-4
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.9-4
+    - name: rhsso-operator.v7.6.10-1
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.10-1
+    - name: rhsso-operator.v7.6.11-1
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-1


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6446

# What
Bump kc to 7.6.11

# Verification steps
https://catalog.redhat.com/software/containers/rh-sso-7/sso7-rhel8-operator-bundle/6160639f5cfcf7adc247ac43
Confirm that the bundles tags match
