### PR TITLE
MGDAPI-6902 bump operator-sdk from 1.39 to 1.42

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,9 +59,11 @@ else
 	OPENAPI_GEN ?= go run k8s.io/kube-openapi/cmd/openapi-gen
 endif
 
+# operator-sdk version (keep in sync with openshift-ci/Dockerfile.tools and scripts/prepare-release.sh)
+OPERATOR_SDK_VERSION ?= v1.42.0
 # If the _correct_ version of operator-sdk is on the path, use that (faster);
 # otherwise use it through "go run" (slower but will always work and will use correct version)
-ifeq ($(shell operator-sdk version 2> /dev/null | sed -e 's/", .*/"/' -e 's/.* //'), "v$(OPERATOR_SDK_VERSION)")
+ifeq ($(shell operator-sdk version 2> /dev/null | sed -e 's/", .*/"/' -e 's/.* //'), "$(OPERATOR_SDK_VERSION)")
 	OPERATOR_SDK ?= operator-sdk
 else
 	OPERATOR_SDK ?= go run github.com/operator-framework/operator-sdk/cmd/operator-sdk

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The operator installs the following products:
 
 ## Prerequisites
 
-- [operator-sdk](https://github.com/operator-framework/operator-sdk) version v1.39.0.
+- [operator-sdk](https://github.com/operator-framework/operator-sdk) version v1.42.0.
 - [go](https://golang.org/dl/) version 1.23+
 - [moq](https://github.com/matryer/moq)
 - [oc](https://docs.okd.io/latest/cli_reference/openshift_cli/getting-started-cli.html) version v4.6+

--- a/bundles/managed-api-service/1.45.0/manifests/integreatly.org_rhmis.yaml
+++ b/bundles/managed-api-service/1.45.0/manifests/integreatly.org_rhmis.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.1
+    controller-gen.kubebuilder.io/version: v0.17.0
   creationTimestamp: null
   name: rhmis.integreatly.org
 spec:
@@ -14,214 +14,206 @@ spec:
     singular: rhmi
   scope: Namespaced
   versions:
-    - name: v1alpha1
-      schema:
-        openAPIV3Schema:
-          description: RHMI is the Schema for the rhmis API
-          properties:
-            apiVersion:
-              description: |-
-                APIVersion defines the versioned schema of this representation of an object.
-                Servers should convert recognized schemas to the latest internal value, and
-                may reject unrecognized values.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
-              type: string
-            kind:
-              description: |-
-                Kind is a string value representing the REST resource this object represents.
-                Servers may infer this from the endpoint the client submits requests to.
-                Cannot be updated.
-                In CamelCase.
-                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
-              type: string
-            metadata:
-              type: object
-            spec:
-              description: RHMISpec defines the desired state of RHMI
-              properties:
-                APIServer:
-                  type: string
-                alertFromAddress:
-                  type: string
-                alertingEmailAddress:
-                  type: string
-                alertingEmailAddresses:
-                  properties:
-                    businessUnit:
-                      type: string
-                    cssre:
-                      type: string
-                  required:
-                    - businessUnit
-                    - cssre
-                  type: object
-                deadMansSnitchSecret:
-                  description: |-
-                    DeadMansSnitchSecret is the name of a secret in the
-                    installation namespace containing connection details
-                    for Dead Mans Snitch. The secret must contain the
-                    following fields:
+  - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: RHMI is the Schema for the rhmis API
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Servers may infer this from the endpoint the client submits requests to.
+              Cannot be updated.
+              In CamelCase.
+              More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: RHMISpec defines the desired state of RHMI
+            properties:
+              APIServer:
+                type: string
+              alertFromAddress:
+                type: string
+              alertingEmailAddress:
+                type: string
+              alertingEmailAddresses:
+                properties:
+                  businessUnit:
+                    type: string
+                  cssre:
+                    type: string
+                required:
+                - businessUnit
+                - cssre
+                type: object
+              deadMansSnitchSecret:
+                description: |-
+                  DeadMansSnitchSecret is the name of a secret in the
+                  installation namespace containing connection details
+                  for Dead Mans Snitch. The secret must contain the
+                  following fields:
 
-                    url
-                  type: string
-                masterURL:
-                  type: string
-                namespacePrefix:
-                  type: string
-                operatorsInProductNamespace:
-                  description: |-
-                    OperatorsInProductNamespace is a flag that decides if
-                    the product operators should be installed in the product
-                    namespace (when set to true) or in standalone namespace
-                    (when set to false, default). Standalone namespace will
-                    be used only for those operators that support it.
-                  type: boolean
-                pagerDutySecret:
-                  description: |-
-                    PagerDutySecret is the name of a secret in the
-                    installation namespace containing PagerDuty account
-                    details. The secret must contain the following fields:
+                  url
+                type: string
+              masterURL:
+                type: string
+              namespacePrefix:
+                type: string
+              operatorsInProductNamespace:
+                description: |-
+                  OperatorsInProductNamespace is a flag that decides if
+                  the product operators should be installed in the product
+                  namespace (when set to true) or in standalone namespace
+                  (when set to false, default). Standalone namespace will
+                  be used only for those operators that support it.
+                type: boolean
+              pagerDutySecret:
+                description: |-
+                  PagerDutySecret is the name of a secret in the
+                  installation namespace containing PagerDuty account
+                  details. The secret must contain the following fields:
 
-                    serviceKey
-                  type: string
-                priorityClassName:
-                  type: string
-                pullSecret:
+                  serviceKey
+                type: string
+              priorityClassName:
+                type: string
+              pullSecret:
+                properties:
+                  name:
+                    type: string
+                  namespace:
+                    type: string
+                required:
+                - name
+                - namespace
+                type: object
+              rebalancePods:
+                type: boolean
+              routingSubdomain:
+                type: string
+              selfSignedCerts:
+                type: boolean
+              smtpSecret:
+                description: |-
+                  SMTPSecret is the name of a secret in the installation
+                  namespace containing SMTP connection details. The secret
+                  must contain the following fields:
+
+                  host
+                  port
+                  tls
+                  username
+                  password
+                type: string
+              type:
+                type: string
+              useClusterStorage:
+                type: string
+            required:
+            - namespacePrefix
+            - type
+            type: object
+          status:
+            description: RHMIStatus defines the observed state of RHMI
+            properties:
+              customDomain:
+                properties:
+                  enabled:
+                    type: boolean
+                  error:
+                    type: string
+                required:
+                - enabled
+                type: object
+              customSmtp:
+                properties:
+                  enabled:
+                    type: boolean
+                  error:
+                    type: string
+                required:
+                - enabled
+                type: object
+              gitHubOAuthEnabled:
+                type: boolean
+              lastError:
+                type: string
+              preflightMessage:
+                type: string
+              preflightStatus:
+                type: string
+              quota:
+                type: string
+              smtpEnabled:
+                type: boolean
+              stage:
+                type: string
+              stages:
+                additionalProperties:
                   properties:
                     name:
                       type: string
-                    namespace:
+                    phase:
                       type: string
-                  required:
-                    - name
-                    - namespace
-                  type: object
-                rebalancePods:
-                  type: boolean
-                routingSubdomain:
-                  type: string
-                selfSignedCerts:
-                  type: boolean
-                smtpSecret:
-                  description: |-
-                    SMTPSecret is the name of a secret in the installation
-                    namespace containing SMTP connection details. The secret
-                    must contain the following fields:
-
-                    host
-                    port
-                    tls
-                    username
-                    password
-                  type: string
-                type:
-                  type: string
-                useClusterStorage:
-                  type: string
-              required:
-                - namespacePrefix
-                - type
-              type: object
-            status:
-              description: RHMIStatus defines the observed state of RHMI
-              properties:
-                customDomain:
-                  properties:
-                    enabled:
-                      type: boolean
-                    error:
-                      type: string
-                  required:
-                    - enabled
-                  type: object
-                customSmtp:
-                  properties:
-                    enabled:
-                      type: boolean
-                    error:
-                      type: string
-                  required:
-                    - enabled
-                  type: object
-                gitHubOAuthEnabled:
-                  type: boolean
-                lastError:
-                  type: string
-                preflightMessage:
-                  type: string
-                preflightStatus:
-                  type: string
-                quota:
-                  type: string
-                smtpEnabled:
-                  type: boolean
-                stage:
-                  type: string
-                stages:
-                  additionalProperties:
-                    properties:
-                      name:
-                        type: string
-                      phase:
-                        type: string
-                      products:
-                        additionalProperties:
-                          properties:
-                            host:
-                              type: string
-                            mobile:
-                              type: boolean
-                            name:
-                              type: string
-                            operator:
-                              type: string
-                            status:
-                              type: string
-                            type:
-                              type: string
-                            uninstall:
-                              type: boolean
-                            version:
-                              type: string
-                          required:
-                            - host
-                            - name
-                            - status
-                            - version
-                          type: object
+                    products:
+                      additionalProperties:
+                        properties:
+                          host:
+                            type: string
+                          mobile:
+                            type: boolean
+                          name:
+                            type: string
+                          operator:
+                            type: string
+                          status:
+                            type: string
+                          type:
+                            type: string
+                          uninstall:
+                            type: boolean
+                          version:
+                            type: string
+                        required:
+                        - host
+                        - name
+                        - status
+                        - version
                         type: object
-                    required:
-                      - name
-                      - phase
-                    type: object
-                  description: |-
-                    INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
-                    Important: Run "make" to regenerate code after modifying this file
+                      type: object
+                  required:
+                  - name
+                  - phase
                   type: object
-                toQuota:
-                  type: string
-                toVersion:
-                  type: string
-                version:
-                  type: string
-              required:
-                - lastError
-                - stage
-                - stages
-              type: object
-          type: object
-      served: true
-      storage: true
-      subresources:
-        status: {}
-  validation:
-    openAPIV3Schema:
-      description: RHOAM is the Schema for the RHOAM API
-      properties:
-        spec:
-          description: RHOAMSpec defines the desired state of Installation
-        status:
-          description: RHOAMStatus defines the observed state of Installation
+                description: |-
+                  INSERT ADDITIONAL STATUS FIELD - define observed state of cluster
+                  Important: Run "make" to regenerate code after modifying this file
+                type: object
+              toQuota:
+                type: string
+              toVersion:
+                type: string
+              version:
+                type: string
+            required:
+            - lastError
+            - stage
+            - stages
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/bundles/managed-api-service/1.45.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.45.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -43,814 +43,772 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     certified: "false"
-    containerImage: quay.io/integreatly/managed-api-service:master
-    createdAt: "2026-02-24T15:52:25Z"
+    containerImage: quay.io/integreatly/managed-api-service:rhoam-v1.1.0
+    createdAt: "2026-03-09T10:25:31Z"
     olm.properties: '[{"type": "olm.maxOpenShiftVersion", "value": "4.19"}]'
     operatorframework.io/suggested-namespace: redhat-rhoam-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.39.0
+    operators.operatorframework.io/builder: operator-sdk-v1.42.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
     support: RHOAM
-    containerImages: |-
-      {
-        "3scale-operator.3scale-2.16.1-GA": {
-          "3scale-operator.v0.13.1": "registry.redhat.io/3scale-amp2/3scale-rhel9-operator@sha256:cabde1dd88dc5b38ae2a385603c44276358bc44e14127e529529ff920dc8c8a6",
-          "3scale-rhel9-operator-cabde1dd88dc5b38ae2a385603c44276358bc44e14127e529529ff920dc8c8a6-annotation": "registry.redhat.io/3scale-amp2/3scale-rhel9-operator@sha256:cabde1dd88dc5b38ae2a385603c44276358bc44e14127e529529ff920dc8c8a6",
-          "manager": "registry.redhat.io/3scale-amp2/3scale-rhel9-operator@sha256:cabde1dd88dc5b38ae2a385603c44276358bc44e14127e529529ff920dc8c8a6",
-          "backend": "registry.redhat.io/3scale-amp2/backend-rhel8@sha256:a2019a42e84b3135d0abd5abc9a5b81fc62625520c0a87885bab9e0af70ed0d6",
-          "apicast": "registry.redhat.io/3scale-amp2/apicast-gateway-rhel8@sha256:5555fb6b7e8907a52f54fd93a19105e36fded2407c344d938dbdc0723b03baed",
-          "system": "registry.redhat.io/3scale-amp2/system-rhel9@sha256:3a01cbf4581099bad69c4fea7cf9182b275f5f60f38610de9a6c1f3038f1b949",
-          "zync": "registry.redhat.io/3scale-amp2/zync-rhel9@sha256:8e42d4f2946786cf5579f23967490c57c8edeac981be1b3af34a4564bae7d6b9",
-          "system_memcached": "registry.redhat.io/rhel9/memcached@sha256:8738110ef16c9e35deeb07c0577ffe09d6ef029761b504a8d20253fa715da394",
-          "system_searchd": "registry.redhat.io/3scale-amp2/manticore-rhel9@sha256:aa1320041d549dad6e7c5436e211b31627c089625a0666f7ecc3f89be5b88059"
-        },
-        "cloud-resource-operator.v1.1.7": {
-          "cloud-resources.v1.1.6": "quay.io/integreatly/cloud-resource-operator:v1.1.6"
-        },
-        "marin3r.v0.13.4": {
-          "marin3r.v0.13.4": "quay.io/3scale-sre/marin3r:v0.13.4"
-        },
-        "rhsso-operator.18.0.x": {
-          "rhsso-operator.7.6.12-opr-005": "registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:1d3048c0a324abbd8d47d9dffb42030e9cb4803e263a613451ba1f37424c427b",
-          "sso7-rhel8-operator-1d3048c0a324abbd8d47d9dffb42030e9cb4803e263a613451ba1f37424c427b-annotation": "registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:1d3048c0a324abbd8d47d9dffb42030e9cb4803e263a613451ba1f37424c427b",
-          "rhsso-operator": "registry.redhat.io/rh-sso-7/sso7-rhel8-operator@sha256:1d3048c0a324abbd8d47d9dffb42030e9cb4803e263a613451ba1f37424c427b",
-          "rhsso_openjdk": "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:211703d9aada0596060cbe688d86727e7fe52b70e4ee7149b057d89aa6d13b2e",
-          "rhsso_openj9": "registry.redhat.io/rh-sso-7/sso76-openshift-rhel8@sha256:211703d9aada0596060cbe688d86727e7fe52b70e4ee7149b057d89aa6d13b2e",
-          "keycloak_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:2e63f15a19d60447d9dfd11b0d04ba634932a9c43e63773051069cdc1f5ad504",
-          "rhsso_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:2e63f15a19d60447d9dfd11b0d04ba634932a9c43e63773051069cdc1f5ad504"
-        },
-        "ratelimit": {
-          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.12-1767872298"
-        },
-        "limitador": {
-          "marin3r-limitador": "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:aff28d76f9cfeefafd6b652e055bb25e1a2bf250e062e3e9b5e54db873f9eeb7"
-        },
-        "grafana": {
-          "grafana": "registry.redhat.io/rhel9/grafana:9.7-1767725073"
-        },
-        "grafana-ose-oauth-proxy": {
-          "grafana-ose-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202512111314.p2.g565f7ed.assembly.stream.el9"
-        }
-      }
-    serviceAffecting: "true"
   name: managed-api-service.v1.45.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
   customresourcedefinitions:
     owned:
-      - description: RHOAM is the Schema for the RHOAM API
-        displayName: RHOAM installation
-        kind: RHMI
-        name: rhmis.integreatly.org
-        resources:
-          - kind: Deployment
-            name: rhoam-operator
-            version: v1
-          - kind: Pod
-            name: rhoam
-            version: v1
-        specDescriptors:
-          - description: namespacePrefix
-            displayName: namespacePrefix
-            path: namespacePrefix
-          - description: operatorsInProductNamespace
-            displayName: operatorsInProductNamespace
-            path: operatorsInProductNamespace
-          - description: pagerDutySecret
-            displayName: pagerDutySecret
-            path: pagerDutySecret
-          - description: selfSignedCerts
-            displayName: selfSignedCerts
-            path: selfSignedCerts
-          - description: deadMansSnitchSecret
-            displayName: deadMansSnitchSecret
-            path: deadMansSnitchSecret
-          - description: type
-            displayName: type
-            path: type
-          - description: useClusterStorage
-            displayName: useClusterStorage
-            path: useClusterStorage
-          - description: priorityClassName
-            displayName: priorityClassName
-            path: priorityClassName
-          - description: smtpSecret
-            displayName: smtpSecret
-            path: smtpSecret
-          - description: pagerDutySecret
-            displayName: pagerDutySecret
-            path: pagerDutySecret
-          - description: priorityClassName
-            displayName: priorityClassName
-            path: priorityClassName
-          - description: selfSignedCerts
-            displayName: selfSignedCerts
-            path: selfSignedCerts
-          - description: smtpSecret
-            displayName: smtpSecret
-            path: smtpSecret
-          - description: type
-            displayName: type
-            path: type
-          - description: useClusterStorage
-            displayName: useClusterStorage
-            path: useClusterStorage
-          - description: deadMansSnitchSecret
-            displayName: deadMansSnitchSecret
-            path: deadMansSnitchSecret
-        statusDescriptors:
-          - description: The status of each of the RHMI CR
-            displayName: RHMI CR Status
-            path: status
-        version: v1alpha1
+    - description: RHOAM is the Schema for the RHOAM API
+      displayName: RHOAM installation
+      kind: RHMI
+      name: rhmis.integreatly.org
+      resources:
+      - kind: Deployment
+        name: rhoam-operator
+        version: v1
+      - kind: Pod
+        name: rhoam
+        version: v1
+      specDescriptors:
+      - description: namespacePrefix
+        displayName: namespacePrefix
+        path: namespacePrefix
+      - description: operatorsInProductNamespace
+        displayName: operatorsInProductNamespace
+        path: operatorsInProductNamespace
+      - description: pagerDutySecret
+        displayName: pagerDutySecret
+        path: pagerDutySecret
+      - description: selfSignedCerts
+        displayName: selfSignedCerts
+        path: selfSignedCerts
+      - description: deadMansSnitchSecret
+        displayName: deadMansSnitchSecret
+        path: deadMansSnitchSecret
+      - description: type
+        displayName: type
+        path: type
+      - description: useClusterStorage
+        displayName: useClusterStorage
+        path: useClusterStorage
+      - description: priorityClassName
+        displayName: priorityClassName
+        path: priorityClassName
+      - description: smtpSecret
+        displayName: smtpSecret
+        path: smtpSecret
+      - description: pagerDutySecret
+        displayName: pagerDutySecret
+        path: pagerDutySecret
+      - description: priorityClassName
+        displayName: priorityClassName
+        path: priorityClassName
+      - description: selfSignedCerts
+        displayName: selfSignedCerts
+        path: selfSignedCerts
+      - description: smtpSecret
+        displayName: smtpSecret
+        path: smtpSecret
+      - description: type
+        displayName: type
+        path: type
+      - description: useClusterStorage
+        displayName: useClusterStorage
+        path: useClusterStorage
+      - description: deadMansSnitchSecret
+        displayName: deadMansSnitchSecret
+        path: deadMansSnitchSecret
+      statusDescriptors:
+      - description: The status of each of the RHMI CR
+        displayName: RHMI CR Status
+        path: status
+      version: v1alpha1
   description: RHOAM integration suite of tools
   displayName: RHOAM
   icon:
-    - base64data: iVBORw0KGgoAAAANSUhEUgAAAXMAAAFyCAYAAAAH5jo3AAAACXBIWXMAAG66AABuugHW3rEXAAAeWklEQVR4nO3dzW8cx5nH8acdJdlFEpKHvUrkHyBB4+tKCJmrDVv00YIDU3uykQBhTl44B1GHNVY3Bohhn1YUNpD2ZsqGdDVlSHs1BeluUrobHG6CzebFvXio6mhMc166urr6qervB2gYskROz0z1b2qerpeiLEsBAKTtJd4/AEgfYQ4AGSDMASADhDkAZOAUb2JzRVEsiMhARJbcUf1Z3J8XU35+QACPROTA/Zod999d/X9lWe7wAjfHaJaaiqIYuKAePeaTehKAPfsisueCXkN+tyzLPd6n2RHmUxRFsSIi1UFwA/Hsu2DXgN8py3KX1348wvwYVzJZdccK4Q2Yse+Cfbssy23elm8jzJ8H+JIL7zUROW/glABMd0eD3YX7Qd9fr96G+bEe+CUDpwTAz3Ak1HvbY+9dmLte+IYLcUooQF60FLMlIpt96633JsyLotDwXheRZQOnA6B9N12o9+LGafZhXhTFmuuJM9Yb6Kf7mgG5j2fPNswJcQDHZB3q2YU5IQ5giixDPZswd5N7NqiJA5jRTRfqWcw0TT7MR0anvG3gdACkZehukm6k/r4lHeZFUay7IGeIIYAmdEjjWsqllyTD3C12tcVsTQCBaellPcUx6smtZ14UhfbEvyTIAbRAy7V77h5cUpIJc62NF0WhX4GuGjgdAPnSsu3nRVFsumU/kpBEmcXN3tyiNg4gskeulm5+Fqn5nrl+OorIJwQ5gA5oOXfHzV8xzWzP3H292aE2DsCIm2VZmg11k2HuRqvs0BsHYIyWXVYsjnYxV2ZxX2cIcgAWVWWXgbVzM9Uzd0F+w8CpAMAkQ9dDN3Nj1EzPvCiKLYIcQCLmrd0YNdEzd0HO2ioAUnSlLMutrs+78545QQ4gcTcs9NA7DXOCHEAmOg/0zsKcIAeQmU4DvZMwJ8gBZKqzQI8e5m7VQ4IcQK5udLHqYtTRLIwjB9AT0cehRwtz90n1eZQHA4DuaaAvxZr6H6XM4qa+bsd4LAAwoppYFGVN9NbD3D0R1iIH0Ee6lstmjOcdo2fOXp0A+uxtt/l8q1qtmbuRK2zzBgAiL7d5Q7S1MOeGJwB8y76IDNq6IdpKmWWkTg4AeG6xzVxsq2a+5U4cAPDCpbbq58HLLG4n/U+C/lIAyMfQlVv2Qj6joGHuyit7DEMEgInul2UZdMp/6DIL48kBYLrl0OWWYD1zRq8AQC1Bp/sH6ZkzegUAapsPOTs0VJllndErAFDb26GWy21cZimKYklEdqmVA4CXR2VZDpq+dCF65hsEOQB4Ox9id6JGPXO3tO2XvIcA0Mh+WZZLTX5B0555lKUdASBzi25hQm/ePXOGIgJAUI2GKjbpmTf6FAEAfMu8GxnoxatnTq0cAFrhXTv37Zm3vmsGAPTQou/Ilto9czeu/CtaGQC0wqt37tMzp1cOAO1Z9JkV6tMzP2CSEAC06k5Zlqt1HqBWz9zVcghyAGjXJVfSnlndMkvjKacAgPB5O3OZhRufABBVrRuhdXrm9MoBIJ5FN6dnJoQ5ANg18+jBmcoszPgEgE4My7JcmOWBZ+2Z0ysHgPjmZx1zPmuYB9nWCABQ20zjzaeWWRjFAgCdmmlUyyw981qzkAAAQS3OMoFoljCnxAIA3ZraqSbMAcC+qTk8MczdkETWYgGAbjULc3rlAGDC/LTZoIQ5AKRhYh5PC/OZ1wUAALTKr2deFIVOIV3kvQEAE7zLLPTKAcCO85POZFKYUy8HAEMm3QSdFOa1d4cGALRqbC4T5gCQDq+eOTVzALDFK8yZ+QkAtozdqOLEMK+z7xwAIJraPfOZtikCAEQ1tmIyLsy5+QkABrkJnd9BmANAWk4stcy6BygAwDDCHAAyMC7MmcoPADZRZgGADNS6AQoASAhhDgAZIMwBIAOEOQBkgDAHgAwQ5gCQAcIcADJAmANABghzAMjAKd7E/Jxxx3GPRWTY9xenR2gH/UKYZ+CciLwiIhdF5MKUp3MoIg9E5KGI3BWRp31/8TJCO+i3oizL77wARVHsiMhy318c6y6LyHsicrrBeerFfN1d2KAd0A6ScK0sy43jJ0rNPEF68T4Skd81vIDF9eA+FZHPXI8O6aAdYBRhnpAz7mILcfEeV13MH/TlxUxYrHYwdrNJmESYJ0J7S1/MUAtt6h33OFzINsVsB5+NuYEKmwjzBFx2vaW5SKd61n19P5f0q5afLtrBF7SDZBDmxl12X6djm3M9My5kG2gHmIYwN+xcRxdwRS/kDym5dI52gFkQ5kbNux5R1866Cxnd0Hbwe9oBZkCYG/VhxNroNK+4r/mI78MWRqzQDvJEmBt00V04ljBULT7aAeogzA16z+A5zbnhaoiHdoA6WJvFmFnW1ZimWnfj8ci/C/F73xWRj1mkKQraAeoizI15s8Hp6MX7vls46fiFdt1NAHmnQc9Ke2Wvisgtk69cXmgHqIsyizG+F/ETETnvLrBxPaan7iJfdhe8D2s13FzRDlAXYW7Iq56nohfwazW+9j52/97nQuYibl8q7YAbobZQZjHkrOepvOVRv3zsvnL/m8fjvXusDtsWa5sojNvsITTfD8zY7eAcS+aaQpgb4rP06O0GGwt85Oqmdccx+1z4vm67kkCXoX7ODclre3GrJrpoBxcIc1Mosxji0+v7uOHpN/35tr3pZsJ29ZX+nHt8y0EuHbUDyiy2EOaG1O0ZHQYod6TQszrb0ZT2akkFKzNxx+mqHbD4li2EecJC1K1j1L5DuNDBDjjvJBDk0rN2gPEIcyQj9kga1iFBSgjzhIUYWZHSTjKxv9ZbWeBqmr61A5yMMDfkWc1TOR3gImTz3vR11Q58R8+gHYS5IT4XR5Np3yF+HjZ00Q4Ic1sIc0N8bkK922CIWIhFl2BDF+3gCe+9KYS5IQ89TmXOc9ielR1sEEYX7YAJQ7YQ5ob4XhwXau7ReCaR8dOoJ2Y7eMISuOYQ5oboxXHP83SqmZLTbmTp1/EvGqwDA9titYPbtANzWJvFmNsNxlPrhfmp6zU9cGWboeuBXXCr8TXtjb8e8OX6NODvsuCJW0cmhHMN1sCJ0Q5Yy9wewtyYu26IYpMxzmfdEXp7r9vUSScaBnx9HngufjWqzXZAicUeyiwGXTd4TodGzytnoXr5IdEO7CLMDbrlObKlTR8xrji6u7QD1ECYG/WLBlt6hfaE3lhnaAeYFWFu1FN3IXft0O1gg27QDjArwtww/Zr9yw5P79DtEcnX6m7RDjALwty4Wx1dyNUFzDrXNtAOMA1hnoDYFzIXsE20A0xCmCdCL+Rlj2Vy69LRE+e5gM2iHWAcwjwhemH9tKURBc9cr+81JoSY12Y7OKQdJIswT8zQXcQDt6N602FrGuK/ceHAFO10tNUOztMOksV0/kQ9dTMEr7u1Nl5xiyvNsubGs5EJKXcze10WFhZkMBhM/Xc7OztRzqdttANUCPPEDV1PqupNnRk5Rtf1qJYsfZzR12cN7ZWVlaP/6nH+/Pnav+P+/fuyu7t7dGjA7+3ttXKubetzO8BzhHlmnmY8Hvj7Cwuytroqq6urRyE+P++7t84Ly8vLR0dlf3//KNS3t7dF9EhUzu0AJyvKsvzOXxRFseNumgOt+XrGX3xqZUV+uLYmP3j77ahvRjkcyp+3tuRPm5vyzQw99ofuxiHQsmtlWW4cfwhugMKsH6ytyfzenvzk88+jB7kq5uflh7/6lcx/9ZX8eHv76EMFsIowhzlViP/oxg15aXHRxOl9/9Klow+Vn+zsyPdmuMEKxEaYwwwNSQ1LSyF+3KnlZZn78kv50daWFAsLtk4OvUaYw4R/3Ng4CslTy2ncqtGyj357+P7qqoGzAQhzdEx743O7u/IPV68m91ZoTf3Hn3xyVE+nl46uEebojNbGj2rQHuPDLTmqp+/syBy1dHSIMEcnNjY2jmrjRYCx4hboB9I/7+wcjYEHukCYI7qtrS25mmBZZZpT8/PyySefyNramu0TRZYIc0SlQf52B2PGY7px4waBjuiYzo9oYgT5o0ePjtZX0bVWxtGlAJaWlmSxxeGPGujinjMQA2GOKNoKcg1vXUdF11OpuxKirrCowa6H1rpDhzuBjqh0bZbjh64Qqn/FwRHiWF9fL0M6ODgoNzc3y6WlpaDvz8rKSrm1tRX8XAeDAe2II+SxcWJuE+YcbR4akCGDcWNjo1xYWGj1nPVDImSo63m3fc4cvToIc464hwaYBlkIGq6xA1F71Ds7O0HOX38P7Y8j0EGYc8Q9QgTh3t7eUe++y/dOy0QhPpT0WwVtkCPAQZhzxDtC1Mm3t7fNlCe0l64fLE2FrvNz9PI4MczZnCIQ3Z7rTbf/YpeGbpOEWx1uC6ajRHR4YJOdgG7evGlurLY+Lx0x47M9XUW3qVvpcF102mkWTtycgp55gOM9kfJrY8eeSPlqR69H05uH2qu3+l7rNwX9xtDE2toa7VS6b6cJH/TM2/CBiLxj+Px+HnnndZ2M89VXX3n//LVr147WbbFOJyX59tB1n1F9nWKinWaFbeNCu2j8AlEfikjMpayaBLGWVlIIcnGzSHXCkg+dnBSzhEQ77QfCvAHrF4iaE5HLkR5Le5u+szw1GFNaz+Tg4OBo1uhw6FfxjfmhRTvtB8K8ga5vIs3qQqTH8Q0oDcQUl47Vm7y+H0Axe+e0034gzBuYS+Q8Y3x91ZEevr3y9fX1o2BMka4Lc+fOHa8zjxXmtNN+IMwRhG8w6VC91Bei0ufuU25ZXl6OfiMU+SLMEYRvmGuvPHVaP9/c3Ozt84cNhDka096lzzA9Hb0yad3xlOj9Ah1yWBfbzCEUwhyN+c5o9O3NWuVTLtIboZRaEAJhjsZ8epc6FDGXXnnF98OJ3jlCIMzRmE/PPLdeubjauZaO6upyrRbkg23jItKFhV4L8HBfG3pOg8HAa0EtHdKXI31edYdo6mtoSY7ttA/omaMRn3qvlli0F5ujuvuQiqub6zh9oAl65j0w3+IswNc9epW59srFlVp07LyOIa/j54OBfOnxQQBUCPMeOCsin7b0NH/sEeY+vdeU6I3dumH+74OB/B9hjgYos6CRwqM8kOrU/Vn5jNJ5iTILGiLM0chLHjXz3MPc5/n5fCgCowhzNPLS4mKtH/ddAzwlPmH+PWMjWpAewhxR5TqKZVTu3zxgE2EOABkgzAEgA4Q5AGSAMEdUfZjpyCqI6AJhjka+qbmGt8+656nxCfO/ZbaCJOIjzNHINx4jN3Lvufo8v7IHo3zQLsIcjfiEUO5h7rMK4jeEORpibZYeeCIi77f0NP9ld1euXLpU62d0/e6c12fxCfN/3d2VL1s5m/bW5YEthHkP6L7xD1p6mv+kYV7zZ3RnHd0zM0d6g7fuIlvqP3d3hb45miDMIzonIp9l9px8ZjvqTVANvRxng/rsGqQbQVt6LXJsp31AmEc0JyIXMntOukLgcDisvduQ9s59NkC2zmc/T2t7oebYTvuAG6BozKf+vb6+nt0Lr9826m4ZJz1Y3x1xEOZozGfnIC21WNv7sinfD6icd15CPIQ5GvPtWebWO19bW6v9M1ovZ5VFhECYozENI591yrUkkUvvXEfnLNZc213olSMgwhxB+N7M3NzcTP4N0Fq577eMHJ4/bCDMEYRvmOuYbJ/yhCX63OuO5lG6iz8lFoRCmDfwMJHzvBfhMXSc9M2bN71+VnunqU7x16GIl2rOgK3EGppJO+0HwryB24mc591Ij+M7q1N7tSnWjvUDyDeQ9cZnrDCnnfYDYd7ArQR6PddF5Gmkx9KSgW/vXIcqpjSJSOvk+gHkU16RBh98Pmin/UCYN/SW4QvlY3eRxNQkpHR0SyprtuhwTN+12WP2yiu00/wR5g3pIlavicgvjdT8Dt3X6tdbXClxkia9c3X16lXT48+rHnmTTTa6+MCinfZAWZbfObTjoX/FweFzLCwslAcHB2UTW1tb5l57fV67u7uNntfOzg5tiqPpsXFibhPmHG0c6+vrjUJPbW9vHwWohfdoMBiUe3t7jZ/T0tIS7Y2j6UGYc8Q9tBfalAboyspKp++dfjA1/aahNjY2aIMcIQ7CnCPuEaLcUtGyS+xeuvbGQ3wglZRXOMIehDlH/EN71aHoB4P2btsOdS2F6IdHyPO2Ui7iyOIgzDm6OULUz4+H4+bmZvD6s37whAzx6ly1h0/b4wh4EOYc3R2hQ7Kio0u0t+5TV9fe8urq6tEHQ4ibmydZW1uj3XGEPk4M88KF97cURaFhXn9XWmACnSjjsxNPHboUr451H92KTdeN0fHhFd2nU6fi+yxZW8eVK1ey3BoPnbum99O/cxL0zDliHm310K2hR87R4nFiz5wZoIhKl7ttMkM0BfTI0QXCHNFpoF+7di27F/6vw6G88cYbBDk6QZijE7o+yR+vXJFyOMziDfjbo0fy3ysrbAOHzhDm6Myft7bkf1ZWjoIwZX+5c+foeRyO3HQFYiPM0am/7e7K4WAgf0qw7KLfKv7wxhvyh9VVKQ8ODJwR+owwhwn/u7Ehhy+/LH+9fz+JN+TPN2/KcGlJ/kJZBUYQ5jBDe+lartBa+jf7+ybfGP2w0Q+dP66t0RuHKYQ5zNFauvZ6LYX6UV38Zz97XuOnNg6DTvGm5OfimGek40YeJ/RsNdT1OLWyIj9cW5MftDx79Ditievj/2lzU77Z24v62CHk0g4wG8I8A6+KyAV38Z6d4enoXpAP3PZhKVzUf93ZOTo+X1+X/1pdldXV1aMp+b6bKU+i+3Pq/p46xPA/EquH594OMBlrsyRKY+wdEbksIqcbPIUnbkPdWx28DF/X/PcP3T6WlcFgcBTq+l89fPblvH///tE6LnpoiO+N9MCbnl8MObQD1Hbi2iyEeYLeE5F3RWQu4Kk/E5FfuJ5aLG2EpS6opcE+jQb3NNbD/F3XFlJvB6jtxDCnzJKQcyLy4YxfoevSXt2nrnd23dVVU6QrJM4S1Ck749rBhRbbwT0X6nnMz+0HRrMkQr9Gf9ZSkI96xz3OmdxewExoPfyLloJ81CuuHZzr2wucMMI8ARrkvwv8dXqSsy4wuJBtuex6zTHbAYGeDsLcuCrIY5ujh25K1+2AQLePMDfsYkcXcEUv5N+7ERPojgbpBx23g89oB+YR5kbNuyDt2ll3sw3dqNpBrNLKOHNG2iPGI8yN+tDABVx5xU1IQXzvNRw/HtIFNxwSNhHmBl10AWrJB3zNju6cG11kyXu0A7MIc4MsljVOGwyW3HVZJx9njnZgFpOGjLkY4Gv1MzeD7+nI/zvnfneT0s1lN6EI7TsTYCx5W+3gXTe5jAlFthDmxjTp9TxzYTtufY1qHQ/fpQBOu9r5XXOvWn4st4M598H+UY4vfMIIc0PmG9TKn7h1QSb1lobuIr/nhpr5XMhv0iMba37CsrN1Xfb8uZjtgDC3hTA3xDcIZrmARz12/97nQn7F4M1ZK866GZpdidkOzroPLz7Y7eAGqCE+NdJDEXnL46J67BZSQh66aAfMCrWFMDfE5+L46NgNrjruut4c0tdFO2h7sS/UQ5gb4rMOyu2Gp/+x6VcEs+qiHbBujy2EuSF1hyQ+a9Abq7BdWPq6ageEuS2EecKaXsBCmGeBdgAhzAEgD4R5wkJ8zU1pRELs3uOzyI/nq2/tACcjzA2pGx6nA1zIKV3E9yI/Xio71XfVDkKUdxAOYW6Iz8XxZsPTT2XRpIcd7Bj/sRu/nYIu2gFhbgthbohPGeHdBr2yVyNsEB3CEzchJrahmyGZQqB30Q4eej4e2kGYG+Jzcfhu7XYukR2Ebtecoh5aNeXdenB10Q4YAWMLa7MY4ltGqHZRnzX0zjVYYOlexIlGj42s/VEF+pmIY6t9toqL2Q6esC6LOYS5IUMXlj4LWemF/EXLS5+K6ynHrl1b8TRinfiWZx07ZjuALUVZlt85oaIodkRkmfcqvosBVt5ra1MC/b3nu3hReki/Aew2fNpttYND1w7omXfmWlmWG8cfnJ65MQ/cRdhkt6HTAUY3nCSVoXo5eOrq9E0Ws2qrHXxEkJvEDVCDLC5N+4xFuaJ73+A5HdIOzCLMDXrQwQSZad6nNxbdY4PBeZ12YBZhbtQvDI1vvse+n525bmhZgYdsFWcaYW7UsKOJMsc9YUeiTlXtoOsP9kMj7RHjEeaGabnllx2e3qELcr5Wd+txx/Xzw44nbmE2hLlxtzoK9OoCZpafDbQDTEOYJ6C6kGN91dbSyk+5gM3RdvB65HZAkKeDME/ELXdhtb0B88fucVgRz6YH7oO27bVi7hHkySHME/LYXcjXW+idPXO9PoYg2vfUBe1vWmwHb9EOkkOYJ+i6m04dYtjaE1fCOd/jNVdS9RHtACNYmyUDr7pp3xdnXJf64cjEJL5G54N20BuszZKru8cm9Vwc8zyHXLRZox30G2GeIb4mQ2gHvUPNHAAyQJgDQAYIcwDIAGEOABkgzAEgA4Q5AGSAMAeADBDmAJABwhwAMkCYA0AGCHMAyABhDgBpOTjpbMeF+Q5vLgCYtHvSSdEzB4AMEOYAkIFxYb7HmwsAJtUqsxDmAGBQWZa1boCe+I8BAJ0ajnvwE8O8LMsTu/EAgE6NzeZJN0DHfgIAADoxtmoyKczpnQOALV49c26CAoAthDkAZGBsLk8Kc6b0A4AhkwanUDMHgDQ8mnSWY8PcDUzf500GABMmdrCnrc1C7xwAbGgU5tTNAcCGiXlMmAOAfcNpM/Mnhrn7YWaCAkC3pnasZ1nPnN45AHSLMAeADGxPewpFWZaT/0FRLInIV7QGAOjEflmWS9MeeGrPvCzLvWmD1QEArZnaK58pzB1KLQDQjZnCfGqZRZ6XWgYi8iVvJABEpUMSF2Z5wJl65m6IIlP7ASCumXrlUqPMorZ4EwEgqs1ZH2ymMoswqgUAYptpFEtl5p65G9Vyn7cTAKKoVQ2pU2YRSi0AEE2tvJ25zPL3HygKXed8nvcTAFpzpyzL1Tq/vG7PXOidA0DrZr7xWfHpmXMjFADaU+vGZ6V2z9zdCL3JGwkArdjw+aW1e+bCjFAAaItXr1w8a+bVjFCGKQJAWN73JL165vK8d74iIp/zRgJAELqr21JZlgc+v8yrZy7Pe+c79M4BIJhN3yCXJj1zoXYOAKF418or3j1zeVE7Z2QLADTjNYJlVKOeubwYd77LrFAA8PKoLMtB05euUc9cXow7rz1bCQBwZD3Ey9C4Zy7Pe+cLrne+GOKkAKAnbpZluRbiqQYJc2GoIgDU1Wgo4nGNyywVN1TxDm8nAMxkI1SQS8ieubwot+xxMxQAJrpfluVKyJcoWM9cnvfO9VMmSP0HADI1bCMng4a5PA/0bcotADDWhhsFGFTQMkuF0S0AcKLaOwjNqpUwF0a3AMBx+yIyCHnTc1TwMkvFjW651tbvB4DErLYV5NJmmMvzQN+gfg4A8mu3llVrWiuzVFz9XHvp53k/AfRQsFmek7Qe5vJiqdwdxp8D6JlHIrLSZnmlEiXMhRuiAPon6HT9aVqtmY9yN0SvxHo8AOjQMFaPvBItzOV5oG8xwgVAD6y2fcPzuKhhLi9GuLA7EYBcXXGViKiih7k8D/Q1Ah1Ahq64CkR0nYS5EOgA8tNZkEuXYS4EOoB8dBrk0nWYC4EOIH2dB7lYCHMh0AGkaWglyCXmpKFZFEWhoX7DzAkBwMmqceRRhx9OYqJnXnGfcFfcCwUAFj2yFuRirWdeYS0XAEbdb3spW1+meuYV94m35D4BAcACXf0w6hT9OkyGubjNocuy1B76bw2cDoD+qm50mt6s3mSZ5biiKHTPvC3KLgAi0+rAmrX6+EnM9sxHuR3/B65eBQAx/Nbijc5xkuiZjyqKQhfqumrnjABkZuhuckZfLKuJJHrmo9yqiy9zcxRAC266DSWSCnJJMczFjXZxN0d/zZh0AAHsi8jP9Can1dEq0yQZ5pWyLDddLZ2lAAD40M7gtbIsk+yNj0quZj6O22NUSzDLNs8QgDHaCdwoy3IvhzcmmzCvuPVdNNQXbZwRAGPuuxBPuid+XHZhXiHUARyTZYhXsg3zCqEO9F7WIV7JPswrbhbpOjV1oDe0Jr6ZyqSfpnoT5pWiKJZcT32V5QGA7Oy7pT82Ux1i6Kt3YV4pimLBBboel2ycFQAPOrxQl/zYyr2UMklvw3yU661rqGt9/bydMwMwwR0X4tt964WfhDA/5liPfYVSDGDGvtu0ZtstvocRhPkUbjJSdQwIdyAaDe/dkQDPYnJPWwjzmtyWdscPAh5oRoN7zwW3Bvgu4V0PYR6AK80M3FZ3elR/Fvdnxrij73SV06quXd2k1NA+6PNNy5AIcwDIQNKrJgIAniPMASADhDkAZIAwB4DUicj/A2sRCWLPVF1BAAAAAElFTkSuQmCC
-      mediatype: image/png
+  - base64data: iVBORw0KGgoAAAANSUhEUgAAAXMAAAFyCAYAAAAH5jo3AAAACXBIWXMAAG66AABuugHW3rEXAAAeWklEQVR4nO3dzW8cx5nH8acdJdlFEpKHvUrkHyBB4+tKCJmrDVv00YIDU3uykQBhTl44B1GHNVY3Bohhn1YUNpD2ZsqGdDVlSHs1BeluUrobHG6CzebFvXio6mhMc166urr6qervB2gYskROz0z1b2qerpeiLEsBAKTtJd4/AEgfYQ4AGSDMASADhDkAZOAUb2JzRVEsiMhARJbcUf1Z3J8XU35+QACPROTA/Zod999d/X9lWe7wAjfHaJaaiqIYuKAePeaTehKAPfsisueCXkN+tyzLPd6n2RHmUxRFsSIi1UFwA/Hsu2DXgN8py3KX1348wvwYVzJZdccK4Q2Yse+Cfbssy23elm8jzJ8H+JIL7zUROW/glABMd0eD3YX7Qd9fr96G+bEe+CUDpwTAz3Ak1HvbY+9dmLte+IYLcUooQF60FLMlIpt96633JsyLotDwXheRZQOnA6B9N12o9+LGafZhXhTFmuuJM9Yb6Kf7mgG5j2fPNswJcQDHZB3q2YU5IQ5giixDPZswd5N7NqiJA5jRTRfqWcw0TT7MR0anvG3gdACkZehukm6k/r4lHeZFUay7IGeIIYAmdEjjWsqllyTD3C12tcVsTQCBaellPcUx6smtZ14UhfbEvyTIAbRAy7V77h5cUpIJc62NF0WhX4GuGjgdAPnSsu3nRVFsumU/kpBEmcXN3tyiNg4gskeulm5+Fqn5nrl+OorIJwQ5gA5oOXfHzV8xzWzP3H292aE2DsCIm2VZmg11k2HuRqvs0BsHYIyWXVYsjnYxV2ZxX2cIcgAWVWWXgbVzM9Uzd0F+w8CpAMAkQ9dDN3Nj1EzPvCiKLYIcQCLmrd0YNdEzd0HO2ioAUnSlLMutrs+78545QQ4gcTcs9NA7DXOCHEAmOg/0zsKcIAeQmU4DvZMwJ8gBZKqzQI8e5m7VQ4IcQK5udLHqYtTRLIwjB9AT0cehRwtz90n1eZQHA4DuaaAvxZr6H6XM4qa+bsd4LAAwoppYFGVN9NbD3D0R1iIH0Ee6lstmjOcdo2fOXp0A+uxtt/l8q1qtmbuRK2zzBgAiL7d5Q7S1MOeGJwB8y76IDNq6IdpKmWWkTg4AeG6xzVxsq2a+5U4cAPDCpbbq58HLLG4n/U+C/lIAyMfQlVv2Qj6joGHuyit7DEMEgInul2UZdMp/6DIL48kBYLrl0OWWYD1zRq8AQC1Bp/sH6ZkzegUAapsPOTs0VJllndErAFDb26GWy21cZimKYklEdqmVA4CXR2VZDpq+dCF65hsEOQB4Ox9id6JGPXO3tO2XvIcA0Mh+WZZLTX5B0555lKUdASBzi25hQm/ePXOGIgJAUI2GKjbpmTf6FAEAfMu8GxnoxatnTq0cAFrhXTv37Zm3vmsGAPTQou/Ilto9czeu/CtaGQC0wqt37tMzp1cOAO1Z9JkV6tMzP2CSEAC06k5Zlqt1HqBWz9zVcghyAGjXJVfSnlndMkvjKacAgPB5O3OZhRufABBVrRuhdXrm9MoBIJ5FN6dnJoQ5ANg18+jBmcoszPgEgE4My7JcmOWBZ+2Z0ysHgPjmZx1zPmuYB9nWCABQ20zjzaeWWRjFAgCdmmlUyyw981qzkAAAQS3OMoFoljCnxAIA3ZraqSbMAcC+qTk8MczdkETWYgGAbjULc3rlAGDC/LTZoIQ5AKRhYh5PC/OZ1wUAALTKr2deFIVOIV3kvQEAE7zLLPTKAcCO85POZFKYUy8HAEMm3QSdFOa1d4cGALRqbC4T5gCQDq+eOTVzALDFK8yZ+QkAtozdqOLEMK+z7xwAIJraPfOZtikCAEQ1tmIyLsy5+QkABrkJnd9BmANAWk4stcy6BygAwDDCHAAyMC7MmcoPADZRZgGADNS6AQoASAhhDgAZIMwBIAOEOQBkgDAHgAwQ5gCQAcIcADJAmANABghzAMjAKd7E/Jxxx3GPRWTY9xenR2gH/UKYZ+CciLwiIhdF5MKUp3MoIg9E5KGI3BWRp31/8TJCO+i3oizL77wARVHsiMhy318c6y6LyHsicrrBeerFfN1d2KAd0A6ScK0sy43jJ0rNPEF68T4Skd81vIDF9eA+FZHPXI8O6aAdYBRhnpAz7mILcfEeV13MH/TlxUxYrHYwdrNJmESYJ0J7S1/MUAtt6h33OFzINsVsB5+NuYEKmwjzBFx2vaW5SKd61n19P5f0q5afLtrBF7SDZBDmxl12X6djm3M9My5kG2gHmIYwN+xcRxdwRS/kDym5dI52gFkQ5kbNux5R1866Cxnd0Hbwe9oBZkCYG/VhxNroNK+4r/mI78MWRqzQDvJEmBt00V04ljBULT7aAeogzA16z+A5zbnhaoiHdoA6WJvFmFnW1ZimWnfj8ci/C/F73xWRj1mkKQraAeoizI15s8Hp6MX7vls46fiFdt1NAHmnQc9Ke2Wvisgtk69cXmgHqIsyizG+F/ETETnvLrBxPaan7iJfdhe8D2s13FzRDlAXYW7Iq56nohfwazW+9j52/97nQuYibl8q7YAbobZQZjHkrOepvOVRv3zsvnL/m8fjvXusDtsWa5sojNvsITTfD8zY7eAcS+aaQpgb4rP06O0GGwt85Oqmdccx+1z4vm67kkCXoX7ODclre3GrJrpoBxcIc1Mosxji0+v7uOHpN/35tr3pZsJ29ZX+nHt8y0EuHbUDyiy2EOaG1O0ZHQYod6TQszrb0ZT2akkFKzNxx+mqHbD4li2EecJC1K1j1L5DuNDBDjjvJBDk0rN2gPEIcyQj9kga1iFBSgjzhIUYWZHSTjKxv9ZbWeBqmr61A5yMMDfkWc1TOR3gImTz3vR11Q58R8+gHYS5IT4XR5Np3yF+HjZ00Q4Ic1sIc0N8bkK922CIWIhFl2BDF+3gCe+9KYS5IQ89TmXOc9ielR1sEEYX7YAJQ7YQ5ob4XhwXau7ReCaR8dOoJ2Y7eMISuOYQ5oboxXHP83SqmZLTbmTp1/EvGqwDA9titYPbtANzWJvFmNsNxlPrhfmp6zU9cGWboeuBXXCr8TXtjb8e8OX6NODvsuCJW0cmhHMN1sCJ0Q5Yy9wewtyYu26IYpMxzmfdEXp7r9vUSScaBnx9HngufjWqzXZAicUeyiwGXTd4TodGzytnoXr5IdEO7CLMDbrlObKlTR8xrji6u7QD1ECYG/WLBlt6hfaE3lhnaAeYFWFu1FN3IXft0O1gg27QDjArwtww/Zr9yw5P79DtEcnX6m7RDjALwty4Wx1dyNUFzDrXNtAOMA1hnoDYFzIXsE20A0xCmCdCL+Rlj2Vy69LRE+e5gM2iHWAcwjwhemH9tKURBc9cr+81JoSY12Y7OKQdJIswT8zQXcQDt6N602FrGuK/ceHAFO10tNUOztMOksV0/kQ9dTMEr7u1Nl5xiyvNsubGs5EJKXcze10WFhZkMBhM/Xc7OztRzqdttANUCPPEDV1PqupNnRk5Rtf1qJYsfZzR12cN7ZWVlaP/6nH+/Pnav+P+/fuyu7t7dGjA7+3ttXKubetzO8BzhHlmnmY8Hvj7Cwuytroqq6urRyE+P++7t84Ly8vLR0dlf3//KNS3t7dF9EhUzu0AJyvKsvzOXxRFseNumgOt+XrGX3xqZUV+uLYmP3j77ahvRjkcyp+3tuRPm5vyzQw99ofuxiHQsmtlWW4cfwhugMKsH6ytyfzenvzk88+jB7kq5uflh7/6lcx/9ZX8eHv76EMFsIowhzlViP/oxg15aXHRxOl9/9Klow+Vn+zsyPdmuMEKxEaYwwwNSQ1LSyF+3KnlZZn78kv50daWFAsLtk4OvUaYw4R/3Ng4CslTy2ncqtGyj357+P7qqoGzAQhzdEx743O7u/IPV68m91ZoTf3Hn3xyVE+nl46uEebojNbGj2rQHuPDLTmqp+/syBy1dHSIMEcnNjY2jmrjRYCx4hboB9I/7+wcjYEHukCYI7qtrS25mmBZZZpT8/PyySefyNramu0TRZYIc0SlQf52B2PGY7px4waBjuiYzo9oYgT5o0ePjtZX0bVWxtGlAJaWlmSxxeGPGujinjMQA2GOKNoKcg1vXUdF11OpuxKirrCowa6H1rpDhzuBjqh0bZbjh64Qqn/FwRHiWF9fL0M6ODgoNzc3y6WlpaDvz8rKSrm1tRX8XAeDAe2II+SxcWJuE+YcbR4akCGDcWNjo1xYWGj1nPVDImSo63m3fc4cvToIc464hwaYBlkIGq6xA1F71Ds7O0HOX38P7Y8j0EGYc8Q9QgTh3t7eUe++y/dOy0QhPpT0WwVtkCPAQZhzxDtC1Mm3t7fNlCe0l64fLE2FrvNz9PI4MczZnCIQ3Z7rTbf/YpeGbpOEWx1uC6ajRHR4YJOdgG7evGlurLY+Lx0x47M9XUW3qVvpcF102mkWTtycgp55gOM9kfJrY8eeSPlqR69H05uH2qu3+l7rNwX9xtDE2toa7VS6b6cJH/TM2/CBiLxj+Px+HnnndZ2M89VXX3n//LVr147WbbFOJyX59tB1n1F9nWKinWaFbeNCu2j8AlEfikjMpayaBLGWVlIIcnGzSHXCkg+dnBSzhEQ77QfCvAHrF4iaE5HLkR5Le5u+szw1GFNaz+Tg4OBo1uhw6FfxjfmhRTvtB8K8ga5vIs3qQqTH8Q0oDcQUl47Vm7y+H0Axe+e0034gzBuYS+Q8Y3x91ZEevr3y9fX1o2BMka4Lc+fOHa8zjxXmtNN+IMwRhG8w6VC91Bei0ufuU25ZXl6OfiMU+SLMEYRvmGuvPHVaP9/c3Ozt84cNhDka096lzzA9Hb0yad3xlOj9Ah1yWBfbzCEUwhyN+c5o9O3NWuVTLtIboZRaEAJhjsZ8epc6FDGXXnnF98OJ3jlCIMzRmE/PPLdeubjauZaO6upyrRbkg23jItKFhV4L8HBfG3pOg8HAa0EtHdKXI31edYdo6mtoSY7ttA/omaMRn3qvlli0F5ujuvuQiqub6zh9oAl65j0w3+IswNc9epW59srFlVp07LyOIa/j54OBfOnxQQBUCPMeOCsin7b0NH/sEeY+vdeU6I3dumH+74OB/B9hjgYos6CRwqM8kOrU/Vn5jNJ5iTILGiLM0chLHjXz3MPc5/n5fCgCowhzNPLS4mKtH/ddAzwlPmH+PWMjWpAewhxR5TqKZVTu3zxgE2EOABkgzAEgA4Q5AGSAMEdUfZjpyCqI6AJhjka+qbmGt8+656nxCfO/ZbaCJOIjzNHINx4jN3Lvufo8v7IHo3zQLsIcjfiEUO5h7rMK4jeEORpibZYeeCIi77f0NP9ld1euXLpU62d0/e6c12fxCfN/3d2VL1s5m/bW5YEthHkP6L7xD1p6mv+kYV7zZ3RnHd0zM0d6g7fuIlvqP3d3hb45miDMIzonIp9l9px8ZjvqTVANvRxng/rsGqQbQVt6LXJsp31AmEc0JyIXMntOukLgcDisvduQ9s59NkC2zmc/T2t7oebYTvuAG6BozKf+vb6+nt0Lr9826m4ZJz1Y3x1xEOZozGfnIC21WNv7sinfD6icd15CPIQ5GvPtWebWO19bW6v9M1ovZ5VFhECYozENI591yrUkkUvvXEfnLNZc213olSMgwhxB+N7M3NzcTP4N0Fq577eMHJ4/bCDMEYRvmOuYbJ/yhCX63OuO5lG6iz8lFoRCmDfwMJHzvBfhMXSc9M2bN71+VnunqU7x16GIl2rOgK3EGppJO+0HwryB24mc591Ij+M7q1N7tSnWjvUDyDeQ9cZnrDCnnfYDYd7ArQR6PddF5Gmkx9KSgW/vXIcqpjSJSOvk+gHkU16RBh98Pmin/UCYN/SW4QvlY3eRxNQkpHR0SyprtuhwTN+12WP2yiu00/wR5g3pIlavicgvjdT8Dt3X6tdbXClxkia9c3X16lXT48+rHnmTTTa6+MCinfZAWZbfObTjoX/FweFzLCwslAcHB2UTW1tb5l57fV67u7uNntfOzg5tiqPpsXFibhPmHG0c6+vrjUJPbW9vHwWohfdoMBiUe3t7jZ/T0tIS7Y2j6UGYc8Q9tBfalAboyspKp++dfjA1/aahNjY2aIMcIQ7CnCPuEaLcUtGyS+xeuvbGQ3wglZRXOMIehDlH/EN71aHoB4P2btsOdS2F6IdHyPO2Ui7iyOIgzDm6OULUz4+H4+bmZvD6s37whAzx6ly1h0/b4wh4EOYc3R2hQ7Kio0u0t+5TV9fe8urq6tEHQ4ibmydZW1uj3XGEPk4M88KF97cURaFhXn9XWmACnSjjsxNPHboUr451H92KTdeN0fHhFd2nU6fi+yxZW8eVK1ey3BoPnbum99O/cxL0zDliHm310K2hR87R4nFiz5wZoIhKl7ttMkM0BfTI0QXCHNFpoF+7di27F/6vw6G88cYbBDk6QZijE7o+yR+vXJFyOMziDfjbo0fy3ysrbAOHzhDm6Myft7bkf1ZWjoIwZX+5c+foeRyO3HQFYiPM0am/7e7K4WAgf0qw7KLfKv7wxhvyh9VVKQ8ODJwR+owwhwn/u7Ehhy+/LH+9fz+JN+TPN2/KcGlJ/kJZBUYQ5jBDe+lartBa+jf7+ybfGP2w0Q+dP66t0RuHKYQ5zNFauvZ6LYX6UV38Zz97XuOnNg6DTvGm5OfimGek40YeJ/RsNdT1OLWyIj9cW5MftDx79Ditievj/2lzU77Z24v62CHk0g4wG8I8A6+KyAV38Z6d4enoXpAP3PZhKVzUf93ZOTo+X1+X/1pdldXV1aMp+b6bKU+i+3Pq/p46xPA/EquH594OMBlrsyRKY+wdEbksIqcbPIUnbkPdWx28DF/X/PcP3T6WlcFgcBTq+l89fPblvH///tE6LnpoiO+N9MCbnl8MObQD1Hbi2iyEeYLeE5F3RWQu4Kk/E5FfuJ5aLG2EpS6opcE+jQb3NNbD/F3XFlJvB6jtxDCnzJKQcyLy4YxfoevSXt2nrnd23dVVU6QrJM4S1Ck749rBhRbbwT0X6nnMz+0HRrMkQr9Gf9ZSkI96xz3OmdxewExoPfyLloJ81CuuHZzr2wucMMI8ARrkvwv8dXqSsy4wuJBtuex6zTHbAYGeDsLcuCrIY5ujh25K1+2AQLePMDfsYkcXcEUv5N+7ERPojgbpBx23g89oB+YR5kbNuyDt2ll3sw3dqNpBrNLKOHNG2iPGI8yN+tDABVx5xU1IQXzvNRw/HtIFNxwSNhHmBl10AWrJB3zNju6cG11kyXu0A7MIc4MsljVOGwyW3HVZJx9njnZgFpOGjLkY4Gv1MzeD7+nI/zvnfneT0s1lN6EI7TsTYCx5W+3gXTe5jAlFthDmxjTp9TxzYTtufY1qHQ/fpQBOu9r5XXOvWn4st4M598H+UY4vfMIIc0PmG9TKn7h1QSb1lobuIr/nhpr5XMhv0iMba37CsrN1Xfb8uZjtgDC3hTA3xDcIZrmARz12/97nQn7F4M1ZK866GZpdidkOzroPLz7Y7eAGqCE+NdJDEXnL46J67BZSQh66aAfMCrWFMDfE5+L46NgNrjruut4c0tdFO2h7sS/UQ5gb4rMOyu2Gp/+x6VcEs+qiHbBujy2EuSF1hyQ+a9Abq7BdWPq6ageEuS2EecKaXsBCmGeBdgAhzAEgD4R5wkJ8zU1pRELs3uOzyI/nq2/tACcjzA2pGx6nA1zIKV3E9yI/Xio71XfVDkKUdxAOYW6Iz8XxZsPTT2XRpIcd7Bj/sRu/nYIu2gFhbgthbohPGeHdBr2yVyNsEB3CEzchJrahmyGZQqB30Q4eej4e2kGYG+Jzcfhu7XYukR2Ebtecoh5aNeXdenB10Q4YAWMLa7MY4ltGqHZRnzX0zjVYYOlexIlGj42s/VEF+pmIY6t9toqL2Q6esC6LOYS5IUMXlj4LWemF/EXLS5+K6ynHrl1b8TRinfiWZx07ZjuALUVZlt85oaIodkRkmfcqvosBVt5ra1MC/b3nu3hReki/Aew2fNpttYND1w7omXfmWlmWG8cfnJ65MQ/cRdhkt6HTAUY3nCSVoXo5eOrq9E0Ws2qrHXxEkJvEDVCDLC5N+4xFuaJ73+A5HdIOzCLMDXrQwQSZad6nNxbdY4PBeZ12YBZhbtQvDI1vvse+n525bmhZgYdsFWcaYW7UsKOJMsc9YUeiTlXtoOsP9kMj7RHjEeaGabnllx2e3qELcr5Wd+txx/Xzw44nbmE2hLlxtzoK9OoCZpafDbQDTEOYJ6C6kGN91dbSyk+5gM3RdvB65HZAkKeDME/ELXdhtb0B88fucVgRz6YH7oO27bVi7hHkySHME/LYXcjXW+idPXO9PoYg2vfUBe1vWmwHb9EOkkOYJ+i6m04dYtjaE1fCOd/jNVdS9RHtACNYmyUDr7pp3xdnXJf64cjEJL5G54N20BuszZKru8cm9Vwc8zyHXLRZox30G2GeIb4mQ2gHvUPNHAAyQJgDQAYIcwDIAGEOABkgzAEgA4Q5AGSAMAeADBDmAJABwhwAMkCYA0AGCHMAyABhDgBpOTjpbMeF+Q5vLgCYtHvSSdEzB4AMEOYAkIFxYb7HmwsAJtUqsxDmAGBQWZa1boCe+I8BAJ0ajnvwE8O8LMsTu/EAgE6NzeZJN0DHfgIAADoxtmoyKczpnQOALV49c26CAoAthDkAZGBsLk8Kc6b0A4AhkwanUDMHgDQ8mnSWY8PcDUzf500GABMmdrCnrc1C7xwAbGgU5tTNAcCGiXlMmAOAfcNpM/Mnhrn7YWaCAkC3pnasZ1nPnN45AHSLMAeADGxPewpFWZaT/0FRLInIV7QGAOjEflmWS9MeeGrPvCzLvWmD1QEArZnaK58pzB1KLQDQjZnCfGqZRZ6XWgYi8iVvJABEpUMSF2Z5wJl65m6IIlP7ASCumXrlUqPMorZ4EwEgqs1ZH2ymMoswqgUAYptpFEtl5p65G9Vyn7cTAKKoVQ2pU2YRSi0AEE2tvJ25zPL3HygKXed8nvcTAFpzpyzL1Tq/vG7PXOidA0DrZr7xWfHpmXMjFADaU+vGZ6V2z9zdCL3JGwkArdjw+aW1e+bCjFAAaItXr1w8a+bVjFCGKQJAWN73JL165vK8d74iIp/zRgJAELqr21JZlgc+v8yrZy7Pe+c79M4BIJhN3yCXJj1zoXYOAKF418or3j1zeVE7Z2QLADTjNYJlVKOeubwYd77LrFAA8PKoLMtB05euUc9cXow7rz1bCQBwZD3Ey9C4Zy7Pe+cLrne+GOKkAKAnbpZluRbiqQYJc2GoIgDU1Wgo4nGNyywVN1TxDm8nAMxkI1SQS8ieubwot+xxMxQAJrpfluVKyJcoWM9cnvfO9VMmSP0HADI1bCMng4a5PA/0bcotADDWhhsFGFTQMkuF0S0AcKLaOwjNqpUwF0a3AMBx+yIyCHnTc1TwMkvFjW651tbvB4DErLYV5NJmmMvzQN+gfg4A8mu3llVrWiuzVFz9XHvp53k/AfRQsFmek7Qe5vJiqdwdxp8D6JlHIrLSZnmlEiXMhRuiAPon6HT9aVqtmY9yN0SvxHo8AOjQMFaPvBItzOV5oG8xwgVAD6y2fcPzuKhhLi9GuLA7EYBcXXGViKiih7k8D/Q1Ah1Ahq64CkR0nYS5EOgA8tNZkEuXYS4EOoB8dBrk0nWYC4EOIH2dB7lYCHMh0AGkaWglyCXmpKFZFEWhoX7DzAkBwMmqceRRhx9OYqJnXnGfcFfcCwUAFj2yFuRirWdeYS0XAEbdb3spW1+meuYV94m35D4BAcACXf0w6hT9OkyGubjNocuy1B76bw2cDoD+qm50mt6s3mSZ5biiKHTPvC3KLgAi0+rAmrX6+EnM9sxHuR3/B65eBQAx/Nbijc5xkuiZjyqKQhfqumrnjABkZuhuckZfLKuJJHrmo9yqiy9zcxRAC266DSWSCnJJMczFjXZxN0d/zZh0AAHsi8jP9Can1dEq0yQZ5pWyLDddLZ2lAAD40M7gtbIsk+yNj0quZj6O22NUSzDLNs8QgDHaCdwoy3IvhzcmmzCvuPVdNNQXbZwRAGPuuxBPuid+XHZhXiHUARyTZYhXsg3zCqEO9F7WIV7JPswrbhbpOjV1oDe0Jr6ZyqSfpnoT5pWiKJZcT32V5QGA7Oy7pT82Ux1i6Kt3YV4pimLBBboel2ycFQAPOrxQl/zYyr2UMklvw3yU661rqGt9/bydMwMwwR0X4tt964WfhDA/5liPfYVSDGDGvtu0ZtstvocRhPkUbjJSdQwIdyAaDe/dkQDPYnJPWwjzmtyWdscPAh5oRoN7zwW3Bvgu4V0PYR6AK80M3FZ3elR/Fvdnxrij73SV06quXd2k1NA+6PNNy5AIcwDIQNKrJgIAniPMASADhDkAZIAwB4DUicj/A2sRCWLPVF1BAAAAAElFTkSuQmCC
+    mediatype: image/png
   install:
     spec:
       clusterPermissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-            - apiGroups:
-                - ""
-              resources:
-                - limitranges
-              verbs:
-                - create
-                - delete
-                - get
-                - update
-            - apiGroups:
-                - ""
-              resources:
-                - namespaces
-              verbs:
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - nodes
-              verbs:
-                - list
-            - apiGroups:
-                - ""
-              resources:
-                - pods
-              verbs:
-                - create
-                - list
-            - apiGroups:
-                - ""
-              resources:
-                - pods/exec
-              verbs:
-                - create
-            - apiGroups:
-                - ""
-              resourceNames:
-                - grafana-datasources
-              resources:
-                - secrets
-              verbs:
-                - get
-            - apiGroups:
-                - ""
-              resourceNames:
-                - pull-secret
-              resources:
-                - secrets
-              verbs:
-                - get
-            - apiGroups:
-                - ""
-                - project.openshift.io
-              resources:
-                - projectrequests
-              verbs:
-                - create
-            - apiGroups:
-                - '*'
-              resources:
-                - configmaps
-                - secrets
-                - services
-                - subscriptions
-              verbs:
-                - create
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - addons.managed.openshift.io
-              resources:
-                - addoninstances
-              verbs:
-                - get
-                - list
-                - patch
-                - watch
-            - apiGroups:
-                - addons.managed.openshift.io
-              resources:
-                - addoninstances/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - admissionregistration.k8s.io
-              resources:
-                - mutatingwebhookconfigurations
-                - validatingwebhookconfigurations
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - apiextensions.k8s.io
-              resources:
-                - customresourcedefinitions
-              verbs:
-                - delete
-                - get
-                - list
-            - apiGroups:
-                - apps
-              resources:
-                - deployments
-                - statefulsets
-              verbs:
-                - create
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - apps
-              resources:
-                - replicasets
-              verbs:
-                - create
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - apps.3scale.net
-              resources:
-                - apimanagers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - apps.openshift.io
-              resources:
-                - deploymentconfigs
-              verbs:
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - apps.openshift.io
-              resources:
-                - deploymentconfigs/instantiate
-              verbs:
-                - create
-            - apiGroups:
-                - config.openshift.io
-              resources:
-                - clusterversions
-                - infrastructures
-                - oauths
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - console.openshift.io
-              resources:
-                - consolelinks
-              verbs:
-                - create
-                - delete
-                - get
-                - update
-            - apiGroups:
-                - coordination.k8s.io
-              resources:
-                - leases
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - image.openshift.io
-              resources:
-                - imagestreams
-              verbs:
-                - create
-                - delete
-                - get
-                - update
-            - apiGroups:
-                - integreatly.org
-              resources:
-                - apimanagementtenant
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - integreatly.org
-              resources:
-                - apimanagementtenant/status
-                - rhmis/status
-              verbs:
-                - get
-                - patch
-                - update
-            - apiGroups:
-                - integreatly.org
-              resources:
-                - rhmis
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - integreatly.org
-                - scheduling.k8s.io
-              resources:
-                - '*'
-              verbs:
-                - '*'
-            - apiGroups:
-                - managed.openshift.io
-              resources:
-                - customdomains
-              verbs:
-                - list
-            - apiGroups:
-                - marin3r.3scale.net
-              resources:
-                - envoyconfigs
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - podmonitors
-                - probes
-                - prometheusrules
-                - servicemonitors
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-            - apiGroups:
-                - monitoring.rhobs
-              resources:
-                - monitoringstacks
-                - podmonitors
-                - probes
-                - prometheusrules
-                - servicemonitors
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - oauth.openshift.io
-              resources:
-                - oauthclients
-              verbs:
-                - create
-                - delete
-                - get
-                - update
-            - apiGroups:
-                - operator.marin3r.3scale.net
-              resources:
-                - discoveryservices
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - operator.openshift.io
-              resources:
-                - cloudcredentials
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - operator.openshift.io
-              resources:
-                - ingresscontrollers
-              verbs:
-                - get
-                - list
-            - apiGroups:
-                - operators.coreos.com
-              resourceNames:
-                - rhmi-registry-cs
-              resources:
-                - catalogsources
-              verbs:
-                - update
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - catalogsources
-                - operatorgroups
-              verbs:
-                - create
-                - get
-                - list
-                - update
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - clusterserviceversions
-              verbs:
-                - delete
-                - get
-                - list
-                - patch
-                - update
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - installplans
-              verbs:
-                - get
-                - update
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - subscriptions
-              verbs:
-                - create
-                - delete
-                - update
-            - apiGroups:
-                - package-operator.run
-              resources:
-                - clusterpackages
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - project.openshift.io
-              resources:
-                - projects
-              verbs:
-                - delete
-                - get
-            - apiGroups:
-                - rbac.authorization.k8s.io
-              resources:
-                - clusterrolebindings
-                - clusterroles
-                - rolebindings
-                - roles
-              verbs:
-                - '*'
-            - apiGroups:
-                - route.openshift.io
-              resources:
-                - routes
-              verbs:
-                - get
-                - list
-                - update
-            - apiGroups:
-                - samples.operator.openshift.io
-              resourceNames:
-                - cluster
-              resources:
-                - configs
-              verbs:
-                - get
-                - update
-            - apiGroups:
-                - template.openshift.io
-              resources:
-                - templates
-              verbs:
-                - create
-                - delete
-                - get
-                - update
-            - apiGroups:
-                - user.openshift.io
-              resources:
-                - groups
-              verbs:
-                - create
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - user.openshift.io
-              resourceNames:
-                - rhmi-developers
-              resources:
-                - groups
-              verbs:
-                - delete
-                - update
-            - apiGroups:
-                - user.openshift.io
-              resources:
-                - identities
-              verbs:
-                - get
-                - list
-            - apiGroups:
-                - user.openshift.io
-              resources:
-                - users
-              verbs:
-                - get
-                - list
-                - update
-                - watch
-          serviceAccountName: rhmi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resources:
+          - limitranges
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - ""
+          resources:
+          - namespaces
+          verbs:
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - nodes
+          verbs:
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods
+          verbs:
+          - create
+          - list
+        - apiGroups:
+          - ""
+          resources:
+          - pods/exec
+          verbs:
+          - create
+        - apiGroups:
+          - ""
+          resourceNames:
+          - grafana-datasources
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          resourceNames:
+          - pull-secret
+          resources:
+          - secrets
+          verbs:
+          - get
+        - apiGroups:
+          - ""
+          - project.openshift.io
+          resources:
+          - projectrequests
+          verbs:
+          - create
+        - apiGroups:
+          - '*'
+          resources:
+          - configmaps
+          - secrets
+          - services
+          - subscriptions
+          verbs:
+          - create
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - addons.managed.openshift.io
+          resources:
+          - addoninstances
+          verbs:
+          - get
+          - list
+          - patch
+          - watch
+        - apiGroups:
+          - addons.managed.openshift.io
+          resources:
+          - addoninstances/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          - validatingwebhookconfigurations
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apiextensions.k8s.io
+          resources:
+          - customresourcedefinitions
+          verbs:
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - apps
+          resources:
+          - deployments
+          - statefulsets
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - apps
+          resources:
+          - replicasets
+          verbs:
+          - create
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - apps.3scale.net
+          resources:
+          - apimanagers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - apps.openshift.io
+          resources:
+          - deploymentconfigs/instantiate
+          verbs:
+          - create
+        - apiGroups:
+          - config.openshift.io
+          resources:
+          - clusterversions
+          - infrastructures
+          - oauths
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - console.openshift.io
+          resources:
+          - consolelinks
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - coordination.k8s.io
+          resources:
+          - leases
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - image.openshift.io
+          resources:
+          - imagestreams
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - apimanagementtenant
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - apimanagementtenant/status
+          - rhmis/status
+          verbs:
+          - get
+          - patch
+          - update
+        - apiGroups:
+          - integreatly.org
+          resources:
+          - rhmis
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - integreatly.org
+          - scheduling.k8s.io
+          resources:
+          - '*'
+          verbs:
+          - '*'
+        - apiGroups:
+          - managed.openshift.io
+          resources:
+          - customdomains
+          verbs:
+          - list
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - podmonitors
+          - probes
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+        - apiGroups:
+          - monitoring.rhobs
+          resources:
+          - monitoringstacks
+          - podmonitors
+          - probes
+          - prometheusrules
+          - servicemonitors
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - oauth.openshift.io
+          resources:
+          - oauthclients
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - cloudcredentials
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - operator.openshift.io
+          resources:
+          - ingresscontrollers
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - operators.coreos.com
+          resourceNames:
+          - rhmi-registry-cs
+          resources:
+          - catalogsources
+          verbs:
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          - operatorgroups
+          verbs:
+          - create
+          - get
+          - list
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - installplans
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - subscriptions
+          verbs:
+          - create
+          - delete
+          - update
+        - apiGroups:
+          - package-operator.run
+          resources:
+          - clusterpackages
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - project.openshift.io
+          resources:
+          - projects
+          verbs:
+          - delete
+          - get
+        - apiGroups:
+          - rbac.authorization.k8s.io
+          resources:
+          - clusterrolebindings
+          - clusterroles
+          - rolebindings
+          - roles
+          verbs:
+          - '*'
+        - apiGroups:
+          - route.openshift.io
+          resources:
+          - routes
+          verbs:
+          - get
+          - list
+          - update
+        - apiGroups:
+          - samples.operator.openshift.io
+          resourceNames:
+          - cluster
+          resources:
+          - configs
+          verbs:
+          - get
+          - update
+        - apiGroups:
+          - template.openshift.io
+          resources:
+          - templates
+          verbs:
+          - create
+          - delete
+          - get
+          - update
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - groups
+          verbs:
+          - create
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - user.openshift.io
+          resourceNames:
+          - rhmi-developers
+          resources:
+          - groups
+          verbs:
+          - delete
+          - update
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - identities
+          verbs:
+          - get
+          - list
+        - apiGroups:
+          - user.openshift.io
+          resources:
+          - users
+          verbs:
+          - get
+          - list
+          - update
+          - watch
+        serviceAccountName: rhmi-operator
       deployments:
-        - name: rhmi-operator
-          spec:
-            replicas: 1
-            selector:
-              matchLabels:
+      - name: rhmi-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: rhmi-operator
+          strategy: {}
+          template:
+            metadata:
+              annotations:
+                kubectl.kubernetes.io/default-container: manager
+              labels:
                 name: rhmi-operator
-            strategy: {}
-            template:
-              metadata:
-                annotations:
-                  kubectl.kubernetes.io/default-container: manager
-                labels:
-                  name: rhmi-operator
-              spec:
-                containers:
-                  - args:
-                      - --enable-leader-election
-                      - --health-probe-bind-address=:8081
-                      - --metrics-bind-address=:8383
-                      - --metrics-secure=false
+            spec:
+              containers:
+              - args:
+                - --enable-leader-election
+                - --health-probe-bind-address=:8081
+                - --metrics-bind-address=:8383
+                - --metrics-secure=false
+                command:
+                - rhmi-operator
+                env:
+                - name: INSTALLATION_TYPE
+                  value: managed-api
+                - name: WATCH_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.annotations['olm.targetNamespaces']
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: OPERATOR_NAME
+                  value: rhmi-operator
+                - name: USE_CLUSTER_STORAGE
+                  value: "true"
+                - name: LOG_LEVEL
+                  value: info
+                - name: REBALANCE_PODS
+                  value: "true"
+                - name: ALERT_SMTP_FROM
+                  value: default@test.com
+                - name: QUOTA
+                  value: "200"
+                image: quay.io/integreatly/managed-api-service:v1.45.0
+                imagePullPolicy: Always
+                livenessProbe:
+                  exec:
                     command:
-                      - rhmi-operator
-                    env:
-                      - name: INSTALLATION_TYPE
-                        value: managed-api
-                      - name: WATCH_NAMESPACE
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.annotations['olm.targetNamespaces']
-                      - name: POD_NAME
-                        valueFrom:
-                          fieldRef:
-                            fieldPath: metadata.name
-                      - name: OPERATOR_NAME
-                        value: rhmi-operator
-                      - name: USE_CLUSTER_STORAGE
-                        value: "true"
-                      - name: LOG_LEVEL
-                        value: info
-                      - name: REBALANCE_PODS
-                        value: "true"
-                      - name: ALERT_SMTP_FROM
-                        value: default@test.com
-                      - name: QUOTA
-                        value: "200"
-                    image: quay.io/integreatly/managed-api-service:master
-                    imagePullPolicy: Always
-                    livenessProbe:
-                      exec:
-                        command:
-                          - ls
-                      initialDelaySeconds: 15
-                      periodSeconds: 20
-                      timeoutSeconds: 10
-                    name: rhmi-operator
-                    ports:
-                      - containerPort: 8090
-                    readinessProbe:
-                      exec:
-                        command:
-                          - ls
-                    resources:
-                      limits:
-                        cpu: 200m
-                        memory: 1536Mi
-                      requests:
-                        cpu: 100m
-                        memory: 64Mi
-                    volumeMounts:
-                      - mountPath: /etc/ssl/certs/webhook
-                        name: webhook-certs
-                serviceAccountName: rhmi-operator
-                terminationGracePeriodSeconds: 10
-                volumes:
-                  - emptyDir: {}
-                    name: webhook-certs
+                    - ls
+                  initialDelaySeconds: 15
+                  periodSeconds: 20
+                  timeoutSeconds: 10
+                name: rhmi-operator
+                ports:
+                - containerPort: 8090
+                readinessProbe:
+                  exec:
+                    command:
+                    - ls
+                resources:
+                  limits:
+                    cpu: 200m
+                    memory: 1536Mi
+                  requests:
+                    cpu: 100m
+                    memory: 64Mi
+                volumeMounts:
+                - mountPath: /etc/ssl/certs/webhook
+                  name: webhook-certs
+              serviceAccountName: rhmi-operator
+              terminationGracePeriodSeconds: 10
+              volumes:
+              - emptyDir: {}
+                name: webhook-certs
       permissions:
-        - rules:
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-              verbs:
-                - get
-                - list
-                - watch
-                - create
-                - update
-                - patch
-                - delete
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps/status
-              verbs:
-                - get
-                - update
-                - patch
-            - apiGroups:
-                - ""
-              resources:
-                - events
-              verbs:
-                - create
-                - patch
-            - apiGroups:
-                - ""
-              resources:
-                - configmaps
-                - secrets
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - endpoints
-              verbs:
-                - get
-                - list
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - events
-                - pods
-              verbs:
-                - create
-                - get
-                - list
-                - patch
-                - update
-                - watch
-            - apiGroups:
-                - ""
-              resources:
-                - services
-                - services/finalizers
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - marin3r.3scale.net
-              resources:
-                - envoyconfigs
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - prometheusrules
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - monitoring.coreos.com
-              resources:
-                - servicemonitors
-              verbs:
-                - create
-                - get
-            - apiGroups:
-                - operator.marin3r.3scale.net
-              resources:
-                - discoveryservices
-              verbs:
-                - create
-                - delete
-                - get
-                - list
-                - update
-                - watch
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - clusterserviceversions
-              verbs:
-                - delete
-                - get
-                - list
-            - apiGroups:
-                - operators.coreos.com
-              resources:
-                - installplans
-                - subscriptions
-                - subscriptions/status
-              verbs:
-                - delete
-                - get
-                - list
-                - patch
-                - update
-                - watch
-          serviceAccountName: rhmi-operator
+      - rules:
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - update
+          - patch
+          - delete
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps/status
+          verbs:
+          - get
+          - update
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+        - apiGroups:
+          - ""
+          resources:
+          - configmaps
+          - secrets
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - endpoints
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - events
+          - pods
+          verbs:
+          - create
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - services/finalizers
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - marin3r.3scale.net
+          resources:
+          - envoyconfigs
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - prometheusrules
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - monitoring.coreos.com
+          resources:
+          - servicemonitors
+          verbs:
+          - create
+          - get
+        - apiGroups:
+          - operator.marin3r.3scale.net
+          resources:
+          - discoveryservices
+          verbs:
+          - create
+          - delete
+          - get
+          - list
+          - update
+          - watch
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - clusterserviceversions
+          verbs:
+          - delete
+          - get
+          - list
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - installplans
+          - subscriptions
+          - subscriptions/status
+          verbs:
+          - delete
+          - get
+          - list
+          - patch
+          - update
+          - watch
+        serviceAccountName: rhmi-operator
     strategy: deployment
   installModes:
-    - supported: true
-      type: OwnNamespace
-    - supported: false
-      type: SingleNamespace
-    - supported: true
-      type: MultiNamespace
-    - supported: false
-      type: AllNamespaces
+  - supported: true
+    type: OwnNamespace
+  - supported: false
+    type: SingleNamespace
+  - supported: true
+    type: MultiNamespace
+  - supported: false
+    type: AllNamespaces
   keywords:
-    - RHOAM
-    - Integration
+  - RHOAM
+  - Integration
   labels:
     alm-owner-rhoam: rhoam-operator
     operated-by: rhoam-operator
   maintainers:
-    - email: rhoam-support@redhat.com
-      name: rhoam
+  - email: rhoam-support@redhat.com
+    name: rhoam
   maturity: alpha
   provider:
     name: rhoam

--- a/bundles/managed-api-service/1.45.0/manifests/rhoam-operator-metrics-service_v1_service.yaml
+++ b/bundles/managed-api-service/1.45.0/manifests/rhoam-operator-metrics-service_v1_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  creationTimestamp: null
+  labels:
+    name: rhmi-operator
+  name: rhoam-operator-metrics-service
+spec:
+  ports:
+  - name: http-metrics
+    port: 8383
+    targetPort: 8383
+  selector:
+    name: rhmi-operator
+status:
+  loadBalancer: {}

--- a/bundles/managed-api-service/1.45.0/metadata/annotations.yaml
+++ b/bundles/managed-api-service/1.45.0/metadata/annotations.yaml
@@ -4,9 +4,8 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: managed-api-service
-  operators.operatorframework.io.bundle.channels.v1: stable
-  operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.39.0
+  operators.operatorframework.io.bundle.channels.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.42.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v4
 

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,6 +1,6 @@
 FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.25-openshift-4.21
 
-ENV OPERATOR_SDK_VERSION=v1.39.0 \
+ENV OPERATOR_SDK_VERSION=v1.42.0 \
     DELOREAN_VERSION=master \
     GOFLAGS="" \
     PROMETHEUS_VERSION=2.37.0 \

--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -19,7 +19,7 @@ Requires you to be oc logged in to any cluster on your host machine.
 ```
 $ docker build -t registry.svc.ci.openshift.org/integr8ly/intly-operator-base-image:latest - < Dockerfile.tools
 $ IMAGE_NAME=registry.svc.ci.openshift.org/integr8ly/intly-operator-base-image:latest test/run
-operator-sdk version: "v1.21.0", commit: "215fc50b2d4acc7d92b36828f42d7d1ae212015c", kubernetes version: "v1.18.8", go version: "go1.19.1", GOOS: "linux", GOARCH: "amd64"
+operator-sdk version: "v1.42.0" (see Dockerfile.tools for exact version)
 go version go1.19.1 linux/amd64
 jq-1.6
 yq version v4.30.6

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -8,7 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Tool versions
-readonly OPERATOR_SDK_VERSION="v1.39.0"
+readonly OPERATOR_SDK_VERSION="v1.42.0"
 
 if [[ -z "$OLM_TYPE" ]]; then
   OLM_TYPE="managed-api-service"


### PR DESCRIPTION
# Issue link
Jira: https://issues.redhat.com/browse/MGDAPI-6902

# What
bump operator-sdk from 1.39 to 1.42

# Verification steps
<details>
## Verification steps

It was validated using OLM. Commands for  images preparations are below

#### Images used for validation:
```
quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0 
quay.io/vmogilev_rhmi/managed-api-service-bundle:v1.45.0
quay.io/vmogilev_rhmi/managed-api-service:v1.45.0
```

#### Images preparation commands used (on MAC, so using platform option)

```
CONTAINER_PLATFORM=linux/amd64 make image/build OPERATOR_IMAGE=quay.io/vmogilev_rhmi/managed-api-service:v1.45.0
docker push quay.io/vmogilev_rhmi/managed-api-service:v1.45.0

// before bundle creation - update CSV , using private image and comment #replace, as we are not checking Upgrade here
make olm/bundle  BUNDLE_TAG="quay.io/vmogilev_rhmi/managed-api-service-bundle:v1.45.0" VERSION=1.45.0 OLM_TYPE=managed-api-service 
docker push quay.io/vmogilev_rhmi/managed-api-service-bundle:v1.45.0

//create index.Dockerfile to allow linux/amd64 image creation on MAC Arm.
opm index add --bundles quay.io/vmogilev_rhmi/managed-api-service-bundle:v1.45.0  --tag quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0  --container-tool docker --generate
docker build --platform=linux/amd64 -f index.Dockerfile -t quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0 .
docker push quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0
```

#### Install RHOAM

1. Create Catalog Source

```
kubectl apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0 
EOF
```

2. Prepare

```
LOCAL=false USE_CLUSTER_STORAGE=true INSTALLATION_TYPE=managed-api make cluster/prepare/local
```

3. Install RHOAM 1.45 from OperatorHub

4. patch RHMI USE_CLUSTER_STORAGE=true

```
INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=true make deploy/integreatly-rhmi-cr.yml   
```

5. check status 
```
 oc get rhmi -n redhat-rhoam-operator -o json | jq ' .items[0] | {addon:.metadata.name} + (.status | {version, toVersion, stage}), (.status | .. | select(.status?) | [.name?,.status?, .version?])' -c
```

#### Logs - check Image 
- Using project "redhat-rhoam-operator" on server xxxx

```
oc describe pod rhmi-operator-7c97bf5885-q765s  |grep Image: 
                  containerImage: quay.io/vmogilev_rhmi/managed-api-service:rhoam-v1.45.0
    Image:         quay.io/vmogilev_rhmi/managed-api-service:v1.45.0
```

- Installation completed:
```
~/go/integreatly-operator oc get rhmi -n redhat-rhoam-operator -o json | jq ' .items[0] | {addon:.metadata.name} + (.status | {version, toVersion, stage}), (.status | .. | select(.status?) | [.name?,.status?, .version?])' -c
{"addon":"rhoam","version":"1.45.0","toVersion":null,"stage":"complete"}
["3scale","completed","2.16.1"]
["cloud-resources","completed","1.1.7"]
["grafana","completed","9.6.0"]
["marin3r","completed","0.13.4"]
["rhsso","completed","7.6"]
["rhssouser","completed","7.6"]
~/go/integreatly-operator 
```

#### Problems found
1. Alerts are firing:
- RHOAMThreescaleCriticalMetricsMissing (New issue, Jira created: MGDAPI-7011#) 
- RHOAMRhssoKeycloakOperatorMetricsServiceEndpointDown (Known issue, see Jira: MGDAPI-6992)
- RHOAMUserRhssoKeycloakOperatorMetricsServiceEndpointDown (Known issue, Jira: MGDAPI-6992)
These issues will be handled separately from current task.
 
2. While checking RHOAMThreescaleCriticalMetricsMissing alert it was found the metrics manifest `rhoam-operator-metrics-service_v1_service.yaml ` is missing in 1.45 bundle. Manifest was added but test via OLM still show alert is firing. It will be investigated in [MGDAPI-7011](https://issues.redhat.com/browse/MGDAPI-7011#).

</details>
