### PR TITLE
MGDAPI-6992 reconcile rhsso  operator metrics service

### DIFF
--- a/pkg/products/rhsso/reconciler.go
+++ b/pkg/products/rhsso/reconciler.go
@@ -186,6 +186,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileOperatorMetricsService(ctx, serverClient, installation, operatorNamespace)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile rhsso-operator metrics Service", err)
+		return phase, err
+	}
+
 	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to handle in progress phase", err)

--- a/pkg/products/rhsso/reconciler_test.go
+++ b/pkg/products/rhsso/reconciler_test.go
@@ -30,8 +30,10 @@ import (
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/api/v1alpha1"
 	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 
 	fakeoauthClient "github.com/openshift/client-go/oauth/clientset/versioned/fake"
 	oauthClient "github.com/openshift/client-go/oauth/clientset/versioned/typed/oauth/v1"
@@ -837,6 +839,10 @@ func TestReconciler_fullReconcile(t *testing.T) {
 			if status != tc.ExpectedStatus {
 				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
 			}
+
+			if err == nil && !tc.ExpectError {
+				assertRhssoOperatorMetricsServiceReconciled(t, context.TODO(), tc.FakeClient, tc.Installation, testReconciler.Config.GetOperatorNamespace())
+			}
 		})
 	}
 }
@@ -1104,4 +1110,22 @@ func configureTestServer(t *testing.T /*, apiList *metav1.APIResourceList*/) *ht
 		}
 	}))
 	return server
+}
+
+func assertRhssoOperatorMetricsServiceReconciled(t *testing.T, ctx context.Context, c k8sclient.Client, installation *integreatlyv1alpha1.RHMI, operatorNamespace string) {
+	t.Helper()
+	svc := &corev1.Service{}
+	key := types.NamespacedName{Namespace: operatorNamespace, Name: rhssocommon.RhssoOperatorMetricsServiceName}
+	if err := c.Get(ctx, key, svc); err != nil {
+		t.Fatalf("rhsso-operator metrics Service not found in namespace %q: %v", operatorNamespace, err)
+	}
+	if got := svc.Spec.Selector["name"]; got != "rhsso-operator" {
+		t.Fatalf("metrics Service selector[name]: got %q, want rhsso-operator", got)
+	}
+	if svc.Annotations[owner.IntegreatlyOwnerName] != installation.Name {
+		t.Errorf("annotation %s: got %q, want %q", owner.IntegreatlyOwnerName, svc.Annotations[owner.IntegreatlyOwnerName], installation.Name)
+	}
+	if svc.Annotations[owner.IntegreatlyOwnerNamespace] != installation.Namespace {
+		t.Errorf("annotation %s: got %q, want %q", owner.IntegreatlyOwnerNamespace, svc.Annotations[owner.IntegreatlyOwnerNamespace], installation.Namespace)
+	}
 }

