### PR TITLE
MGDAPI-6993 Add IsInReconcilingErrorState alerts to C04 test

### DIFF
--- a/test/common/alerts_exist.go
+++ b/test/common/alerts_exist.go
@@ -165,9 +165,14 @@ func managedApiSpecificRules(installationName string) []alertsTestRule {
 			},
 		},
 		{
-			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
+			File: ObservabilityNamespacePrefix + "rhoam-component-reconciling-errors.yaml",
 			Rules: []string{
-				"RHOAMIsInReconcilingErrorState",
+				"RHOAMRHSSOIsInReconcilingErrorState",
+				"RHOAM3ScaleIsInReconcilingErrorState",
+				"RHOAMCloudResourcesIsInReconcilingErrorState",
+				"RHOAMMarin3rIsInReconcilingErrorState",
+				"RHOAMGrafanaIsInReconcilingErrorState",
+				"RHOAMRHSSOUserIsInReconcilingErrorState",
 			},
 		},
 	}
@@ -235,9 +240,14 @@ func mtManagedApiSpecificRules() []alertsTestRule {
 			},
 		},
 		{
-			File: ObservabilityNamespacePrefix + "rhoam-rhmi-controller-alerts.yaml",
+			File: ObservabilityNamespacePrefix + "rhoam-component-reconciling-errors.yaml",
 			Rules: []string{
-				"RHOAMIsInReconcilingErrorState",
+				"RHOAMRHSSOIsInReconcilingErrorState",
+				"RHOAM3ScaleIsInReconcilingErrorState",
+				"RHOAMCloudResourcesIsInReconcilingErrorState",
+				"RHOAMMarin3rIsInReconcilingErrorState",
+				"RHOAMGrafanaIsInReconcilingErrorState",
+				"RHOAMRHSSOUserIsInReconcilingErrorState",
 			},
 		},
 		{
@@ -750,12 +760,7 @@ func TestIntegreatlyAlertsExist(t TestingTB, ctx *TestingContext) {
 		t.Fatalf("failed to get expected cloud platform rules: %s", err)
 	}
 
-	// exec into the prometheus pod
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/rules",
-
-		ObservabilityPrometheusPodName,
-		ObservabilityProductNamespace,
-		"prometheus", ctx)
+	output, err := PrometheusPodLocalhostGET(ctx, ObservabilityPrometheusPodName, "/api/v1/rules")
 	if err != nil {
 		t.Fatal("failed to exec to pod:", err)
 	}

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -284,6 +284,23 @@ func execToPod(command string, podName string, namespace string, container strin
 	return ExecToPod(ctx.KubeClient, ctx.KubeConfig, command, podName, namespace, container)
 }
 
+// PrometheusPodLocalhostGET execs into the Prometheus pod and GETs http://localhost:9090{path} (curl/wget).
+// Currently used by C04; intended for reuse in other tests.
+func PrometheusPodLocalhostGET(ctx *TestingContext, podName, path string) (string, error) {
+	if path == "" || path[0] != '/' {
+		return "", fmt.Errorf("path must be non-empty and start with /, got %q", path)
+	}
+	fullURL := "http://localhost:9090" + path
+	out, err := ExecToPodArgs(ctx.KubeClient, ctx.KubeConfig, []string{"curl", "-sS", fullURL}, podName, ObservabilityProductNamespace, "prometheus")
+	if err == nil {
+		return out, nil
+	}
+	if strings.Contains(err.Error(), "not found") || strings.Contains(err.Error(), "No such file") {
+		return ExecToPodArgs(ctx.KubeClient, ctx.KubeConfig, []string{"wget", "-qO", "-", fullURL}, podName, ObservabilityProductNamespace, "prometheus")
+	}
+	return "", err
+}
+
 // Is the cluster using on cluster or external storage
 func isClusterStorage(ctx *TestingContext) (bool, error) {
 	rhmi, err := GetRHMI(ctx.Client, true)


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/MGDAPI-6993

Add IsInReconcilingErrorState alerts to C04 test

# What
- This PR updates the C04 test by adding and updating alerting rules:
  - "RHOAMRHSSOIsInReconcilingErrorState"
  - "RHOAM3ScaleIsInReconcilingErrorState"
  - "RHOAMCloudResourcesIsInReconcilingErrorState"
  - "RHOAMMarin3rIsInReconcilingErrorState"
  - "RHOAMGrafanaIsInReconcilingErrorState"
  - "RHOAMRHSSOUserIsInReconcilingErrorState"

- This PR also fixes an issue with missing wget by introducing a shared helper function PrometheusPodLocalhostGET.
  The function is currently used only by the C04 test but can be reused later for other test hardening.

# Verification steps
1. Checkout this PR
2. Create a CCS cluster
3. Install RHOAM and IDP
4. Run tests:
   TEST="C04" make test/e2e/single

Expected result: C04 test passes, similar to the example below (see details)

<details>

```

~/go/integreatly-operator TEST="C04" make test/e2e/single                                             
cd test && go clean -testcache && go test ./functional -ginkgo.focus="C04.*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
time="2026-04-28T12:37:00+03:00" level=info msg="calling reset on all prometheus gauge vectors" custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /Users/valerymogilevsky/go/integreatly-operator/test/functional
======================================================================================================
Random Seed: 1777369020

Will run 1 of 59 specs
------------------------------
[BeforeSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:79
  STEP: bootstrapping test environment @ 04/28/26 12:37:08.009
[BeforeSuite] PASSED [0.011 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
integreatly managed-api OBSERVABILITY TESTS C04 - Verify Alerts exist
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
• [6.984 seconds]
........

Ran 1 of 59 Specs in 7.000 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
You're using deprecated Ginkgo functionality:
.....
PASS
ok  	github.com/integr8ly/integreatly-operator/test/functional	15.904s
~/go/integreatly-operator 

```

</details>
