### PR TITLE
MGDAPI-6841 Use wget instead of curl in Prometheus/Grafana tests

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -751,7 +751,7 @@ func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
 	}
 
 	// exec into the prometheus pod
-	output, err := execToPod("curl -s localhost:9090/api/v1/rules",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
 
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,

--- a/test/common/alerts_firing.go
+++ b/test/common/alerts_firing.go
@@ -130,7 +130,7 @@ func TestIntegreatlyAlertsFiring(t TestingTB, ctx *TestingContext) {
 
 }
 func getFiringAlerts(t TestingTB, ctx *TestingContext) error {
-	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",
@@ -275,7 +275,7 @@ func TestIntegreatlyAlertsPendingOrFiring(t TestingTB, ctx *TestingContext) {
 }
 
 func getFiringOrPendingAlerts(t TestingTB, ctx *TestingContext) error {
-	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/alerts_mechanism.go
+++ b/test/common/alerts_mechanism.go
@@ -240,7 +240,7 @@ func waitForKeycloakAlertState(expectedState string, ctx *TestingContext, t Test
 }
 
 func getKeycloakAlertState(ctx *TestingContext) error {
-	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/dashboards_data.go
+++ b/test/common/dashboards_data.go
@@ -43,7 +43,7 @@ func getMonitoringAppPodName(app string, ctx *TestingContext) (string, error) {
 }
 
 func queryPrometheus(query string, podName string, ctx *TestingContext) ([]prometheusQueryResult, error) {
-	queryOutput, err := execToPod("curl -s localhost:9090/api/v1/query?query="+url.QueryEscape(query),
+	queryOutput, err := execToPod("wget -qO - localhost:9090/api/v1/query?query="+url.QueryEscape(query),
 		podName,
 		ObservabilityProductNamespace,
 		"prometheus", ctx)

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -40,7 +40,7 @@ func TestIntegreatlyCustomerDashboardsExist(t TestingTB, ctx *TestingContext) {
 
 	customerMonitoringGrafanaPods := getGrafanaPods(t, ctx, CustomerGrafanaNamespace)
 
-	output, err := execToPod(fmt.Sprintf("curl -s %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
+	output, err := execToPod(fmt.Sprintf("wget -qO - %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
 		prometheusPodName,
 		ObservabilityProductNamespace,
 		curlContainerName, ctx)

--- a/test/common/selfmanaged_apicast.go
+++ b/test/common/selfmanaged_apicast.go
@@ -44,7 +44,7 @@ import (
 )
 
 const (
-	apicastOperatorVersion       = "0.12.3"
+	apicastOperatorVersion       = "0.12.5"
 	apicastOperatorChannel       = "threescale-2.15"
 	apicastImageStreamTag        = "3scale-amp2"
 	apicastNamespace             = "selfmanaged-apicast"

--- a/test/common/verify_3scale_UIBBT_alerts.go
+++ b/test/common/verify_3scale_UIBBT_alerts.go
@@ -143,7 +143,7 @@ func isThreeScaleUIBBTAlertFiring(ctx *TestingContext, t TestingTB) (bool, error
 		"ThreeScaleSystemAdminUIBBT": false,
 	}
 
-	output, err := execToPod("curl -s localhost:9090/api/v1/alerts",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/alerts",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",

--- a/test/common/verify_alert_links_to_SOPs.go
+++ b/test/common/verify_alert_links_to_SOPs.go
@@ -29,7 +29,7 @@ func TestSOPUrls(t TestingTB, ctx *TestingContext) {
 	testUrl := "https://gitlab.cee.redhat.com/rhcloudservices/integreatly-help/-/blob/master/sops/rhoam/alerts/AddonManagedApiServiceParameters.asciidoc"
 	validateGitlabToken(t, testUrl)
 
-	output, err := execToPod("curl -s localhost:9090/api/v1/rules",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus", ctx)

--- a/test/common/verify_prometheus_metrics.go
+++ b/test/common/verify_prometheus_metrics.go
@@ -103,7 +103,7 @@ func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
 }
 
 func getPrometheusTargets(ctx *TestingContext) (*prometheusv1.TargetsResult, error) {
-	output, err := execToPod("curl -s localhost:9090/api/v1/targets?state=active",
+	output, err := execToPod("wget -qO - localhost:9090/api/v1/targets?state=active",
 		ObservabilityPrometheusPodName,
 		ObservabilityProductNamespace,
 		"prometheus",


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6841

# What
`curl` is no longer available in containers from Prometheus/Grafana Pods, `wget` needs to be used instead

Also this updates the APIcast Operator version in H24 test

# Verification steps
Just execute the tests:
`TEST="C03|C01|C19|C04|C10B|E09|M02B|Verify Alerts are not firing|Verify prometheus metrics|H24" make test/e2e/single`
