### PR TITLE
MGDAPI-6547 prepare to build rhsso-index 7.6.11-3

### DIFF
--- a/bundles/rhsso-operator/bundles.yaml
+++ b/bundles/rhsso-operator/bundles.yaml
@@ -71,3 +71,7 @@ bundles:
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.10-1
     - name: rhsso-operator.v7.6.11-1
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-1
+    - name: rhsso-operator.v7.6.11-2
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-2
+    - name: rhsso-operator.v7.6.11-3
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-3


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6547
This PR is preparation for [PR - RHSSO update for RHOAM 1.42](https://github.com/integr8ly/integreatly-operator/pull/3532) 

# What
prepare to build rhsso-index 7.6.11-3
After PR merge, will use PL similar to previouse rhsso-build: https://jenkins-csb-intly-master.dno.corp.redhat.com/job/ManagedAPI/job/build-product-index/50/

# Verification steps
Before creation this PR we checked [PR - RHSSO update for RHOAM 1.42](https://github.com/integr8ly/integreatly-operator/pull/3532)   locally, using private image quay.io/vmogilev_rhmi/rhsso-index:v7.6.11-3  that was created by PL: https://jenkins-csb-intly-master.dno.corp.redhat.com/job/Playground/job/vmogilev/job/build-product-index/29/
