### PR TITLE
MGDAPI-6811 set s3 deletion to false by default when addon is deleted

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -381,7 +381,7 @@ func (r *Reconciler) createDeletionStrategy(ctx context.Context, installation *i
 				}
 
 				if resources.IsSkipFinalDBSnapshots(installation) {
-					r.log.Info("RHMI CR is annotated with skip_final_db_snapshots=true so CRO will skip creating Postgres/Redis snapshots")
+					r.log.Info("RHMI CR is annotated with skip_final_db_snapshots=true so CRO will skip creating final Postgres/Redis snapshots and will force delete the S3 bucket")
 
 					forceBucketDeletion = true
 					skipFinalSnapshot := true


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6811

# What
Set S3 deletion to false by default on addon uninstall.
Delete S3 if the `skip_final_db_snapshots=true` is present on RHMI CR

# Verification steps
- CCS cluster
- Install RHOAM addon
- Populate S3 data in 3scale CMS
- Double check that S3 for 3scale has data in it
- Uninstall Addon
- The s3 bucket along with final snapshots should remain in place

- Install addon again
- Populate S3 data in 3scale CMS
- Double check that S3 for 3scale has data in it
- Add annotation skip_final_db_snapshots=true to RHMI CR
- Uninstall Addon
- Confirm that S3 and final snapshots are deleted
