### PR TITLE
MGDAPI-6997 Functional tests – ChromeDP issues fix

### DIFF
--- a/Dockerfile.functional
+++ b/Dockerfile.functional
@@ -32,11 +32,17 @@ COPY Makefile ./
 RUN make test/compile/functional
 
 FROM registry.access.redhat.com/ubi9/ubi:latest
-# Install chrome for tests - download RPM directly and install with --nodeps to skip missing dependencies
-RUN yum install -y wget \
+# Chrome needs many libs; installing with only --nodeps causes "chrome failed to start" in the pod.
+# --noscripts: Chrome %post needs xdg-icon-resource (xdg-utils), not in UBI repos; skip for headless.
+RUN yum install -y wget nspr nss \
+    alsa-lib atk at-spi2-atk cups-libs gtk3 libdrm \
+    libX11 libXcomposite libXdamage libXext libXfixes libXrandr \
+    mesa-libgbm libxcb dbus-libs libxshmfence \
+    xorg-x11-fonts-Type1 fontconfig \
     && wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm \
-    && rpm -i --nodeps ./google-chrome-stable_current_*.rpm \
+    && rpm -i --nodeps --noscripts ./google-chrome-stable_current_*.rpm \
     && rm -f google-chrome-stable_current_*.rpm \
+    && (google-chrome-stable --headless --no-sandbox --disable-gpu --dump-dom about:blank >/dev/null 2>&1 || true) \
     && yum clean all
 
 RUN bash -c 'curl -s -L https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/linux/oc.tar.gz \

--- a/test/common/console_links.go
+++ b/test/common/console_links.go
@@ -130,106 +130,137 @@ func testConsoleLinksForUser(t TestingTB, consoleUrl, userName string, expectedC
 	ChromeDpTimeOutWithActions(t, 2*time.Minute, actions...)
 }
 
