### PR TITLE
MGDAPI-6617 bump RHOAM maxOpenShiftVersion to 4.19

### DIFF
--- a/bundles/managed-api-service/1.43.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.43.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -44,7 +44,7 @@ metadata:
     categories: Integration & Delivery
     certified: "false"
     containerImage: quay.io/integreatly/managed-api-service:master
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.19"}]'
     operatorframework.io/suggested-namespace: redhat-rhoam-operator
     operators.operatorframework.io/builder: operator-sdk-v1.21.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2

--- a/config/manifests-multitenant-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-multitenant-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.19"}]'
     support: RHOAM
   name: managed-api-service.v1.37.0
   namespace: placeholder

--- a/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
+++ b/config/manifests-rhoam/bases/managed-api-service.clusterserviceversion.yaml
@@ -10,7 +10,7 @@ metadata:
     containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
     operators.operatorframework.io/builder: operator-sdk-v1.2.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v2
-    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.17"}]'
+    olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.19"}]'
     support: RHOAM
   name: managed-api-service.v1.43.0
   namespace: placeholder


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6617

# What
- we want to ensure that RHOAM is supported on latest available version of OSD, and to be in sync with 3scale.
- 3scale 2.15.4 - max Openshift is `4.19`
So we set RHOAM maxOpenShiftVersion to 4.19

# Verification steps
E2E
