### PR TITLE
MGDAPI-7057 update test scritp h22-validate-that-rate-limit-service

### DIFF
--- a/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
+++ b/test/scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/h22-validate-that-rate-limit-service-is-working-as-expected.go
@@ -152,12 +152,14 @@ func createRedis(ctx context.Context, client k8sclient.Client, namespace string)
 			Name:      "throw-away-redis-pod",
 			Namespace: namespace,
 		},
-		Spec: types.ResourceTypeSpec{
-			SecretRef: &types.SecretRef{
-				Name: "throw-away-redis-ref",
+		Spec: crov1alpha1.RedisSpec{
+			ResourceTypeSpec: types.ResourceTypeSpec{
+				SecretRef: &types.SecretRef{
+					Name: "throw-away-redis-ref",
+				},
+				Tier: "development",
+				Type: "workshop",
 			},
-			Tier: "development",
-			Type: "workshop",
 		},
 	}
 


### PR DESCRIPTION
# Issue link
Jira: https://redhat.atlassian.net/browse/MGDAPI-7057

# What
h22-validate-that-rate-limit-service-is-working-as-expected.go - need to be updated to support Redis-to-Valkey migration - RedisSpec was added

# Verification steps
```
cd integreatly-operator/test
./scripts/products/h22-validate-that-rate-limit-service-is-working-as-expected/test.sh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated rate-limit service validation coverage to use the current Redis resource configuration.
  * Preserved existing security and service settings while improving test compatibility and reliability.
  * No user-facing functionality or behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->