--- a/pkg/products/rhssocommon/operator_metrics_service.go
+++ b/pkg/products/rhssocommon/operator_metrics_service.go
@@ -1,0 +1,63 @@
+package rhssocommon
+
+import (
+	"context"
+	"fmt"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/api/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+)
+
+// Note: The code in this file was developed in collaboration with Cursor AI
+
+// RHOAM PrometheusRules expect kube_endpoint_address{endpoint='rhsso-operator-metrics'} in the
+// RH SSO operator namespace. Upstream RH SSO operator CSV may not ship this Service; reconcile it here.
+const (
+	RhssoOperatorMetricsServiceName = "rhsso-operator-metrics"
+	// Operator SDK / RHOAM operators commonly bind Prometheus metrics on 8383 (see cloud-resource-operator CSV).
+	rhssoOperatorMetricsPort int32 = 8383
+)
+
+// ReconcileOperatorMetricsService ensures a ClusterIP Service selects the rhsso-operator deployment and
+// exposes a port named rhsso-operator-metrics (required for kube-state-metrics endpoint alerts).
+func (r *Reconciler) ReconcileOperatorMetricsService(ctx context.Context, serverClient k8sclient.Client, installation *integreatlyv1alpha1.RHMI, operatorNamespace string) (integreatlyv1alpha1.StatusPhase, error) {
+	if operatorNamespace == "" {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("operator namespace is empty")
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      RhssoOperatorMetricsServiceName,
+			Namespace: operatorNamespace,
+		},
+	}
+	_, err := controllerutil.CreateOrUpdate(ctx, serverClient, svc, func() error {
+		owner.AddIntegreatlyOwnerAnnotations(svc, installation)
+		if svc.Labels == nil {
+			svc.Labels = map[string]string{}
+		}
+		svc.Labels["name"] = "rhsso-operator"
+
+		svc.Spec.Selector = map[string]string{
+			"name": "rhsso-operator",
+		}
+		svc.Spec.Type = corev1.ServiceTypeClusterIP
+		svc.Spec.Ports = []corev1.ServicePort{
+			{
+				Name:       RhssoOperatorMetricsServiceName,
+				Protocol:   corev1.ProtocolTCP,
+				Port:       rhssoOperatorMetricsPort,
+				TargetPort: intstr.FromInt(int(rhssoOperatorMetricsPort)),
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return integreatlyv1alpha1.PhaseFailed, fmt.Errorf("failed to reconcile %s/%s Service: %w", operatorNamespace, RhssoOperatorMetricsServiceName, err)
+	}
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}

--- a/pkg/products/rhssocommon/operator_metrics_service_test.go
+++ b/pkg/products/rhssocommon/operator_metrics_service_test.go
@@ -1,0 +1,132 @@
+package rhssocommon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/api/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
+	"github.com/integr8ly/integreatly-operator/utils"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// Note: The code in this file was developed in collaboration with Cursor AI
+
+func TestReconciler_ReconcileOperatorMetricsService(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	const operatorNS = "redhat-rhoam-rhsso-operator"
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhoam",
+			Namespace: "redhat-rhoam-operator",
+		},
+	}
+
+	r := &Reconciler{}
+
+	t.Run("empty operator namespace returns failed phase", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithScheme(scheme).Build()
+		phase, err := r.ReconcileOperatorMetricsService(context.Background(), client, installation, "")
+		if phase != integreatlyv1alpha1.PhaseFailed {
+			t.Fatalf("phase = %v, want PhaseFailed", phase)
+		}
+		if err == nil || !strings.Contains(err.Error(), "operator namespace is empty") {
+			t.Fatalf("err = %v, want message containing operator namespace is empty", err)
+		}
+	})
+
+	t.Run("creates Service with expected spec and owner annotations", func(t *testing.T) {
+		client := fake.NewClientBuilder().WithScheme(scheme).Build()
+		phase, err := r.ReconcileOperatorMetricsService(context.Background(), client, installation, operatorNS)
+		if err != nil {
+			t.Fatalf("ReconcileOperatorMetricsService: %v", err)
+		}
+		if phase != integreatlyv1alpha1.PhaseCompleted {
+			t.Fatalf("phase = %v, want PhaseCompleted", phase)
+		}
+
+		got := &corev1.Service{}
+		key := types.NamespacedName{Namespace: operatorNS, Name: RhssoOperatorMetricsServiceName}
+		if err := client.Get(context.Background(), key, got); err != nil {
+			t.Fatalf("Get Service: %v", err)
+		}
+
+		if got.Labels["name"] != "rhsso-operator" {
+			t.Errorf("labels[name] = %q, want rhsso-operator", got.Labels["name"])
+		}
+		if got.Annotations[owner.IntegreatlyOwnerName] != installation.Name {
+			t.Errorf("owner name annotation = %q, want %q", got.Annotations[owner.IntegreatlyOwnerName], installation.Name)
+		}
+		if got.Annotations[owner.IntegreatlyOwnerNamespace] != installation.Namespace {
+			t.Errorf("owner namespace annotation = %q, want %q", got.Annotations[owner.IntegreatlyOwnerNamespace], installation.Namespace)
+		}
+		if got.Spec.Type != corev1.ServiceTypeClusterIP {
+			t.Errorf("Spec.Type = %v, want ClusterIP", got.Spec.Type)
+		}
+		if len(got.Spec.Ports) != 1 {
+			t.Fatalf("len(Spec.Ports) = %d, want 1", len(got.Spec.Ports))
+		}
+		p := got.Spec.Ports[0]
+		if p.Name != RhssoOperatorMetricsServiceName || p.Port != rhssoOperatorMetricsPort || p.Protocol != corev1.ProtocolTCP {
+			t.Errorf("port = {Name:%q Port:%d Protocol:%v}, want name=%q port=%d TCP",
+				p.Name, p.Port, p.Protocol, RhssoOperatorMetricsServiceName, rhssoOperatorMetricsPort)
+		}
+		if p.TargetPort != intstr.FromInt(int(rhssoOperatorMetricsPort)) {
+			t.Errorf("TargetPort = %#v, want FromInt(%d)", p.TargetPort, rhssoOperatorMetricsPort)
+		}
+		wantSel := map[string]string{"name": "rhsso-operator"}
+		if len(got.Spec.Selector) != len(wantSel) || got.Spec.Selector["name"] != wantSel["name"] {
+			t.Errorf("Spec.Selector = %v, want %v", got.Spec.Selector, wantSel)
+		}
+	})
+
+	t.Run("updates existing Service to expected spec", func(t *testing.T) {
+		existing := &corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RhssoOperatorMetricsServiceName,
+				Namespace: operatorNS,
+			},
+			Spec: corev1.ServiceSpec{
+				Type: corev1.ServiceTypeClusterIP,
+				Selector: map[string]string{
+					"name": "wrong-selector",
+				},
+				Ports: []corev1.ServicePort{
+					{Name: "metrics", Port: 9999, Protocol: corev1.ProtocolTCP, TargetPort: intstr.FromInt(9999)},
+				},
+			},
+		}
+		client := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(existing).Build()
+
+		phase, err := r.ReconcileOperatorMetricsService(context.Background(), client, installation, operatorNS)
+		if err != nil {
+			t.Fatalf("ReconcileOperatorMetricsService: %v", err)
+		}
+		if phase != integreatlyv1alpha1.PhaseCompleted {
+			t.Fatalf("phase = %v, want PhaseCompleted", phase)
+		}
+
+		got := &corev1.Service{}
+		key := types.NamespacedName{Namespace: operatorNS, Name: RhssoOperatorMetricsServiceName}
+		if err := client.Get(context.Background(), key, got); err != nil {
+			t.Fatalf("Get Service: %v", err)
+		}
+		if got.Spec.Selector["name"] != "rhsso-operator" {
+			t.Errorf("Spec.Selector[name] = %q after update", got.Spec.Selector["name"])
+		}
+		if len(got.Spec.Ports) != 1 || got.Spec.Ports[0].Port != rhssoOperatorMetricsPort {
+			t.Errorf("ports after update = %#v", got.Spec.Ports)
+		}
+	})
+}

