### PR TITLE
MGDAPI-6819 update images

### DIFF
--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -347,7 +347,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// Container #1
 		grafanaDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].Name = "grafana"
-		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana:9.6-1747642001"
+		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana:9.6-1755762368"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/grafana/",
@@ -473,7 +473,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// container #2
 		grafanaDeployment.Spec.Template.Spec.Containers[1].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].Name = "grafana-proxy"
-		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.17.0-202504281009.p0.g07d03d7.assembly.stream.el9"
+		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.15.0-202508190116.p2.g241a88c.assembly.stream.el9"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/tls/private",

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -36,7 +36,7 @@ const (
 	multitenantDescriptorValue    = "per-mt-limit"
 	RateLimitingConfigMapName     = "ratelimit-config"
 	RateLimitingConfigMapDataName = "apicast-ratelimiting.yaml"
-	rateLimitImage                = "quay.io/kuadrant/limitador:v2.0.0"
+	rateLimitImage                = "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425"
 )
 
 type RateLimitServiceReconciler struct {

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.7-5"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.9-6"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,13 +5,13 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.7-5"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.9-6"
 limitador:
   - name: marin3r-limitador
-    url: "quay.io/kuadrant/limitador:v2.0.0"
+    url: "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:98f85a05da53fbf7f20845d1969441620407cc13a185fd52714308679f116425"
 grafana:
   - name: grafana
-    url: "registry.redhat.io/rhel9/grafana:9.6-1747642001"
+    url: "registry.redhat.io/rhel9/grafana:9.6-1755762368"
 grafana-ose-oauth-proxy:
   - name: grafana-ose-oauth-proxy
-    url: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.17.0-202504281009.p0.g07d03d7.assembly.stream.el9"
+    url: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.15.0-202508190116.p2.g241a88c.assembly.stream.el9"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6816

# What
Bumped images for:
- oauth proxy
- limitador (moved to productized image)
- envoy
- grafana

# Verification steps
- Install RHOAM locally
- Wait for install to complete
- Scale down RHOAM operator
- update the rate limit map to 5 hits under redhat-rhoam-marin3r ns
- restart marin3r deployments
- access 3scale and hit apicast endpoint 5 times
- confirm 429
- scale rhoam back
- confirm ratelimiting limit is reverted to default per quota
- access monitoring dashboard and confirm it's accessible and working
