### PR TITLE
MGDAPI-6451 missing rbac

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -325,6 +325,7 @@ rules:
   resources:
   - ingresscontrollers
   verbs:
+  - get
   - list
 - apiGroups:
   - operators.coreos.com

--- a/controllers/rhmi/rhmi_controller.go
+++ b/controllers/rhmi/rhmi_controller.go
@@ -237,7 +237,7 @@ func New(mgr ctrl.Manager) *RHMIReconciler {
 
 // +kubebuilder:rbac:groups=managed.openshift.io,resources=customdomains,verbs=list
 
-// +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=list
+// +kubebuilder:rbac:groups=operator.openshift.io,resources=ingresscontrollers,verbs=get;list
 
 // +kubebuilder:rbac:groups=operator.openshift.io,resources=cloudcredentials,verbs=get;list;watch
 

--- a/pkg/resources/custom-domain/custom-domain.go
+++ b/pkg/resources/custom-domain/custom-domain.go
@@ -117,7 +117,7 @@ func HasValidIngressControllerCR(ctx context.Context, serverClient client.Client
 
 		err := serverClient.Get(ctx, key, ingressControllerCR)
 		if err != nil {
-			return false, fmt.Errorf("no ingress controller CR found for: \"%s\"", domain)
+			return false, err
 		}
 
 		for _, condition := range ingressControllerCR.Status.Conditions {


### PR DESCRIPTION
# Issue link
IngressController get missing an rbac permission

# What
IngressController get missing an rbac permission

# Verification steps
Before adding the rbac:
User \"system:serviceaccount:redhat-rhoam-operator:rhmi-operator\" cannot get resource \"ingresscontrollers\" in API group \"operator.openshift.io\" in the namespace \"openshift-ingress-operator\"\""

After adding the rbac:
![image](https://github.com/user-attachments/assets/9775ff16-0ecc-4ee4-abbd-0a0be3b023c8)

![image](https://github.com/user-attachments/assets/873c9b77-f68b-445d-99d7-9a758d86b59d)

