### PR TITLE
MGDAPI-6489 Bump grafana and ose-oauth-proxy images

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -347,7 +347,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// Container #1
 		grafanaDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].Name = "grafana"
-		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana@sha256:31cac5b19c9709d9d7aa00b10858a5f1c0e2badd7b9fdf9b6772e47c87e4cc16"
+		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana@sha256:043f656f9c940b66131f8932a9485c66317c1e274d91129d1b9a9a9b594e4547"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/grafana/",
@@ -473,7 +473,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// container #2
 		grafanaDeployment.Spec.Template.Spec.Containers[1].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].Name = "grafana-proxy"
-		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:cdd63d660b8a629cbca27269b8c9e6ea76ece2b257a8f29a35610f822941b2db"
+		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4387d0fdb0e8ac72b7d95525e22109b5a95effa1845b7f38113750c071a84253"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/tls/private",

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -11,7 +11,7 @@ limitador:
     url: "quay.io/kuadrant/limitador:v1.3.0"
 grafana:
   - name: grafana
-    url: "registry.redhat.io/rhel9/grafana@sha256:31cac5b19c9709d9d7aa00b10858a5f1c0e2badd7b9fdf9b6772e47c87e4cc16"
+    url: "registry.redhat.io/rhel9/grafana@sha256:043f656f9c940b66131f8932a9485c66317c1e274d91129d1b9a9a9b594e4547"
 grafana-ose-oauth-proxy:
   - name: grafana-ose-oauth-proxy
-    url: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:cdd63d660b8a629cbca27269b8c9e6ea76ece2b257a8f29a35610f822941b2db"
+    url: "registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4387d0fdb0e8ac72b7d95525e22109b5a95effa1845b7f38113750c071a84253"


### PR DESCRIPTION
# Issue Link
JIRA: [MGDAPI-6489](https://issues.redhat.com/browse/MGDAPI-6489)

# What
* Bump `grafana` image to `9-63.1727117435`.
* Bump `grafana-ose-oauth-proxy` image to `v4.14.0-202409250238`.

# Verification Steps
1. Prepare the cluster:
```bash
make cluster/prepare/local
```

2. Install RHOAM:
```bash
make code/run
```

3. Wait for the installation to complete:
```bash
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
```

4. Confirm that the `grafana` container in the `grafana-deployment` Pod is running the image `registry.redhat.io/rhel9/grafana@sha256:043f656f9c940b66131f8932a9485c66317c1e274d91129d1b9a9a9b594e4547`:
```bash
GRAFANA_POD=$(oc get pod -n redhat-rhoam-customer-monitoring --no-headers | awk '{print $1}')

oc get pod -n redhat-rhoam-customer-monitoring ${GRAFANA_POD} -ojson | jq -r '.spec.containers[] | select(.name == "grafana") | .image'
```

5. Confirm that the `grafana-proxy` container in the `grafana-deployment` Pod is running the image `registry.redhat.io/openshift4/ose-oauth-proxy@sha256:4387d0fdb0e8ac72b7d95525e22109b5a95effa1845b7f38113750c071a84253`:
```bash
GRAFANA_POD=$(oc get pod -n redhat-rhoam-customer-monitoring --no-headers | awk '{print $1}')

oc get pod -n redhat-rhoam-customer-monitoring ${GRAFANA_POD} -ojson | jq -r '.spec.containers[] | select(.name == "grafana-proxy") | .image'
```

6. Navigate to the `redhat-rhoam-customer-monitoring` Namespace -> Routes and open the `grafana-route` in your browser.

7. Verify that the `Rate Limiting` dashboard is working as expected.
