### PR TITLE
MGDAPI-6648 remove the installation delayed alert

### DIFF
--- a/pkg/resources/prometheusRules.go
+++ b/pkg/resources/prometheusRules.go
@@ -65,13 +65,6 @@ func (r *AlertReconcilerImpl) ReconcileAlerts(ctx context.Context, client k8scli
 		}
 	}
 
-	//removing RHOAMUpgradeExpectedDuration30minExceeded alert as it was renamed (30min -> 60min)
-	alertToDelete := AlertConfiguration{
-		AlertName: "RHOAMUpgradeExpectedDuration30minExceeded",
-		Namespace: "openshift-monitoring",
-	}
-	r.RemovedAlerts = append(r.RemovedAlerts, alertToDelete)
-
 	if err := r.deleteAlerts(ctx, client, r.RemovedAlerts); err != nil {
 		return integreatlyv1alpha1.PhaseFailed, err
 	}

--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -168,7 +168,6 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
-				"RHOAMInstallationControllerReconcileDelayed",
 			},
 		},
 	}
@@ -239,7 +238,6 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
 			Rules: []string{
 				"RHOAMIsInReconcilingErrorState",
-				"RHOAMInstallationControllerReconcileDelayed",
 			},
 		},
 		{


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6648

# What
InstallationControllerReconcileDelayed is no longer required and, therefore, has been removed.

# Verification steps
- install RHOAM from master via make code/run
- confirm that under "redhat-rhoam-operator-observability" there is prometheusRule monitoring.rhobs/v1 called rhoam-rhmi-controller-alerts present
- inside that rule, confirm there's a rule called: RHOAMInstallationControllerReconcileDelayed present.
- run RHOAM operator from this branch and confirm that the RHOAMInstallationControllerReconcileDelayed rule has been deleted.
