### PR TITLE
MGDAPI-7053 bump Images for ratelimit, limitador, grafana

### DIFF
--- a/api/v1alpha1/rhmi_types.go
+++ b/api/v1alpha1/rhmi_types.go
@@ -68,7 +68,7 @@ var (
 	VersionRHSSO          ProductVersion = "7.6"
 	VersionRHSSOUser      ProductVersion = "7.6"
 	VersionMarin3r        ProductVersion = "0.13.4"
-	VersionGrafana        ProductVersion = "9.6.0"
+	VersionGrafana        ProductVersion = "9.8.0"
 
 	PreflightInProgress PreflightStatus = ""
 	PreflightSuccess    PreflightStatus = "successful"

--- a/bundles/managed-api-service/1.45.0/manifests/managed-api-service.clusterserviceversion.yaml
+++ b/bundles/managed-api-service/1.45.0/manifests/managed-api-service.clusterserviceversion.yaml
@@ -79,16 +79,16 @@ metadata:
           "rhsso_init_container": "registry.redhat.io/rh-sso-7/sso7-rhel8-init-container@sha256:2e63f15a19d60447d9dfd11b0d04ba634932a9c43e63773051069cdc1f5ad504"
         },
         "ratelimit": {
-          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.12-1767872298"
+          "3scale-openshift-service-mesh": "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.17-1781604724"
         },
         "limitador": {
-          "marin3r-limitador": "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:aff28d76f9cfeefafd6b652e055bb25e1a2bf250e062e3e9b5e54db873f9eeb7"
+          "marin3r-limitador": "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4"
         },
         "grafana": {
-          "grafana": "registry.redhat.io/rhel9/grafana:9.7-1767725073"
+          "grafana": "registry.redhat.io/rhel9/grafana:9.8-1785444441"
         },
         "grafana-ose-oauth-proxy": {
-          "grafana-ose-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202512111314.p2.g565f7ed.assembly.stream.el9"
+          "grafana-ose-oauth-proxy": "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202607171822.p2.g565f7ed.assembly.stream.el9"
         }
       }
     serviceAffecting: "true"

--- a/pkg/products/grafana/reconciler.go
+++ b/pkg/products/grafana/reconciler.go
@@ -347,7 +347,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// Container #1
 		grafanaDeployment.Spec.Template.Spec.Containers[0].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].Name = "grafana"
-		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana:9.7-1767725073"
+		grafanaDeployment.Spec.Template.Spec.Containers[0].Image = "registry.redhat.io/rhel9/grafana:9.8-1785444441"
 		grafanaDeployment.Spec.Template.Spec.Containers[0].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/grafana/",
@@ -473,7 +473,7 @@ func (r *Reconciler) ReconcileGrafanaDeployment(ctx context.Context, client k8sc
 		// container #2
 		grafanaDeployment.Spec.Template.Spec.Containers[1].TerminationMessagePath = "/dev/termination-log"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].Name = "grafana-proxy"
-		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202512111314.p2.g565f7ed.assembly.stream.el9"
+		grafanaDeployment.Spec.Template.Spec.Containers[1].Image = "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202607171822.p2.g565f7ed.assembly.stream.el9"
 		grafanaDeployment.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{
 			{
 				MountPath: "/etc/tls/private",

--- a/pkg/products/marin3r/rateLimitService.go
+++ b/pkg/products/marin3r/rateLimitService.go
@@ -36,7 +36,7 @@ const (
 	multitenantDescriptorValue    = "per-mt-limit"
 	RateLimitingConfigMapName     = "ratelimit-config"
 	RateLimitingConfigMapDataName = "apicast-ratelimiting.yaml"
-	rateLimitImage                = "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:aff28d76f9cfeefafd6b652e055bb25e1a2bf250e062e3e9b5e54db873f9eeb7"
+	rateLimitImage                = "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4"
 )
 
 type RateLimitServiceReconciler struct {

--- a/pkg/resources/ratelimit/envoy.go
+++ b/pkg/resources/ratelimit/envoy.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.12-1767872298"
+	EnvoyImage = "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.17-1781604724"
 )
 
 type envoyProxyServer struct {

--- a/products/additional-images.yaml
+++ b/products/additional-images.yaml
@@ -5,13 +5,13 @@
 
 ratelimit:
   - name: 3scale-openshift-service-mesh
-    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.12-1767872298"
+    url: "registry.redhat.io/openshift-service-mesh/proxyv2-rhel9:2.6.17-1781604724"
 limitador:
   - name: marin3r-limitador
-    url: "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:aff28d76f9cfeefafd6b652e055bb25e1a2bf250e062e3e9b5e54db873f9eeb7"
+    url: "registry.redhat.io/rhcl-1/limitador-rhel9@sha256:a233ab32e26cf2ea46c31dfc4fcaf89ce541a9351bba99182036a91f357cc2b4"
 grafana:
   - name: grafana
-    url: "registry.redhat.io/rhel9/grafana:9.7-1767725073"
+    url: "registry.redhat.io/rhel9/grafana:9.8-1785444441"
 grafana-ose-oauth-proxy:
   - name: grafana-ose-oauth-proxy
-    url: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202512111314.p2.g565f7ed.assembly.stream.el9"
+    url: "registry.redhat.io/openshift4/ose-oauth-proxy-rhel9:v4.16.0-202607171822.p2.g565f7ed.assembly.stream.el9"


### PR DESCRIPTION
# Issue link
Jira: https://redhat.atlassian.net/browse/MGDAPI-7053

# What
bump Images for ratelimit, limitador, grafana

# Verification steps
RHOAM local installation, check Grafana, simulate traffic using h22:
```
cd test
./scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh
```
<img width="1546" height="293" alt="image" src="https://github.com/user-attachments/assets/7f19dc7c-0308-4147-9838-4f3ab256906e" />

<img width="1460" height="747" alt="image" src="https://github.com/user-attachments/assets/b896b349-a279-4581-9845-7d7bf682abd7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated Grafana to version 9.8.0.
  * Upgraded Grafana OAuth proxy, service mesh proxy, and Limitador container images.
  * Updated Envoy proxy image references to newer builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->