### PR TITLE
MGDAPI-6551 Add Cluster Observability Operator to local install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -362,7 +362,7 @@ cluster/prepare/crd: kustomize
 	$(KUSTOMIZE) build config/crd-sandbox | oc apply -f -
 
 .PHONY: cluster/prepare/local
-cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/addon-params cluster/prepare/delorean cluster/prepare/rbac/dedicated-admins cluster/prepare/addon-instance cluster/prepare/rhoam-config
+cluster/prepare/local: kustomize cluster/prepare/project cluster/prepare/crd cluster/prepare/smtp cluster/prepare/dms cluster/prepare/pagerduty cluster/prepare/addon-params cluster/prepare/delorean cluster/prepare/rbac/dedicated-admins cluster/prepare/addon-instance cluster/prepare/rhoam-config install-oo
 	@if [ "$(CREDENTIALS_MODE)" = Manual ]; then \
 		echo "manual mode (sts)"; \
 		$(MAKE) cluster/prepare/sts; \
@@ -641,3 +641,8 @@ test/scripts:
 	# Preform a basic check on scripts checking for a non zero exit
 	echo "Running make release/prepare"
 	SEMVER=$(RHOAM_TAG) make release/prepare
+
+.PHONY: install-oo
+install-oo:
+	@echo "Installing Cluster Observability Operator Subscription..."
+	kubectl apply -f  config/samples/subscription_oo.yaml

--- a/Makefile
+++ b/Makefile
@@ -295,7 +295,7 @@ test/products:
 	delorean pipeline product-tests --test-config ./test-containers.yaml --output $(TEST_RESULTS_DIR) --namespace test-products
 
 .PHONY: cluster/deploy
-cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare cluster/prepare/rbac/dedicated-admins deploy/integreatly-rhmi-cr.yml
+cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare cluster/prepare/rbac/dedicated-admins deploy/integreatly-rhmi-cr.yml install-oo
 	@ - oc create -f config/rbac/service_account.yaml
 	@ - cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_FORMAT}
 	@ - $(KUSTOMIZE) build config/$(CLUSTER_CONFIG) | oc apply -f -
@@ -644,5 +644,5 @@ test/scripts:
 
 .PHONY: install-oo
 install-oo:
-	@echo "Installing Cluster Observability Operator Subscription..."
+	@echo "Creating Cluster Observability Operator Subscription"
 	kubectl apply -f  config/samples/subscription_oo.yaml

--- a/Makefile
+++ b/Makefile
@@ -245,7 +245,7 @@ test/e2e/multitenant-rhoam/prow: test/e2e
 
 .PHONY: test/e2e
 test/e2e: export SURF_DEBUG_HEADERS=1
-test/e2e: cluster/deploy test/prepare/ocp/obo
+test/e2e: cluster/deploy/e2e test/prepare/ocp/obo
 	cd test && go clean -testcache && go test -v ./e2e -timeout=120m -ginkgo.v
 
 .PHONY: test/e2e/single
@@ -296,6 +296,12 @@ test/products:
 
 .PHONY: cluster/deploy
 cluster/deploy: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare cluster/prepare/rbac/dedicated-admins deploy/integreatly-rhmi-cr.yml install-oo
+	@ - oc create -f config/rbac/service_account.yaml
+	@ - cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_FORMAT}
+	@ - $(KUSTOMIZE) build config/$(CLUSTER_CONFIG) | oc apply -f -
+
+.PHONY: cluster/deploy/e2e
+cluster/deploy/e2e: kustomize cluster/cleanup cluster/cleanup/crds cluster/prepare/crd cluster/prepare cluster/prepare/rbac/dedicated-admins deploy/integreatly-rhmi-cr.yml
 	@ - oc create -f config/rbac/service_account.yaml
 	@ - cd config/manager && $(KUSTOMIZE) edit set image controller=${IMAGE_FORMAT}
 	@ - $(KUSTOMIZE) build config/$(CLUSTER_CONFIG) | oc apply -f -

--- a/config/samples/subscription_oo.yaml
+++ b/config/samples/subscription_oo.yaml
@@ -1,0 +1,15 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  generation: 1
+  labels:
+    operators.coreos.com/cluster-observability-operator.openshift-operators: ""
+  name: cluster-observability-operator
+  namespace: openshift-operators
+spec:
+  channel: development
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  startingCSV: cluster-observability-operator.0.4.1

--- a/config/samples/subscription_oo.yaml
+++ b/config/samples/subscription_oo.yaml
@@ -1,9 +1,6 @@
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  generation: 1
-  labels:
-    operators.coreos.com/cluster-observability-operator.openshift-operators: ""
   name: cluster-observability-operator
   namespace: openshift-operators
 spec:
@@ -12,4 +9,4 @@ spec:
   name: cluster-observability-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: cluster-observability-operator.0.4.1
+


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6551

# What
PR allow to add Cluster Observability Operator for local installation
OO required for local install to provide monitoring CRDs

# Verification steps
- make install-oo
-  check subscription: Add Cluster Observability Operator to local install
- See Jira description

- For complete RHOAM check run following:
```bash
LOCAL=false USE_CLUSTER_STORAGE=true INSTALLATION_TYPE=managed-api make cluster/prepare/local
LOCAL=false USE_CLUSTER_STORAGE=true INSTALLATION_TYPE=managed-api make code/run
```
where `cluster/prepare/local` contains `install-oo` target
- Expected resullts: 
```bash
~/go/integreatly-operator oc get rhmi rhoam -n redhat-rhoam-operator -o json | jq -r '.status.stage'
complete
```

