### PR TITLE
MGDAPI-6456 Bump RHOAM maxOpenShiftVersion to 4.17

### DIFF
--- a/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/integreatly/managed-api-service:master
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
     operatorframework.io/suggested-namespace: redhat-rhoam-operator
     operators.operatorframework.io/builder: operator-sdk-v1.21.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/config/manifests-multitenant-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-multitenant-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.13"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
     support: RHOAM
   name: managed-api-service.v1.37.0
   namespace: placeholder

--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.15"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
     support: RHOAM
   name: managed-api-service.v1.41.0
   namespace: placeholder


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6456

# What
Bump RHOAM's maxOpenShiftVersion for 1.41.0 to 4.17

# Verification steps
RHOAM 1.41.0 maxOpenShiftVersion is set to 4.17
```
$ oc describe deploy rhmi-operator |grep -i maxOpen
                    olm.properties: [{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]
                      {"properties":[{"type":"olm.maxOpenShiftVersion","value":"4.17"},{"type":"olm.gvk","value":{"group":"integreatly.org","kind":"RHMI","versi...

$ oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.stage'
complete

$ date
Thu Oct 10 15:22:26 EEST 2024
```
Images created and used for testing:
- quay.io/vmogilev_rhmi/managed-api-service-index:1.41.0
- quay.io/vmogilev_rhmi/managed-api-service-bundle:1.41.0
- quay.io/vmogilev_rhmi/managed-api-service:rhoam-v1.41.0

