### PR TITLE
MGDAPI-6913 use 3scale 2.16.2 in RHOAM 1.44 - bundles updates

### DIFF
--- a/bundles/3scale-operator/bundles.yaml
+++ b/bundles/3scale-operator/bundles.yaml
@@ -11,3 +11,5 @@ bundles:
       image: registry.redhat.io/3scale-amp2/3scale-operator-bundle:2.15.4
     - name: 3scale-operator.v0.12.5
       image: registry.redhat.io/3scale-amp2/3scale-operator-bundle:2.15.5
+    - name: 3scale-operator.v0.13.0
+      image: registry.redhat.io/3scale-amp2/3scale-operator-bundle:2.16.0


### PR DESCRIPTION
# Issue link
https://issues.redhat.com/browse/MGDAPI-6913

# What
use latest 3scale version 2.16.2 in RHOAM 1.44  - bundles updates

# Verification steps
E2E
