### PR TITLE
MGDAPI-6910 prepare to build rhsso-index for RHOAM 1.44

### DIFF
--- a/bundles/rhsso-operator/bundles.yaml
+++ b/bundles/rhsso-operator/bundles.yaml
@@ -81,3 +81,13 @@ bundles:
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-6
     - name: rhsso-operator.v7.6.11-7
       image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.11-7
+    - name: rhsso-operator.v7.6.12-3
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.12-3
+    - name: rhsso-operator.v7.6.12-4
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.12-4
+    - name: rhsso-operator.v7.6.12-6
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.12-6
+    - name: rhsso-operator.v7.6.12-8
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.12-8
+    - name: rhsso-operator.v7.6.12-9
+      image: registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle:7.6.12-9


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6910

# What
prepare to build rhsso-index for RHOAM 1.44

# Verification steps

```
 docker images
REPOSITORY                                              TAG         IMAGE ID      CREATED       SIZE
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.12-9    2470b585d370  6 weeks ago   283 kB
<none>                                                  <none>      4da591ef851e  2 months ago  137 MB
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.12-8    ca27cf9f89b4  3 months ago  276 kB
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.12-6    07b4f1a5bf93  4 months ago  276 kB
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.12-4    71727bdc907f  4 months ago  276 kB
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.12-3    b8c73f104a42  6 months ago  276 kB
registry.redhat.io/rh-sso-7/sso7-rhel8-operator-bundle  7.6.11-7    12c2ad459f9d  9 months ago  221 kB
~/go/integreatly-operator 

```
