### PR TITLE
MGDAPI-6551 Using stable channel for Observability Operator

### DIFF
--- a/config/samples/subscription_oo.yaml
+++ b/config/samples/subscription_oo.yaml
@@ -4,7 +4,7 @@ metadata:
   name: cluster-observability-operator
   namespace: openshift-operators
 spec:
-  channel: development
+  channel: stable
   installPlanApproval: Automatic
   name: cluster-observability-operator
   source: redhat-operators


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6551

# What
The stable channel needs to be used. The Observability Operator cannot be found otherwise.

# Verification steps
<!-- Add thorough verification steps with sufficient level of detail for those without context to verify the change-->
<!-- AND Add thorough upgrade verification steps OR include a reason as to why it is not required -->
<!-- OR state "Not applicable" or "N/A" if your type of change doesn't require verification -->

Install RHOAM on cluster via `cluster/deploy` make target. However, given the triviality of the change I think that eye review should suffice and full verification can be done via nightly pipelines.
