### PR TITLE
MGDAPI-6536 remove entitled content image from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi9/go-toolset:1.20.12 AS builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.20.12 AS builder
 
 # this is required for podman
 USER root


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6536

# What
Removing entitled content builder image from upstream

# Verification steps
Prow checks pass
