### PR TITLE
MGDAPI-6710 ElastiCache service update

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -57,7 +57,7 @@ const (
 	cidrRangeKeyAws              = "cidr-range"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20250507-intel", "elasticache-20241007-intel", "elasticache-redis-cve-patch-update-202410", "elasticache-patch-update-202501", "elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240225-intel", "elasticache-20240501-intel"}
+var redisServiceUpdatesToInstall = []string{"elasticache-april-patch-update-202504", "elasticache-20250507-intel", "elasticache-20241007-intel", "elasticache-redis-cve-patch-update-202410", "elasticache-patch-update-202501", "elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240225-intel", "elasticache-20240501-intel"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6710

# What
ElastiCache service update

# Verification steps
- Notes based on [PR](https://github.com/integr8ly/integreatly-operator/pull/3585): Hard to verify as all new elasticache will have the service update already.
merge and test a release time.

- CCS cluster created for verification

![image](https://github.com/user-attachments/assets/bb2e7c97-6d81-4887-9e1a-3de40ce9c816)
