### PR TITLE
MGDAPI-6875 fix GOBIN is not set error

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -25,7 +25,7 @@ RUN mkdir -p $GOPATH/src/github.com/operator-framework \
     && git clone --depth 1 -b $OPERATOR_SDK_VERSION https://github.com/operator-framework/operator-sdk \
     && cd operator-sdk \
     && go mod vendor \
-    && make install
+    && env GOBIN=$GOPATH/bin && make install
 
 # install kustomize
 RUN go install sigs.k8s.io/kustomize/kustomize/v5@$KUSTOMIZE_VERSION


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6875

# What
Fix Error: GOBIN is not set

# Verification steps
1. Merge this PR.
2. After the merge, rebuild the other PRs that failed with the GOBIN is not set error.