--- a/pkg/products/rhssouser/reconciler.go
+++ b/pkg/products/rhssouser/reconciler.go
@@ -217,6 +217,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, err
 	}
 
+	phase, err = r.ReconcileOperatorMetricsService(ctx, serverClient, installation, operatorNamespace)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.Recorder, installation, phase, "Failed to reconcile user-sso rhsso-operator metrics Service", err)
+		return phase, err
+	}
+
 	phase, err = r.CreateKeycloakRoute(ctx, serverClient, r.Config, r.Config.RHSSOCommon, routeName)
 	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
 		events.HandleError(r.Recorder, installation, phase, "Failed to handle in progress phase", err)

--- a/pkg/products/rhssouser/reconciler_test.go
+++ b/pkg/products/rhssouser/reconciler_test.go
@@ -30,7 +30,9 @@ import (
 
 	integreatlyv1alpha1 "github.com/integr8ly/integreatly-operator/api/v1alpha1"
 	"github.com/integr8ly/integreatly-operator/pkg/config"
+	"github.com/integr8ly/integreatly-operator/pkg/products/rhssocommon"
 	"github.com/integr8ly/integreatly-operator/pkg/resources/marketplace"
+	"github.com/integr8ly/integreatly-operator/pkg/resources/owner"
 	keycloak "github.com/integr8ly/keycloak-client/apis/keycloak/v1alpha1"
 	keycloakCommon "github.com/integr8ly/keycloak-client/pkg/common"
 	configv1 "github.com/openshift/api/config/v1"
@@ -727,6 +729,10 @@ func TestReconciler_full_RHMI_Reconcile(t *testing.T) {
 			if status != tc.ExpectedStatus {
 				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
 			}
+
+			if err == nil && !tc.ExpectError {
+				assertRhssoOperatorMetricsServiceReconciled(t, context.TODO(), tc.FakeClient, tc.Installation, testReconciler.Config.GetOperatorNamespace())
+			}
 		})
 	}
 }
