### PR TITLE
MGDAPI-6602 Jenkins PLs test suite, avoid using wget

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -753,7 +753,7 @@ func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
 	}
 
 	// exec into the prometheus pod
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
+	output, err := execToPod("curl -s localhost:9090/api/v1/rules",
 
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -130,7 +130,7 @@ func TestIntegreatlyAlertsFiring(t TestingTB, ctx *TestingContext) {
 
 }
 func getFiringAlerts(t TestingTB, ctx *TestingContext) error {
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
+	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",
@@ -275,7 +275,7 @@ func TestIntegreatlyAlertsPendingOrFiring(t TestingTB, ctx *TestingContext) {
 }
 
 func getFiringOrPendingAlerts(t TestingTB, ctx *TestingContext) error {
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
+	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -240,7 +240,7 @@ func waitForKeycloakAlertState(expectedState string, ctx *TestingContext, t Test
 }
 
 func getKeycloakAlertState(ctx *TestingContext) error {
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
+	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/dashboards_data.go
+++ b/test/common/dashboards_data.go
@@ -43,7 +43,7 @@ func getMonitoringAppPodName(app string, ctx *TestingContext) (string, error) {
 }
 
 func queryPrometheus(query string, podName string, ctx *TestingContext) ([]prometheusQueryResult, error) {
-	queryOutput, err := execToPod("wget -qO - localhost:9090/api/v1/query?query="+url.QueryEscape(query),
+	queryOutput, err := execToPod("curl -s localhost:9090/api/v1/query?query="+url.QueryEscape(query),
 		podName,
 		ObservabilityProductNamespace,
 		"prometheus", ctx)

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -40,7 +40,7 @@ func TestIntegreatlyCustomerDashboardsExist(t TestingTB, ctx *TestingContext) {
 
 	customerMonitoringGrafanaPods := getGrafanaPods(t, ctx, CustomerGrafanaNamespace)
 
-	output, err := execToPod(fmt.Sprintf("wget -qO - %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
+	output, err := execToPod(fmt.Sprintf("curl -s %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
 		prometheusPodName,
 		ObservabilityProductNamespace,
 		curlContainerName, ctx)

--- a/test/common/verify_3scale_UIBBT_alerts.go
+++ b/test/common/verify_3scale_UIBBT_alerts.go
@@ -143,7 +143,7 @@ func isThreeScaleUIBBTAlertFiring(ctx *TestingContext, t TestingTB) (bool, error
 		"ThreeScaleSystemAdminUIBBT": false,
 	}
 
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
+	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/verify_alert_links_to_SOPs.go
+++ b/test/common/verify_alert_links_to_SOPs.go
@@ -29,7 +29,7 @@ func TestSOPUrls(t TestingTB, ctx *TestingContext) {
 	testUrl := "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/-/blob/master/sops/rhoam/alerts/AddonManagedApiServiceParameters.asciidoc"
 	validateGitlabToken(t, testUrl)
 
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
+	output, err := execToPod("curl -s localhost:9090/api/v1/rules",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus", ctx)

--- a/test/common/verify_prometheus_metrics.go
+++ b/test/common/verify_prometheus_metrics.go
@@ -103,7 +103,7 @@ func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
 }
 
 func getPrometheusTargets(ctx *TestingContext) (*prometheusv1.TargetsResult, error) {
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/targets?state=active",
+	output, err := execToPod("curl -s localhost:9090/api/v1/targets?state=active",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",


### PR DESCRIPTION
# Issue link
Jira https://issues.redhat.com/browse/MGDAPI-6602

# What
Replaced wget with curl in the tests to avoid failures in the Jenkins pipeline tests due to the absence of wget.
It will allow to avoid errors like:
```
[FAILED] Failed to query prometheus: failed to exec to prometheus pod: error in Stream: command terminated with exit code 255 (time="2025-03-17T09:57:28Z" level=error msg="exec failed: unable to start container process: exec: \"wget\": executable file not found in $PATH
```


# Verification steps
Ensure that the E2E tests pass successfully.
Confirm that Jenkins pipelines are no longer failing due to the missing wget command.