### PR TITLE
MGDAPI-7004 ElastiCache service update

### DIFF
--- a/pkg/products/cloudresources/reconciler.go
+++ b/pkg/products/cloudresources/reconciler.go
@@ -57,7 +57,7 @@ const (
 	cidrRangeKeyAws              = "cidr-range"
 )
 
-var redisServiceUpdatesToInstall = []string{"elasticache-20250804-intel", "elasticache-july-patch-update-202507", "elasticache-20250603-intel", "elasticache-april-patch-update-202504", "elasticache-20250507-intel", "elasticache-20241007-intel", "elasticache-redis-cve-patch-update-202410", "elasticache-patch-update-202501", "elasticache-20210615-002", "elasticache-redis-6-2-6-update-20230109", "elasticache-20230315-001", "elasticache-redis-6-2-update", "elasticache-20240225-intel", "elasticache-20240501-intel"}
+var redisServiceUpdatesToInstall = []string{"elasticache-20260608-intel", "elasticache-may-patch-update-202605", "elasticache-apr-patch-update-202604", "elasticache-feb-patch-update-202602", "elasticache-20260105-intel", "elasticache-october-patch-update-2-202510", "elasticache-october-patch-update-202510", "elasticache-20250901-intel", "elasticache-20250804-intel", "elasticache-july-patch-update-202507", "elasticache-20250603-intel", "elasticache-april-patch-update-202504", "elasticache-20250507-intel"}
 
 // this timestamp is 2022-01-15-00:00:01
 var postgresServiceUpdateTimestamp = []string{"1642204801"}


### PR DESCRIPTION
# Issue link
Jira: https://redhat.atlassian.net/browse/MGDAPI-7004

# What
MGDAPI-7004 ElastiCache service update
- add new ElastiCache service updates
- remove old ElastiCache service updates that not available already in AWS:

 `
aws elasticache describe-service-updates \
  --service-update-status available \
  --query "reverse(sort_by(ServiceUpdates,&ServiceUpdateReleaseDate))[?contains(ServiceUpdateName, '2023')].{Name:ServiceUpdateName,Released:ServiceUpdateReleaseDate,Severity:ServiceUpdateSeverity,Type:ServiceUpdateType,Status:ServiceUpdateStatus}" \   
  --output table
`

# Verification steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the set of Redis service updates automatically installed during reconciliation.
  * Helps ensure supported Redis maintenance updates are applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->