### PR TITLE
MGDAPI-6676 fix labeling of the deployment and cluster package issue

### DIFF
--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -418,24 +418,75 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 					&packageOperatorv1alpha1.ClusterPackage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "managed-api-service",
+							Generation: 1,
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
-							Phase: packageOperatorv1alpha1.PackagePhaseAvailable,
+							Conditions: []metav1.Condition{
+								metav1.Condition{
+									Type: "Available",
+									Status: metav1.ConditionTrue,
+									ObservedGeneration: 1,
+								},
+								metav1.Condition{
+									Type: "Progressing",
+									Status: metav1.ConditionFalse,
+									ObservedGeneration: 1,
+								},
+							},
 						},
 					},
 				)},
 			wantErr: false,
 		},
 		{
-			name: "Test - RHOAM - cluster package is not phase available",
+			name: "Test - RHOAM - cluster package successfully reconciled but with wrong generation being available",
 			fields: fields{
 				Client: utils.NewTestClient(scheme,
 					&packageOperatorv1alpha1.ClusterPackage{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "managed-api-service",
+							Generation: 1,
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
-							Phase: packageOperatorv1alpha1.PackagePhaseNotReady,
+							Conditions: []metav1.Condition{
+								metav1.Condition{
+									Type: "Available",
+									Status: metav1.ConditionTrue,
+									ObservedGeneration: 0,
+								},
+								metav1.Condition{
+									Type: "Progressing",
+									Status: metav1.ConditionFalse,
+									ObservedGeneration: 0,
+								},
+							},
+						},
+					},
+				)},
+			wantErr: true,
+		},
+		{
+			name: "Test - RHOAM - cluster package is not available",
+			fields: fields{
+				Client: utils.NewTestClient(scheme,
+					&packageOperatorv1alpha1.ClusterPackage{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "managed-api-service",
+							Generation: 1,
+						},
+						Status: packageOperatorv1alpha1.PackageStatus{
+							Conditions: []metav1.Condition{
+								metav1.Condition{
+									Type: "Available",
+									Status: metav1.ConditionFalse,
+									ObservedGeneration: 0,
+								},
+								metav1.Condition{
+									Type: "Progressing",
+									Status: metav1.ConditionTrue,
+									ObservedGeneration: 1,
+								},
+							},
 						},
 					},
 				)},
@@ -450,7 +501,16 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 							Name: "incorrect-name",
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
-							Phase: packageOperatorv1alpha1.PackagePhaseAvailable,
+							Conditions: []metav1.Condition{
+								metav1.Condition{
+									Type: "Available",
+									Status: metav1.ConditionTrue,
+								},
+								metav1.Condition{
+									Type: "Progressing",
+									Status: metav1.ConditionFalse,
+								},
+							},
 						},
 					},
 				)},
