### PR TITLE
MGDAPI-6652 update Alert ThreeScaleZyncPodAvailability

### DIFF
--- a/pkg/products/threescale/prometheusRules.go
+++ b/pkg/products/threescale/prometheusRules.go
@@ -284,9 +284,9 @@ func (r *Reconciler) newAlertReconciler(logger l.Logger, installType string, ctx
 						Alert: "ThreeScaleZyncPodAvailability",
 						Annotations: map[string]string{
 							"sop_url": resources.SopUrlAlertsAndTroubleshooting,
-							"message": fmt.Sprintf("3Scale Zync has no pods in a ready state. Expected %d of pods.", r.Config.GetReplicasConfig(r.installation)["zyncApp"]),
+							"message": fmt.Sprintf("3Scale Zync has no pods in a ready state. Expected number of pods for zync: %d, and for zync-que: %d.", r.Config.GetReplicasConfig(r.installation)["zyncApp"], r.Config.GetReplicasConfig(r.installation)["zyncQue"]),
 						},
-						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true', namespace='%[1]v', pod=~'zync.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running'}) < 1", r.Config.GetNamespace(), r.Config.GetReplicasConfig(r.installation)["zyncApp"])),
+						Expr:   intstr.FromString(fmt.Sprintf("sum(kube_pod_status_ready{condition='true', namespace='%[1]v', pod=~'zync.*', pod!~'zync-database-.*'} * on(pod, namespace) group_left() kube_pod_status_phase{phase='Running'}) < 1", r.Config.GetNamespace(), r.Config.GetReplicasConfig(r.installation)["zyncApp"])),
 						For:    "15m",
 						Labels: map[string]string{"severity": "critical", "product": installationName},
 					},


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6652
- Update Alert ThreeScaleZyncPodAvailability - change Expression
- Create SOP  - see [MR](https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/-/merge_requests/929) 

# What
We are checking and updating SOPs for Alerts. See [Jira](https://issues.redhat.com/browse/MGDAPI-6652). We created a new SOP and reviewed/updated the ThreeScaleZyncPodAvailability Alert to make the query expression more precise.

# Verification steps
- Checkout this PR/branch.
- Refer to the SOP on how to open Prometheus (using port forwarding).
- Verify that the ThreeScaleZyncPodAvailability alert expression has been updated.
