### PR TITLE
MGDAPI-6907 bump marin3r version to 0.13.4 latest in Rhoam

### DIFF
--- a/api/v1alpha1/rhmi_types.go
+++ b/api/v1alpha1/rhmi_types.go
@@ -67,7 +67,7 @@ var (
 	VersionCloudResources ProductVersion = "1.1.6"
 	VersionRHSSO          ProductVersion = "7.6"
 	VersionRHSSOUser      ProductVersion = "7.6"
-	VersionMarin3r        ProductVersion = "0.13.3"
+	VersionMarin3r        ProductVersion = "0.13.4"
 	VersionGrafana        ProductVersion = "9.6.0"
 
 	PreflightInProgress PreflightStatus = ""
@@ -79,7 +79,7 @@ var (
 	OperatorVersionRHSSOUser      OperatorVersion = "7.6.11-7"
 	OperatorVersionCloudResources OperatorVersion = "1.1.6"
 	OperatorVersion3Scale         OperatorVersion = "0.12.5"
-	OperatorVersionMarin3r        OperatorVersion = "0.13.3"
+	OperatorVersionMarin3r        OperatorVersion = "0.13.4"
 
 	// Event reasons to be used when emitting events
 	EventProcessingError       = "ProcessingError"

--- a/bundles/managed-api-service/1.44.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.44.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -66,8 +66,8 @@ metadata:
         "cloud-resource-operator.v1.1.5": {
           "cloud-resources.v1.1.6": "quay.io/integreatly/cloud-resource-operator:v1.1.6"
         },
-        "marin3r.v0.13.3": {
-          "marin3r.v0.13.3": "quay.io/integreatly/marin3r-operator:v0.13.3"
+        "marin3r.v0.13.4": {
+          "marin3r.v0.13.4": "quay.io/integreatly/marin3r-operator:v0.13.4"
         },
         "rhsso-operator.18.0.x": {
           "rhsso-operator.7.6.11-opr-006": "registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:d1f3225e0d465ccf7015cbdf5d61f16979e1b1bb3c10fa221a211ef1801dc03b",

--- a/manifests/integreatly-marin3r/0.13.4/marin3r-controller-manager-metrics-service_v1_service.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r-controller-manager-metrics-service_v1_service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+    app.kubernetes.io/name: marin3r
+    control-plane: controller-manager
+  name: marin3r-controller-manager-metrics-service
+spec:
+  ports:
+  - name: metrics
+    port: 8080
+    protocol: TCP
+    targetPort: metrics
+  selector:
+    control-plane: controller-manager
+status:
+  loadBalancer: {}

--- a/manifests/integreatly-marin3r/0.13.4/marin3r-manager-config_v1_configmap.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r-manager-config_v1_configmap.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+data:
+  controller_manager_config.yaml: |
+    apiVersion: controller-runtime.sigs.k8s.io/v1alpha1
+    kind: ControllerManagerConfig
+    health:
+      healthProbeBindAddress: :8081
+    metrics:
+      bindAddress: 127.0.0.1:8080
+    webhook:
+      port: 9443
+    leaderElection:
+      leaderElect: true
+      resourceName: 9444f1d7.3scale.net
+kind: ConfigMap
+metadata:
+  name: marin3r-manager-config

--- a/manifests/integreatly-marin3r/0.13.4/marin3r-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r-metrics-reader_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -1,0 +1,12 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: marin3r-metrics-reader
+rules:
+- nonResourceURLs:
+  - /metrics
+  verbs:
+  - get

--- a/manifests/integreatly-marin3r/0.13.4/marin3r-webhook-service_v1_service.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r-webhook-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: marin3r-webhook-service
+spec:
+  ports:
+  - port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    control-plane: controller-webhook
+status:
+  loadBalancer: {}

--- a/manifests/integreatly-marin3r/0.13.4/marin3r.3scale.net_envoyconfigrevisions.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r.3scale.net_envoyconfigrevisions.yaml
@@ -1,0 +1,549 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: envoyconfigrevisions.marin3r.3scale.net
+spec:
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfigRevision
+    listKind: EnvoyConfigRevisionList
+    plural: envoyconfigrevisions
+    shortNames:
+    - ecr
+    singular: envoyconfigrevision
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.nodeID
+      name: Node ID
+      type: string
+    - jsonPath: .spec.envoyAPI
+      name: Envoy API
+      type: string
+    - jsonPath: .spec.version
+      name: Version
+      type: string
+    - jsonPath: .status.published
+      name: Published
+      type: boolean
+    - format: date-time
+      jsonPath: .metadata.creationTimestamp
+      name: Created At
+      type: string
+    - format: date-time
+      jsonPath: .status.lastPublishedAt
+      name: Last Published At
+      type: string
+    - jsonPath: .status.tainted
+      name: Tainted
+      type: boolean
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          EnvoyConfigRevision is an internal resource that stores a specific version of an EnvoyConfig
+          resource. EnvoyConfigRevisions are automatically created and deleted by the EnvoyConfig
+          controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnvoyConfigRevisionSpec defines the desired state of EnvoyConfigRevision
+            properties:
+              envoyAPI:
+                description: EnvoyAPI is the version of envoy's API to use. Defaults
+                  to v3.
+                enum:
+                - v3
+                type: string
+              envoyResources:
+                description: EnvoyResources holds the different types of resources
+                  suported by the envoy discovery service
+                properties:
+                  clusters:
+                    description: |-
+                      Clusters is a list of the envoy Cluster resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  endpoints:
+                    description: |-
+                      Endpoints is a list of the envoy ClusterLoadAssignment resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  extensionConfigs:
+                    description: |-
+                      ExtensionConfigs is a list of the envoy ExtensionConfig resource type
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/extension.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  listeners:
+                    description: |-
+                      Listeners is a list of the envoy Listener resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  routes:
+                    description: |-
+                      Routes is a list of the envoy Route resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  runtimes:
+                    description: |-
+                      Runtimes is a list of the envoy Runtime resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  scopedRoutes:
+                    description: |-
+                      ScopedRoutes is a list of the envoy ScopeRoute resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/scoped_route.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  secrets:
+                    description: Secrets is a list of references to Kubernetes Secret
+                      objects.
+                    items:
+                      description: |-
+                        EnvoySecretResource holds a reference to a k8s Secret from where
+                        to take a secret from. Only Secrets within the same namespace can
+                        be referred.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy tslCerticate secret resource. The certificate will be fetched
+                            from a Kubernetes Secrets of type 'kubernetes.io/tls' with this same name.
+                          type: string
+                        ref:
+                          description: |-
+                            DEPRECATED: this field is deprecated and it's value will be ignored. The 'name' of the
+                            Kubernetes Secret must match the 'name' field.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              nodeID:
+                description: |-
+                  NodeID holds the envoy identifier for the discovery service to know which set
+                  of resources to send to each of the envoy clients that connect to it.
+                type: string
+              resources:
+                description: Resources holds the different types of resources suported
+                  by the envoy discovery service
+                items:
+                  description: |-
+                    Resource holds serialized representation of an envoy
+                    resource
+                  properties:
+                    blueprint:
+                      description: |-
+                        Blueprint specifies a template to generate a configuration proto. It is currently
+                        only supported to generate secret configuration resources from k8s Secrets
+                      enum:
+                      - tlsCertificate
+                      - validationContext
+                      type: string
+                    generateFromEndpointSlices:
+                      description: |-
+                        Specifies a label selector to watch for EndpointSlices that will
+                        be used to generate the endpoint resource
+                      properties:
+                        clusterName:
+                          type: string
+                        selector:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPort:
+                          type: string
+                      required:
+                      - clusterName
+                      - selector
+                      - targetPort
+                      type: object
+                    generateFromOpaqueSecret:
+                      description: |-
+                        The name of a Kubernetes Secret of type "Opaque". It will generate an
+                        envoy "generic secret" proto.
+                      properties:
+                        alias:
+                          description: A unique name to refer to the name:key combination
+                          type: string
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: The name of the secret in the pod's namespace
+                            to select from.
+                          type: string
+                      required:
+                      - alias
+                      - key
+                      - name
+                      type: object
+                    generateFromTlsSecret:
+                      description: The name of a Kubernetes Secret of type "kubernetes.io/tls"
+                      type: string
+                    type:
+                      description: Type is the type url for the protobuf message
+                      enum:
+                      - listener
+                      - route
+                      - scopedRoute
+                      - cluster
+                      - endpoint
+                      - secret
+                      - runtime
+                      - extensionConfig
+                      type: string
+                    value:
+                      description: |-
+                        Value is the protobufer message that configures the resource. The proto
+                        must match the envoy configuration API v3 specification for the given resource
+                        type (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - type
+                  type: object
+                type: array
+              serialization:
+                description: |-
+                  Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
+                  are supported. "json" is used if unset.
+                enum:
+                - json
+                - b64json
+                - yaml
+                type: string
+              version:
+                description: Version is a hash of the EnvoyResources field
+                type: string
+            required:
+            - nodeID
+            - version
+            type: object
+          status:
+            description: EnvoyConfigRevisionStatus defines the observed state of EnvoyConfigRevision
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              lastPublishedAt:
+                description: |-
+                  LastPublishedAt indicates the last time this config review transitioned to
+                  published
+                format: date-time
+                type: string
+              providesVersions:
+                description: |-
+                  ProvidesVersions keeps track of the version that this revision
+                  publishes in the xDS server for each resource type
+                properties:
+                  clusters:
+                    type: string
+                  endpoints:
+                    type: string
+                  extensionConfigs:
+                    type: string
+                  listeners:
+                    type: string
+                  routes:
+                    type: string
+                  runtimes:
+                    type: string
+                  scopedRoutes:
+                    type: string
+                  secrets:
+                    type: string
+                type: object
+              published:
+                description: |-
+                  Published signals if the EnvoyConfigRevision is the one currently published
+                  in the xds server cache
+                type: boolean
+              tainted:
+                description: |-
+                  Tainted indicates whether the EnvoyConfigRevision is eligible for publishing
+                  or not
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-marin3r/0.13.4/marin3r.3scale.net_envoyconfigs.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r.3scale.net_envoyconfigs.yaml
@@ -1,0 +1,578 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: envoyconfigs.marin3r.3scale.net
+spec:
+  group: marin3r.3scale.net
+  names:
+    kind: EnvoyConfig
+    listKind: EnvoyConfigList
+    plural: envoyconfigs
+    shortNames:
+    - ec
+    singular: envoyconfig
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.nodeID
+      name: Node ID
+      type: string
+    - jsonPath: .spec.envoyAPI
+      name: Envoy API
+      type: string
+    - jsonPath: .status.desiredVersion
+      name: Desired Version
+      type: string
+    - jsonPath: .status.publishedVersion
+      name: Published Version
+      type: string
+    - jsonPath: .status.cacheState
+      name: Cache State
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig
+          object holds the Envoy resources that conform the desired configuration for the given nodeID
+          and that the discovery service will send to any envoy client that identifies itself with that
+          nodeID.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnvoyConfigSpec defines the desired state of EnvoyConfig
+            properties:
+              envoyAPI:
+                description: EnvoyAPI is the version of envoy's API to use. Defaults
+                  to v3.
+                enum:
+                - v3
+                type: string
+              envoyResources:
+                description: |-
+                  EnvoyResources holds the different types of resources suported by the envoy discovery service
+                  DEPRECATED. Use the `resources` field instead.
+                properties:
+                  clusters:
+                    description: |-
+                      Clusters is a list of the envoy Cluster resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  endpoints:
+                    description: |-
+                      Endpoints is a list of the envoy ClusterLoadAssignment resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  extensionConfigs:
+                    description: |-
+                      ExtensionConfigs is a list of the envoy ExtensionConfig resource type
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/extension.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  listeners:
+                    description: |-
+                      Listeners is a list of the envoy Listener resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  routes:
+                    description: |-
+                      Routes is a list of the envoy Route resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  runtimes:
+                    description: |-
+                      Runtimes is a list of the envoy Runtime resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  scopedRoutes:
+                    description: |-
+                      ScopedRoutes is a list of the envoy ScopeRoute resource type.
+                      API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/scoped_route.proto
+                    items:
+                      description: |-
+                        EnvoyResource holds serialized representation of an envoy
+                        resource
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy resource.
+                            DEPRECATED: this field has no effect and will be removed in an
+                            upcoming release. The name of the resources for discovery purposes
+                            is included in the resource itself. Refer to the envoy API reference
+                            to check how the name is specified for each resource type.
+                          type: string
+                        value:
+                          description: Value is the serialized representation of the
+                            envoy resource
+                          type: string
+                      required:
+                      - value
+                      type: object
+                    type: array
+                  secrets:
+                    description: Secrets is a list of references to Kubernetes Secret
+                      objects.
+                    items:
+                      description: |-
+                        EnvoySecretResource holds a reference to a k8s Secret from where
+                        to take a secret from. Only Secrets within the same namespace can
+                        be referred.
+                      properties:
+                        name:
+                          description: |-
+                            Name of the envoy tslCerticate secret resource. The certificate will be fetched
+                            from a Kubernetes Secrets of type 'kubernetes.io/tls' with this same name.
+                          type: string
+                        ref:
+                          description: |-
+                            DEPRECATED: this field is deprecated and it's value will be ignored. The 'name' of the
+                            Kubernetes Secret must match the 'name' field.
+                          properties:
+                            name:
+                              description: name is unique within a namespace to reference
+                                a secret resource.
+                              type: string
+                            namespace:
+                              description: namespace defines the space within which
+                                the secret name must be unique.
+                              type: string
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      required:
+                      - name
+                      type: object
+                    type: array
+                type: object
+              nodeID:
+                description: |-
+                  NodeID holds the envoy identifier for the discovery service to know which set
+                  of resources to send to each of the envoy clients that connect to it.
+                type: string
+              resources:
+                description: Resources holds the different types of resources suported
+                  by the envoy discovery service
+                items:
+                  description: |-
+                    Resource holds serialized representation of an envoy
+                    resource
+                  properties:
+                    blueprint:
+                      description: |-
+                        Blueprint specifies a template to generate a configuration proto. It is currently
+                        only supported to generate secret configuration resources from k8s Secrets
+                      enum:
+                      - tlsCertificate
+                      - validationContext
+                      type: string
+                    generateFromEndpointSlices:
+                      description: |-
+                        Specifies a label selector to watch for EndpointSlices that will
+                        be used to generate the endpoint resource
+                      properties:
+                        clusterName:
+                          type: string
+                        selector:
+                          description: |-
+                            A label selector is a label query over a set of resources. The result of matchLabels and
+                            matchExpressions are ANDed. An empty label selector matches all objects. A null
+                            label selector matches no objects.
+                          properties:
+                            matchExpressions:
+                              description: matchExpressions is a list of label selector
+                                requirements. The requirements are ANDed.
+                              items:
+                                description: |-
+                                  A label selector requirement is a selector that contains values, a key, and an operator that
+                                  relates the key and values.
+                                properties:
+                                  key:
+                                    description: key is the label key that the selector
+                                      applies to.
+                                    type: string
+                                  operator:
+                                    description: |-
+                                      operator represents a key's relationship to a set of values.
+                                      Valid operators are In, NotIn, Exists and DoesNotExist.
+                                    type: string
+                                  values:
+                                    description: |-
+                                      values is an array of string values. If the operator is In or NotIn,
+                                      the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                      the values array must be empty. This array is replaced during a strategic
+                                      merge patch.
+                                    items:
+                                      type: string
+                                    type: array
+                                    x-kubernetes-list-type: atomic
+                                required:
+                                - key
+                                - operator
+                                type: object
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            matchLabels:
+                              additionalProperties:
+                                type: string
+                              description: |-
+                                matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                operator is "In", and the values array contains only "value". The requirements are ANDed.
+                              type: object
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        targetPort:
+                          type: string
+                      required:
+                      - clusterName
+                      - selector
+                      - targetPort
+                      type: object
+                    generateFromOpaqueSecret:
+                      description: |-
+                        The name of a Kubernetes Secret of type "Opaque". It will generate an
+                        envoy "generic secret" proto.
+                      properties:
+                        alias:
+                          description: A unique name to refer to the name:key combination
+                          type: string
+                        key:
+                          description: The key of the secret to select from.  Must
+                            be a valid secret key.
+                          type: string
+                        name:
+                          description: The name of the secret in the pod's namespace
+                            to select from.
+                          type: string
+                      required:
+                      - alias
+                      - key
+                      - name
+                      type: object
+                    generateFromTlsSecret:
+                      description: The name of a Kubernetes Secret of type "kubernetes.io/tls"
+                      type: string
+                    type:
+                      description: Type is the type url for the protobuf message
+                      enum:
+                      - listener
+                      - route
+                      - scopedRoute
+                      - cluster
+                      - endpoint
+                      - secret
+                      - runtime
+                      - extensionConfig
+                      type: string
+                    value:
+                      description: |-
+                        Value is the protobufer message that configures the resource. The proto
+                        must match the envoy configuration API v3 specification for the given resource
+                        type (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)
+                      type: object
+                      x-kubernetes-preserve-unknown-fields: true
+                  required:
+                  - type
+                  type: object
+                type: array
+              serialization:
+                description: |-
+                  Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
+                  are supported. "json" is used if unset.
+                enum:
+                - json
+                - yaml
+                type: string
+            required:
+            - nodeID
+            type: object
+          status:
+            description: EnvoyConfigStatus defines the observed state of EnvoyConfig
+            properties:
+              cacheState:
+                description: |-
+                  CacheState summarizes all the observations about the EnvoyConfig
+                  to give the user a concrete idea on the general status of the discovery servie cache.
+                  It is intended only for human consumption. Other controllers should relly on conditions
+                  to determine the status of the discovery server cache.
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              desiredVersion:
+                description: |-
+                  DesiredVersion represents the resources version described in
+                  the spec of the EnvoyConfig object
+                type: string
+              publishedVersion:
+                description: |-
+                  PublishedVersion is the config version currently
+                  served by the envoy discovery service for the give nodeID
+                type: string
+              revisions:
+                description: |-
+                  ConfigRevisions is an ordered list of references to EnvoyConfigRevision
+                  objects
+                items:
+                  description: ConfigRevisionRef holds a reference to EnvoyConfigRevision
+                    object
+                  properties:
+                    ref:
+                      description: |-
+                        Ref is a reference to the EnvoyConfigRevision object that
+                        holds the configuration matching the Version field.
+                      properties:
+                        apiVersion:
+                          description: API version of the referent.
+                          type: string
+                        fieldPath:
+                          description: |-
+                            If referring to a piece of an object instead of an entire object, this string
+                            should contain a valid JSON/Go field access statement, such as desiredState.manifest.containers[2].
+                            For example, if the object reference is to a container within a pod, this would take on a value like:
+                            "spec.containers{name}" (where "name" refers to the name of the container that triggered
+                            the event) or if no container name is specified "spec.containers[2]" (container with
+                            index 2 in this pod). This syntax is chosen only to have some well-defined way of
+                            referencing a part of an object.
+                          type: string
+                        kind:
+                          description: |-
+                            Kind of the referent.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+                          type: string
+                        name:
+                          description: |-
+                            Name of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                          type: string
+                        namespace:
+                          description: |-
+                            Namespace of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/
+                          type: string
+                        resourceVersion:
+                          description: |-
+                            Specific resourceVersion to which this reference is made, if any.
+                            More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency
+                          type: string
+                        uid:
+                          description: |-
+                            UID of the referent.
+                            More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids
+                          type: string
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    version:
+                      description: Version is a hash of the EnvoyResources field
+                      type: string
+                  required:
+                  - ref
+                  - version
+                  type: object
+                type: array
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-marin3r/0.13.4/marin3r.clusterserviceversion.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/marin3r.clusterserviceversion.yaml
@@ -1,0 +1,1438 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [
+        {
+          "apiVersion": "marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyConfig",
+          "metadata": {
+            "name": "envoyconfig-example",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "nodeID": "example",
+            "resources": [
+              {
+                "type": "cluster",
+                "value": {
+                  "connect_timeout": "0.01s",
+                  "dns_lookup_family": "V4_ONLY",
+                  "lb_policy": "ROUND_ROBIN",
+                  "load_assignment": {
+                    "cluster_name": "example",
+                    "endpoints": [
+                      {
+                        "lb_endpoints": [
+                          {
+                            "endpoint": {
+                              "address": {
+                                "socket_address": {
+                                  "address": "example",
+                                  "port_value": 8080
+                                }
+                              }
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  },
+                  "name": "example",
+                  "type": "STRICT_DNS"
+                }
+              },
+              {
+                "type": "route",
+                "value": {
+                  "name": "local",
+                  "virtual_hosts": [
+                    {
+                      "domains": [
+                        "*"
+                      ],
+                      "name": "all",
+                      "routes": [
+                        {
+                          "match": {
+                            "prefix": "/"
+                          },
+                          "route": {
+                            "cluster": "example"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              },
+              {
+                "type": "listener",
+                "value": {
+                  "address": {
+                    "socket_address": {
+                      "address": "0.0.0.0",
+                      "port_value": 8443
+                    }
+                  },
+                  "filter_chains": [
+                    {
+                      "filters": [
+                        {
+                          "name": "envoy.filters.network.http_connection_manager",
+                          "typed_config": {
+                            "@type": "type.googleapis.com/envoy.extensions.filters.network.http_connection_manager.v3.HttpConnectionManager",
+                            "access_log": [
+                              {
+                                "name": "envoy.access_loggers.file",
+                                "typed_config": {
+                                  "@type": "type.googleapis.com/envoy.extensions.access_loggers.file.v3.FileAccessLog",
+                                  "path": "/dev/stdout"
+                                }
+                              }
+                            ],
+                            "http_filters": [
+                              {
+                                "name": "envoy.filters.http.router",
+                                "typed_config": {
+                                  "@type": "type.googleapis.com/envoy.extensions.filters.http.router.v3.Router"
+                                }
+                              }
+                            ],
+                            "rds": {
+                              "config_source": {
+                                "ads": {},
+                                "resource_api_version": "V3"
+                              },
+                              "route_config_name": "local"
+                            },
+                            "stat_prefix": "https"
+                          }
+                        }
+                      ],
+                      "transport_socket": {
+                        "name": "envoy.transport_sockets.tls",
+                        "typed_config": {
+                          "@type": "type.googleapis.com/envoy.extensions.transport_sockets.tls.v3.DownstreamTlsContext",
+                          "common_tls_context": {
+                            "tls_certificate_sds_secret_configs": [
+                              {
+                                "name": "example.default.svc",
+                                "sds_config": {
+                                  "ads": {},
+                                  "resource_api_version": "V3"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      }
+                    }
+                  ],
+                  "name": "https"
+                }
+              },
+              {
+                "blueprint": "tlsCertificate",
+                "generateFromTlsSecret": "example.default.svc",
+                "type": "secret"
+              }
+            ]
+          }
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "DiscoveryService",
+          "metadata": {
+            "name": "discoveryservice-example",
+            "namespace": "my-namespace"
+          },
+          "spec": {}
+        },
+        {
+          "apiVersion": "operator.marin3r.3scale.net/v1alpha1",
+          "kind": "EnvoyDeployment",
+          "metadata": {
+            "name": "envoydeployment-sample",
+            "namespace": "my-namespace"
+          },
+          "spec": {
+            "discoveryServiceRef": "discoveryservice-example",
+            "envoyConfigRef": "envoyconfig-example",
+            "ports": [
+              {
+                "name": "https",
+                "port": 8443
+              }
+            ]
+          }
+        }
+      ]
+    capabilities: Full Lifecycle
+    categories: Networking
+    certified: "false"
+    containerImage: quay.io/3scale-sre/marin3r
+    createdAt: "2025-11-03T17:36:38Z"
+    description: Lighweight, CRD based Envoy control plane for Kubernetes
+    operators.operatorframework.io/builder: operator-sdk-v1.39.0
+    operators.operatorframework.io/internal-objects: '["envoyconfigrevisions.marin3r.3scale.net","discoveryservicecertificates.operator.marin3r.3scale.net"]'
+    operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+    repository: https://github.com/3scale-sre/marin3r
+    support: Red Hat, Inc.
+  labels:
+    operatorframework.io/arch.amd64: supported
+    operatorframework.io/arch.arm64: supported
+    operatorframework.io/os.linux: supported
+  name: marin3r.v0.13.4
+  namespace: placeholder
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+    - description: |-
+        DiscoveryServiceCertificate is an internal resource used to create certificates. This resource
+        is used by the DiscoveryService controller to create the required certificates for the different
+        components. Direct use of DiscoveryServiceCertificate objects is discouraged.
+      displayName: DiscoveryServiceCertificate
+      kind: DiscoveryServiceCertificate
+      name: discoveryservicecertificates.operator.marin3r.3scale.net
+      specDescriptors:
+      - description: |-
+          CertificateRenewalConfig configures the certificate renewal process. If unset default
+          behavior is to renew the certificate but not notify of renewals.
+        displayName: Certificate Renewal Config
+        path: certificateRenewal
+      - description: Enabled is a flag to enable or disable renewal of the certificate
+        displayName: Enabled
+        path: certificateRenewal.enabled
+      - description: CommonName is the CommonName of the certificate
+        displayName: Common Name
+        path: commonName
+      - description: |-
+          Hosts is the list of hosts the certificate is valid for. Only
+          use when 'IsServerCertificate' is true. If unset, the CommonName
+          field will be used to populate the valid hosts of the certificate.
+        displayName: Hosts
+        path: hosts
+      - description: IsCA is a boolean specifying that the certificate is a CA
+        displayName: Is CA
+        path: isCA
+      - description: |-
+          SecretRef is a reference to the secret that will hold the certificate
+          and the private key.
+        displayName: Secret Ref
+        path: secretRef
+      - description: |-
+          IsServerCertificate is a boolean specifying if the certificate should be
+          issued with server auth usage enabled
+        displayName: Is Server Certificate
+        path: server
+      - description: |-
+          Signer specifies  the signer to use to create this certificate. Supported
+          signers are CertManager and SelfSigned.
+        displayName: Signer
+        path: signer
+      - description: CASigned holds specific configuration for the CASigned signer
+        displayName: CASigned
+        path: signer.caSigned
+      - description: A reference to a Secret containing the CA
+        displayName: Secret Ref
+        path: signer.caSigned.caSecretRef
+      - description: SelfSigned holds specific configuration for the SelfSigned signer
+        displayName: Self Signed
+        path: signer.selfSigned
+      - description: ValidFor specifies the validity of the certificate in seconds
+        displayName: Valid For
+        path: validFor
+      statusDescriptors:
+      - description: |-
+          CertificateHash stores the current hash of the certificate. It is used
+          for other controllers to validate if a certificate has been re-issued.
+        displayName: Certificate Hash
+        path: certificateHash
+      - description: Conditions represent the latest available observations of an
+          object's state
+        displayName: Conditions
+        path: conditions
+      - description: NotAfter is the time at which the certificate expires
+        displayName: Not After
+        path: notAfter
+      - description: |-
+          NotBefore is the time at which the certificate starts
+          being valid
+        displayName: Not Before
+        path: notBefore
+      - description: Ready is a boolean that specifies if the certificate is ready
+          to be used
+        displayName: Ready
+        path: ready
+      version: v1alpha1
+    - description: |-
+        DiscoveryService represents an envoy discovery service server. Only one
+        instance per namespace is currently supported.
+      displayName: DiscoveryService
+      kind: DiscoveryService
+      name: discoveryservices.operator.marin3r.3scale.net
+      specDescriptors:
+      - description: Affinity configuration for the discovery service pods
+        displayName: Affinity
+        path: affinity
+      - description: |-
+          Debug enables debugging log level for the discovery service controllers. It is safe to
+          use since secret data is never shown in the logs.
+        displayName: Debug
+        path: debug
+      - description: Image holds the image to use for the discovery service Deployment
+        displayName: Image
+        path: image
+      - description: MetricsPort is the port where metrics are served. Defaults to
+          8383.
+        displayName: Metrics Port
+        path: metricsPort
+      - description: |-
+          PKIConfig has configuration for the PKI that marin3r manages for the
+          different certificates it requires
+        displayName: PKIConfig
+        path: pkiConfg
+      - displayName: Root Certificate Authority
+        path: pkiConfg.rootCertificateAuthority
+      - displayName: Duration
+        path: pkiConfg.rootCertificateAuthority.duration
+      - displayName: Secret Name
+        path: pkiConfg.rootCertificateAuthority.secretName
+      - displayName: Server Certificate
+        path: pkiConfg.serverCertificate
+      - displayName: Duration
+        path: pkiConfg.serverCertificate.duration
+      - displayName: Secret Name
+        path: pkiConfg.serverCertificate.secretName
+      - description: PriorityClass to assign the discovery service Pod to
+        displayName: Pod Priority Class
+        path: podPriorityClass
+      - description: ProbePort is the port where healthz endpoint is served. Defaults
+          to 8384.
+        displayName: Probe Port
+        path: probePort
+      - description: |-
+          Resources holds the Resource Requirements to use for the discovery service
+          Deployment. When not set it defaults to no resource requests nor limits.
+          CPU and Memory resources are supported.
+        displayName: Resources
+        path: resources
+      - description: ServiceConfig configures the way the DiscoveryService endpoints
+          are exposed
+        displayName: Service Config
+        path: serviceConfig
+      - displayName: Name
+        path: serviceConfig.name
+      - displayName: Type
+        path: serviceConfig.type
+      - description: XdsServerPort is the port where the xDS server listens. Defaults
+          to 18000.
+        displayName: Xds Server Port
+        path: xdsServerPort
+      version: v1alpha1
+    - description: |-
+        EnvoyConfigRevision is an internal resource that stores a specific version of an EnvoyConfig
+        resource. EnvoyConfigRevisions are automatically created and deleted by the EnvoyConfig
+        controller and are not intended to be directly used. Use EnvoyConfig objects instead.
+      displayName: EnvoyConfigRevision
+      kind: EnvoyConfigRevision
+      name: envoyconfigrevisions.marin3r.3scale.net
+      specDescriptors:
+      - description: EnvoyAPI is the version of envoy's API to use. Defaults to v3.
+        displayName: Envoy API
+        path: envoyAPI
+      - description: EnvoyResources holds the different types of resources suported
+          by the envoy discovery service
+        displayName: Envoy Resources
+        path: envoyResources
+      - description: |-
+          Clusters is a list of the envoy Cluster resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto
+        displayName: Clusters
+        path: envoyResources.clusters
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.clusters[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.clusters[0].value
+      - description: |-
+          Endpoints is a list of the envoy ClusterLoadAssignment resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto
+        displayName: Endpoints
+        path: envoyResources.endpoints
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.endpoints[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.endpoints[0].value
+      - description: |-
+          ExtensionConfigs is a list of the envoy ExtensionConfig resource type
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/extension.proto
+        displayName: Extension Configs
+        path: envoyResources.extensionConfigs
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.extensionConfigs[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.extensionConfigs[0].value
+      - description: |-
+          Listeners is a list of the envoy Listener resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto
+        displayName: Listeners
+        path: envoyResources.listeners
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.listeners[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.listeners[0].value
+      - description: |-
+          Routes is a list of the envoy Route resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto
+        displayName: Routes
+        path: envoyResources.routes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.routes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.routes[0].value
+      - description: |-
+          Runtimes is a list of the envoy Runtime resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto
+        displayName: Runtimes
+        path: envoyResources.runtimes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.runtimes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.runtimes[0].value
+      - description: |-
+          ScopedRoutes is a list of the envoy ScopeRoute resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/scoped_route.proto
+        displayName: Scoped Routes
+        path: envoyResources.scopedRoutes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.scopedRoutes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.scopedRoutes[0].value
+      - description: Secrets is a list of references to Kubernetes Secret objects.
+        displayName: Secrets
+        path: envoyResources.secrets
+      - description: |-
+          Name of the envoy tslCerticate secret resource. The certificate will be fetched
+          from a Kubernetes Secrets of type 'kubernetes.io/tls' with this same name.
+        displayName: Name
+        path: envoyResources.secrets[0].name
+      - description: |-
+          DEPRECATED: this field is deprecated and it's value will be ignored. The 'name' of the
+          Kubernetes Secret must match the 'name' field.
+        displayName: Ref
+        path: envoyResources.secrets[0].ref
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:SecretReference
+      - description: |-
+          NodeID holds the envoy identifier for the discovery service to know which set
+          of resources to send to each of the envoy clients that connect to it.
+        displayName: Node ID
+        path: nodeID
+      - description: Resources holds the different types of resources suported by
+          the envoy discovery service
+        displayName: Resources
+        path: resources
+      - description: |-
+          Blueprint specifies a template to generate a configuration proto. It is currently
+          only supported to generate secret configuration resources from k8s Secrets
+        displayName: Blueprint
+        path: resources[0].blueprint
+      - description: |-
+          Specifies a label selector to watch for EndpointSlices that will
+          be used to generate the endpoint resource
+        displayName: Generate From Endpoint Slices
+        path: resources[0].generateFromEndpointSlices
+      - description: |-
+          The name of a Kubernetes Secret of type "Opaque". It will generate an
+          envoy "generic secret" proto.
+        displayName: Generate From Opaque Secret
+        path: resources[0].generateFromOpaqueSecret
+      - description: The name of a Kubernetes Secret of type "kubernetes.io/tls"
+        displayName: Generate From Tls Secret
+        path: resources[0].generateFromTlsSecret
+      - description: Type is the type url for the protobuf message
+        displayName: Type
+        path: resources[0].type
+      - description: |-
+          Value is the protobufer message that configures the resource. The proto
+          must match the envoy configuration API v3 specification for the given resource
+          type (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)
+        displayName: Value
+        path: resources[0].value
+      - description: |-
+          Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
+          are supported. "json" is used if unset.
+        displayName: Serialization
+        path: serialization
+      - description: Version is a hash of the EnvoyResources field
+        displayName: Version
+        path: version
+      statusDescriptors:
+      - description: Conditions represent the latest available observations of an
+          object's state
+        displayName: Conditions
+        path: conditions
+      - description: |-
+          LastPublishedAt indicates the last time this config review transitioned to
+          published
+        displayName: Last Published At
+        path: lastPublishedAt
+      - description: |-
+          ProvidesVersions keeps track of the version that this revision
+          publishes in the xDS server for each resource type
+        displayName: Provides Versions
+        path: providesVersions
+      - description: |-
+          Published signals if the EnvoyConfigRevision is the one currently published
+          in the xds server cache
+        displayName: Published
+        path: published
+      - description: |-
+          Tainted indicates whether the EnvoyConfigRevision is eligible for publishing
+          or not
+        displayName: Tainted
+        path: tainted
+      version: v1alpha1
+    - description: |-
+        EnvoyConfig holds the configuration for a given envoy nodeID. The spec of an EnvoyConfig
+        object holds the Envoy resources that conform the desired configuration for the given nodeID
+        and that the discovery service will send to any envoy client that identifies itself with that
+        nodeID.
+      displayName: EnvoyConfig
+      kind: EnvoyConfig
+      name: envoyconfigs.marin3r.3scale.net
+      resources:
+      - kind: EnvoyConfigRevision
+        name: ""
+        version: v1alpha1
+      specDescriptors:
+      - description: EnvoyAPI is the version of envoy's API to use. Defaults to v3.
+        displayName: Envoy API
+        path: envoyAPI
+      - description: |-
+          EnvoyResources holds the different types of resources suported by the envoy discovery service
+          DEPRECATED. Use the `resources` field instead.
+        displayName: Envoy Resources
+        path: envoyResources
+      - description: |-
+          Clusters is a list of the envoy Cluster resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/cluster/v3/cluster.proto
+        displayName: Clusters
+        path: envoyResources.clusters
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.clusters[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.clusters[0].value
+      - description: |-
+          Endpoints is a list of the envoy ClusterLoadAssignment resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/endpoint/v3/endpoint.proto
+        displayName: Endpoints
+        path: envoyResources.endpoints
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.endpoints[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.endpoints[0].value
+      - description: |-
+          ExtensionConfigs is a list of the envoy ExtensionConfig resource type
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/core/v3/extension.proto
+        displayName: Extension Configs
+        path: envoyResources.extensionConfigs
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.extensionConfigs[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.extensionConfigs[0].value
+      - description: |-
+          Listeners is a list of the envoy Listener resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/listener/v3/listener.proto
+        displayName: Listeners
+        path: envoyResources.listeners
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.listeners[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.listeners[0].value
+      - description: |-
+          Routes is a list of the envoy Route resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route.proto
+        displayName: Routes
+        path: envoyResources.routes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.routes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.routes[0].value
+      - description: |-
+          Runtimes is a list of the envoy Runtime resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/service/runtime/v3/rtds.proto
+        displayName: Runtimes
+        path: envoyResources.runtimes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.runtimes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.runtimes[0].value
+      - description: |-
+          ScopedRoutes is a list of the envoy ScopeRoute resource type.
+          API V3 reference: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/scoped_route.proto
+        displayName: Scoped Routes
+        path: envoyResources.scopedRoutes
+      - description: |-
+          Name of the envoy resource.
+          DEPRECATED: this field has no effect and will be removed in an
+          upcoming release. The name of the resources for discovery purposes
+          is included in the resource itself. Refer to the envoy API reference
+          to check how the name is specified for each resource type.
+        displayName: Name
+        path: envoyResources.scopedRoutes[0].name
+      - description: Value is the serialized representation of the envoy resource
+        displayName: Value
+        path: envoyResources.scopedRoutes[0].value
+      - description: Secrets is a list of references to Kubernetes Secret objects.
+        displayName: Secrets
+        path: envoyResources.secrets
+      - description: |-
+          Name of the envoy tslCerticate secret resource. The certificate will be fetched
+          from a Kubernetes Secrets of type 'kubernetes.io/tls' with this same name.
+        displayName: Name
+        path: envoyResources.secrets[0].name
+      - description: |-
+          DEPRECATED: this field is deprecated and it's value will be ignored. The 'name' of the
+          Kubernetes Secret must match the 'name' field.
+        displayName: Ref
+        path: envoyResources.secrets[0].ref
+        x-descriptors:
+        - urn:alm:descriptor:io.kubernetes:SecretReference
+      - description: |-
+          NodeID holds the envoy identifier for the discovery service to know which set
+          of resources to send to each of the envoy clients that connect to it.
+        displayName: Node ID
+        path: nodeID
+      - description: Resources holds the different types of resources suported by
+          the envoy discovery service
+        displayName: Resources
+        path: resources
+      - description: |-
+          Blueprint specifies a template to generate a configuration proto. It is currently
+          only supported to generate secret configuration resources from k8s Secrets
+        displayName: Blueprint
+        path: resources[0].blueprint
+      - description: |-
+          Specifies a label selector to watch for EndpointSlices that will
+          be used to generate the endpoint resource
+        displayName: Generate From Endpoint Slices
+        path: resources[0].generateFromEndpointSlices
+      - description: |-
+          The name of a Kubernetes Secret of type "Opaque". It will generate an
+          envoy "generic secret" proto.
+        displayName: Generate From Opaque Secret
+        path: resources[0].generateFromOpaqueSecret
+      - description: The name of a Kubernetes Secret of type "kubernetes.io/tls"
+        displayName: Generate From Tls Secret
+        path: resources[0].generateFromTlsSecret
+      - description: Type is the type url for the protobuf message
+        displayName: Type
+        path: resources[0].type
+      - description: |-
+          Value is the protobufer message that configures the resource. The proto
+          must match the envoy configuration API v3 specification for the given resource
+          type (https://www.envoyproxy.io/docs/envoy/latest/api-docs/xds_protocol#resource-types)
+        displayName: Value
+        path: resources[0].value
+      - description: |-
+          Serialization specicifies the serialization format used to describe the resources. "json" and "yaml"
+          are supported. "json" is used if unset.
+        displayName: Serialization
+        path: serialization
+      statusDescriptors:
+      - description: |-
+          CacheState summarizes all the observations about the EnvoyConfig
+          to give the user a concrete idea on the general status of the discovery servie cache.
+          It is intended only for human consumption. Other controllers should relly on conditions
+          to determine the status of the discovery server cache.
+        displayName: Cache State
+        path: cacheState
+      - description: Conditions represent the latest available observations of an
+          object's state
+        displayName: Conditions
+        path: conditions
+      - description: |-
+          DesiredVersion represents the resources version described in
+          the spec of the EnvoyConfig object
+        displayName: Desired Version
+        path: desiredVersion
+      - description: |-
+          PublishedVersion is the config version currently
+          served by the envoy discovery service for the give nodeID
+        displayName: Published Version
+        path: publishedVersion
+      - description: |-
+          ConfigRevisions is an ordered list of references to EnvoyConfigRevision
+          objects
+        displayName: Config Revisions
+        path: revisions
+      - description: |-
+          Ref is a reference to the EnvoyConfigRevision object that
+          holds the configuration matching the Version field.
+        displayName: Ref
+        path: revisions[0].ref
+      - description: Version is a hash of the EnvoyResources field
+        displayName: Version
+        path: revisions[0].version
+      version: v1alpha1
+    - description: |-
+        EnvoyDeployment is a resource to deploy and manage a Kubernetes Deployment
+        of Envoy Pods.
+      displayName: EnvoyDeployment
+      kind: EnvoyDeployment
+      name: envoydeployments.operator.marin3r.3scale.net
+      specDescriptors:
+      - description: Configures envoy's admin access log path. Defaults to /dev/null.
+        displayName: Admin Access Log Path
+        path: adminAccessLogPath
+      - description: Configures envoy's admin port. Defaults to 9901.
+        displayName: Admin Port
+        path: adminPort
+      - description: Affinity configuration for the envoy pods
+        displayName: Affinity
+        path: affinity
+      - description: |-
+          Defines the local service cluster name where Envoy is running. Defaults
+          to the NodeID in the EnvoyConfig if unset
+        displayName: Cluster ID
+        path: clusterID
+      - description: |-
+          DiscoveryServiceRef points to a DiscoveryService in the same
+          namespace
+        displayName: Discovery Service Ref
+        path: discoveryServiceRef
+      - description: |-
+          Defines the duration of the client certificate that is used to authenticate
+          with the DiscoveryService
+        displayName: Client Certificate Duration
+        path: duration
+      - description: |-
+          EnvoyConfigRef points to an EnvoyConfig in the same namespace
+          that holds the envoy resources for this Deployment
+        displayName: Envoy Config Ref
+        path: envoyConfigRef
+      - description: Allows the user to define extra command line arguments for the
+          Envoy process
+        displayName: Extra Args
+        path: extraArgs
+      - description: Image is the envoy image and tag to use
+        displayName: Image
+        path: image
+      - description: |-
+          InitManager defines configuration for Envoy's init
+          manager, which handles initialization for Envoy pods
+        displayName: Init Manager
+        path: initManager
+      - description: Image is the init manager image and tag to use
+        displayName: Image
+        path: initManager.image
+      - description: Liveness probe for the envoy pods
+        displayName: Liveness Probe
+        path: livenessProbe
+      - description: Minimum consecutive failures for the probe to be considered failed
+          after having succeeded
+        displayName: Failure Threshold
+        path: livenessProbe.failureThreshold
+      - description: Number of seconds after the container has started before liveness
+          probes are initiated
+        displayName: Initial Delay Seconds
+        path: livenessProbe.initialDelaySeconds
+      - description: How often (in seconds) to perform the probe
+        displayName: Period Seconds
+        path: livenessProbe.periodSeconds
+      - description: Minimum consecutive successes for the probe to be considered
+          successful after having failed
+        displayName: Success Threshold
+        path: livenessProbe.successThreshold
+      - description: Number of seconds after which the probe times out
+        displayName: Timeout Seconds
+        path: livenessProbe.timeoutSeconds
+      - description: Configures PodDisruptionBudget for the envoy Pods
+        displayName: Pod Disruption Budget
+        path: podDisruptionBudget
+      - description: |-
+          An eviction is allowed if at most "maxUnavailable" pods selected by
+          "selector" are unavailable after the eviction, i.e. even in absence of
+          the evicted pod. For example, one can prevent all voluntary evictions
+          by specifying 0. This is a mutually exclusive setting with "minAvailable".
+        displayName: Max Unavailable
+        path: podDisruptionBudget.maxUnavailable
+      - description: |-
+          An eviction is allowed if at least "minAvailable" pods selected by
+          "selector" will still be available after the eviction, i.e. even in the
+          absence of the evicted pod.  So for example you can prevent all voluntary
+          evictions by specifying "100%".
+        displayName: Min Available
+        path: podDisruptionBudget.minAvailable
+      - description: Ports exposed by the Envoy container
+        displayName: Ports
+        path: ports
+      - description: Port name
+        displayName: Name
+        path: ports[0].name
+      - description: Port value
+        displayName: Port
+        path: ports[0].port
+      - description: Protocol. Defaults to TCP.
+        displayName: Protocol
+        path: ports[0].protocol
+      - description: Readiness probe for the envoy pods
+        displayName: Readiness Probe
+        path: readinessProbe
+      - description: Minimum consecutive failures for the probe to be considered failed
+          after having succeeded
+        displayName: Failure Threshold
+        path: readinessProbe.failureThreshold
+      - description: Number of seconds after the container has started before liveness
+          probes are initiated
+        displayName: Initial Delay Seconds
+        path: readinessProbe.initialDelaySeconds
+      - description: How often (in seconds) to perform the probe
+        displayName: Period Seconds
+        path: readinessProbe.periodSeconds
+      - description: Minimum consecutive successes for the probe to be considered
+          successful after having failed
+        displayName: Success Threshold
+        path: readinessProbe.successThreshold
+      - description: Number of seconds after which the probe times out
+        displayName: Timeout Seconds
+        path: readinessProbe.timeoutSeconds
+      - description: |-
+          Replicas configures the number of replicas in the Deployment. One of
+          'static', 'dynamic' can be set. If both are set, static has precedence.
+        displayName: Replicas
+        path: replicas
+      - description: Configure a min and max value for the number of pods to autoscale
+          dynamically.
+        displayName: Dynamic
+        path: replicas.dynamic
+      - description: |-
+          behavior configures the scaling behavior of the target
+          in both Up and Down directions (scaleUp and scaleDown fields respectively).
+          If not set, the default HPAScalingRules for scale up and scale down are used.
+        displayName: Behavior
+        path: replicas.dynamic.behavior
+      - description: |-
+          metrics contains the specifications for which to use to calculate the
+          desired replica count (the maximum replica count across all metrics will
+          be used).  The desired replica count is calculated multiplying the
+          ratio between the target value and the current value by the current
+          number of pods.  Ergo, metrics used must decrease as the pod count is
+          increased, and vice-versa.  See the individual metric source types for
+          more information about how each type of metric must respond.
+          If not set, the default metric will be set to 80% average CPU utilization.
+        displayName: Metrics
+        path: replicas.dynamic.metrics
+      - description: |-
+          minReplicas is the lower limit for the number of replicas to which the autoscaler
+          can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
+          alpha feature gate HPAScaleToZero is enabled and at least one Object or External
+          metric is configured.  Scaling is active as long as at least one metric value is
+          available.
+        displayName: Min Replicas
+        path: replicas.dynamic.minReplicas
+      - description: Configure a static number of replicas. Defaults to 1.
+        displayName: Static
+        path: replicas.static
+      - description: |-
+          Resources holds the resource requirements to use for the Envoy
+          Deployment. Defaults to no resource requests nor limits.
+        displayName: Resources
+        path: resources
+      - description: |-
+          ShutdownManager defines configuration for Envoy's shutdown
+          manager, which handles graceful termination of Envoy pods
+        displayName: Shutdown Manager
+        path: shutdownManager
+      - description: |-
+          The drain strategy for the graceful shutdown. It also affects
+          drain when listeners are modified or removed via LDS.
+        displayName: Drain Strategy
+        path: shutdownManager.drainStrategy
+      - description: |-
+          The time in seconds that Envoy will drain connections during shutdown.
+          It also affects drain behaviour when listeners are modified or removed via LDS.
+        displayName: Drain Time
+        path: shutdownManager.drainTime
+      - description: Image is the shutdown manager image and tag to use
+        displayName: Image
+        path: shutdownManager.image
+      - description: Configures the sutdown manager's server port. Defaults to 8090.
+        displayName: Server Port
+        path: shutdownManager.serverPort
+      version: v1alpha1
+  description: |
+    MARIN3R implements a control plane to deploy, configure and operate a fleet of envoy instances within a Kubernetes cluster.
+    It operates a group of gateways and Pod sidecar containers to provide general purpose functionality required to operate production systems.
+
+    Features:
+
+    * Deploy and manage an Envoy xDS server using the DiscoveryService custom resource.
+    * Inject Envoy sidecar containers based on Pod annotations.
+    * Deploy Envoy as a Kubernetes Deployment using the EnvoyDeployment custom resource.
+    * Dynamic Envoy configuration and re-configuration using the EnvoyConfig custom resource.
+    * Use Kubernetes Secrets as certificate sources.
+    * Syntactic validation of Envoy configurations.
+    * Lifecycle management of Envoy containers (graceful shutdown and connection draining).
+    * Self-healing.
+
+    Check the [docs](https://github.com/3scale-sre/marin3r#readme) for more information.
+
+    ## License
+    MARIN3R is licensed under the [Apache 2.0 license](https://github.com/3scale/prometheus-exporter-operator/blob/master/LICENSE)
+  displayName: MARIN3R
+  icon:
+  - base64data: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB3aWR0aD0iMzc1cHQiIGhlaWdodD0iMzc0Ljk5OTk5MXB0IiB2aWV3Qm94PSIwIDAgMzc1IDM3NC45OTk5OTEiIHZlcnNpb249IjEuMiI+CjxkZWZzPgo8Zz4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0wIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iIi8+Cjwvc3ltYm9sPgo8c3ltYm9sIG92ZXJmbG93PSJ2aXNpYmxlIiBpZD0iZ2x5cGgwLTEiPgo8cGF0aCBzdHlsZT0ic3Ryb2tlOm5vbmU7IiBkPSJNIDk1Ljk1MzEyNSAwIEwgODUuODkwNjI1IDAgTCA4NS44OTA2MjUgLTQyLjc5Njg3NSBMIDU0Ljk4NDM3NSAwIEwgNDkuODEyNSAwIEwgMTguOTA2MjUgLTQyLjc5Njg3NSBMIDE4LjkwNjI1IDAgTCA4LjgyODEyNSAwIEwgOC44MjgxMjUgLTYzLjMyODEyNSBMIDE2LjQyMTg3NSAtNjMuMzI4MTI1IEwgNTIuNDIxODc1IC0xMy41OTM3NSBMIDg4LjM1OTM3NSAtNjMuMzI4MTI1IEwgOTUuOTUzMTI1IC02My4zMjgxMjUgWiBNIDk1Ljk1MzEyNSAwICIvPgo8L3N5bWJvbD4KPHN5bWJvbCBvdmVyZmxvdz0idmlzaWJsZSIgaWQ9ImdseXBoMC0yIj4KPHBhdGggc3R5bGU9InN0cm9rZTpub25lOyIgZD0iTSA2MS45NTMxMjUgMCBMIDYuNjI1IDAgTCA2LjYyNSAtMTAuMDYyNSBMIDYxLjk1MzEyNSAtMTAuMDYyNSBDIDYzLjMzNTkzOCAtMTAuMDYyNSA2NC41MTk1MzEgLTEwLjU1NDY4OCA2NS41IC0xMS41NDY4NzUgQyA2Ni40ODgyODEgLTEyLjUzNTE1NiA2Ni45ODQzNzUgLTEzLjcyMjY1NiA2Ni45ODQzNzUgLTE1LjEwOTM3NSBMIDY2Ljk4NDM3NSAtMjEuNTkzNzUgQyA2Ni45ODQzNzUgLTIyLjk3NjU2MiA2Ni41MDc4MTIgLTI0LjE0ODQzOCA2NS41NjI1IC0yNS4xMDkzNzUgQyA2NC42MjUgLTI2LjA2NjQwNiA2My40Njg3NSAtMjYuNTcwMzEyIDYyLjA5Mzc1IC0yNi42MjUgTCAxNi42ODc1IC0yNi42MjUgTCAxNi42ODc1IC0zNi43MDMxMjUgTCA2Mi4wOTM3NSAtMzYuNzAzMTI1IEMgNjMuNDY4NzUgLTM2Ljc1MzkwNiA2NC42MjUgLTM3LjI1NzgxMiA2NS41NjI1IC0zOC4yMTg3NSBDIDY2LjUwNzgxMiAtMzkuMTc1NzgxIDY2Ljk4NDM3NSAtNDAuMzQ3NjU2IDY2Ljk4NDM3NSAtNDEuNzM0Mzc1IEwgNjYuOTg0Mzc1IC00OC4yNjU2MjUgQyA2Ni45ODQzNzUgLTQ5LjY0ODQzOCA2Ni40ODgyODEgLTUwLjgyODEyNSA2NS41IC01MS43OTY4NzUgQyA2NC41MTk1MzEgLTUyLjc2NTYyNSA2My4zMzU5MzggLTUzLjI1IDYxLjk1MzEyNSAtNTMuMjUgTCA2LjYyNSAtNTMuMjUgTCA2LjYyNSAtNjMuMzI4MTI1IEwgNjEuOTUzMTI1IC02My4zMjgxMjUgQyA2Ni4xMDkzNzUgLTYzLjMyODEyNSA2OS42NjQwNjIgLTYxLjg1MTU2MiA3Mi42MjUgLTU4LjkwNjI1IEMgNzUuNTgyMDMxIC01NS45NTcwMzEgNzcuMDYyNSAtNTIuNDEwMTU2IDc3LjA2MjUgLTQ4LjI2NTYyNSBMIDc3LjA2MjUgLTQxLjczNDM3NSBDIDc3LjA2MjUgLTM3Ljg3ODkwNiA3NS43ODEyNSAtMzQuNTE5NTMxIDczLjIxODc1IC0zMS42NTYyNSBDIDc1Ljc4MTI1IC0yOC44MzIwMzEgNzcuMDYyNSAtMjUuNDc2NTYyIDc3LjA2MjUgLTIxLjU5Mzc1IEwgNzcuMDYyNSAtMTUuMTA5Mzc1IEMgNzcuMDYyNSAtMTAuOTIxODc1IDc1LjU4MjAzMSAtNy4zNTE1NjIgNzIuNjI1IC00LjQwNjI1IEMgNjkuNjY0MDYyIC0xLjQ2ODc1IDY2LjEwOTM3NSAwIDYxLjk1MzEyNSAwIFogTSA2MS45NTMxMjUgMCAiLz4KPC9zeW1ib2w+CjxzeW1ib2wgb3ZlcmZsb3c9InZpc2libGUiIGlkPSJnbHlwaDAtMyI+CjxwYXRoIHN0eWxlPSJzdHJva2U6bm9uZTsiIGQ9Ik0gODQuMjk2ODc1IDAgTCA3NC4yMzQzNzUgMCBMIDc0LjIzNDM3NSAtMTcuODQzNzUgQyA3NC4yMzQzNzUgLTE5LjIyNjU2MiA3My43MzgyODEgLTIwLjQxMDE1NiA3Mi43NSAtMjEuMzkwNjI1IEMgNzEuNzU3ODEyIC0yMi4zNzg5MDYgNzAuNTc4MTI1IC0yMi44NzUgNjkuMjAzMTI1IC0yMi44NzUgTCAxOC45MDYyNSAtMjIuODc1IEwgMTguOTA2MjUgMCBMIDguODI4MTI1IDAgTCA4LjgyODEyNSAtNjMuMzI4MTI1IEwgNjkuMjAzMTI1IC02My4zMjgxMjUgQyA3My4zNDc2NTYgLTYzLjMyODEyNSA3Ni44OTg0MzggLTYxLjg1MTU2MiA3OS44NTkzNzUgLTU4LjkwNjI1IEMgODIuODE2NDA2IC01NS45NTcwMzEgODQuMjk2ODc1IC01Mi40MTAxNTYgODQuMjk2ODc1IC00OC4yNjU2MjUgTCA4NC4yOTY4NzUgLTM3Ljk4NDM3NSBDIDg0LjI5Njg3NSAtMzQuMDg1OTM4IDgzIC0zMC43MjY1NjIgODAuNDA2MjUgLTI3LjkwNjI1IEMgODMgLTI1LjA1MDc4MSA4NC4yOTY4NzUgLTIxLjY5NTMxMiA4NC4yOTY4NzUgLTE3Ljg0Mzc1IFogTSA2OS4yMDMxMjUgLTMyLjkzNzUgQyA3MC41NzgxMjUgLTMyLjkzNzUgNzEuNzU3ODEyIC0zMy40Mjk2ODggNzIuNzUgLTM0LjQyMTg3NSBDIDczLjczODI4MSAtMzUuNDEwMTU2IDc0LjIzNDM3NSAtMzYuNTk3NjU2IDc0LjIzNDM3NSAtMzcuOTg0Mzc1IEwgNzQuMjM0Mzc1IC00OC4yNjU2MjUgQyA3NC4yMzQzNzUgLTQ5LjY0ODQzOCA3My43MzgyODEgLTUwLjgzMjAzMSA3Mi43NSAtNTEuODEyNSBDIDcxLjc1NzgxMiAtNTIuODAwNzgxIDcwLjU3ODEyNSAtNTMuMjk2ODc1IDY5LjIwMzEyNSAtNTMuMjk2ODc1IEwgMTguOTA2MjUgLTUzLjI5Njg3NSBMIDE4LjkwNjI1IC0zMi45Mzc1IFogTSA2OS4yMDMxMjUgLTMyLjkzNzUgIi8+Cjwvc3ltYm9sPgo8L2c+CjwvZGVmcz4KPGcgaWQ9InN1cmZhY2UxIj4KPHJlY3QgeD0iMCIgeT0iMCIgd2lkdGg9IjM3NSIgaGVpZ2h0PSIzNzQuOTk5OTkxIiBzdHlsZT0iZmlsbDpyZ2IoMTAwJSwxMDAlLDEwMCUpO2ZpbGwtb3BhY2l0eToxO3N0cm9rZTpub25lOyIvPgo8cmVjdCB4PSIwIiB5PSIwIiB3aWR0aD0iMzc1IiBoZWlnaHQ9IjM3NC45OTk5OTEiIHN0eWxlPSJmaWxsOnJnYigxMDAlLDEwMCUsMTAwJSk7ZmlsbC1vcGFjaXR5OjE7c3Ryb2tlOm5vbmU7Ii8+CjxyZWN0IHg9IjAiIHk9IjAiIHdpZHRoPSIzNzUiIGhlaWdodD0iMzc0Ljk5OTk5MSIgc3R5bGU9ImZpbGw6cmdiKDEwMCUsMTAwJSwxMDAlKTtmaWxsLW9wYWNpdHk6MTtzdHJva2U6bm9uZTsiLz4KPHBhdGggc3R5bGU9IiBzdHJva2U6bm9uZTtmaWxsLXJ1bGU6bm9uemVybztmaWxsOnJnYigwJSwwJSwwJSk7ZmlsbC1vcGFjaXR5OjE7IiBkPSJNIDE4Ny41IDE5LjMyODEyNSBDIDE4NC43NDYwOTQgMTkuMzI4MTI1IDE4MS45OTYwOTQgMTkuMzk4NDM4IDE3OS4yNSAxOS41MzEyNSBDIDE3Ni41IDE5LjY2Nzk2OSAxNzMuNzUzOTA2IDE5Ljg3MTA5NCAxNzEuMDE1NjI1IDIwLjE0MDYyNSBDIDE2OC4yNzczNDQgMjAuNDEwMTU2IDE2NS41NDY4NzUgMjAuNzQ2MDk0IDE2Mi44MjQyMTkgMjEuMTQ4NDM4IEMgMTYwLjEwMTU2MiAyMS41NTQ2ODggMTU3LjM5MDYyNSAyMi4wMjM0MzggMTU0LjY5MTQwNiAyMi41NjI1IEMgMTUxLjk5MjE4OCAyMy4wOTc2NTYgMTQ5LjMwODU5NCAyMy42OTkyMTkgMTQ2LjYzNjcxOSAyNC4zNzEwOTQgQyAxNDMuOTY4NzUgMjUuMDM5MDYyIDE0MS4zMTY0MDYgMjUuNzczNDM4IDEzOC42ODM1OTQgMjYuNTcwMzEyIEMgMTM2LjA1MDc4MSAyNy4zNzEwOTQgMTMzLjQzNzUgMjguMjM0Mzc1IDEzMC44NDM3NSAyOS4xNjAxNTYgQyAxMjguMjUzOTA2IDMwLjA4NTkzOCAxMjUuNjg3NSAzMS4wNzgxMjUgMTIzLjE0NDUzMSAzMi4xMzI4MTIgQyAxMjAuNjAxNTYyIDMzLjE4MzU5NCAxMTguMDg1OTM4IDM0LjMwMDc4MSAxMTUuNTk3NjU2IDM1LjQ3NjU2MiBDIDExMy4xMDkzNzUgMzYuNjUyMzQ0IDExMC42NTIzNDQgMzcuODkwNjI1IDEwOC4yMjY1NjIgMzkuMTg3NSBDIDEwNS43OTY4NzUgNDAuNDg0Mzc1IDEwMy40MDIzNDQgNDEuODM5ODQ0IDEwMS4wNDI5NjkgNDMuMjUzOTA2IEMgOTguNjgzNTk0IDQ0LjY3MTg3NSA5Ni4zNTkzNzUgNDYuMTQ0NTMxIDk0LjA3MDMxMiA0Ny42NzE4NzUgQyA5MS43ODEyNSA0OS4xOTkyMTkgODkuNTMxMjUgNTAuNzg1MTU2IDg3LjMyMDMxMiA1Mi40MjU3ODEgQyA4NS4xMDkzNzUgNTQuMDYyNSA4Mi45NDE0MDYgNTUuNzU3ODEyIDgwLjgxMjUgNTcuNTAzOTA2IEMgNzguNjg3NSA1OS4yNSA3Ni42MDE1NjIgNjEuMDQ2ODc1IDc0LjU2MjUgNjIuODk0NTMxIEMgNzIuNTIzNDM4IDY0Ljc0MjE4OCA3MC41MzEyNSA2Ni42NDA2MjUgNjguNTg1OTM4IDY4LjU4NTkzOCBDIDY2LjY0MDYyNSA3MC41MzEyNSA2NC43NDIxODggNzIuNTIzNDM4IDYyLjg5NDUzMSA3NC41NjI1IEMgNjEuMDQ2ODc1IDc2LjYwMTU2MiA1OS4yNSA3OC42ODc1IDU3LjUwMzkwNiA4MC44MTI1IEMgNTUuNzU3ODEyIDgyLjk0MTQwNiA1NC4wNjI1IDg1LjEwOTM3NSA1Mi40MjU3ODEgODcuMzIwMzEyIEMgNTAuNzg1MTU2IDg5LjUzMTI1IDQ5LjE5OTIxOSA5MS43ODEyNSA0Ny42NzE4NzUgOTQuMDcwMzEyIEMgNDYuMTQ0NTMxIDk2LjM1OTM3NSA0NC42NzE4NzUgOTguNjgzNTk0IDQzLjI1MzkwNiAxMDEuMDQyOTY5IEMgNDEuODM5ODQ0IDEwMy40MDIzNDQgNDAuNDg0Mzc1IDEwNS43OTY4NzUgMzkuMTg3NSAxMDguMjI2NTYyIEMgMzcuODkwNjI1IDExMC42NTIzNDQgMzYuNjUyMzQ0IDExMy4xMDkzNzUgMzUuNDc2NTYyIDExNS41OTc2NTYgQyAzNC4zMDA3ODEgMTE4LjA4NTkzOCAzMy4xODM1OTQgMTIwLjYwMTU2MiAzMi4xMzI4MTIgMTIzLjE0NDUzMSBDIDMxLjA3ODEyNSAxMjUuNjg3NSAzMC4wODU5MzggMTI4LjI1MzkwNiAyOS4xNjAxNTYgMTMwLjg0Mzc1IEMgMjguMjM0Mzc1IDEzMy40Mzc1IDI3LjM3MTA5NCAxMzYuMDUwNzgxIDI2LjU3MDMxMiAxMzguNjgzNTk0IEMgMjUuNzczNDM4IDE0MS4zMTY0MDYgMjUuMDM5MDYyIDE0My45Njg3NSAyNC4zNzEwOTQgMTQ2LjYzNjcxOSBDIDIzLjY5OTIxOSAxNDkuMzA4NTk0IDIzLjA5NzY1NiAxNTEuOTkyMTg4IDIyLjU2MjUgMTU0LjY5MTQwNiBDIDIyLjAyMzQzOCAxNTcuMzkwNjI1IDIxLjU1NDY4OCAxNjAuMTAxNTYyIDIxLjE0ODQzOCAxNjIuODI0MjE5IEMgMjAuNzQ2MDk0IDE2NS41NDY4NzUgMjAuNDEwMTU2IDE2OC4yNzczNDQgMjAuMTQwNjI1IDE3MS4wMTU2MjUgQyAxOS44NzEwOTQgMTczLjc1MzkwNiAxOS42Njc5NjkgMTc2LjUgMTkuNTMxMjUgMTc5LjI1IEMgMTkuMzk4NDM4IDE4MS45OTYwOTQgMTkuMzI4MTI1IDE4NC43NDYwOTQgMTkuMzI4MTI1IDE4Ny41IEMgMTkuMzI4MTI1IDE5MC4yNTM5MDYgMTkuMzk4NDM4IDE5My4wMDM5MDYgMTkuNTMxMjUgMTk1Ljc1IEMgMTkuNjY3OTY5IDE5OC41IDE5Ljg3MTA5NCAyMDEuMjQ2MDk0IDIwLjE0MDYyNSAyMDMuOTg0Mzc1IEMgMjAuNDEwMTU2IDIwNi43MjI2NTYgMjAuNzQ2MDk0IDIwOS40NTMxMjUgMjEuMTQ4NDM4IDIxMi4xNzU3ODEgQyAyMS41NTQ2ODggMjE0Ljg5ODQzOCAyMi4wMjM0MzggMjE3LjYwOTM3NSAyMi41NjI1IDIyMC4zMDg1OTQgQyAyMy4wOTc2NTYgMjIzLjAwNzgxMiAyMy42OTkyMTkgMjI1LjY5MTQwNiAyNC4zNzEwOTQgMjI4LjM2MzI4MSBDIDI1LjAzOTA2MiAyMzEuMDMxMjUgMjUuNzczNDM4IDIzMy42ODM1OTQgMjYuNTcwMzEyIDIzNi4zMTY0MDYgQyAyNy4zNzEwOTQgMjM4Ljk0OTIxOSAyOC4yMzQzNzUgMjQxLjU2MjUgMjkuMTYwMTU2IDI0NC4xNTYyNSBDIDMwLjA4NTkzOCAyNDYuNzQ2MDk0IDMxLjA3ODEyNSAyNDkuMzEyNSAzMi4xMzI4MTIgMjUxLjg1NTQ2OSBDIDMzLjE4MzU5NCAyNTQuMzk4NDM4IDM0LjMwMDc4MSAyNTYuOTE0MDYyIDM1LjQ3NjU2MiAyNTkuNDAyMzQ0IEMgMzYuNjUyMzQ0IDI2MS44OTA2MjUgMzcuODkwNjI1IDI2NC4zNDc2NTYgMzkuMTg3NSAyNjYuNzczNDM4IEMgNDAuNDg0Mzc1IDI2OS4yMDMxMjUgNDEuODM5ODQ0IDI3MS41OTc2NTYgNDMuMjUzOTA2IDI3My45NTcwMzEgQyA0NC42NzE4NzUgMjc2LjMxNjQwNiA0Ni4xNDQ1MzEgMjc4LjY0MDYyNSA0Ny42NzE4NzUgMjgwLjkyOTY4OCBDIDQ5LjE5OTIxOSAyODMuMjE4NzUgNTAuNzg1MTU2IDI4NS40Njg3NSA1Mi40MjU3ODEgMjg3LjY3OTY4OCBDIDU0LjA2MjUgMjg5Ljg5MDYyNSA1NS43NTc4MTIgMjkyLjA1ODU5NCA1Ny41MDM5MDYgMjk0LjE4NzUgQyA1OS4yNSAyOTYuMzEyNSA2MS4wNDY4NzUgMjk4LjM5ODQzOCA2Mi44OTQ1MzEgMzAwLjQzNzUgQyA2NC43NDIxODggMzAyLjQ3NjU2MiA2Ni42NDA2MjUgMzA0LjQ2ODc1IDY4LjU4NTkzOCAzMDYuNDE0MDYyIEMgNzAuNTMxMjUgMzA4LjM1OTM3NSA3Mi41MjM0MzggMzEwLjI1NzgxMiA3NC41NjI1IDMxMi4xMDU0NjkgQyA3Ni42MDE1NjIgMzEzLjk1MzEyNSA3OC42ODc1IDMxNS43NSA4MC44MTI1IDMxNy40OTYwOTQgQyA4Mi45NDE0MDYgMzE5LjI0MjE4OCA4NS4xMDkzNzUgMzIwLjkzNzUgODcuMzIwMzEyIDMyMi41NzQyMTkgQyA4OS41MzEyNSAzMjQuMjE0ODQ0IDkxLjc4MTI1IDMyNS44MDA3ODEgOTQuMDcwMzEyIDMyNy4zMjgxMjUgQyA5Ni4zNTkzNzUgMzI4Ljg1NTQ2OSA5OC42ODM1OTQgMzMwLjMyODEyNSAxMDEuMDQyOTY5IDMzMS43NDYwOTQgQyAxMDMuNDAyMzQ0IDMzMy4xNjAxNTYgMTA1Ljc5Njg3NSAzMzQuNTE1NjI1IDEwOC4yMjY1NjIgMzM1LjgxMjUgQyAxMTAuNjUyMzQ0IDMzNy4xMDkzNzUgMTEzLjEwOTM3NSAzMzguMzQ3NjU2IDExNS41OTc2NTYgMzM5LjUyMzQzOCBDIDExOC4wODU5MzggMzQwLjY5OTIxOSAxMjAuNjAxNTYyIDM0MS44MTY0MDYgMTIzLjE0NDUzMSAzNDIuODY3MTg4IEMgMTI1LjY4NzUgMzQzLjkyMTg3NSAxMjguMjUzOTA2IDM0NC45MTQwNjIgMTMwLjg0Mzc1IDM0NS44Mzk4NDQgQyAxMzMuNDM3NSAzNDYuNzY1NjI1IDEzNi4wNTA3ODEgMzQ3LjYyODkwNiAxMzguNjgzNTk0IDM0OC40Mjk2ODggQyAxNDEuMzE2NDA2IDM0OS4yMjY1NjIgMTQzLjk2ODc1IDM0OS45NjA5MzggMTQ2LjYzNjcxOSAzNTAuNjI4OTA2IEMgMTQ5LjMwODU5NCAzNTEuMzAwNzgxIDE1MS45OTIxODggMzUxLjkwMjM0NCAxNTQuNjkxNDA2IDM1Mi40Mzc1IEMgMTU3LjM5MDYyNSAzNTIuOTc2NTYyIDE2MC4xMDE1NjIgMzUzLjQ0NTMxMiAxNjIuODI0MjE5IDM1My44NTE1NjIgQyAxNjUuNTQ2ODc1IDM1NC4yNTM5MDYgMTY4LjI3NzM0NCAzNTQuNTg5ODQ0IDE3MS4wMTU2MjUgMzU0Ljg1OTM3NSBDIDE3My43NTM5MDYgMzU1LjEyODkwNiAxNzYuNSAzNTUuMzMyMDMxIDE3OS4yNSAzNTUuNDY4NzUgQyAxODEuOTk2MDk0IDM1NS42MDE1NjIgMTg0Ljc0NjA5NCAzNTUuNjcxODc1IDE4Ny41IDM1NS42NzE4NzUgQyAxOTAuMjUzOTA2IDM1NS42NzE4NzUgMTkzLjAwMzkwNiAzNTUuNjAxNTYyIDE5NS43NSAzNTUuNDY4NzUgQyAxOTguNSAzNTUuMzMyMDMxIDIwMS4yNDYwOTQgMzU1LjEyODkwNiAyMDMuOTg0Mzc1IDM1NC44NTkzNzUgQyAyMDYuNzIyNjU2IDM1NC41ODk4NDQgMjA5LjQ1MzEyNSAzNTQuMjUzOTA2IDIxMi4xNzU3ODEgMzUzLjg1MTU2MiBDIDIxNC44OTg0MzggMzUzLjQ0NTMxMiAyMTcuNjA5Mzc1IDM1Mi45NzY1NjIgMjIwLjMwODU5NCAzNTIuNDM3NSBDIDIyMy4wMDc4MTIgMzUxLjkwMjM0NCAyMjUuNjkxNDA2IDM1MS4zMDA3ODEgMjI4LjM2MzI4MSAzNTAuNjI4OTA2IEMgMjMxLjAzMTI1IDM0OS45NjA5MzggMjMzLjY4MzU5NCAzNDkuMjI2NTYyIDIzNi4zMTY0MDYgMzQ4LjQyOTY4OCBDIDIzOC45NDkyMTkgMzQ3LjYyODkwNiAyNDEuNTYyNSAzNDYuNzY1NjI1IDI0NC4xNTYyNSAzNDUuODM5ODQ0IEMgMjQ2Ljc0NjA5NCAzNDQuOTE0MDYyIDI0OS4zMTI1IDM0My45MjE4NzUgMjUxLjg1NTQ2OSAzNDIuODY3MTg4IEMgMjU0LjM5ODQzOCAzNDEuODE2NDA2IDI1Ni45MTQwNjIgMzQwLjY5OTIxOSAyNTkuNDAyMzQ0IDMzOS41MjM0MzggQyAyNjEuODkwNjI1IDMzOC4zNDc2NTYgMjY0LjM0NzY1NiAzMzcuMTA5Mzc1IDI2Ni43NzM0MzggMzM1LjgxMjUgQyAyNjkuMjAzMTI1IDMzNC41MTU2MjUgMjcxLjU5NzY1NiAzMzMuMTYwMTU2IDI3My45NTcwMzEgMzMxLjc0NjA5NCBDIDI3Ni4zMTY0MDYgMzMwLjMyODEyNSAyNzguNjQwNjI1IDMyOC44NTU0NjkgMjgwLjkyOTY4OCAzMjcuMzI4MTI1IEMgMjgzLjIxODc1IDMyNS44MDA3ODEgMjg1LjQ2ODc1IDMyNC4yMTQ4NDQgMjg3LjY3OTY4OCAzMjIuNTc0MjE5IEMgMjg5Ljg5MDYyNSAzMjAuOTM3NSAyOTIuMDU4NTk0IDMxOS4yNDIxODggMjk0LjE4NzUgMzE3LjQ5NjA5NCBDIDI5Ni4zMTI1IDMxNS43NSAyOTguMzk4NDM4IDMxMy45NTMxMjUgMzAwLjQzNzUgMzEyLjEwNTQ2OSBDIDMwMi40NzY1NjIgMzEwLjI1NzgxMiAzMDQuNDY4NzUgMzA4LjM1OTM3NSAzMDYuNDE0MDYyIDMwNi40MTQwNjIgQyAzMDguMzU5Mzc1IDMwNC40Njg3NSAzMTAuMjU3ODEyIDMwMi40NzY1NjIgMzEyLjEwNTQ2OSAzMDAuNDM3NSBDIDMxMy45NTMxMjUgMjk4LjM5ODQzOCAzMTUuNzUgMjk2LjMxMjUgMzE3LjQ5NjA5NCAyOTQuMTg3NSBDIDMxOS4yNDIxODggMjkyLjA1ODU5NCAzMjAuOTM3NSAyODkuODkwNjI1IDMyMi41NzQyMTkgMjg3LjY3OTY4OCBDIDMyNC4yMTQ4NDQgMjg1LjQ2ODc1IDMyNS44MDA3ODEgMjgzLjIxODc1IDMyNy4zMjgxMjUgMjgwLjkyOTY4OCBDIDMyOC44NTU0NjkgMjc4LjY0MDYyNSAzMzAuMzI4MTI1IDI3Ni4zMTY0MDYgMzMxLjc0NjA5NCAyNzMuOTU3MDMxIEMgMzMzLjE2MDE1NiAyNzEuNTk3NjU2IDMzNC41MTU2MjUgMjY5LjIwMzEyNSAzMzUuODEyNSAyNjYuNzczNDM4IEMgMzM3LjEwOTM3NSAyNjQuMzQ3NjU2IDMzOC4zNDc2NTYgMjYxLjg5MDYyNSAzMzkuNTIzNDM4IDI1OS40MDIzNDQgQyAzNDAuNjk5MjE5IDI1Ni45MTQwNjIgMzQxLjgxNjQwNiAyNTQuMzk4NDM4IDM0Mi44NjcxODggMjUxLjg1NTQ2OSBDIDM0My45MjE4NzUgMjQ5LjMxMjUgMzQ0LjkxNDA2MiAyNDYuNzQ2MDk0IDM0NS44Mzk4NDQgMjQ0LjE1NjI1IEMgMzQ2Ljc2NTYyNSAyNDEuNTYyNSAzNDcuNjI4OTA2IDIzOC45NDkyMTkgMzQ4LjQyOTY4OCAyMzYuMzE2NDA2IEMgMzQ5LjIyNjU2MiAyMzMuNjgzNTk0IDM0OS45NjA5MzggMjMxLjAzMTI1IDM1MC42Mjg5MDYgMjI4LjM2MzI4MSBDIDM1MS4zMDA3ODEgMjI1LjY5MTQwNiAzNTEuOTAyMzQ0IDIyMy4wMDc4MTIgMzUyLjQzNzUgMjIwLjMwODU5NCBDIDM1Mi45NzY1NjIgMjE3LjYwOTM3NSAzNTMuNDQ1MzEyIDIxNC44OTg0MzggMzUzLjg1MTU2MiAyMTIuMTc1NzgxIEMgMzU0LjI1MzkwNiAyMDkuNDUzMTI1IDM1NC41ODk4NDQgMjA2LjcyMjY1NiAzNTQuODU5Mzc1IDIwMy45ODQzNzUgQyAzNTUuMTI4OTA2IDIwMS4yNDYwOTQgMzU1LjMzMjAzMSAxOTguNSAzNTUuNDY4NzUgMTk1Ljc1IEMgMzU1LjYwMTU2MiAxOTMuMDAzOTA2IDM1NS42NzE4NzUgMTkwLjI1MzkwNiAzNTUuNjcxODc1IDE4Ny41IEMgMzU1LjY3MTg3NSAxODQuNzQ2MDk0IDM1NS42MDE1NjIgMTgxLjk5NjA5NCAzNTUuNDY4NzUgMTc5LjI1IEMgMzU1LjMzMjAzMSAxNzYuNSAzNTUuMTI4OTA2IDE3My43NTM5MDYgMzU0Ljg1OTM3NSAxNzEuMDE1NjI1IEMgMzU0LjU4OTg0NCAxNjguMjc3MzQ0IDM1NC4yNTM5MDYgMTY1LjU0Njg3NSAzNTMuODUxNTYyIDE2Mi44MjQyMTkgQyAzNTMuNDQ1MzEyIDE2MC4xMDE1NjIgMzUyLjk3NjU2MiAxNTcuMzkwNjI1IDM1Mi40Mzc1IDE1NC42OTE0MDYgQyAzNTEuOTAyMzQ0IDE1MS45OTIxODggMzUxLjMwMDc4MSAxNDkuMzA4NTk0IDM1MC42Mjg5MDYgMTQ2LjYzNjcxOSBDIDM0OS45NjA5MzggMTQzLjk2ODc1IDM0OS4yMjY1NjIgMTQxLjMxNjQwNiAzNDguNDI5Njg4IDEzOC42ODM1OTQgQyAzNDcuNjI4OTA2IDEzNi4wNTA3ODEgMzQ2Ljc2NTYyNSAxMzMuNDM3NSAzNDUuODM5ODQ0IDEzMC44NDM3NSBDIDM0NC45MTQwNjIgMTI4LjI1MzkwNiAzNDMuOTIxODc1IDEyNS42ODc1IDM0Mi44NjcxODggMTIzLjE0NDUzMSBDIDM0MS44MTY0MDYgMTIwLjYwMTU2MiAzNDAuNjk5MjE5IDExOC4wODU5MzggMzM5LjUyMzQzOCAxMTUuNTk3NjU2IEMgMzM4LjM0NzY1NiAxMTMuMTA5Mzc1IDMzNy4xMDkzNzUgMTEwLjY1MjM0NCAzMzUuODEyNSAxMDguMjI2NTYyIEMgMzM0LjUxNTYyNSAxMDUuNzk2ODc1IDMzMy4xNjAxNTYgMTAzLjQwMjM0NCAzMzEuNzQ2MDk0IDEwMS4wNDI5NjkgQyAzMzAuMzI4MTI1IDk4LjY4MzU5NCAzMjguODU1NDY5IDk2LjM1OTM3NSAzMjcuMzI4MTI1IDk0LjA3MDMxMiBDIDMyNS44MDA3ODEgOTEuNzgxMjUgMzI0LjIxNDg0NCA4OS41MzEyNSAzMjIuNTc0MjE5IDg3LjMyMDMxMiBDIDMyMC45Mzc1IDg1LjEwOTM3NSAzMTkuMjQyMTg4IDgyLjk0MTQwNiAzMTcuNDk2MDk0IDgwLjgxMjUgQyAzMTUuNzUgNzguNjg3NSAzMTMuOTUzMTI1IDc2LjYwMTU2MiAzMTIuMTA1NDY5IDc0LjU2MjUgQyAzMTAuMjU3ODEyIDcyLjUyMzQzOCAzMDguMzU5Mzc1IDcwLjUzMTI1IDMwNi40MTQwNjIgNjguNTg1OTM4IEMgMzA0LjQ2ODc1IDY2LjY0MDYyNSAzMDIuNDc2NTYyIDY0Ljc0MjE4OCAzMDAuNDM3NSA2Mi44OTQ1MzEgQyAyOTguMzk4NDM4IDYxLjA0Njg3NSAyOTYuMzEyNSA1OS4yNSAyOTQuMTg3NSA1Ny41MDM5MDYgQyAyOTIuMDU4NTk0IDU1Ljc1NzgxMiAyODkuODkwNjI1IDU0LjA2MjUgMjg3LjY3OTY4OCA1Mi40MjU3ODEgQyAyODUuNDY4NzUgNTAuNzg1MTU2IDI4My4yMTg3NSA0OS4xOTkyMTkgMjgwLjkyOTY4OCA0Ny42NzE4NzUgQyAyNzguNjQwNjI1IDQ2LjE0NDUzMSAyNzYuMzE2NDA2IDQ0LjY3MTg3NSAyNzMuOTU3MDMxIDQzLjI1MzkwNiBDIDI3MS41OTc2NTYgNDEuODM5ODQ0IDI2OS4yMDMxMjUgNDAuNDg0Mzc1IDI2Ni43NzM0MzggMzkuMTg3NSBDIDI2NC4zNDc2NTYgMzcuODkwNjI1IDI2MS44OTA2MjUgMzYuNjUyMzQ0IDI1OS40MDIzNDQgMzUuNDc2NTYyIEMgMjU2LjkxNDA2MiAzNC4zMDA3ODEgMjU0LjM5ODQzOCAzMy4xODM1OTQgMjUxLjg1NTQ2OSAzMi4xMzI4MTIgQyAyNDkuMzEyNSAzMS4wNzgxMjUgMjQ2Ljc0NjA5NCAzMC4wODU5MzggMjQ0LjE1NjI1IDI5LjE2MDE1NiBDIDI0MS41NjI1IDI4LjIzNDM3NSAyMzguOTQ5MjE5IDI3LjM3MTA5NCAyMzYuMzE2NDA2IDI2LjU3MDMxMiBDIDIzMy42ODM1OTQgMjUuNzczNDM4IDIzMS4wMzEyNSAyNS4wMzkwNjIgMjI4LjM2MzI4MSAyNC4zNzEwOTQgQyAyMjUuNjkxNDA2IDIzLjY5OTIxOSAyMjMuMDA3ODEyIDIzLjA5NzY1NiAyMjAuMzA4NTk0IDIyLjU2MjUgQyAyMTcuNjA5Mzc1IDIyLjAyMzQzOCAyMTQuODk4NDM4IDIxLjU1NDY4OCAyMTIuMTc1NzgxIDIxLjE0ODQzOCBDIDIwOS40NTMxMjUgMjAuNzQ2MDk0IDIwNi43MjI2NTYgMjAuNDEwMTU2IDIwMy45ODQzNzUgMjAuMTQwNjI1IEMgMjAxLjI0NjA5NCAxOS44NzEwOTQgMTk4LjUgMTkuNjY3OTY5IDE5NS43NSAxOS41MzEyNSBDIDE5My4wMDM5MDYgMTkuMzk4NDM4IDE5MC4yNTM5MDYgMTkuMzI4MTI1IDE4Ny41IDE5LjMyODEyNSBaIE0gMTg3LjUgMTkuMzI4MTI1ICIvPgo8ZyBzdHlsZT0iZmlsbDpyZ2IoMTAwJSwxMDAlLDEwMCUpO2ZpbGwtb3BhY2l0eToxOyI+CiAgPHVzZSB4bGluazpocmVmPSIjZ2x5cGgwLTEiIHg9IjQ3Ljg0NjE1NCIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjxnIHN0eWxlPSJmaWxsOnJnYigxMDAlLDU2Ljg1ODgyNiUsMzAuMTk4NjY5JSk7ZmlsbC1vcGFjaXR5OjE7Ij4KICA8dXNlIHhsaW5rOmhyZWY9IiNnbHlwaDAtMiIgeD0iMTUyLjYwMzYwNyIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjxnIHN0eWxlPSJmaWxsOnJnYigxMDAlLDEwMCUsMTAwJSk7ZmlsbC1vcGFjaXR5OjE7Ij4KICA8dXNlIHhsaW5rOmhyZWY9IiNnbHlwaDAtMyIgeD0iMjM2LjI0NTY3MyIgeT0iMjE1LjQ3MTcyOCIvPgo8L2c+CjwvZz4KPC9zdmc+Cg==
+    mediatype: image/svg+xml
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: marin3r-controller-manager
+      deployments:
+      - label:
+          app.kubernetes.io/managed-by: olm
+          app.kubernetes.io/name: marin3r
+          control-plane: controller-manager
+        name: marin3r-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              control-plane: controller-manager
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
+                control-plane: controller-manager
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - operator
+                - --leader-elect
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=:8080
+                command:
+                - /manager
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/3scale-sre/marin3r:v0.13.4
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: manager
+                ports:
+                - containerPort: 8080
+                  name: metrics
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 300m
+                    memory: 300Mi
+                  requests:
+                    cpu: 50m
+                    memory: 100Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: marin3r-controller-manager
+              terminationGracePeriodSeconds: 10
+      - label:
+          app.kubernetes.io/managed-by: olm
+          control-plane: controller-webhook
+        name: marin3r-controller-webhook
+        spec:
+          replicas: 2
+          selector:
+            matchLabels:
+              control-plane: controller-webhook
+          strategy: {}
+          template:
+            metadata:
+              labels:
+                app.kubernetes.io/managed-by: kustomize
+                app.kubernetes.io/name: marin3r
+                control-plane: controller-webhook
+            spec:
+              affinity:
+                nodeAffinity:
+                  requiredDuringSchedulingIgnoredDuringExecution:
+                    nodeSelectorTerms:
+                    - matchExpressions:
+                      - key: kubernetes.io/arch
+                        operator: In
+                        values:
+                        - amd64
+                        - arm64
+                      - key: kubernetes.io/os
+                        operator: In
+                        values:
+                        - linux
+              containers:
+              - args:
+                - webhook
+                - --tls-dir=/apiserver.local.config/certificates
+                - --tls-cert-name=apiserver.crt
+                - --tls-key-name=apiserver.key
+                command:
+                - /manager
+                env:
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                image: quay.io/3scale-sre/marin3r:v0.13.4
+                livenessProbe:
+                  httpGet:
+                    path: /healthz
+                    port: 8081
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                name: webhook
+                ports:
+                - containerPort: 9443
+                  name: webhook-server
+                  protocol: TCP
+                readinessProbe:
+                  httpGet:
+                    path: /readyz
+                    port: 8081
+                  initialDelaySeconds: 5
+                  periodSeconds: 10
+                resources:
+                  limits:
+                    cpu: 500m
+                    memory: 128Mi
+                  requests:
+                    cpu: 10m
+                    memory: 64Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
+              securityContext:
+                runAsNonRoot: true
+              serviceAccountName: marin3r-controller-manager
+              terminationGracePeriodSeconds: 10
+      permissions:
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - secrets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - serviceaccounts
+          - services
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - autoscaling
+          resources:
+          - horizontalpodautoscalers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigrevisions
+          - envoyconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigrevisions/status
+          - envoyconfigs/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - marin3r.3scale.net
+          - operator.marin3r.3scale.net
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservicecertificates
+          - envoydeployments
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservicecertificates/status
+          - envoydeployments/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - envoydeployments/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - policy
+          resources:
+          - poddisruptionbudgets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - rolebindings
+          - roles
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: marin3r-controller-manager
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - envoy
+  - discovery
+  - controlplane
+  - proxy
+  - sidecar
+  - xds
+  - network
+  - gateway
+  links:
+  - name: GitHub
+    url: https://github.com/3scale-sre/marin3r
+  maintainers:
+  - email: 3scale-operations+marin3r@redhat.com
+    name: 3scale Operations Team
+  maturity: alpha
+  provider:
+    name: Red Hat
+  version: 0.13.4
+  webhookdefinitions:
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: marin3r-controller-webhook
+    failurePolicy: Fail
+    generateName: envoyconfig.marin3r.3scale.net-v1alpha1
+    rules:
+    - apiGroups:
+      - marin3r.3scale.net
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - envoyconfigs
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-marin3r-3scale-net-v1alpha1-envoyconfig
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: marin3r-controller-webhook
+    failurePolicy: Fail
+    generateName: envoydeployment.operator.marin3r.3scale.net
+    rules:
+    - apiGroups:
+      - operator.marin3r.3scale.net
+      apiVersions:
+      - v1alpha1
+      operations:
+      - CREATE
+      - UPDATE
+      resources:
+      - envoydeployments
+    sideEffects: None
+    targetPort: 9443
+    type: ValidatingAdmissionWebhook
+    webhookPath: /validate-operator-marin3r-3scale-net-v1alpha1-envoydeployment
+  - admissionReviewVersions:
+    - v1
+    containerPort: 443
+    deploymentName: marin3r-controller-webhook
+    failurePolicy: Fail
+    generateName: sidecar-injector.marin3r.3scale.net
+    matchPolicy: Equivalent
+    objectSelector:
+      matchLabels:
+        marin3r.3scale.net/status: enabled
+    reinvocationPolicy: Never
+    rules:
+    - apiGroups:
+      - ""
+      apiVersions:
+      - v1
+      operations:
+      - CREATE
+      resources:
+      - pods
+    sideEffects: None
+    targetPort: 9443
+    type: MutatingAdmissionWebhook
+    webhookPath: /pod-v1-mutate

--- a/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_discoveryservicecertificates.yaml
@@ -1,0 +1,240 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: discoveryservicecertificates.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryServiceCertificate
+    listKind: DiscoveryServiceCertificateList
+    plural: discoveryservicecertificates
+    singular: discoveryservicecertificate
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: boolean
+    - format: date-time
+      jsonPath: .status.notBefore
+      name: Not Before
+      type: string
+    - format: date-time
+      jsonPath: .status.notAfter
+      name: Not After
+      type: string
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DiscoveryServiceCertificate is an internal resource used to create certificates. This resource
+          is used by the DiscoveryService controller to create the required certificates for the different
+          components. Direct use of DiscoveryServiceCertificate objects is discouraged.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DiscoveryServiceCertificateSpec defines the desired state
+              of DiscoveryServiceCertificate
+            properties:
+              certificateRenewal:
+                description: |-
+                  CertificateRenewalConfig configures the certificate renewal process. If unset default
+                  behavior is to renew the certificate but not notify of renewals.
+                properties:
+                  enabled:
+                    description: Enabled is a flag to enable or disable renewal of
+                      the certificate
+                    type: boolean
+                required:
+                - enabled
+                type: object
+              commonName:
+                description: CommonName is the CommonName of the certificate
+                type: string
+              hosts:
+                description: |-
+                  Hosts is the list of hosts the certificate is valid for. Only
+                  use when 'IsServerCertificate' is true. If unset, the CommonName
+                  field will be used to populate the valid hosts of the certificate.
+                items:
+                  type: string
+                type: array
+              isCA:
+                description: IsCA is a boolean specifying that the certificate is
+                  a CA
+                type: boolean
+              secretRef:
+                description: |-
+                  SecretRef is a reference to the secret that will hold the certificate
+                  and the private key.
+                properties:
+                  name:
+                    description: name is unique within a namespace to reference a
+                      secret resource.
+                    type: string
+                  namespace:
+                    description: namespace defines the space within which the secret
+                      name must be unique.
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              server:
+                description: |-
+                  IsServerCertificate is a boolean specifying if the certificate should be
+                  issued with server auth usage enabled
+                type: boolean
+              signer:
+                description: |-
+                  Signer specifies  the signer to use to create this certificate. Supported
+                  signers are CertManager and SelfSigned.
+                properties:
+                  caSigned:
+                    description: CASigned holds specific configuration for the CASigned
+                      signer
+                    properties:
+                      caSecretRef:
+                        description: A reference to a Secret containing the CA
+                        properties:
+                          name:
+                            description: name is unique within a namespace to reference
+                              a secret resource.
+                            type: string
+                          namespace:
+                            description: namespace defines the space within which
+                              the secret name must be unique.
+                            type: string
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                    - caSecretRef
+                    type: object
+                  selfSigned:
+                    description: SelfSigned holds specific configuration for the SelfSigned
+                      signer
+                    type: object
+                type: object
+              validFor:
+                description: ValidFor specifies the validity of the certificate in
+                  seconds
+                format: int64
+                type: integer
+            required:
+            - commonName
+            - secretRef
+            - signer
+            - validFor
+            type: object
+          status:
+            description: DiscoveryServiceCertificateStatus defines the observed state
+              of DiscoveryServiceCertificate
+            properties:
+              certificateHash:
+                description: |-
+                  CertificateHash stores the current hash of the certificate. It is used
+                  for other controllers to validate if a certificate has been re-issued.
+                type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              notAfter:
+                description: NotAfter is the time at which the certificate expires
+                format: date-time
+                type: string
+              notBefore:
+                description: |-
+                  NotBefore is the time at which the certificate starts
+                  being valid
+                format: date-time
+                type: string
+              ready:
+                description: Ready is a boolean that specifies if the certificate
+                  is ready to be used
+                type: boolean
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_discoveryservices.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_discoveryservices.yaml
@@ -1,0 +1,1199 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: discoveryservices.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: DiscoveryService
+    listKind: DiscoveryServiceList
+    plural: discoveryservices
+    singular: discoveryservice
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          DiscoveryService represents an envoy discovery service server. Only one
+          instance per namespace is currently supported.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: DiscoveryServiceSpec defines the desired state of DiscoveryService
+            properties:
+              affinity:
+                description: Affinity configuration for the discovery service pods
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              debug:
+                description: |-
+                  Debug enables debugging log level for the discovery service controllers. It is safe to
+                  use since secret data is never shown in the logs.
+                type: boolean
+              image:
+                description: Image holds the image to use for the discovery service
+                  Deployment
+                type: string
+              metricsPort:
+                description: MetricsPort is the port where metrics are served. Defaults
+                  to 8383.
+                format: int32
+                type: integer
+              pkiConfg:
+                description: |-
+                  PKIConfig has configuration for the PKI that marin3r manages for the
+                  different certificates it requires
+                properties:
+                  rootCertificateAuthority:
+                    description: |-
+                      CertificateOptions specifies options to generate the server certificate used both
+                      for the xDS server and the mutating webhook server.
+                    properties:
+                      duration:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - duration
+                    - secretName
+                    type: object
+                  serverCertificate:
+                    description: |-
+                      CertificateOptions specifies options to generate the server certificate used both
+                      for the xDS server and the mutating webhook server.
+                    properties:
+                      duration:
+                        type: string
+                      secretName:
+                        type: string
+                    required:
+                    - duration
+                    - secretName
+                    type: object
+                required:
+                - rootCertificateAuthority
+                - serverCertificate
+                type: object
+              podPriorityClass:
+                description: PriorityClass to assign the discovery service Pod to
+                type: string
+              probePort:
+                description: ProbePort is the port where healthz endpoint is served.
+                  Defaults to 8384.
+                format: int32
+                type: integer
+              resources:
+                description: |-
+                  Resources holds the Resource Requirements to use for the discovery service
+                  Deployment. When not set it defaults to no resource requests nor limits.
+                  CPU and Memory resources are supported.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              serviceConfig:
+                description: ServiceConfig configures the way the DiscoveryService
+                  endpoints are exposed
+                properties:
+                  name:
+                    type: string
+                  type:
+                    description: ServiceType is an enum with the available discovery
+                      service Service types
+                    type: string
+                type: object
+              xdsServerPort:
+                description: XdsServerPort is the port where the xDS server listens.
+                  Defaults to 18000.
+                format: int32
+                type: integer
+            type: object
+          status:
+            description: DiscoveryServiceStatus defines the observed state of DiscoveryService
+            properties:
+              deploymentName:
+                type: string
+              deploymentStatus:
+                description: DeploymentStatus is the most recently observed status
+                  of the Deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this deployment.
+                    format: int32
+                    type: integer
+                  collisionCount:
+                    description: |-
+                      Count of hash collisions for the Deployment. The Deployment controller uses this
+                      field as a collision avoidance mechanism when it needs to create the name for the
+                      newest ReplicaSet.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: Represents the latest available observations of a
+                      deployment's current state.
+                    items:
+                      description: DeploymentCondition describes the state of a deployment
+                        at a certain point.
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one
+                            status to another.
+                          format: date-time
+                          type: string
+                        lastUpdateTime:
+                          description: The last time this condition was updated.
+                          format: date-time
+                          type: string
+                        message:
+                          description: A human readable message indicating details
+                            about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of deployment condition.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  observedGeneration:
+                    description: The generation observed by the deployment controller.
+                    format: int64
+                    type: integer
+                  readyReplicas:
+                    description: readyReplicas is the number of pods targeted by this
+                      Deployment with a Ready Condition.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this deployment. This is the total number of
+                      pods that are still required for the deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_envoydeployments.yaml
+++ b/manifests/integreatly-marin3r/0.13.4/operator.marin3r.3scale.net_envoydeployments.yaml
@@ -1,0 +1,1935 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.17.1
+  creationTimestamp: null
+  labels:
+    app.kubernetes.io/managed-by: olm
+  name: envoydeployments.operator.marin3r.3scale.net
+spec:
+  group: operator.marin3r.3scale.net
+  names:
+    kind: EnvoyDeployment
+    listKind: EnvoyDeploymentList
+    plural: envoydeployments
+    singular: envoydeployment
+  scope: Namespaced
+  versions:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          EnvoyDeployment is a resource to deploy and manage a Kubernetes Deployment
+          of Envoy Pods.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: EnvoyDeploymentSpec defines the desired state of EnvoyDeployment
+            properties:
+              adminAccessLogPath:
+                description: Configures envoy's admin access log path. Defaults to
+                  /dev/null.
+                type: string
+              adminPort:
+                description: Configures envoy's admin port. Defaults to 9901.
+                format: int32
+                type: integer
+              affinity:
+                description: Affinity configuration for the envoy pods
+                properties:
+                  nodeAffinity:
+                    description: Describes node affinity scheduling rules for the
+                      pod.
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node matches the corresponding matchExpressions; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: |-
+                            An empty preferred scheduling term matches all objects with implicit weight 0
+                            (i.e. it's a no-op). A null preferred scheduling term matches no objects (i.e. is also a no-op).
+                          properties:
+                            preference:
+                              description: A node selector term, associated with the
+                                corresponding weight.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            weight:
+                              description: Weight associated with matching the corresponding
+                                nodeSelectorTerm, in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - preference
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to an update), the system
+                          may or may not try to eventually evict the pod from its node.
+                        properties:
+                          nodeSelectorTerms:
+                            description: Required. A list of node selector terms.
+                              The terms are ORed.
+                            items:
+                              description: |-
+                                A null or empty node selector term matches no objects. The requirements of
+                                them are ANDed.
+                                The TopologySelectorTerm type implements a subset of the NodeSelectorTerm.
+                              properties:
+                                matchExpressions:
+                                  description: A list of node selector requirements
+                                    by node's labels.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchFields:
+                                  description: A list of node selector requirements
+                                    by node's fields.
+                                  items:
+                                    description: |-
+                                      A node selector requirement is a selector that contains values, a key, and an operator
+                                      that relates the key and values.
+                                    properties:
+                                      key:
+                                        description: The label key that the selector
+                                          applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          Represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists, DoesNotExist. Gt, and Lt.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          An array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. If the operator is Gt or Lt, the values
+                                          array must have a single element, which will be interpreted as an integer.
+                                          This array is replaced during a strategic merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            type: array
+                            x-kubernetes-list-type: atomic
+                        required:
+                        - nodeSelectorTerms
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    type: object
+                  podAffinity:
+                    description: Describes pod affinity scheduling rules (e.g. co-locate
+                      this pod in the same node, zone, etc. as some other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                  podAntiAffinity:
+                    description: Describes pod anti-affinity scheduling rules (e.g.
+                      avoid putting this pod in the same node, zone, etc. as some
+                      other pod(s)).
+                    properties:
+                      preferredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          The scheduler will prefer to schedule pods to nodes that satisfy
+                          the anti-affinity expressions specified by this field, but it may choose
+                          a node that violates one or more of the expressions. The node that is
+                          most preferred is the one with the greatest sum of weights, i.e.
+                          for each node that meets all of the scheduling requirements (resource
+                          request, requiredDuringScheduling anti-affinity expressions, etc.),
+                          compute a sum by iterating through the elements of this field and adding
+                          "weight" to the sum if the node has pods which matches the corresponding podAffinityTerm; the
+                          node(s) with the highest sum are the most preferred.
+                        items:
+                          description: The weights of all of the matched WeightedPodAffinityTerm
+                            fields are added per-node to find the most preferred node(s)
+                          properties:
+                            podAffinityTerm:
+                              description: Required. A pod affinity term, associated
+                                with the corresponding weight.
+                              properties:
+                                labelSelector:
+                                  description: |-
+                                    A label query over a set of resources, in this case pods.
+                                    If it's null, this PodAffinityTerm matches with no Pods.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                matchLabelKeys:
+                                  description: |-
+                                    MatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                    Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                mismatchLabelKeys:
+                                  description: |-
+                                    MismatchLabelKeys is a set of pod label keys to select which pods will
+                                    be taken into consideration. The keys are used to lookup values from the
+                                    incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                    to select the group of existing pods which pods will be taken into consideration
+                                    for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                    pod labels will be ignored. The default value is empty.
+                                    The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                    Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                    This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                namespaceSelector:
+                                  description: |-
+                                    A label query over the set of namespaces that the term applies to.
+                                    The term is applied to the union of the namespaces selected by this field
+                                    and the ones listed in the namespaces field.
+                                    null selector and null or empty namespaces list means "this pod's namespace".
+                                    An empty selector ({}) matches all namespaces.
+                                  properties:
+                                    matchExpressions:
+                                      description: matchExpressions is a list of label
+                                        selector requirements. The requirements are
+                                        ANDed.
+                                      items:
+                                        description: |-
+                                          A label selector requirement is a selector that contains values, a key, and an operator that
+                                          relates the key and values.
+                                        properties:
+                                          key:
+                                            description: key is the label key that
+                                              the selector applies to.
+                                            type: string
+                                          operator:
+                                            description: |-
+                                              operator represents a key's relationship to a set of values.
+                                              Valid operators are In, NotIn, Exists and DoesNotExist.
+                                            type: string
+                                          values:
+                                            description: |-
+                                              values is an array of string values. If the operator is In or NotIn,
+                                              the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                              the values array must be empty. This array is replaced during a strategic
+                                              merge patch.
+                                            items:
+                                              type: string
+                                            type: array
+                                            x-kubernetes-list-type: atomic
+                                        required:
+                                        - key
+                                        - operator
+                                        type: object
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                    matchLabels:
+                                      additionalProperties:
+                                        type: string
+                                      description: |-
+                                        matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                        map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                        operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                      type: object
+                                  type: object
+                                  x-kubernetes-map-type: atomic
+                                namespaces:
+                                  description: |-
+                                    namespaces specifies a static list of namespace names that the term applies to.
+                                    The term is applied to the union of the namespaces listed in this field
+                                    and the ones selected by namespaceSelector.
+                                    null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                topologyKey:
+                                  description: |-
+                                    This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                    the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                    whose value of the label with key topologyKey matches that of any node on which any of the
+                                    selected pods is running.
+                                    Empty topologyKey is not allowed.
+                                  type: string
+                              required:
+                              - topologyKey
+                              type: object
+                            weight:
+                              description: |-
+                                weight associated with matching the corresponding podAffinityTerm,
+                                in the range 1-100.
+                              format: int32
+                              type: integer
+                          required:
+                          - podAffinityTerm
+                          - weight
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                      requiredDuringSchedulingIgnoredDuringExecution:
+                        description: |-
+                          If the anti-affinity requirements specified by this field are not met at
+                          scheduling time, the pod will not be scheduled onto the node.
+                          If the anti-affinity requirements specified by this field cease to be met
+                          at some point during pod execution (e.g. due to a pod label update), the
+                          system may or may not try to eventually evict the pod from its node.
+                          When there are multiple elements, the lists of nodes corresponding to each
+                          podAffinityTerm are intersected, i.e. all terms must be satisfied.
+                        items:
+                          description: |-
+                            Defines a set of pods (namely those matching the labelSelector
+                            relative to the given namespace(s)) that this pod should be
+                            co-located (affinity) or not co-located (anti-affinity) with,
+                            where co-located is defined as running on a node whose value of
+                            the label with key <topologyKey> matches that of any node on which
+                            a pod of the set of pods is running
+                          properties:
+                            labelSelector:
+                              description: |-
+                                A label query over a set of resources, in this case pods.
+                                If it's null, this PodAffinityTerm matches with no Pods.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            matchLabelKeys:
+                              description: |-
+                                MatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key in (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both matchLabelKeys and labelSelector.
+                                Also, matchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            mismatchLabelKeys:
+                              description: |-
+                                MismatchLabelKeys is a set of pod label keys to select which pods will
+                                be taken into consideration. The keys are used to lookup values from the
+                                incoming pod labels, those key-value labels are merged with `labelSelector` as `key notin (value)`
+                                to select the group of existing pods which pods will be taken into consideration
+                                for the incoming pod's pod (anti) affinity. Keys that don't exist in the incoming
+                                pod labels will be ignored. The default value is empty.
+                                The same key is forbidden to exist in both mismatchLabelKeys and labelSelector.
+                                Also, mismatchLabelKeys cannot be set when labelSelector isn't set.
+                                This is a beta field and requires enabling MatchLabelKeysInPodAffinity feature gate (enabled by default).
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            namespaceSelector:
+                              description: |-
+                                A label query over the set of namespaces that the term applies to.
+                                The term is applied to the union of the namespaces selected by this field
+                                and the ones listed in the namespaces field.
+                                null selector and null or empty namespaces list means "this pod's namespace".
+                                An empty selector ({}) matches all namespaces.
+                              properties:
+                                matchExpressions:
+                                  description: matchExpressions is a list of label
+                                    selector requirements. The requirements are ANDed.
+                                  items:
+                                    description: |-
+                                      A label selector requirement is a selector that contains values, a key, and an operator that
+                                      relates the key and values.
+                                    properties:
+                                      key:
+                                        description: key is the label key that the
+                                          selector applies to.
+                                        type: string
+                                      operator:
+                                        description: |-
+                                          operator represents a key's relationship to a set of values.
+                                          Valid operators are In, NotIn, Exists and DoesNotExist.
+                                        type: string
+                                      values:
+                                        description: |-
+                                          values is an array of string values. If the operator is In or NotIn,
+                                          the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                          the values array must be empty. This array is replaced during a strategic
+                                          merge patch.
+                                        items:
+                                          type: string
+                                        type: array
+                                        x-kubernetes-list-type: atomic
+                                    required:
+                                    - key
+                                    - operator
+                                    type: object
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                                matchLabels:
+                                  additionalProperties:
+                                    type: string
+                                  description: |-
+                                    matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                    map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                    operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                  type: object
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            namespaces:
+                              description: |-
+                                namespaces specifies a static list of namespace names that the term applies to.
+                                The term is applied to the union of the namespaces listed in this field
+                                and the ones selected by namespaceSelector.
+                                null or empty namespaces list and null namespaceSelector means "this pod's namespace".
+                              items:
+                                type: string
+                              type: array
+                              x-kubernetes-list-type: atomic
+                            topologyKey:
+                              description: |-
+                                This pod should be co-located (affinity) or not co-located (anti-affinity) with the pods matching
+                                the labelSelector in the specified namespaces, where co-located is defined as running on a node
+                                whose value of the label with key topologyKey matches that of any node on which any of the
+                                selected pods is running.
+                                Empty topologyKey is not allowed.
+                              type: string
+                          required:
+                          - topologyKey
+                          type: object
+                        type: array
+                        x-kubernetes-list-type: atomic
+                    type: object
+                type: object
+              clusterID:
+                description: |-
+                  Defines the local service cluster name where Envoy is running. Defaults
+                  to the NodeID in the EnvoyConfig if unset
+                type: string
+              discoveryServiceRef:
+                description: |-
+                  DiscoveryServiceRef points to a DiscoveryService in the same
+                  namespace
+                type: string
+              duration:
+                description: |-
+                  Defines the duration of the client certificate that is used to authenticate
+                  with the DiscoveryService
+                type: string
+              envoyConfigRef:
+                description: |-
+                  EnvoyConfigRef points to an EnvoyConfig in the same namespace
+                  that holds the envoy resources for this Deployment
+                type: string
+              extraArgs:
+                description: Allows the user to define extra command line arguments
+                  for the Envoy process
+                items:
+                  type: string
+                type: array
+              image:
+                description: Image is the envoy image and tag to use
+                type: string
+              initManager:
+                description: |-
+                  InitManager defines configuration for Envoy's init
+                  manager, which handles initialization for Envoy pods
+                properties:
+                  image:
+                    description: Image is the init manager image and tag to use
+                    type: string
+                type: object
+              livenessProbe:
+                description: Liveness probe for the envoy pods
+                properties:
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded
+                    format: int32
+                    type: integer
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started
+                      before liveness probes are initiated
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - initialDelaySeconds
+                - periodSeconds
+                - successThreshold
+                - timeoutSeconds
+                type: object
+              podDisruptionBudget:
+                description: Configures PodDisruptionBudget for the envoy Pods
+                properties:
+                  maxUnavailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      An eviction is allowed if at most "maxUnavailable" pods selected by
+                      "selector" are unavailable after the eviction, i.e. even in absence of
+                      the evicted pod. For example, one can prevent all voluntary evictions
+                      by specifying 0. This is a mutually exclusive setting with "minAvailable".
+                    x-kubernetes-int-or-string: true
+                  minAvailable:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    description: |-
+                      An eviction is allowed if at least "minAvailable" pods selected by
+                      "selector" will still be available after the eviction, i.e. even in the
+                      absence of the evicted pod.  So for example you can prevent all voluntary
+                      evictions by specifying "100%".
+                    x-kubernetes-int-or-string: true
+                type: object
+              ports:
+                description: Ports exposed by the Envoy container
+                items:
+                  description: ContainerPort defines port for the Marin3r sidecar
+                    container
+                  properties:
+                    name:
+                      description: Port name
+                      type: string
+                    port:
+                      description: Port value
+                      format: int32
+                      type: integer
+                    protocol:
+                      description: Protocol. Defaults to TCP.
+                      type: string
+                  required:
+                  - name
+                  - port
+                  type: object
+                type: array
+              readinessProbe:
+                description: Readiness probe for the envoy pods
+                properties:
+                  failureThreshold:
+                    description: Minimum consecutive failures for the probe to be
+                      considered failed after having succeeded
+                    format: int32
+                    type: integer
+                  initialDelaySeconds:
+                    description: Number of seconds after the container has started
+                      before liveness probes are initiated
+                    format: int32
+                    type: integer
+                  periodSeconds:
+                    description: How often (in seconds) to perform the probe
+                    format: int32
+                    type: integer
+                  successThreshold:
+                    description: Minimum consecutive successes for the probe to be
+                      considered successful after having failed
+                    format: int32
+                    type: integer
+                  timeoutSeconds:
+                    description: Number of seconds after which the probe times out
+                    format: int32
+                    type: integer
+                required:
+                - failureThreshold
+                - initialDelaySeconds
+                - periodSeconds
+                - successThreshold
+                - timeoutSeconds
+                type: object
+              replicas:
+                description: |-
+                  Replicas configures the number of replicas in the Deployment. One of
+                  'static', 'dynamic' can be set. If both are set, static has precedence.
+                properties:
+                  dynamic:
+                    description: Configure a min and max value for the number of pods
+                      to autoscale dynamically.
+                    properties:
+                      behavior:
+                        description: |-
+                          behavior configures the scaling behavior of the target
+                          in both Up and Down directions (scaleUp and scaleDown fields respectively).
+                          If not set, the default HPAScalingRules for scale up and scale down are used.
+                        properties:
+                          scaleDown:
+                            description: |-
+                              scaleDown is scaling policy for scaling Down.
+                              If not set, the default value is to allow to scale down to minReplicas pods, with a
+                              300 second stabilization window (i.e., the highest recommendation for
+                              the last 300sec is used).
+                            properties:
+                              policies:
+                                description: |-
+                                  policies is a list of potential scaling polices which can be used during scaling.
+                                  At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: |-
+                                        periodSeconds specifies the window of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value contains the amount of change which is permitted by the policy.
+                                        It must be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: |-
+                                  selectPolicy is used to specify which policy should be used.
+                                  If not set, the default value Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: |-
+                                  stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                  considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                  If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                format: int32
+                                type: integer
+                            type: object
+                          scaleUp:
+                            description: |-
+                              scaleUp is scaling policy for scaling Up.
+                              If not set, the default value is the higher of:
+                                * increase no more than 4 pods per 60 seconds
+                                * double the number of pods per 60 seconds
+                              No stabilization is used.
+                            properties:
+                              policies:
+                                description: |-
+                                  policies is a list of potential scaling polices which can be used during scaling.
+                                  At least one policy must be specified, otherwise the HPAScalingRules will be discarded as invalid
+                                items:
+                                  description: HPAScalingPolicy is a single policy
+                                    which must hold true for a specified past interval.
+                                  properties:
+                                    periodSeconds:
+                                      description: |-
+                                        periodSeconds specifies the window of time for which the policy should hold true.
+                                        PeriodSeconds must be greater than zero and less than or equal to 1800 (30 min).
+                                      format: int32
+                                      type: integer
+                                    type:
+                                      description: type is used to specify the scaling
+                                        policy.
+                                      type: string
+                                    value:
+                                      description: |-
+                                        value contains the amount of change which is permitted by the policy.
+                                        It must be greater than zero
+                                      format: int32
+                                      type: integer
+                                  required:
+                                  - periodSeconds
+                                  - type
+                                  - value
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              selectPolicy:
+                                description: |-
+                                  selectPolicy is used to specify which policy should be used.
+                                  If not set, the default value Max is used.
+                                type: string
+                              stabilizationWindowSeconds:
+                                description: |-
+                                  stabilizationWindowSeconds is the number of seconds for which past recommendations should be
+                                  considered while scaling up or scaling down.
+                                  StabilizationWindowSeconds must be greater than or equal to zero and less than or equal to 3600 (one hour).
+                                  If not set, use the default values:
+                                  - For scale up: 0 (i.e. no stabilization is done).
+                                  - For scale down: 300 (i.e. the stabilization window is 300 seconds long).
+                                format: int32
+                                type: integer
+                            type: object
+                        type: object
+                      maxReplicas:
+                        description: |-
+                          maxReplicas is the upper limit for the number of replicas to which the autoscaler can scale up.
+                          It cannot be less that minReplicas.
+                        format: int32
+                        type: integer
+                      metrics:
+                        description: |-
+                          metrics contains the specifications for which to use to calculate the
+                          desired replica count (the maximum replica count across all metrics will
+                          be used).  The desired replica count is calculated multiplying the
+                          ratio between the target value and the current value by the current
+                          number of pods.  Ergo, metrics used must decrease as the pod count is
+                          increased, and vice-versa.  See the individual metric source types for
+                          more information about how each type of metric must respond.
+                          If not set, the default metric will be set to 80% average CPU utilization.
+                        items:
+                          description: |-
+                            MetricSpec specifies how to scale based on a single metric
+                            (only `type` and one other matching field should be set at once).
+                          properties:
+                            containerResource:
+                              description: |-
+                                containerResource refers to a resource metric (such as those specified in
+                                requests and limits) known to Kubernetes describing a single container in
+                                each pod of the current scale target (e.g. CPU or memory). Such metrics are
+                                built in to Kubernetes, and have special scaling options on top of those
+                                available to normal per-pod metrics using the "pods" source.
+                              properties:
+                                container:
+                                  description: container is the name of the container
+                                    in the pods of the scaling target
+                                  type: string
+                                name:
+                                  description: name is the name of the resource in
+                                    question.
+                                  type: string
+                                target:
+                                  description: target specifies the target value for
+                                    the given metric
+                                  properties:
+                                    averageUtilization:
+                                      description: |-
+                                        averageUtilization is the target value of the average of the
+                                        resource metric across all relevant pods, represented as a percentage of
+                                        the requested value of the resource for the pods.
+                                        Currently only valid for Resource metric source type
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        averageValue is the target value of the average of the
+                                        metric across all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: type represents whether the metric
+                                        type is Utilization, Value, or AverageValue
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: value is the target value of the
+                                        metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - container
+                              - name
+                              - target
+                              type: object
+                            external:
+                              description: |-
+                                external refers to a global metric that is not associated
+                                with any Kubernetes object. It allows autoscaling based on information
+                                coming from components running outside of cluster
+                                (for example length of queue in cloud messaging service, or
+                                QPS from loadbalancer running outside of cluster).
+                              properties:
+                                metric:
+                                  description: metric identifies the target metric
+                                    by name and selector
+                                  properties:
+                                    name:
+                                      description: name is the name of the given metric
+                                      type: string
+                                    selector:
+                                      description: |-
+                                        selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                        When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                        When unset, just the metricName will be used to gather metrics.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  description: target specifies the target value for
+                                    the given metric
+                                  properties:
+                                    averageUtilization:
+                                      description: |-
+                                        averageUtilization is the target value of the average of the
+                                        resource metric across all relevant pods, represented as a percentage of
+                                        the requested value of the resource for the pods.
+                                        Currently only valid for Resource metric source type
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        averageValue is the target value of the average of the
+                                        metric across all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: type represents whether the metric
+                                        type is Utilization, Value, or AverageValue
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: value is the target value of the
+                                        metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            object:
+                              description: |-
+                                object refers to a metric describing a single kubernetes object
+                                (for example, hits-per-second on an Ingress object).
+                              properties:
+                                describedObject:
+                                  description: describedObject specifies the descriptions
+                                    of a object,such as kind,name apiVersion
+                                  properties:
+                                    apiVersion:
+                                      description: apiVersion is the API version of
+                                        the referent
+                                      type: string
+                                    kind:
+                                      description: 'kind is the kind of the referent;
+                                        More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                                      type: string
+                                    name:
+                                      description: 'name is the name of the referent;
+                                        More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                                      type: string
+                                  required:
+                                  - kind
+                                  - name
+                                  type: object
+                                metric:
+                                  description: metric identifies the target metric
+                                    by name and selector
+                                  properties:
+                                    name:
+                                      description: name is the name of the given metric
+                                      type: string
+                                    selector:
+                                      description: |-
+                                        selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                        When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                        When unset, just the metricName will be used to gather metrics.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  description: target specifies the target value for
+                                    the given metric
+                                  properties:
+                                    averageUtilization:
+                                      description: |-
+                                        averageUtilization is the target value of the average of the
+                                        resource metric across all relevant pods, represented as a percentage of
+                                        the requested value of the resource for the pods.
+                                        Currently only valid for Resource metric source type
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        averageValue is the target value of the average of the
+                                        metric across all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: type represents whether the metric
+                                        type is Utilization, Value, or AverageValue
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: value is the target value of the
+                                        metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - describedObject
+                              - metric
+                              - target
+                              type: object
+                            pods:
+                              description: |-
+                                pods refers to a metric describing each pod in the current scale target
+                                (for example, transactions-processed-per-second).  The values will be
+                                averaged together before being compared to the target value.
+                              properties:
+                                metric:
+                                  description: metric identifies the target metric
+                                    by name and selector
+                                  properties:
+                                    name:
+                                      description: name is the name of the given metric
+                                      type: string
+                                    selector:
+                                      description: |-
+                                        selector is the string-encoded form of a standard kubernetes label selector for the given metric
+                                        When set, it is passed as an additional parameter to the metrics server for more specific metrics scoping.
+                                        When unset, just the metricName will be used to gather metrics.
+                                      properties:
+                                        matchExpressions:
+                                          description: matchExpressions is a list
+                                            of label selector requirements. The requirements
+                                            are ANDed.
+                                          items:
+                                            description: |-
+                                              A label selector requirement is a selector that contains values, a key, and an operator that
+                                              relates the key and values.
+                                            properties:
+                                              key:
+                                                description: key is the label key
+                                                  that the selector applies to.
+                                                type: string
+                                              operator:
+                                                description: |-
+                                                  operator represents a key's relationship to a set of values.
+                                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                                type: string
+                                              values:
+                                                description: |-
+                                                  values is an array of string values. If the operator is In or NotIn,
+                                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                                  the values array must be empty. This array is replaced during a strategic
+                                                  merge patch.
+                                                items:
+                                                  type: string
+                                                type: array
+                                                x-kubernetes-list-type: atomic
+                                            required:
+                                            - key
+                                            - operator
+                                            type: object
+                                          type: array
+                                          x-kubernetes-list-type: atomic
+                                        matchLabels:
+                                          additionalProperties:
+                                            type: string
+                                          description: |-
+                                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                          type: object
+                                      type: object
+                                      x-kubernetes-map-type: atomic
+                                  required:
+                                  - name
+                                  type: object
+                                target:
+                                  description: target specifies the target value for
+                                    the given metric
+                                  properties:
+                                    averageUtilization:
+                                      description: |-
+                                        averageUtilization is the target value of the average of the
+                                        resource metric across all relevant pods, represented as a percentage of
+                                        the requested value of the resource for the pods.
+                                        Currently only valid for Resource metric source type
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        averageValue is the target value of the average of the
+                                        metric across all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: type represents whether the metric
+                                        type is Utilization, Value, or AverageValue
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: value is the target value of the
+                                        metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - metric
+                              - target
+                              type: object
+                            resource:
+                              description: |-
+                                resource refers to a resource metric (such as those specified in
+                                requests and limits) known to Kubernetes describing each pod in the
+                                current scale target (e.g. CPU or memory). Such metrics are built in to
+                                Kubernetes, and have special scaling options on top of those available
+                                to normal per-pod metrics using the "pods" source.
+                              properties:
+                                name:
+                                  description: name is the name of the resource in
+                                    question.
+                                  type: string
+                                target:
+                                  description: target specifies the target value for
+                                    the given metric
+                                  properties:
+                                    averageUtilization:
+                                      description: |-
+                                        averageUtilization is the target value of the average of the
+                                        resource metric across all relevant pods, represented as a percentage of
+                                        the requested value of the resource for the pods.
+                                        Currently only valid for Resource metric source type
+                                      format: int32
+                                      type: integer
+                                    averageValue:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: |-
+                                        averageValue is the target value of the average of the
+                                        metric across all relevant pods (as a quantity)
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                    type:
+                                      description: type represents whether the metric
+                                        type is Utilization, Value, or AverageValue
+                                      type: string
+                                    value:
+                                      anyOf:
+                                      - type: integer
+                                      - type: string
+                                      description: value is the target value of the
+                                        metric (as a quantity).
+                                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                      x-kubernetes-int-or-string: true
+                                  required:
+                                  - type
+                                  type: object
+                              required:
+                              - name
+                              - target
+                              type: object
+                            type:
+                              description: |-
+                                type is the type of metric source.  It should be one of "ContainerResource", "External",
+                                "Object", "Pods" or "Resource", each mapping to a matching field in the object.
+                              type: string
+                          required:
+                          - type
+                          type: object
+                        type: array
+                      minReplicas:
+                        description: |-
+                          minReplicas is the lower limit for the number of replicas to which the autoscaler
+                          can scale down.  It defaults to 1 pod.  minReplicas is allowed to be 0 if the
+                          alpha feature gate HPAScaleToZero is enabled and at least one Object or External
+                          metric is configured.  Scaling is active as long as at least one metric value is
+                          available.
+                        format: int32
+                        type: integer
+                    required:
+                    - maxReplicas
+                    type: object
+                  static:
+                    description: Configure a static number of replicas. Defaults to
+                      1.
+                    format: int32
+                    type: integer
+                type: object
+              resources:
+                description: |-
+                  Resources holds the resource requirements to use for the Envoy
+                  Deployment. Defaults to no resource requests nor limits.
+                properties:
+                  claims:
+                    description: |-
+                      Claims lists the names of resources, defined in spec.resourceClaims,
+                      that are used by this container.
+
+                      This is an alpha field and requires enabling the
+                      DynamicResourceAllocation feature gate.
+
+                      This field is immutable. It can only be set for containers.
+                    items:
+                      description: ResourceClaim references one entry in PodSpec.ResourceClaims.
+                      properties:
+                        name:
+                          description: |-
+                            Name must match the name of one entry in pod.spec.resourceClaims of
+                            the Pod where this field is used. It makes that resource available
+                            inside a container.
+                          type: string
+                        request:
+                          description: |-
+                            Request is the name chosen for a request in the referenced claim.
+                            If empty, everything from the claim is made available, otherwise
+                            only the result of this request.
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - name
+                    x-kubernetes-list-type: map
+                  limits:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Limits describes the maximum amount of compute resources allowed.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                  requests:
+                    additionalProperties:
+                      anyOf:
+                      - type: integer
+                      - type: string
+                      pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                      x-kubernetes-int-or-string: true
+                    description: |-
+                      Requests describes the minimum amount of compute resources required.
+                      If Requests is omitted for a container, it defaults to Limits if that is explicitly specified,
+                      otherwise to an implementation-defined value. Requests cannot exceed Limits.
+                      More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+                    type: object
+                type: object
+              shutdownManager:
+                description: |-
+                  ShutdownManager defines configuration for Envoy's shutdown
+                  manager, which handles graceful termination of Envoy pods
+                properties:
+                  drainStrategy:
+                    description: |-
+                      The drain strategy for the graceful shutdown. It also affects
+                      drain when listeners are modified or removed via LDS.
+                    enum:
+                    - gradual
+                    - immediate
+                    type: string
+                  drainTime:
+                    description: |-
+                      The time in seconds that Envoy will drain connections during shutdown.
+                      It also affects drain behaviour when listeners are modified or removed via LDS.
+                    format: int64
+                    type: integer
+                  image:
+                    description: Image is the shutdown manager image and tag to use
+                    type: string
+                  serverPort:
+                    description: Configures the sutdown manager's server port. Defaults
+                      to 8090.
+                    format: int32
+                    type: integer
+                type: object
+            required:
+            - discoveryServiceRef
+            - envoyConfigRef
+            type: object
+          status:
+            description: EnvoyDeploymentStatus defines the observed state of EnvoyDeployment
+            properties:
+              deploymentName:
+                type: string
+              deploymentStatus:
+                description: DeploymentStatus is the most recently observed status
+                  of the Deployment.
+                properties:
+                  availableReplicas:
+                    description: Total number of available pods (ready for at least
+                      minReadySeconds) targeted by this deployment.
+                    format: int32
+                    type: integer
+                  collisionCount:
+                    description: |-
+                      Count of hash collisions for the Deployment. The Deployment controller uses this
+                      field as a collision avoidance mechanism when it needs to create the name for the
+                      newest ReplicaSet.
+                    format: int32
+                    type: integer
+                  conditions:
+                    description: Represents the latest available observations of a
+                      deployment's current state.
+                    items:
+                      description: DeploymentCondition describes the state of a deployment
+                        at a certain point.
+                      properties:
+                        lastTransitionTime:
+                          description: Last time the condition transitioned from one
+                            status to another.
+                          format: date-time
+                          type: string
+                        lastUpdateTime:
+                          description: The last time this condition was updated.
+                          format: date-time
+                          type: string
+                        message:
+                          description: A human readable message indicating details
+                            about the transition.
+                          type: string
+                        reason:
+                          description: The reason for the condition's last transition.
+                          type: string
+                        status:
+                          description: Status of the condition, one of True, False,
+                            Unknown.
+                          type: string
+                        type:
+                          description: Type of deployment condition.
+                          type: string
+                      required:
+                      - status
+                      - type
+                      type: object
+                    type: array
+                    x-kubernetes-list-map-keys:
+                    - type
+                    x-kubernetes-list-type: map
+                  observedGeneration:
+                    description: The generation observed by the deployment controller.
+                    format: int64
+                    type: integer
+                  readyReplicas:
+                    description: readyReplicas is the number of pods targeted by this
+                      Deployment with a Ready Condition.
+                    format: int32
+                    type: integer
+                  replicas:
+                    description: Total number of non-terminated pods targeted by this
+                      deployment (their labels match the selector).
+                    format: int32
+                    type: integer
+                  unavailableReplicas:
+                    description: |-
+                      Total number of unavailable pods targeted by this deployment. This is the total number of
+                      pods that are still required for the deployment to have 100% available capacity. They may
+                      either be pods that are running but not yet available or pods that still have not been created.
+                    format: int32
+                    type: integer
+                  updatedReplicas:
+                    description: Total number of non-terminated pods targeted by this
+                      deployment that have the desired template spec.
+                    format: int32
+                    type: integer
+                type: object
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+status:
+  acceptedNames:
+    kind: ""
+    plural: ""
+  conditions: null
+  storedVersions: null

--- a/manifests/integreatly-marin3r/marin3r.package.yaml
+++ b/manifests/integreatly-marin3r/marin3r.package.yaml
@@ -1,5 +1,5 @@
 channels:
-  - currentCSV: marin3r.v0.13.3
+  - currentCSV: marin3r.v0.13.4
     name: rhmi
 defaultChannel: rhmi
 packageName: rhmi-marin3r

--- a/products/installation-cpaas.yaml
+++ b/products/installation-cpaas.yaml
@@ -70,7 +70,7 @@ products:
     channel: stable
     installFrom: index
     package: marin3r
-    index: quay.io/integreatly/marin3r-index:v0.13.3
+    index: quay.io/integreatly/marin3r-index:v0.13.4
   rhsso:
     channel: stable
     installFrom: index

--- a/products/installation.yaml
+++ b/products/installation.yaml
@@ -70,7 +70,7 @@ products:
         channel: stable
         installFrom: index
         package: marin3r
-        index: quay.io/integreatly/marin3r-index:v0.13.3
+        index: quay.io/integreatly/marin3r-index:v0.13.4
     rhsso:
         channel: stable
         installFrom: index

--- a/products/products.yaml
+++ b/products/products.yaml
@@ -19,7 +19,7 @@ products:
     manifestsDir: "integreatly-cloud-resources"
     quayScan: true
   - name: marin3r
-    version: v0.13.3
+    version: v0.13.4
     url: "https://github.com/3scale-sre/marin3r"
     installType: "rhoam"
     manifestsDir: "integreatly-marin3r"


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6907

# What
<!-- describe a summary of the change, add any additional motivation and context as needed -->

# Verification steps
## RHOAM Installation
- status

<details>

```
Install:
   },
    "status": {
        "lastError": "",
        "preflightMessage": "preflight checks passed",
        "preflightStatus": "successful",
        "quota": "100K",
        "stage": "complete",
        "stages": {
            "bootstrap": {
                "name": "bootstrap",
                "phase": "completed"
            },
            "installation": {
                "name": "installation",
                "phase": "completed",
                "products": {
                    "3scale": {
                        "host": "https://3scale-admin.<cluster-domain>",
                        "name": "3scale",
                        "operator": "0.12.5",
                        "status": "completed",
                        "version": "2.15.5"
                    },
                    "cloud-resources": {
                        "host": "",
                        "name": "cloud-resources",
                        "operator": "1.1.6",
                        "status": "completed",
                        "version": "1.1.6"
                    },
                    "grafana": {
                        "host": "https://grafana-route-redhat-rhoam-customer-monitoring.<cluster-domain>",
                        "name": "grafana",
                        "status": "completed",
                        "version": "9.6.0"
                    },
                    "marin3r": {
                        "host": "",
                        "name": "marin3r",
                        "operator": "0.13.4",
                        "status": "completed",
                        "version": "0.13.4"
                    },
                    "rhsso": {
                        "host": "https://keycloak-edge-redhat-rhoam-rhsso.<cluster-domain>",
                        "name": "rhsso",
                        "operator": "7.6.11-7",
                        "status": "completed",
                        "version": "7.6"
                    },
                    "rhssouser": {
                        "host": "https://keycloak-redhat-rhoam-user-sso.<cluster-domain>",
                        "name": "rhssouser",
                        "operator": "7.6.11-7",
                        "status": "completed",
                        "version": "7.6"
                    }
                }
            }
        },
        "version": "1.44.0"
    }

```

</details>

- CSV

<img width="1901" height="191" alt="image" src="https://github.com/user-attachments/assets/30b10277-84b9-4a2a-a1c0-a61e9504ab54" />

- Try following commands:
```
oc get pods -n redhat-rhoam-marin3r-operator
oc get pods -n redhat-rhoam-marin3r
oc get envoyconfigrevision -n redhat-rhoam-3scale
oc get envoyconfig -n redhat-rhoam-3scale
oc get discoveryservice -n  redhat-rhoam-3scale
```


## RHOAM Upgrade
The upgrade of Mariner from 0.13.3 to 0.13.4 in RHOAM could likely be done later, together with other component upgrades.