### PR TITLE
MGDAPI-6598 omit CRO 1.1.6 from fresh index; rely on 1.1.8 skipRange

### DIFF
--- a/bundles/cloud-resource-operator/bundles.yaml
+++ b/bundles/cloud-resource-operator/bundles.yaml
@@ -1,7 +1,6 @@
-# initial bundle must contain olm.skipRange (for 1.1.6)
+# Omit 1.1.6: midstream 1.1.7 has no replaces, so opm would prune 1.1.6 from a fresh index.
+# Installed 1.1.6 (RHOAM 1.43) still upgrades via 1.1.8 olm.skipRange; 1.1.7 via replaces.
 bundles:
-    - name: cloud-resource-operator.v1.1.6
-      image: quay.io/integreatly/cloud-resource-operator:v1.1.6-bundle
     - name: cloud-resource-operator.v1.1.7
       image: quay.io/integreatly/cloud-resource-operator:v1.1.7-bundle
     - name: cloud-resource-operator.v1.1.8


### PR DESCRIPTION
# Issue link
Jira: https://redhat.atlassian.net/browse/MGDAPI-6598

# What
omit CRO 1.1.6 from fresh index; rely on 1.1.8 skipRange

# Verification steps
Jenkins - create index image for CRO 1.1.8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the initial bundle selection to omit version 1.1.6.
  * Versions 1.1.7 and 1.1.8 remain available, with existing upgrade behavior preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->