### PR TITLE
MGDAPI-7023 Functional tests check/fix: B04, E09, H35

### DIFF
--- a/test/common/3scale_smtp.go
+++ b/test/common/3scale_smtp.go
@@ -30,10 +30,11 @@ import (
 )
 
 const (
-	testNamespace = "smtp-server"
-	none          = "None"
-	partial       = "Partial"
-	full          = "Full"
+	testNamespace         = "smtp-server"
+	none                  = "None"
+	partial               = "Partial"
+	full                  = "Full"
+	smtpStatusPollTimeout = 10 * time.Minute
 )
 
 var (
@@ -67,7 +68,7 @@ func Test3ScaleSMTPConfig(t TestingTB, ctx *TestingContext) {
 	}
 
 	if !okToTest {
-		t.Skip("Addon custom smtp values are configured. This test is not ok to run.")
+		t.Skip("Custom SMTP parameters are configured. This test is not ok to run.")
 	}
 
 	defer restartThreeScalePods(t, ctx, inst)
@@ -165,7 +166,7 @@ func Test3ScaleCustomSMTPFullConfig(t TestingTB, ctx *TestingContext) {
 			return nil
 		})
 		if err != nil {
-			return
+			t.Fatalf("failed to patch addon parameters secret for full custom SMTP test: %v", err)
 		}
 
 		defer resetSecretData(t, ctx, data, secret)
@@ -178,10 +179,10 @@ func Test3ScaleCustomSMTPFullConfig(t TestingTB, ctx *TestingContext) {
 	}
 
 	if !okToTest {
-		t.Skip("Addon custom smtp values are not fully configured. This test is not ok to run.")
+		t.Skip("Custom SMTP parameters are not fully configured. This test is not ok to run.")
 	}
 
