### PR TITLE
MGDAPI-6907 update marin3r-operator/bundles.yaml to v0.13.4

### DIFF
--- a/bundles/marin3r-operator/bundles.yaml
+++ b/bundles/marin3r-operator/bundles.yaml
@@ -1,3 +1,3 @@
 bundles:
-    - name: marin3r-operator.v0.13.3
-      image: quay.io/integreatly/marin3r-operator:v0.13.3-bundle
+    - name: marin3r-operator.v0.13.4
+      image: quay.io/integreatly/marin3r-operator:v0.13.4-bundle


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6907

# What
update marin3r-operator/bundles.yaml to v0.13.4

# Verification steps
prow checks are optional since this is just a yaml update that’s not being tested by e2e. It's a preparation for build-product-index Jenkins PL