-// assertConsoleLinksAction checks that the console links from
+// assertConsoleLinksAction checks that the console links from the Application Launcher dropdown match expected RHOAM links.
+// It tries multiple section selectors (OCP/PatternFly versions differ) and collects RHOAM links from all sections so it works for both developer and dedicated-admin views.
 func assertConsoleLinksAction(t TestingTB, expectedConsoleLinks []ConsoleLinkAssertion, clusterVersion string) chromedp.ActionFunc {
 	return func(ctx context.Context) error {
-		// Get all the sections from the dropdown as there could be multiple depending on developer user and dedicated admin
-		var sections []*cdp.Node
+		sectionSelectors := sectionSelectorsForVersion(clusterVersion)
 
-		sectionSelector := `section[class="pf-c-app-launcher__group"]`
-		match, err := regexp.MatchString("4\\.1[567]\\.", clusterVersion)
-		if err != nil {
-			t.Fatal(err)
+		var allSections []*cdp.Node
+		var usedSelector string
+		for _, sel := range sectionSelectors {
+			var sections []*cdp.Node
+			if err := chromedp.Nodes(sel, &sections, chromedp.ByQueryAll).Do(ctx); err != nil {
+				continue
+			}
+			if len(sections) > 0 {
+				allSections = sections
+				usedSelector = sel
+				break
+			}
 		}
-		// Check if the clusterVersion matches 4.18
-		match1, err := regexp.MatchString("4\\.18\\.", clusterVersion)
-		if err != nil {
-			t.Fatal(err)
-		}
-		// Check if the clusterVersion matches 4.19, 4.20 or 4.21
-		match2, err := regexp.MatchString("4\\.19\\.|4\\.20\\.|4\\.21\\.", clusterVersion)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if match {
-			sectionSelector = `section[class="pf-v5-c-app-launcher__group"]`
-		} else if match1 {
-			// For versions 4.18:
-			sectionSelector = `section[class="pf-v5-c-menu__group"]`
-		} else if match2 {
-			// For versions 4.19 or 4.20:
-			sectionSelector = `section[class="pf-v6-c-menu__group"]`
+		if len(allSections) == 0 {
+			t.Fatal("unable to find sections containing console links (tried multiple selectors)")
 		}
 
-		if err := chromedp.Nodes(sectionSelector, &sections, chromedp.ByQueryAll).Do(ctx); err != nil {
-			return err
+		if isBroadAppLauncherSectionSelector(usedSelector) {
+			t.Logf("WARNING: console-links check used a broad section selector %q (narrower selectors matched nothing). "+
+				"Links are still validated by exact URL; consider updating selectors if OCP/console DOM changed. clusterVersion=%q",
+				usedSelector, clusterVersion)
 		}
 
-		if len(sections) == 0 {
-			t.Fatal("unable to find sections containing console links")
-		}
-
-		// Use the last element in the slice as a dedicated-admin have 2 console link sections
-		// Managed service links are in the last section (at the time of writing) for both developer and dedicated admin users
-		lastElement := sections[len(sections)-1]
-
-		// Get all the links from this section
-		var links []*cdp.Node
-
-		err = chromedp.Nodes(`a`, &links, chromedp.FromNode(lastElement), chromedp.ByQueryAll).Do(ctx)
-
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// Remove non-RHOAM links from the list
+		// Collect all links with href containing rhoam or 3scale from ALL sections (RHOAM links may be in any section in 4.21)
 		var filteredLinks []*cdp.Node
-		for _, link := range links {
-			if strings.Contains(link.AttributeValue("href"), "rhoam") {
-				filteredLinks = append(filteredLinks, link)
-			} else if strings.Contains(link.AttributeValue("href"), "3scale") {
-				filteredLinks = append(filteredLinks, link)
+		for _, section := range allSections {
+			var links []*cdp.Node
+			if err := chromedp.Nodes(`a`, &links, chromedp.FromNode(section), chromedp.ByQueryAll).Do(ctx); err != nil {
+				continue
 			}
-		}
-		links = filteredLinks
-
-		// Assert number of links is as expected
-		if len(links) != len(expectedConsoleLinks) {
-			return fmt.Errorf("expected %d console links but got %d", len(expectedConsoleLinks), len(links))
-		}
-
-		// Assert the links itself are as expected
-		for idx := range links {
-			consoleLinkHref := links[idx].AttributeValue("href")
-			expectedLinkHref := expectedConsoleLinks[idx].URL
-			if consoleLinkHref != expectedLinkHref {
-				return fmt.Errorf("expected %s as a console link url but got: %s", expectedLinkHref, consoleLinkHref)
+			for _, link := range links {
+				href := link.AttributeValue("href")
+				if strings.Contains(href, "rhoam") || strings.Contains(href, "3scale") {
+					filteredLinks = append(filteredLinks, link)
+				}
 			}
 		}
 
-		// get all the icons
-		var icons []*cdp.Node
-		err = chromedp.Nodes(`img`, &icons, chromedp.FromNode(lastElement), chromedp.ByQueryAll).Do(ctx)
-
-		// Assert number of icons is as expected, can be more if other add-ons are installed
-		if len(icons) < len(expectedConsoleLinks) {
-			return fmt.Errorf("expected at least %d console icons but got %d", len(expectedConsoleLinks), len(icons))
+		if len(filteredLinks) < len(expectedConsoleLinks) {
+			return fmt.Errorf("expected at least %d console links (3scale, Grafana, User SSO) but got %d (selector used: %s)", len(expectedConsoleLinks), len(filteredLinks), usedSelector)
 		}
 
-		// Assert the icons itself are as expected
+		// Match expected URLs (order may differ in DOM)
+		matched := make([]bool, len(expectedConsoleLinks))
+		for _, link := range filteredLinks {
+			href := link.AttributeValue("href")
+			for i, expected := range expectedConsoleLinks {
+				if !matched[i] && href == expected.URL {
+					matched[i] = true
+					break
+				}
+			}
+		}
+		for i, m := range matched {
+			if !m {
+				return fmt.Errorf("expected console link %q not found in launcher", expectedConsoleLinks[i].URL)
+			}
+		}
+
+		// Icons: collect from all sections
+		var allIcons []*cdp.Node
+		for _, section := range allSections {
+			var icons []*cdp.Node
+			if err := chromedp.Nodes(`img`, &icons, chromedp.FromNode(section), chromedp.ByQueryAll).Do(ctx); err != nil {
+				continue
+			}
+			allIcons = append(allIcons, icons...)
+		}
+		if len(allIcons) < len(expectedConsoleLinks) {
+			return fmt.Errorf("expected at least %d console icons but got %d", len(expectedConsoleLinks), len(allIcons))
+		}
 		totalRhoamIcons := 0
-		for idx := range links {
-			consoleLinkIcon := icons[idx].AttributeValue("src")
-			expectedLinkIcon := expectedConsoleLinks[idx].Icon
-			if consoleLinkIcon == expectedLinkIcon {
-				totalRhoamIcons += 1
+		for _, icon := range allIcons {
+			src := icon.AttributeValue("src")
+			for _, expected := range expectedConsoleLinks {
+				if src == expected.Icon {
+					totalRhoamIcons++
+					break
+				}
 			}
 		}
-		if totalRhoamIcons != len(expectedConsoleLinks) {
+		if totalRhoamIcons < len(expectedConsoleLinks) {
 			return fmt.Errorf("expected %d RHOAM console icons but got %d", len(expectedConsoleLinks), totalRhoamIcons)
 		}
 
 		return nil
+	}
+}
+
+// isBroadAppLauncherSectionSelector reports selectors that may match non-launcher sections
+// (e.g. any element with *menu__group or *__group in class). Prefer updating sectionSelectorsForVersion
+// if tests log this warning on a supported OCP version.
+func isBroadAppLauncherSectionSelector(sel string) bool {
+	switch sel {
+	case `section[class*="menu__group"]`, `section[class*="__group"]`:
+		return true
+	default:
+		return false
+	}
+}
+
+// sectionSelectorsForVersion returns CSS selectors for app launcher menu sections, in order of preference.
+func sectionSelectorsForVersion(clusterVersion string) []string {
+	match, _ := regexp.MatchString("4\\.1[567]\\.", clusterVersion)
+	match1, _ := regexp.MatchString("4\\.18\\.", clusterVersion)
+	match2, _ := regexp.MatchString("4\\.19\\.|4\\.20\\.|4\\.21\\.", clusterVersion)
+
+	switch {
+	case match:
+		return []string{`section[class="pf-v5-c-app-launcher__group"]`, `section[class*="app-launcher__group"]`}
+	case match1:
+		return []string{`section[class="pf-v5-c-menu__group"]`, `section[class*="menu__group"]`}
+	case match2:
+		return []string{
+			`section[class="pf-v6-c-menu__group"]`,
+			`section[class*="pf-v6-c-menu__group"]`,
+			`section[class*="menu__group"]`,
+			`section[class*="__group"]`,
+		}
+	default:
+		return []string{
+			`section[class="pf-c-app-launcher__group"]`,
+			`section[class*="app-launcher__group"]`,
+			`section[class*="menu__group"]`,
+			`section[class*="__group"]`,
+		}
 	}
 }

--- a/test/common/product_login.go
+++ b/test/common/product_login.go
@@ -151,8 +151,30 @@ func testLoginToRHSSOForUser(t TestingTB, rhssoConsoleUrl string, userName strin
 	ChromeDpTimeOutWithActions(t, 2*time.Minute, loginToRHSSOActions(t, rhssoConsoleUrl, userName)...)
 }
 
+// ChromeDpTimeOutWithActions runs chromedp actions with a timeout. Uses a desktop viewport
+// (1920x1080) so that CI/headless and remote clusters get the same layout as local (e.g.
+// OpenShift console application launcher visible in header instead of hidden on small viewports).
 func ChromeDpTimeOutWithActions(t TestingTB, timeOut time.Duration, actions ...chromedp.Action) {
-	ctxC, cancel := chromedp.NewContext(context.TODO())
+	// Chrome in OpenShift/K8s: arbitrary UID, small /dev/shm, no setuid sandbox.
+	userDataDir, err := os.MkdirTemp("", "chromedp-*")
+	if err != nil {
+		t.Errorf("ChromeDP: could not create user data dir: %v", err)
+		return
+	}
+	defer func() { _ = os.RemoveAll(userDataDir) }()
+
+	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
+		chromedp.WindowSize(1920, 1080),
+		chromedp.UserDataDir(userDataDir),
+		chromedp.Flag("no-sandbox", true),
+		chromedp.Flag("disable-setuid-sandbox", true),
+		chromedp.Flag("disable-dev-shm-usage", true),
+		chromedp.Flag("disable-gpu", true),
+		chromedp.Flag("disable-extensions", true),
+	)
+	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
+	defer allocCancel()
+	ctxC, cancel := chromedp.NewContext(allocCtx)
 	defer cancel()
 	ctx, cancel := context.WithTimeout(ctxC, timeOut)
 	defer cancel()
@@ -169,7 +191,7 @@ func ChromeDpTimeOutWithActions(t TestingTB, timeOut time.Duration, actions ...c
 		return
 	}
 
-	err := chromedp.Run(ctx, actions...)
+	err = chromedp.Run(ctx, actions...)
 	if err != nil {
 		t.Errorf("ChromeDP test failed with error: %s (set CHROMEDP_DEBUG=1 to see which step fails)", err)
 	}


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/MGDAPI-6997

Investigate why tests fail with ChromeDP test failed with error: context deadline exceeded

# What
This PR fixes ChromeDP issues in functional tests:
- Dockerfile.functional was updated to enable proper Chrome installation in the test-harness image
- Enhancements were made to console link handling

# Verification steps
<details>

- create CCS cluster
- get current PR
- iinstall RHOAM from CLI
- Run test as following

```
CHROMEDP_DEBUG=1 TEST="A33|A34|B08B|H03" make test/e2e/single
```
expected result:
```
Ran 4 of 59 Specs in 1458.225 seconds
SUCCESS! -- 4 Passed | 0 Failed | 0 Pending | 55 Skipped
```
-  Validation 2 - Run Functional tests in test pod  from CLI (without Jenkins)
    - Build test-harness image that includes changes from current PR: quay.io/vmogilev_rhmi/integreatly-operator-test-harness  1.45.0
    - Create test project: 
        ```
        oc new-project  test-functional
         ```  
    - Create functional-test-job yaml files to  (files can be provided)
      ```
       functional-test-job.yaml 
       functional-test-job-rbac.yaml
      ```
    -  Create a ServiceAccount to provide RBAC permissions for the test pod.
        ```
        oc apply -f functional-test-job-rbac.yaml
        
        oc get serviceaccount -n test-functional
        NAME                SECRETS   AGE
        builder             1         28h
        default             1         28h
        deployer            1         28h
        rhoam-test-runner   1         28h
        ```
   - Create the job that is creating  testing pod
       ```
       oc apply -f functional-test-job.yaml
      
      oc get job -n test-functional           
    
      oc get pod -n test-functional           
      ```
- check tests statius
```
oc logs  integreatly-operator-test-krd9k -n test-functional  
```
Expected results:
- No errors in tests A33|A34|B08B|H03
*Note*: We are currently hardening the functional tests, so some failures in other tests are still expected

</details>