@@ -464,6 +524,7 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		t.Setenv("WATCH_NAMESPACE", "test")
 		t.Run(tt.name, func(t *testing.T) {
 
 			r := &RHMIReconciler{

--- a/controllers/rhmi/rhmi_controller_test.go
+++ b/controllers/rhmi/rhmi_controller_test.go
@@ -417,19 +417,19 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 				Client: utils.NewTestClient(scheme,
 					&packageOperatorv1alpha1.ClusterPackage{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "managed-api-service",
+							Name:       "managed-api-service",
 							Generation: 1,
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
 							Conditions: []metav1.Condition{
 								metav1.Condition{
-									Type: "Available",
-									Status: metav1.ConditionTrue,
+									Type:               "Available",
+									Status:             metav1.ConditionTrue,
 									ObservedGeneration: 1,
 								},
 								metav1.Condition{
-									Type: "Progressing",
-									Status: metav1.ConditionFalse,
+									Type:               "Progressing",
+									Status:             metav1.ConditionFalse,
 									ObservedGeneration: 1,
 								},
 							},
@@ -444,19 +444,19 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 				Client: utils.NewTestClient(scheme,
 					&packageOperatorv1alpha1.ClusterPackage{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "managed-api-service",
+							Name:       "managed-api-service",
 							Generation: 1,
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
 							Conditions: []metav1.Condition{
 								metav1.Condition{
-									Type: "Available",
-									Status: metav1.ConditionTrue,
+									Type:               "Available",
+									Status:             metav1.ConditionTrue,
 									ObservedGeneration: 0,
 								},
 								metav1.Condition{
-									Type: "Progressing",
-									Status: metav1.ConditionFalse,
+									Type:               "Progressing",
+									Status:             metav1.ConditionFalse,
 									ObservedGeneration: 0,
 								},
 							},
@@ -471,19 +471,19 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 				Client: utils.NewTestClient(scheme,
 					&packageOperatorv1alpha1.ClusterPackage{
 						ObjectMeta: metav1.ObjectMeta{
-							Name: "managed-api-service",
+							Name:       "managed-api-service",
 							Generation: 1,
 						},
 						Status: packageOperatorv1alpha1.PackageStatus{
 							Conditions: []metav1.Condition{
 								metav1.Condition{
-									Type: "Available",
-									Status: metav1.ConditionFalse,
+									Type:               "Available",
+									Status:             metav1.ConditionFalse,
 									ObservedGeneration: 0,
 								},
 								metav1.Condition{
-									Type: "Progressing",
-									Status: metav1.ConditionTrue,
+									Type:               "Progressing",
+									Status:             metav1.ConditionTrue,
 									ObservedGeneration: 1,
 								},
 							},
@@ -503,11 +503,11 @@ func TestRHMIReconciler_checkClusterPackageAvailability(t *testing.T) {
 						Status: packageOperatorv1alpha1.PackageStatus{
 							Conditions: []metav1.Condition{
 								metav1.Condition{
-									Type: "Available",
+									Type:   "Available",
 									Status: metav1.ConditionTrue,
 								},
 								metav1.Condition{
-									Type: "Progressing",
+									Type:   "Progressing",
 									Status: metav1.ConditionFalse,
 								},
 							},

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -2452,11 +2452,11 @@ func (r *Reconciler) RolloutDeployment(ctx context.Context, client k8sclient.Cli
 		return err
 	}
 
-	if deployment.Spec.Template.Labels == nil {
-		deployment.Spec.Template.Labels = make(map[string]string)
+	if deployment.Spec.Template.Annotations == nil {
+		deployment.Spec.Template.Annotations = make(map[string]string)
 	}
 
-	deployment.Spec.Template.Labels["rollout-restarted-at"] = time.Now().Format(time.RFC3339)
+	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
 	err = client.Update(ctx, deployment)
 	if err != nil {

--- a/pkg/products/threescale/reconciler.go
+++ b/pkg/products/threescale/reconciler.go
@@ -2456,7 +2456,7 @@ func (r *Reconciler) RolloutDeployment(ctx context.Context, client k8sclient.Cli
 		deployment.Spec.Template.Annotations = make(map[string]string)
 	}
 
-	deployment.Spec.Template.Annotations["kubectl.kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
+	deployment.Spec.Template.Annotations["kubernetes.io/restartedAt"] = time.Now().Format(time.RFC3339)
 
 	err = client.Update(ctx, deployment)
 	if err != nil {


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6676

# What
Fix labeling of the deployments to trigger restart
Fix clusterPackage issue

# Verification steps

verify in order:

## ClusterPackage issue
- provision new cluster
- run `make cluster/prepare/local` from this branch
- run `make code/run`
- expectation is successful installation

## Labeling of 3scale deployments to trigger rollout
- scale down RHOAM
- on successful installation from this branch, scale down 3scale operator and zync-db
- both, zync-que and zync will start crashing
- run RHOAM again and confirm that RHOAM is restarting deployments of zync and zync-que by adding: kubectl.kubernetes.io/restartedAt spec.template.metadata.annotations. 

