### PR TITLE
MGDAPI-6489 Bump envoy and limitador images

### DIFF
--- a/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -79,7 +79,7 @@ metadata:
           "rhsso_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:81122cb34e5d927ba20d4e0fc4165acfc70382dbe0679cc8ee568bf048e601d7"
         },
         "ratelimit": {
-          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
+          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.5-6"
         },
         "limitador": {
           "marin3r-limitador": "quay.io/kuadrant/limitador:v1.6.0"

--- a/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.41.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -82,7 +82,7 @@ metadata:
           "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
         },
         "limitador": {
-          "marin3r-limitador": "quay.io/kuadrant/limitador:v1.3.0"
+          "marin3r-limitador": "quay.io/kuadrant/limitador:v1.6.0"
         },
         "grafana": {
           "grafana": "registry.redhat.io/rhel9/grafana@sha256:31cac5b19c9709d9d7aa00b10858a5f1c0e2badd7b9fdf9b6772e47c87e4cc16"

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -35,7 +35,7 @@ const (
 	multitenantDescriptorValue    = "per-mt-limit"
 	RateLimitingConfigMapName     = "ratelimit-config"
 	RateLimitingConfigMapDataName = "apicast-ratelimiting.yaml"
-	rateLimitImage                = "quay.io/kuadrant/limitador:v1.3.0"
+	rateLimitImage                = "quay.io/kuadrant/limitador:v1.6.0"
 )
 
 type RateLimitServiceReconciler struct {

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.5-6"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -8,7 +8,7 @@ ratelimit:
     url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
 limitador:
   - name: marin3r-limitador
-    url: "quay.io/kuadrant/limitador:v1.3.0"
+    url: "quay.io/kuadrant/limitador:v1.6.0"
 grafana:
   - name: grafana
     url: "registry.redhat.io/rhel9/grafana@sha256:31cac5b19c9709d9d7aa00b10858a5f1c0e2badd7b9fdf9b6772e47c87e4cc16"

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,7 +5,7 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.3-8"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.5-6"
 limitador:
   - name: marin3r-limitador
     url: "quay.io/kuadrant/limitador:v1.6.0"


### PR DESCRIPTION
# Issue Link
JIRA: [MGDAPI-6489](https://issues.redhat.com/browse/MGDAPI-6489)

# What
Bump envoy image from `2.5.3-8` to `2.5.5-6` and bump limitador image from `v1.3.0` to `v1.6.0`.

# Verification Steps
1. Prepare the cluster:
```bash
make cluster/prepare/local
```

2. Install RHOAM:
```bash
make code/run
```

3. Wait for the installation to complete:
```bash
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
```

4. Confirm that the `ratelimit` Pod in the `redhat-rhoam-marin3r` Namespace is running the image `quay.io/kuadrant/limitador:v1.3.0`:
```bash
RATELIMIT_POD=$(oc get pods -n redhat-rhoam-marin3r | grep ratelimit | grep Running | head -n 1 | awk '{print $1}')

oc get pod -n redhat-rhoam-marin3r ${RATELIMIT_POD} -ojson | jq -r '.spec.containers[] | select(.name == "ratelimit") | .image'
```

5. Confirm that the `envoy-sidecar` container in the `apicast-production` Pod is running the image `registry.redhat.io/openshift-service-mesh/proxyv2-rhel8:2.5.5-6`:
```bash
APICAST_POD=$(oc get pods -n redhat-rhoam-3scale | grep apicast-production | grep Running | head -n 1 | awk '{print $1}')

oc get pod -n redhat-rhoam-3scale ${APICAST_POD} -ojson | jq -r '.spec.containers[] | select(.name == "envoy-sidecar") | .image'
```

6. Cancel `make code/run` in your terminal to stop the rhoam operator.

7. Navigate to the `redhat-rhoam-marin3r` Namespace -> ConfigMaps -> `ratelimit-config` and change the value of `max_value` to `5`.

8. Get the password for the 3scale Admin Portal:
```bash
 oc get secret system-seed -n redhat-rhoam-3scale -ojson | jq -r '.data["ADMIN_PASSWORD"]' | base64 -d
```

9. Navigate to `redhat-rhoam-3scale` Namespace -> Routes -> find the 3scale-admin Route and navigate to it in your browser.

10. Login with `admin` and password copied from step 7.

11. Go through the 3scale wizard to create the example Product and Backend.

12. Once in the 3scale Admin Portal -> Click on the newly created Product -> Integration -> Configuration and copy the curl request from Staging env.

13. In your terminal curl the endpoint with added `-i` flag `curl -i <endpoint>`. The first 5 requests should be successful but the 6th request should fail with 429 too many requests.
