### PR TITLE
MGDAPI-6611 updates: ratelimit-config CM, Grafana config

### DIFF
--- a/apis/v1alpha1/rhmi_types.go
+++ b/apis/v1alpha1/rhmi_types.go
@@ -68,7 +68,7 @@ var (
 	VersionRHSSO          ProductVersion = "7.6"
 	VersionRHSSOUser      ProductVersion = "7.6"
 	VersionMarin3r        ProductVersion = "0.13.3"
-	VersionGrafana        ProductVersion = "9.0.9"
+	VersionGrafana        ProductVersion = "9.6.0"
 
 	PreflightInProgress PreflightStatus = ""
 	PreflightSuccess    PreflightStatus = "successful"

--- a/pkg/products/grafana/grafanaConfig.go
+++ b/pkg/products/grafana/grafanaConfig.go
@@ -116,7 +116,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {
@@ -196,7 +196,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {
@@ -274,7 +274,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {
@@ -334,7 +334,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         "alertThreshold": true
       },
       "percentage": false,
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "pointradius": 2,
       "points": false,
       "renderer": "flot",
@@ -457,7 +457,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {
@@ -537,7 +537,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {
@@ -615,7 +615,7 @@ func getCustomerMonitoringGrafanaRateLimitJSON(requestsPerUnit, activeQuota stri
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.9",
+      "pluginVersion": "9.6.0",
       "targets": [
         {
           "datasource": {

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -486,11 +486,9 @@ func (r *RateLimitServiceReconciler) getRHOAMLimitadorSetting() ([]limitadorLimi
 			MaxValue:  r.RateLimitConfig.RequestsPerUnit,
 			Seconds:   unitInSeconds,
 			Conditions: []string{
-				fmt.Sprintf("%s == %s", genericKey, ratelimit.RateLimitDescriptorValue),
+				fmt.Sprintf(`descriptors[0]['%s'] == "%s"`, genericKey, ratelimit.RateLimitDescriptorValue),
 			},
-			Variables: []string{
-				genericKey,
-			},
+			Variables: []string{},
 		},
 	}, nil
 }
@@ -513,11 +511,9 @@ func (r *RateLimitServiceReconciler) getMultitenantRHOAMLimitadorSetting(ctx con
 			MaxValue:  r.RateLimitConfig.RequestsPerUnit,
 			Seconds:   unitInSeconds,
 			Conditions: []string{
-				fmt.Sprintf("%s == %s", genericKey, ratelimit.RateLimitDescriptorValue),
+				fmt.Sprintf(`descriptors[0]['%s'] == "%s"`, genericKey, ratelimit.RateLimitDescriptorValue),
 			},
-			Variables: []string{
-				genericKey,
-			},
+			Variables: []string{},
 		},
 		{
 			Namespace: ratelimit.RateLimitDomain,

--- a/pkg/products/marin3r/rateLimitService_test.go
+++ b/pkg/products/marin3r/rateLimitService_test.go
@@ -42,7 +42,7 @@ func TestRateLimitService(t *testing.T) {
 
 	podExecutorMock := &resources.PodExecutorInterfaceMock{
 		ExecuteRemoteCommandFunc: func(ns string, podName string, command []string) (string, string, error) {
-			return "[{\"namespace\":\"apicast-ratelimit\",\"max_value\":1,\"seconds\":60,\"name\":null,\"conditions\":[\"generic_key == slowpath\"],\"variables\":[\"generic_key\"]}]", "", nil
+			return "[{\"namespace\":\"apicast-ratelimit\",\"max_value\":1,\"seconds\":60,\"name\":null,\"conditions\":[\"descriptors[0]['generic_key'] == \\\"slowpath\\\"\"],\"variables\":[]}]", "", nil
 		},
 	}
 
@@ -496,11 +496,9 @@ func TestRateLimitServiceReconciler_getLimitadorSetting(t *testing.T) {
 					MaxValue:  1,
 					Seconds:   1,
 					Conditions: []string{
-						fmt.Sprintf("%s == %s", genericKey, ratelimit.RateLimitDescriptorValue),
+						fmt.Sprintf("descriptors[0]['%s'] == \"%s\"", genericKey, ratelimit.RateLimitDescriptorValue),
 					},
-					Variables: []string{
-						genericKey,
-					},
+					Variables: []string{},
 				},
 			},
 		},
@@ -546,11 +544,9 @@ func TestRateLimitServiceReconciler_getLimitadorSetting(t *testing.T) {
 					MaxValue:  1,
 					Seconds:   1,
 					Conditions: []string{
-						fmt.Sprintf("%s == %s", genericKey, ratelimit.RateLimitDescriptorValue),
+						fmt.Sprintf("descriptors[0]['%s'] == \"%s\"", genericKey, ratelimit.RateLimitDescriptorValue),
 					},
-					Variables: []string{
-						genericKey,
-					},
+					Variables: []string{},
 				},
 				{
 					Namespace: ratelimit.RateLimitDomain,

--- a/pkg/products/marin3r/reconciler_test.go
+++ b/pkg/products/marin3r/reconciler_test.go
@@ -36,13 +36,12 @@ var (
 
 func getRateLimitConfigMap() *corev1.ConfigMap {
 	rateLimtCMString := `
-domain: kuard
-descriptors:
-  - key: generic_key
-    value: slowpath
-    ratelimit:
-      unit: minute
-      requestsperunit: 1`
+- namespace: kuard
+  max_value: 1
+  seconds: 60
+  conditions:
+    - descriptors[0]['generic_key'] == "slowpath"
+  variables: []`
 
 	return &corev1.ConfigMap{
 		ObjectMeta: v1.ObjectMeta{


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6611

# What
- Limitador configuration changed.
- Grafana version/config update

# Verification steps
#### ratelimit-config cm

```
 oc describe cm  ratelimit-config  -n redhat-rhoam-marin3r
Name:         ratelimit-config
Namespace:    redhat-rhoam-marin3r
Labels:       app=ratelimit
              part-of=3scale-saas
Annotations:  <none>

Data
====
apicast-ratelimiting.yaml:
----
- namespace: apicast-ratelimit
  max_value: 70
  seconds: 60
  conditions:
  - descriptors[0]['generic_key'] == "slowpath"
  variables: []


BinaryData
====

Events:  <none>

```
#### Grafana 
- sanity check, using 3scale for testing (curl "https://myprod1-3scale-apicast-staging.apps.<mycluster>:443/?user_key=xxxxxx"
<img src="https://github.com/user-attachments/assets/bfe0d592-b3e5-4a86-b7d7-a09707af80ca" width="400">