@@ -1087,6 +1093,10 @@ func TestReconciler_full_RHOAM_Reconcile(t *testing.T) {
 
 			if status != tc.ExpectedStatus {
 				t.Fatalf("Expected status: '%v', got: '%v'", tc.ExpectedStatus, status)
+			}
+
+			if err == nil && !tc.ExpectError {
+				assertRhssoOperatorMetricsServiceReconciled(t, context.TODO(), tc.FakeClient, tc.Installation, testReconciler.Config.GetOperatorNamespace())
 			}
 		})
 	}
@@ -1600,4 +1610,22 @@ func configureTestServer(t *testing.T) *httptest.Server {
 		}
 	}))
 	return server
+}
+
+func assertRhssoOperatorMetricsServiceReconciled(t *testing.T, ctx context.Context, c k8sclient.Client, installation *integreatlyv1alpha1.RHMI, operatorNamespace string) {
+	t.Helper()
+	svc := &corev1.Service{}
+	key := types.NamespacedName{Namespace: operatorNamespace, Name: rhssocommon.RhssoOperatorMetricsServiceName}
+	if err := c.Get(ctx, key, svc); err != nil {
+		t.Fatalf("rhsso-operator metrics Service not found in namespace %q: %v", operatorNamespace, err)
+	}
+	if got := svc.Spec.Selector["name"]; got != "rhsso-operator" {
+		t.Fatalf("metrics Service selector[name]: got %q, want rhsso-operator", got)
+	}
+	if svc.Annotations[owner.IntegreatlyOwnerName] != installation.Name {
+		t.Errorf("annotation %s: got %q, want %q", owner.IntegreatlyOwnerName, svc.Annotations[owner.IntegreatlyOwnerName], installation.Name)
+	}
+	if svc.Annotations[owner.IntegreatlyOwnerNamespace] != installation.Namespace {
+		t.Errorf("annotation %s: got %q, want %q", owner.IntegreatlyOwnerNamespace, svc.Annotations[owner.IntegreatlyOwnerNamespace], installation.Namespace)
+	}
 }


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/MGDAPI-6992

# What
**Jira**: Investigate why the Keycloak operator is missing its metrics service
**Result of the investigation:**
It was found that metrics services are not provided by RHSSO. Therefore, we had two options:
- Remove related alerts, or
- Handle the issue within RHOAM

This PR implements the fix in RHOAM by reconciling/creating the rhsso-operator-metrics Service in both the rhsso and user-sso operator namespaces. 
This resolves the issue of the following alerts firing:
- RHOAMRhssoKeycloakOperatorMetricsServiceEndpointDown
- RHOAMUserRhssoKeycloakOperatorMetricsServiceEndpointDown

# Verification steps
- Apply this PR
- Install RHOAM locally
- Verify that the alerts are not firing
_Note: In comparison with the eng-long-live cluster, these alerts are firing there._
