### PR TITLE
MGDAPI-6495 Fix gofmt path for prepare-release.sh script

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -42,10 +42,16 @@ echo "Using kustomize path: $KUSTOMIZE"
 
 # Path to gofmt
 if [[ -z $GOROOT ]]; then
-  GOFMT="gofmt"
+  if [[ -x /usr/local/go/bin/gofmt ]]; then
+    GOFMT="/usr/local/go/bin/gofmt"
+  else
+    GOFMT="gofmt"
+  fi
 else
   GOFMT="$GOROOT/bin/gofmt"
 fi
+
+echo "Using gofmt path: $GOFMT"
 
 # The base CSV is used to generate the final CSV by combining it with the other operator
 # manifests. In operator-sdk v1.2.0, the replaces field of the new CSV is set from


### PR DESCRIPTION
# Issue link
JIRA: MGDAPI-6495

# What
This PR fixes the `prepare-release.sh` script which is required to run the release pipeline.

# Verification steps