### PR TITLE
MGDAPI-6451 update ingress controller logic

### DIFF
--- a/pkg/products/threescale/reconciler_test.go
+++ b/pkg/products/threescale/reconciler_test.go
@@ -1910,7 +1910,7 @@ func TestReconciler_findCustomDomainCr(t *testing.T) {
 				recorder:      tt.fields.recorder,
 				log:           tt.fields.log,
 			}
-			got, err := r.findCustomDomainCr(tt.args.ctx, tt.args.serverClient)
+			got, _, err := r.findCustomDomainCr(tt.args.ctx, tt.args.serverClient)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("findCustomDomainCr() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/resources/custom-domain/custom-domain_test.go
+++ b/pkg/resources/custom-domain/custom-domain_test.go
@@ -321,7 +321,7 @@ func TestHasValidCustomDomainCR(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := HasValidCustomDomainCR(tt.args.ctx, tt.args.serverClient, tt.args.domain)
+			got, _, err := HasValidCustomDomainCR(tt.args.ctx, tt.args.serverClient, tt.args.domain)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("HasValidCustomDomainCR() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
# Issue link
Fix an issue where ingressControllers spec.domain isn't actual domain but part of dns

# What
When coming from osd 4.13 to 4.14, openshift automatically creates ingressController of the same name as the custom domain and deprecates the custom domain. Our goal here is to find custom domain name and find ingressController of the same name -> then check the available condition of ingressController
On fresh installs, the spec.domain in ingressController is expected to be of the same value as routing subdomain in rhmi cr

# Verification steps
Already done on cluster with Tomas, please review code.
