### PR TITLE
MGDAPI-6498 Fixed 3scale CSV container image

### DIFF
--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -357,6 +357,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileCsvContainerImage(
+		ctx,
+		serverClient,
+		fmt.Sprintf("3scale-operator.v%s", integreatlyv1alpha1.OperatorVersion3Scale),
+		r.Config.GetOperatorNamespace(),
+	)
+	if err != nil || phase == integreatlyv1alpha1.PhaseFailed {
+		events.HandleError(r.recorder, installation, phase, "Failed to reconcile 3scale-operator csv container image", err)
+		return phase, err
+	}
+
 	if r.installation.GetDeletionTimestamp() == nil {
 		phase, err = r.reconcileSMTPCredentials(ctx, serverClient)
 		if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {

--- a/pkg/resources/reconciler.go
+++ b/pkg/resources/reconciler.go
@@ -353,3 +353,20 @@ func (r *Reconciler) ReconcileCsvDeploymentsPriority(ctx context.Context, client
 	}
 	return k8s.PatchIfExists(ctx, client, mutateFn, csv)
 }
+
+func (r *Reconciler) ReconcileCsvContainerImage(ctx context.Context, client k8sclient.Client, csvName, csvNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+	csv := &operatorsv1alpha1.ClusterServiceVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      csvName,
+			Namespace: csvNamespace,
+		},
+	}
+	mutateFn := func() error {
+		deployments := csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs
+		for i := range deployments {
+			deployments[i].Spec.Template.Spec.Containers[0].Image = "quay.io/integreatly/3scale-operator:v0.12.1-mas"
+		}
+		return nil
+	}
+	return k8s.PatchIfExists(ctx, client, mutateFn, csv)
+}


### PR DESCRIPTION
# Issue link
JIRA: [MGDAPI-6498](https://issues.redhat.com/browse/MGDAPI-6498)

# What
This PR patches the `containerImage` in the 3scale CSV so the 3scale-operator is running the correct image.

# Verification steps
1. Checkout this PR

2. Prepare the cluster:
```bash
make cluster/prepare/local
```

3. Install RHOAM:
```bash
make code/run
```

4. Wait for the installation to complete:
```bash
oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq .status.stage
```

5. Confirm that the `threescale-operator-controller-manager-v2-*` Pod in the `redhat-rhoam-3scale-operator` Namespace is running the image `quay.io/integreatly/3scale-operator:v0.12.1-mas`:
```bash
THREESCALE_OPERATOR_POD=$(oc get pods -n redhat-rhoam-3scale-operator | grep threescale-operator-controller-manager-v2 | awk '{print $1}')

oc get pod -n redhat-rhoam-3scale-operator ${THREESCALE_OPERATOR_POD} -ojson | jq -r '.spec.containers[] | select(.name == "manager") | .image'
```