-	err = wait.PollUntilContextTimeout(goctx.TODO(), retryInterval, timeout, false, func(ctx2 goctx.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(goctx.TODO(), retryInterval, smtpStatusPollTimeout, false, func(ctx2 goctx.Context) (done bool, err error) {
 		inst, err = GetRHMI(ctx.Client, true)
 		if err != nil {
 			t.Logf("failed to get RHOAM instance %v", err)
@@ -197,7 +198,7 @@ func Test3ScaleCustomSMTPFullConfig(t TestingTB, ctx *TestingContext) {
 
 	})
 	if err != nil {
-		t.Errorf("CR conditions not meet", err)
+		t.Fatalf("CR conditions not met for full custom SMTP: %v", err)
 	}
 
 	if inst.Status.CustomSmtp.Error != "" {
@@ -276,7 +277,7 @@ func Test3ScaleCustomSMTPPartialConfig(t TestingTB, ctx *TestingContext) {
 			return nil
 		})
 		if err != nil {
-			return
+			t.Fatalf("failed to patch addon parameters secret for partial custom SMTP test: %v", err)
 		}
 
 		defer resetSecretData(t, ctx, data, secret)
@@ -288,10 +289,10 @@ func Test3ScaleCustomSMTPPartialConfig(t TestingTB, ctx *TestingContext) {
 	}
 
 	if !okToTest {
-		t.Skip("Addon custom smtp values are not partial configured. This test is not ok to run.")
+		t.Skip("Custom SMTP parameters are not partially configured. This test is not ok to run.")
 	}
 
-	err = wait.PollUntilContextTimeout(goctx.TODO(), retryInterval, timeout, false, func(ctx2 goctx.Context) (done bool, err error) {
+	err = wait.PollUntilContextTimeout(goctx.TODO(), retryInterval, smtpStatusPollTimeout, false, func(ctx2 goctx.Context) (done bool, err error) {
 		inst, err = GetRHMI(ctx.Client, true)
 		if err != nil {
 			t.Logf("failed to get RHOAM instance %v", err)
@@ -802,7 +803,7 @@ func copyAddonSecretData(secret *v1.Secret, ctx *TestingContext, inst *rhmiv1alp
 	// copy the current custom smtp values
 	newSecret, err := addonSecret(inst, ctx.Client)
 	if err != nil {
-		return nil, fmt.Errorf("error getting addon: %v", err)
+		return nil, fmt.Errorf("error getting addon parameters secret: %v", err)
 	}
 
 	data := make(map[string][]byte)

--- a/test/common/dashboards_exist.go
+++ b/test/common/dashboards_exist.go
@@ -40,10 +40,17 @@ func TestIntegreatlyCustomerDashboardsExist(t TestingTB, ctx *TestingContext) {
 
 	customerMonitoringGrafanaPods := getGrafanaPods(t, ctx, CustomerGrafanaNamespace)
 
-	output, err := execToPod(fmt.Sprintf("wget -qO - %v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP),
+	grafanaSearchURL := fmt.Sprintf("http://%v:3000/api/search", customerMonitoringGrafanaPods.Items[0].Status.PodIP)
+	output, err := execToPod("curl -sS "+grafanaSearchURL,
 		prometheusPodName,
 		ObservabilityProductNamespace,
 		curlContainerName, ctx)
+	if err != nil && (strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "No such file")) {
+		output, err = execToPod("wget -qO - "+grafanaSearchURL,
+			prometheusPodName,
+			ObservabilityProductNamespace,
+			curlContainerName, ctx)
+	}
 	if err != nil {
 		t.Fatal("failed to exec to pod:", err, "pod name:", prometheusPodName, "container name:", curlContainerName, "namespace:", ObservabilityProductNamespace)
 	}


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/MGDAPI-7023

# What
- Jira: Functional tests check/fix: B04, E09, H35
  - B04-Verify Dedicated Admin User Permissions are Correct  – the test is working. It appears to have been fixed during previous test hardening tasks.
- This PR fixes tests: 
    - E09-Verify customer dashboards exist
    - H35-Verify 3scale custom SMTP partial config

Main changes:
- E09 – use curl, with fallback to wget if not available
- H35 – increased timeout; introduced smtpStatusPollTimeout = 10 min

# Verification steps
1. Checkout this PR
2. Create a CCS cluster
3. Install RHOAM and IDP
4. Run tests:
   TEST="B04|E09|H35" make test/e2e/single

Expected result: all three tests pass.

- Test log example:
<details>

```

~/go/integreatly-operator TEST="B04|E09|H35" make test/e2e/single
cd test && go clean -testcache && go test ./functional -ginkgo.focus="B04|E09|H35.*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
time="2026-04-27T17:23:50+03:00" level=info msg="calling reset on all prometheus gauge vectors" custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /Users/valerymogilevsky/go/integreatly-operator/test/functional
======================================================================================================
Random Seed: 1777299830

Will run 3 of 59 specs
------------------------------
[BeforeSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:79
  STEP: bootstrapping test environment @ 04/27/26 17:23:57.264
[BeforeSuite] PASSED [0.011 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
integreatly managed-api IDP BASED B04 - Verify Dedicated Admin User Permissions are Correct
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
  not creating IDP, it's already created
  Performing OpenShift HTTP client setup with URL https://console-openshift-console.xxxxxx.org/auth/login
  Verifying Dedicated admin permissions for Secrets Resource
• [15.104 seconds]
------------------------------
SSSSSSSSS
------------------------------
integreatly managed-api IDP BASED H35 - Verify 3scale custom SMTP partial config
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
  CR conditions met
  Resetting data
• [26.406 seconds]
------------------------------
SSSSS
------------------------------
integreatly managed-api OBSERVABILITY TESTS E09 - Verify customer dashboards exist
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
• [6.274 seconds]
------------------------------
SSSSSSSSSSSSSS
------------------------------
[AfterSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:108
  STEP: tearing down the test environment @ 04/27/26 17:24:45.067
[AfterSuite] PASSED [0.002 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.005 seconds]
------------------------------

Ran 3 of 59 Specs in 47.801 seconds
SUCCESS! -- 3 Passed | 0 Failed | 0 Pending | 56 Skipped
.....
--- PASS: TestAPIs (54.17s)
PASS
ok  	github.com/integr8ly/integreatly-operator/test/functional	55.005s
~/go/integreatly-operator 

```

</details>