### PR TITLE
MGDAPI-7022 functional tests fixes - Prometheus targets, probes, RHOAM metrics

### DIFF
--- a/test/common/dashboards_data.go
+++ b/test/common/dashboards_data.go
@@ -43,12 +43,10 @@ func getMonitoringAppPodName(app string, ctx *TestingContext) (string, error) {
 }
 
 func queryPrometheus(query string, podName string, ctx *TestingContext) ([]prometheusQueryResult, error) {
-	queryOutput, err := execToPod("wget -qO - localhost:9090/api/v1/query?query="+url.QueryEscape(query),
-		podName,
-		ObservabilityProductNamespace,
-		"prometheus", ctx)
+	path := "/api/v1/query?query=" + url.QueryEscape(query)
+	queryOutput, err := PrometheusPodLocalhostGET(ctx, podName, path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to exec to prometheus pod: %w", err)
+		return nil, fmt.Errorf("failed to query prometheus: %w", err)
 	}
 
 	return getPrometheusQueryResult(queryOutput)

--- a/test/common/shared_functions.go
+++ b/test/common/shared_functions.go
@@ -285,7 +285,6 @@ func execToPod(command string, podName string, namespace string, container strin
 }
 
 // PrometheusPodLocalhostGET execs into the Prometheus pod and GETs http://localhost:9090{path} (curl/wget).
-// Currently used by C04; intended for reuse in other tests.
 func PrometheusPodLocalhostGET(ctx *TestingContext, podName, path string) (string, error) {
 	if path == "" || path[0] != '/' {
 		return "", fmt.Errorf("path must be non-empty and start with /, got %q", path)

--- a/test/common/verify_prometheus_metrics.go
+++ b/test/common/verify_prometheus_metrics.go
@@ -20,27 +20,15 @@ func mangedApiTargets() map[string][]string {
 			"/integreatly-rhssouser",
 		},
 		"serviceMonitor/" + ObservabilityProductNamespace: {
+			"/threescale-operator-controller-manager-metrics-monitor/0",
+			"/3scale-service-monitor/0",
+			"/cloud-resource-operator-metrics/0",
+			"/ratelimit/0",
 			"/rhsso-keycloak-service-monitor/0",
 			"/rhsso-keycloak-service-monitor/1",
-		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {
-			"/rhsso-operator-metrics/0",
-			"/rhsso-operator-metrics/1",
-		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {
 			"/user-sso-keycloak-service-monitor/0",
 			"/user-sso-keycloak-service-monitor/1",
 		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {
-			"/user-sso-operator-rhsso-operator-metrics/0",
-			"/user-sso-operator-rhsso-operator-metrics/1",
-		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/cloud-resource-operator-metrics/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/ratelimit/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/threescale-operator-controller-manager-metrics-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/3scale-service-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/openshift-monitoring-federation/0"},
-		"serviceMonitor/" + RHOAMOperatorNamespace:        {"/rhmi-operator-metrics/0"},
 	}
 }
 
@@ -54,19 +42,15 @@ func mtMangedApiTargets() map[string][]string {
 			"/integreatly-rhsso",
 		},
 		"serviceMonitor/" + ObservabilityProductNamespace: {
+			"/threescale-operator-controller-manager-metrics-monitor/0",
+			"/3scale-service-monitor/0",
+			"/cloud-resource-operator-metrics/0",
+			"/ratelimit/0",
 			"/rhsso-keycloak-service-monitor/0",
 			"/rhsso-keycloak-service-monitor/1",
+			"/user-sso-keycloak-service-monitor/0",
+			"/user-sso-keycloak-service-monitor/1",
 		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {
-			"/rhsso-operator-metrics/0",
-			"/rhsso-operator-metrics/1",
-		},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/cloud-resource-operator-metrics/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/ratelimit/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/threescale-operator-controller-manager-metrics-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/3scale-service-monitor/0"},
-		"serviceMonitor/" + ObservabilityProductNamespace: {"/openshift-monitoring-federation/0"},
-		"serviceMonitor/" + RHOAMOperatorNamespace:        {"/rhmi-operator-metrics/0"},
 	}
 }
 
@@ -103,13 +87,9 @@ func TestMetricsScrappedByPrometheus(t TestingTB, ctx *TestingContext) {
 }
 
 func getPrometheusTargets(ctx *TestingContext) (*prometheusv1.TargetsResult, error) {
-	output, err := execToPod("wget -qO - localhost:9090/api/v1/targets?state=active",
-		ObservabilityPrometheusPodName,
-		ObservabilityProductNamespace,
-		"prometheus",
-		ctx)
+	output, err := PrometheusPodLocalhostGET(ctx, ObservabilityPrometheusPodName, "/api/v1/targets?state=active")
 	if err != nil {
-		return nil, fmt.Errorf("failed to exec to prometheus pod: %v", err)
+		return nil, fmt.Errorf("failed to fetch prometheus targets from pod: %w", err)
 	}
 
 	// get all found active targets from the prometheus api


### PR DESCRIPTION
# Issue link
https://redhat.atlassian.net/browse/MGDAPI-7022

# What
- Check and fix following Functional tests
M02B – RHOAM version metric
C10B – Prometheus blackbox targets
Verify Prometheus Probe targets Active
Test RHMI installation CR metric

# Verification steps
1. Checkout this PR
2. Create a CCS cluster
3. Install RHOAM and IDP
4. Run tests:
       TEST="M02B|C10B" make test/e2e/single
       TEST="Verify Prometheus Probe targets Active" make test/e2e/single
       TEST="Test RHMI installation CR metric" make test/e2e/single

Expected result: all four tests pass.

- Test log example:
<details>

~/go/integreatly-operator 
~/go/integreatly-operator 
~/go/integreatly-operator        TEST="M02B|C10B" make test/e2e/single
       TEST="Verify Prometheus Probe targets Active" make test/e2e/single
       TEST="Test RHMI installation CR metric" make test/e2e/single

cd test && go clean -testcache && go test ./functional -ginkgo.focus="M02B|C10B.*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
time="2026-05-10T12:37:43+03:00" level=info msg="calling reset on all prometheus gauge vectors" custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /Users/valerymogilevsky/go/integreatly-operator/test/functional
======================================================================================================
Random Seed: 1778405863

Will run 2 of 59 specs
------------------------------
[BeforeSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:79
  STEP: bootstrapping test environment @ 05/10/26 12:37:50.33
[BeforeSuite] PASSED [0.011 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
integreatly managed-api OBSERVABILITY TESTS C10B - Verify Prometheus blackbox targets
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
• [6.254 seconds]
------------------------------
S
------------------------------
integreatly managed-api OBSERVABILITY TESTS M02B - Verify RHOAM version metric is exposed in Prometheus
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
• [5.573 seconds]
------------------------------
SSSSSSSSSSSSS
------------------------------
[AfterSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:108
  STEP: tearing down the test environment @ 05/10/26 12:38:02.169
[AfterSuite] PASSED [0.002 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.005 seconds]
------------------------------

Ran 2 of 59 Specs in 11.842 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 57 Skipped
.......

To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.23.4

--- PASS: TestAPIs (18.54s)
PASS
ok  	github.com/integr8ly/integreatly-operator/test/functional	20.534s
cd test && go clean -testcache && go test ./functional -ginkgo.focus="Verify Prometheus Probe targets Active.*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
time="2026-05-10T12:38:08+03:00" level=info msg="calling reset on all prometheus gauge vectors" custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /Users/valerymogilevsky/go/integreatly-operator/test/functional
======================================================================================================
Random Seed: 1778405888

Will run 1 of 59 specs
------------------------------
[BeforeSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:79
  STEP: bootstrapping test environment @ 05/10/26 12:38:14.985
[BeforeSuite] PASSED [0.011 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
integreatly managed-api OBSERVABILITY TESTS Verify Prometheus Probe targets Active
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
  Starting validation of Prometheus Probe Targets...
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-3scale-admin-ui
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-3scale-admin-ui is active and healthy.
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-3scale-system-developer
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-3scale-system-developer is active and healthy.
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-3scale-system-master
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-3scale-system-master is active and healthy.
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-grafana
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-grafana is active and healthy.
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-rhsso
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-rhsso is active and healthy.
  Polling Prometheus targets for job: probe/redhat-rhoam-operator-observability/integreatly-rhssouser
  SUCCESS: Prometheus target probe/redhat-rhoam-operator-observability/integreatly-rhssouser is active and healthy.
• [14.299 seconds]
------------------------------
SSSSSSSSS
------------------------------
[AfterSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:108
  STEP: tearing down the test environment @ 05/10/26 12:38:29.296
[AfterSuite] PASSED [0.002 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.004 seconds]
------------------------------

Ran 1 of 59 Specs in 14.314 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
.......
To silence deprecations that can be silenced set the following environment variable:
  ACK_GINKGO_DEPRECATIONS=2.23.4

--- PASS: TestAPIs (20.54s)
PASS
ok  	github.com/integr8ly/integreatly-operator/test/functional	21.375s
cd test && go clean -testcache && go test ./functional -ginkgo.focus="Test RHMI installation CR metric.*" -test.v -ginkgo.v -ginkgo.progress -timeout=80m
time="2026-05-10T12:38:34+03:00" level=info msg="calling reset on all prometheus gauge vectors" custom_metrics=StartGaugeVector
=== RUN   TestAPIs
Running Suite: Functional Test Suite - /Users/valerymogilevsky/go/integreatly-operator/test/functional
======================================================================================================
Random Seed: 1778405914

Will run 1 of 59 specs
------------------------------
[BeforeSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:79
  STEP: bootstrapping test environment @ 05/10/26 12:38:41.086
[BeforeSuite] PASSED [0.012 seconds]
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
integreatly managed-api OBSERVABILITY TESTS Test RHMI installation CR metric
/Users/valerymogilevsky/go/integreatly-operator/test/functional/integreatly_test.go:139
• [6.349 seconds]
------------------------------
SSSSSSSSSSSS
------------------------------
[AfterSuite] 
/Users/valerymogilevsky/go/integreatly-operator/test/functional/suite_test.go:108
  STEP: tearing down the test environment @ 05/10/26 12:38:47.447
[AfterSuite] PASSED [0.001 seconds]
------------------------------
[ReportAfterSuite] Autogenerated ReportAfterSuite for --junit-report
autogenerated by Ginkgo
[ReportAfterSuite] PASSED [0.005 seconds]
------------------------------

Ran 1 of 59 Specs in 6.363 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 58 Skipped
You're using deprecated Ginkgo functionality:
=============================================
...
--- PASS: TestAPIs (12.67s)
PASS
ok  	github.com/integr8ly/integreatly-operator/test/functional	13.493s
~/go/integreatly-operator 


</details>
