### PR TITLE
MGDAPI-6846 PostgresFreeableMemoryLow alert is 5% but the description is 20%

### DIFF
--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -503,7 +503,7 @@ func reconcilePostgresFreeableMemoryAlert(ctx context.Context, client k8sclient.
 	// build and reconcile postgres low freeable memory alert
 	alertName := "PostgresFreeableMemoryLow"
 	ruleName := "postgres-freeable-memory-low"
-	alertDescription := "The postgres instance {{ $labels.instanceID }} for product {{  $labels.productName  }}, freeable memory is currently under 20 percent of its capacity"
+	alertDescription := "The postgres instance {{ $labels.instanceID }} for product {{  $labels.productName  }}, freeable memory is currently under 5 percent of its capacity"
 	labels := map[string]string{
 		"severity": "critical",
 		"product":  installationName,


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6846

# What
PostgresFreeableMemoryLow alert is triggered at 5% but the description is 20%
- fix in description
- added `on (instanceID)` to alert expression

# Verification steps
CCS cluster is required to check Postgres alerts; if in-cluster storage - Postgres alerts are skipped.
