### PR TITLE
MGDAPI-7080 Make Redis memory usage alerts configurable via ConfigMap

### DIFF
--- a/internal/controller/rhmi/bootstrapReconciler.go
+++ b/internal/controller/rhmi/bootstrapReconciler.go
@@ -146,6 +146,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, installation *integreatlyv1a
 		return phase, errors.Wrap(err, "failed to check rate limit alert config settings")
 	}
 
+	phase, err = r.checkRedisMemoryAlertsConfig(ctx, serverClient)
+	if err != nil || phase != integreatlyv1alpha1.PhaseCompleted {
+		events.HandleError(r.recorder, installation, phase, "Failed to check redis memory alert config settings", err)
+		return phase, errors.Wrap(err, "failed to check redis memory alert config settings")
+	}
+
 	if err = r.processQuota(installation, request.Namespace, installationQuota, serverClient); err != nil {
 		events.HandleError(r.recorder, installation, integreatlyv1alpha1.PhaseFailed, "Error while processing the Quota", err)
 		installation.Status.LastError = err.Error()
@@ -355,6 +361,39 @@ func (r *Reconciler) checkRateLimitAlertsConfig(ctx context.Context, serverClien
 
 		alertsConfig.Data["alerts"] = string(defaultConfigJSON)
 
+		return nil
+	}); err != nil {
+		return integreatlyv1alpha1.PhaseInProgress, err
+	}
+
+	return integreatlyv1alpha1.PhaseCompleted, nil
+}
+
+func (r *Reconciler) checkRedisMemoryAlertsConfig(ctx context.Context, serverClient k8sclient.Client) (integreatlyv1alpha1.StatusPhase, error) {
+	alertsConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      resources.RedisMemoryAlertsConfigMapName,
+			Namespace: r.installation.Namespace,
+		},
+	}
+
+	if _, err := controllerutil.CreateOrUpdate(ctx, serverClient, alertsConfig, func() error {
+		owner.AddIntegreatlyOwnerAnnotations(alertsConfig, r.installation)
+
+		if alertsConfig.Data == nil {
+			alertsConfig.Data = map[string]string{}
+		}
+
+		if _, ok := alertsConfig.Data[resources.RedisMemoryAlertsConfigMapKey]; ok {
+			return nil
+		}
+
+		defaultConfigJSON, err := json.MarshalIndent(resources.DefaultRedisMemoryAlertsConfig(), "", "  ")
+		if err != nil {
+			return err
+		}
+
+		alertsConfig.Data[resources.RedisMemoryAlertsConfigMapKey] = string(defaultConfigJSON)
 		return nil
 	}); err != nil {
 		return integreatlyv1alpha1.PhaseInProgress, err

--- a/internal/controller/rhmi/bootstrapReconciler_test.go
+++ b/internal/controller/rhmi/bootstrapReconciler_test.go
@@ -941,3 +941,102 @@ func TestReconciler_checkCloudResourcesConfig(t *testing.T) {
 		})
 	}
 }
+
+func TestReconciler_checkRedisMemoryAlertsConfig(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	installation := &integreatlyv1alpha1.RHMI{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rhoam",
+			Namespace: rhoamOperatorNs,
+		},
+	}
+
+	t.Run("creates default configmap when missing", func(t *testing.T) {
+		serverClient := utils.NewTestClient(scheme)
+		r := &Reconciler{
+			installation: installation,
+			log:          l.NewLogger(),
+		}
+
+		got, err := r.checkRedisMemoryAlertsConfig(context.TODO(), serverClient)
+		if err != nil {
+			t.Fatalf("checkRedisMemoryAlertsConfig() error = %v", err)
+		}
+		if got != integreatlyv1alpha1.PhaseCompleted {
+			t.Fatalf("checkRedisMemoryAlertsConfig() got = %v, want %v", got, integreatlyv1alpha1.PhaseCompleted)
+		}
+
+		cm := &corev1.ConfigMap{}
+		if err := serverClient.Get(context.TODO(), types.NamespacedName{Name: resources.RedisMemoryAlertsConfigMapName, Namespace: rhoamOperatorNs}, cm); err != nil {
+			t.Fatalf("expected configmap to be created: %v", err)
+		}
+		raw, ok := cm.Data[resources.RedisMemoryAlertsConfigMapKey]
+		if !ok || raw == "" {
+			t.Fatal("expected alerts key to be populated")
+		}
+		cfg, err := resources.GetRedisMemoryAlertsConfig(context.TODO(), serverClient, rhoamOperatorNs)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg.HighUsage.Threshold != 80 {
+			t.Errorf("default threshold = %d, want 80", cfg.HighUsage.Threshold)
+		}
+		if cfg.MaxIn4Hours.PredictHours != 5 {
+			t.Errorf("default predictHours = %d, want 5", cfg.MaxIn4Hours.PredictHours)
+		}
+		if cfg.MaxIn4Hours.UsageThreshold != 75 {
+			t.Errorf("default usageThreshold = %d, want 75", cfg.MaxIn4Hours.UsageThreshold)
+		}
+	})
+
+	t.Run("preserves existing customer config", func(t *testing.T) {
+		custom := `{"RedisMemoryUsageHigh":{"threshold":95,"severity":"warning","for":"1h"}}`
+		serverClient := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      resources.RedisMemoryAlertsConfigMapName,
+				Namespace: rhoamOperatorNs,
+			},
+			Data: map[string]string{
+				resources.RedisMemoryAlertsConfigMapKey: custom,
+			},
+		})
+		r := &Reconciler{
+			installation: installation,
+			log:          l.NewLogger(),
+		}
+
+		if _, err := r.checkRedisMemoryAlertsConfig(context.TODO(), serverClient); err != nil {
+			t.Fatalf("checkRedisMemoryAlertsConfig() error = %v", err)
+		}
+
+		cm := &corev1.ConfigMap{}
+		if err := serverClient.Get(context.TODO(), types.NamespacedName{Name: resources.RedisMemoryAlertsConfigMapName, Namespace: rhoamOperatorNs}, cm); err != nil {
+			t.Fatal(err)
+		}
+		if cm.Data[resources.RedisMemoryAlertsConfigMapKey] != custom {
+			t.Errorf("customer config was overwritten: %s", cm.Data[resources.RedisMemoryAlertsConfigMapKey])
+		}
+	})
+
+	t.Run("returns in progress when client get fails", func(t *testing.T) {
+		mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+		mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj k8sclient.Object, opts ...k8sclient.GetOption) error {
+			return fmt.Errorf("generic error")
+		}
+		r := &Reconciler{
+			installation: installation,
+			log:          l.NewLogger(),
+		}
+		got, err := r.checkRedisMemoryAlertsConfig(context.TODO(), mockClient)
+		if err == nil {
+			t.Fatal("expected error")
+		}
+		if got != integreatlyv1alpha1.PhaseInProgress {
+			t.Fatalf("got = %v, want %v", got, integreatlyv1alpha1.PhaseInProgress)
+		}
+	})
+}

--- a/pkg/resources/metrics.go
+++ b/pkg/resources/metrics.go
@@ -576,69 +576,90 @@ func createRedisResourceStatusPhasePendingAlert(ctx context.Context, client k8sc
 	return pr, nil
 }
 
-// CreateRedisMemoryUsageHighAlert creates a PrometheusRule alert to watch for High Memory usage
-// of a Redis cache
+const redisMemoryMetricsJob = "operator-metrics-service"
+
+// redisMemoryUsageHighPending is a short debounce so a single eval blip does not
+// flap the alert. The real persistence check is avg_over_time over cfg.For.
+const redisMemoryUsageHighPending = alertFor5Mins
+
+func redisMemoryUsageHighExpr(threshold int, window string) string {
+	return fmt.Sprintf("avg_over_time(cro_redis_memory_usage_percentage_average[%s]) > %d", window, threshold)
+}
+
+func redisMemoryPredictHoursExpr(job, lookback string, predictHours, usageThreshold int) string {
+	return fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[%s:1m], %d * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > %d)", job, lookback, predictHours, job, usageThreshold)
+}
+
+func redisMemoryPredictDaysExpr(job, lookback string, predictDays, usageThreshold int) string {
+	return fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[%s:1m], %d * 24 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > %d)", job, lookback, predictDays, job, usageThreshold)
+}
+
+// createRedisMemoryUsageAlerts reconciles Redis memory PrometheusRules from the
+// redis-memory-alerts ConfigMap. RedisMemoryUsageHigh uses avg_over_time so
+// missed scrapes do not reset a long pending timer; MaxIn4Hours / MaxIn4Days
+// use predict_linear so paging tracks whether usage will hit 100% in the window.
 func createRedisMemoryUsageAlerts(ctx context.Context, client k8sclient.Client, inst *v1alpha1.RHMI, cr *crov1.Redis, log l.Logger) error {
 	if strings.ToLower(inst.Spec.UseClusterStorage) == "true" {
 		log.Info("skipping redis memory usage high alert creation, useClusterStorage is true")
 		return nil
 	}
 	productName := cr.Labels["productName"]
-
-	alertName := "RedisMemoryUsageHigh"
-	ruleName := "redis-memory-usage-high"
-	alertDescription := "Redis Memory for instance {{ $labels.instanceID }} is 80 percent or higher for the last hour. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
-	labels := map[string]string{
-		"severity":    "critical",
-		"productName": productName,
-	}
-
-	alertExp := intstr.FromString(fmt.Sprintf("cro_redis_memory_usage_percentage_average > %s", alertPercentage))
-
 	ruleNs := config.GetOboNamespace(inst.Namespace)
-	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor30Mins, alertExp, labels)
+
+	cfg, err := GetRedisMemoryAlertsConfig(ctx, client, inst.Namespace)
 	if err != nil {
+		return fmt.Errorf("failed to get redis memory alerts config: %w", err)
+	}
+
+	if err := reconcileRedisMemoryUsageHighAlert(ctx, client, ruleNs, productName, cfg.HighUsage); err != nil {
 		return err
 	}
-
-	// job to check time that the operator metrics are exposed
-	job := "operator-metrics-service"
-
-	alertName = "RedisMemoryUsageMaxIn4Hours"
-	ruleName = "redis-memory-usage-will-max-in-4-hours"
-	alertDescription = "Redis Memory Usage is predicted to max with in four hours for instance {{ $labels.instanceID }}. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
-	labels = map[string]string{
-		"severity":    "critical",
-		"productName": productName,
-	}
-	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
-	//    * [1h] - one hour data points
-	//    * , 4 * 3600 - multiplying data points by 4 hours
-	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[1h:1m], 5 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > 75)", job, job))
-
-	_, err = reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor30Mins, alertExp, labels)
-	if err != nil {
+	if err := reconcileRedisMemoryPredictHoursAlert(ctx, client, ruleNs, productName, cfg.MaxIn4Hours); err != nil {
 		return err
 	}
-
-	alertName = "RedisMemoryUsageMaxIn4Days"
-	ruleName = "redis-memory-usage-max-fill-in-4-days"
-	alertDescription = "Redis Memory Usage is predicted to max in four days for instance {{ $labels.instanceID }}. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}"
-	labels = map[string]string{
-		"severity":    "critical",
-		"productName": productName,
-	}
-	// building a predict_linear query using 1 hour of data points to predict a 4 hour projection, and checking if it is less than or equal 0
-	//    * [6h] - six hour data points
-	//    * , 4 * 24 * 3600 - multiplying data points by 4 days
-	alertExp = intstr.FromString(fmt.Sprintf("(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'})[6h:1m], 4 * 24 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='%s'} > 75)", job, job))
-
-	_, err = reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, alertFor30Mins, alertExp, labels)
-	if err != nil {
+	if err := reconcileRedisMemoryPredictDaysAlert(ctx, client, ruleNs, productName, cfg.MaxIn4Days); err != nil {
 		return err
 	}
-
 	return nil
+}
+
+func reconcileRedisMemoryUsageHighAlert(ctx context.Context, client k8sclient.Client, ruleNs, productName string, cfg RedisMemoryUsageHighConfig) error {
+	ruleName := "redis-memory-usage-high"
+	alertName := "RedisMemoryUsageHigh"
+	alertDescription := fmt.Sprintf("Redis Memory for instance {{ $labels.instanceID }} averaged %d percent or higher over the last %s. Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}", cfg.Threshold, cfg.For)
+	labels := map[string]string{
+		"severity":    cfg.Severity,
+		"productName": productName,
+	}
+	alertExp := intstr.FromString(redisMemoryUsageHighExpr(cfg.Threshold, cfg.For))
+	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, redisMemoryUsageHighPending, alertExp, labels)
+	return err
+}
+
+func reconcileRedisMemoryPredictHoursAlert(ctx context.Context, client k8sclient.Client, ruleNs, productName string, cfg RedisMemoryPredictConfig) error {
+	ruleName := "redis-memory-usage-will-max-in-4-hours"
+	alertName := "RedisMemoryUsageMaxIn4Hours"
+	alertDescription := fmt.Sprintf("Redis Memory Usage is predicted to reach 100 percent within %d hours for instance {{ $labels.instanceID }} (current usage above %d percent). Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}", cfg.PredictHours, cfg.UsageThreshold)
+	labels := map[string]string{
+		"severity":    cfg.Severity,
+		"productName": productName,
+	}
+	alertExp := intstr.FromString(redisMemoryPredictHoursExpr(redisMemoryMetricsJob, cfg.Lookback, cfg.PredictHours, cfg.UsageThreshold))
+	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, cfg.For, alertExp, labels)
+	return err
+}
+
+func reconcileRedisMemoryPredictDaysAlert(ctx context.Context, client k8sclient.Client, ruleNs, productName string, cfg RedisMemoryPredictConfig) error {
+	ruleName := "redis-memory-usage-max-fill-in-4-days"
+	alertName := "RedisMemoryUsageMaxIn4Days"
+	alertDescription := fmt.Sprintf("Redis Memory Usage is predicted to reach 100 percent within %d days for instance {{ $labels.instanceID }} (current usage above %d percent). Redis Custom Resource: {{ $labels.resourceID }} in namespace {{ $labels.namespace }} for the product: {{ $labels.productName }}", cfg.PredictDays, cfg.UsageThreshold)
+	labels := map[string]string{
+		"severity":    cfg.Severity,
+		"productName": productName,
+	}
+	alertExp := intstr.FromString(redisMemoryPredictDaysExpr(redisMemoryMetricsJob, cfg.Lookback, cfg.PredictDays, cfg.UsageThreshold))
+	_, err := reconcilePrometheusRule(ctx, client, ruleName, ruleNs, alertName, alertDescription, sopUrlRedisMemoryUsageHigh, cfg.For, alertExp, labels)
+	return err
 }
 
 // createRedisResourceStatusPhaseFailedAlert creates a PrometheusRule alert to watch for Redis CR state

--- a/pkg/resources/redisMemoryAlertsConfig.go
+++ b/pkg/resources/redisMemoryAlertsConfig.go
@@ -1,0 +1,170 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+const (
+	// RedisMemoryAlertsConfigMapName is the ConfigMap used to tune Redis memory
+	// Prometheus alerts per installation. This follows the same pattern as the
+	// rate-limit-alerts ConfigMap: the operator writes defaults once, and later
+	// edits (by SRE / support) are preserved across reconciles.
+	RedisMemoryAlertsConfigMapName = "redis-memory-alerts"
+	RedisMemoryAlertsConfigMapKey  = "alerts"
+
+	defaultRedisMemoryHighThreshold        = 80
+	defaultRedisMemoryPredictThreshold     = 75
+	defaultRedisMemoryPredictHours         = 5
+	defaultRedisMemoryPredictDays          = 4
+	defaultRedisMemoryPredictHoursLookback = "1h"
+	defaultRedisMemoryPredictDaysLookback  = "6h"
+	defaultRedisMemoryAlertSeverity        = "critical"
+)
+
+// RedisMemoryAlertsConfig is the JSON payload stored in redis-memory-alerts.
+// Missing keys or zero-values fall back to the operator defaults so partial
+// customer edits remain valid.
+type RedisMemoryAlertsConfig struct {
+	HighUsage   RedisMemoryUsageHighConfig `json:"RedisMemoryUsageHigh"`
+	MaxIn4Hours RedisMemoryPredictConfig   `json:"RedisMemoryUsageMaxIn4Hours"`
+	MaxIn4Days  RedisMemoryPredictConfig   `json:"RedisMemoryUsageMaxIn4Days"`
+}
+
+// RedisMemoryUsageHighConfig controls the static high-usage page.
+// For noisy clusters that sit stably above the default 80% threshold, raise
+// Threshold (e.g. 90 or 95) or lower Severity to "warning".
+// For is the avg_over_time window (not the Prometheus pending duration), so a
+// missed scrape does not reset the alert the way an instant vector + for: 30m does.
+type RedisMemoryUsageHighConfig struct {
+	Threshold int    `json:"threshold"`
+	For       string `json:"for"`
+	Severity  string `json:"severity"`
+}
+
+// RedisMemoryPredictConfig controls a predict_linear growth-rate alert.
+// UsageThreshold is the floor at which the operator starts evaluating growth.
+// PredictHours / PredictDays is the window in which usage is projected to hit 100%.
+type RedisMemoryPredictConfig struct {
+	UsageThreshold int    `json:"usageThreshold"`
+	PredictHours   int    `json:"predictHours,omitempty"`
+	PredictDays    int    `json:"predictDays,omitempty"`
+	Lookback       string `json:"lookback"`
+	For            string `json:"for"`
+	Severity       string `json:"severity"`
+}
+
+// DefaultRedisMemoryAlertsConfig returns the in-tree defaults, matching current
+// production MaxIn4Hours behaviour (75% gate, 5h prediction) so upgrade does not
+// change paging. SRE can tighten per cluster via the ConfigMap (e.g. 80% / 4h).
+func DefaultRedisMemoryAlertsConfig() RedisMemoryAlertsConfig {
+	return RedisMemoryAlertsConfig{
+		HighUsage: RedisMemoryUsageHighConfig{
+			Threshold: defaultRedisMemoryHighThreshold,
+			For:       alertFor30Mins,
+			Severity:  defaultRedisMemoryAlertSeverity,
+		},
+		MaxIn4Hours: RedisMemoryPredictConfig{
+			UsageThreshold: defaultRedisMemoryPredictThreshold,
+			PredictHours:   defaultRedisMemoryPredictHours,
+			Lookback:       defaultRedisMemoryPredictHoursLookback,
+			For:            alertFor30Mins,
+			Severity:       defaultRedisMemoryAlertSeverity,
+		},
+		MaxIn4Days: RedisMemoryPredictConfig{
+			UsageThreshold: defaultRedisMemoryPredictThreshold,
+			PredictDays:    defaultRedisMemoryPredictDays,
+			Lookback:       defaultRedisMemoryPredictDaysLookback,
+			For:            alertFor30Mins,
+			Severity:       defaultRedisMemoryAlertSeverity,
+		},
+	}
+}
+
+func (c *RedisMemoryAlertsConfig) applyDefaults() {
+	defaults := DefaultRedisMemoryAlertsConfig()
+	c.HighUsage.applyDefaults(defaults.HighUsage)
+	c.MaxIn4Hours.applyDefaults(defaults.MaxIn4Hours)
+	c.MaxIn4Days.applyDefaults(defaults.MaxIn4Days)
+}
+
+func (c *RedisMemoryUsageHighConfig) applyDefaults(def RedisMemoryUsageHighConfig) {
+	if c.Threshold <= 0 {
+		c.Threshold = def.Threshold
+	}
+	c.For = validDurationOrDefault(c.For, def.For)
+	if c.Severity == "" {
+		c.Severity = def.Severity
+	}
+}
+
+func (c *RedisMemoryPredictConfig) applyDefaults(def RedisMemoryPredictConfig) {
+	if c.UsageThreshold <= 0 {
+		c.UsageThreshold = def.UsageThreshold
+	}
+	if c.PredictHours <= 0 && def.PredictHours > 0 {
+		c.PredictHours = def.PredictHours
+	}
+	if c.PredictDays <= 0 && def.PredictDays > 0 {
+		c.PredictDays = def.PredictDays
+	}
+	c.Lookback = validDurationOrDefault(c.Lookback, def.Lookback)
+	c.For = validDurationOrDefault(c.For, def.For)
+	if c.Severity == "" {
+		c.Severity = def.Severity
+	}
+}
+
+// PromQL range / rule durations: integer + unit, optionally concatenated (1h30m).
+// Units are ms, s, m, h, d, w, y. Go time.ParseDuration also accepts ns/us and
+// negatives, which Prometheus rejects in range selectors.
+var (
+	promQLDurationRE = regexp.MustCompile(`^(?:[0-9]+(?:ms|[smhdwy]))+$`)
+	promQLZeroRE     = regexp.MustCompile(`^(?:0+(?:ms|[smhdwy]))+$`)
+)
+
+func validDurationOrDefault(value, fallback string) string {
+	if !isPositivePromQLDuration(value) {
+		return fallback
+	}
+	return value
+}
+
+func isPositivePromQLDuration(value string) bool {
+	return promQLDurationRE.MatchString(value) && !promQLZeroRE.MatchString(value)
+}
+
+// GetRedisMemoryAlertsConfig reads redis-memory-alerts from the RHMI operator
+// namespace. A missing ConfigMap returns defaults so Redis reconcile does not
+// fail if bootstrap has not created it yet.
+func GetRedisMemoryAlertsConfig(ctx context.Context, client k8sclient.Client, namespace string) (RedisMemoryAlertsConfig, error) {
+	cfg := DefaultRedisMemoryAlertsConfig()
+
+	configMap := &corev1.ConfigMap{}
+	if err := client.Get(ctx, k8sclient.ObjectKey{
+		Name:      RedisMemoryAlertsConfigMapName,
+		Namespace: namespace,
+	}, configMap); err != nil {
+		if k8serr.IsNotFound(err) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+
+	raw, ok := configMap.Data[RedisMemoryAlertsConfigMapKey]
+	if !ok || raw == "" {
+		return cfg, nil
+	}
+
+	if err := json.Unmarshal([]byte(raw), &cfg); err != nil {
+		return DefaultRedisMemoryAlertsConfig(), fmt.Errorf("failed to parse %s ConfigMap: %w", RedisMemoryAlertsConfigMapName, err)
+	}
+	cfg.applyDefaults()
+	return cfg, nil
+}

--- a/pkg/resources/redisMemoryAlertsConfig_test.go
+++ b/pkg/resources/redisMemoryAlertsConfig_test.go
@@ -1,0 +1,222 @@
+package resources
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/utils"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestGetRedisMemoryAlertsConfig(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	namespace := "redhat-rhoam-operator"
+
+	t.Run("missing configmap returns defaults", func(t *testing.T) {
+		client := utils.NewTestClient(scheme)
+		cfg, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		defaults := DefaultRedisMemoryAlertsConfig()
+		if cfg.HighUsage.Threshold != defaults.HighUsage.Threshold {
+			t.Errorf("threshold = %d, want %d", cfg.HighUsage.Threshold, defaults.HighUsage.Threshold)
+		}
+		if cfg.MaxIn4Hours.PredictHours != defaults.MaxIn4Hours.PredictHours {
+			t.Errorf("predictHours = %d, want %d", cfg.MaxIn4Hours.PredictHours, defaults.MaxIn4Hours.PredictHours)
+		}
+	})
+
+	t.Run("partial config fills remaining defaults", func(t *testing.T) {
+		raw := `{
+			"RedisMemoryUsageHigh": {
+				"threshold": 90,
+				"severity": "warning"
+			}
+		}`
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				RedisMemoryAlertsConfigMapKey: raw,
+			},
+		})
+
+		cfg, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.HighUsage.Threshold != 90 {
+			t.Errorf("threshold = %d, want 90", cfg.HighUsage.Threshold)
+		}
+		if cfg.HighUsage.Severity != "warning" {
+			t.Errorf("severity = %s, want warning", cfg.HighUsage.Severity)
+		}
+		if cfg.HighUsage.For != alertFor30Mins {
+			t.Errorf("for = %s, want %s", cfg.HighUsage.For, alertFor30Mins)
+		}
+		if cfg.MaxIn4Hours.UsageThreshold != defaultRedisMemoryPredictThreshold {
+			t.Errorf("max in 4 hours usage threshold = %d, want %d", cfg.MaxIn4Hours.UsageThreshold, defaultRedisMemoryPredictThreshold)
+		}
+		if cfg.MaxIn4Hours.PredictHours != defaultRedisMemoryPredictHours {
+			t.Errorf("predictHours = %d, want %d", cfg.MaxIn4Hours.PredictHours, defaultRedisMemoryPredictHours)
+		}
+	})
+
+	t.Run("invalid duration falls back to default", func(t *testing.T) {
+		raw := `{
+			"RedisMemoryUsageHigh": {
+				"threshold": 95,
+				"for": "not-a-duration"
+			}
+		}`
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				RedisMemoryAlertsConfigMapKey: raw,
+			},
+		})
+
+		cfg, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.HighUsage.For != alertFor30Mins {
+			t.Errorf("for = %s, want %s", cfg.HighUsage.For, alertFor30Mins)
+		}
+	})
+
+	t.Run("invalid json returns error", func(t *testing.T) {
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				RedisMemoryAlertsConfigMapKey: "{not-json",
+			},
+		})
+
+		_, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err == nil {
+			t.Fatal("expected error for invalid json")
+		}
+	})
+
+	t.Run("missing alerts key returns defaults", func(t *testing.T) {
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{},
+		})
+		cfg, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.HighUsage.Threshold != defaultRedisMemoryHighThreshold {
+			t.Errorf("threshold = %d, want %d", cfg.HighUsage.Threshold, defaultRedisMemoryHighThreshold)
+		}
+	})
+
+	t.Run("zero values are filled from defaults", func(t *testing.T) {
+		raw := `{
+			"RedisMemoryUsageHigh": {
+				"threshold": 0,
+				"severity": ""
+			},
+			"RedisMemoryUsageMaxIn4Hours": {
+				"usageThreshold": 0,
+				"predictHours": 0,
+				"lookback": "",
+				"for": "",
+				"severity": ""
+			},
+			"RedisMemoryUsageMaxIn4Days": {
+				"usageThreshold": 0,
+				"predictDays": 0
+			}
+		}`
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{
+				RedisMemoryAlertsConfigMapKey: raw,
+			},
+		})
+		cfg, err := GetRedisMemoryAlertsConfig(context.TODO(), client, namespace)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg.HighUsage.Threshold != defaultRedisMemoryHighThreshold {
+			t.Errorf("high threshold = %d, want %d", cfg.HighUsage.Threshold, defaultRedisMemoryHighThreshold)
+		}
+		if cfg.HighUsage.Severity != defaultRedisMemoryAlertSeverity {
+			t.Errorf("high severity = %s, want %s", cfg.HighUsage.Severity, defaultRedisMemoryAlertSeverity)
+		}
+		if cfg.MaxIn4Hours.UsageThreshold != defaultRedisMemoryPredictThreshold {
+			t.Errorf("hours usage threshold = %d, want %d", cfg.MaxIn4Hours.UsageThreshold, defaultRedisMemoryPredictThreshold)
+		}
+		if cfg.MaxIn4Hours.PredictHours != defaultRedisMemoryPredictHours {
+			t.Errorf("predictHours = %d, want %d", cfg.MaxIn4Hours.PredictHours, defaultRedisMemoryPredictHours)
+		}
+		if cfg.MaxIn4Hours.Severity != defaultRedisMemoryAlertSeverity {
+			t.Errorf("hours severity = %s, want %s", cfg.MaxIn4Hours.Severity, defaultRedisMemoryAlertSeverity)
+		}
+		if cfg.MaxIn4Days.PredictDays != defaultRedisMemoryPredictDays {
+			t.Errorf("predictDays = %d, want %d", cfg.MaxIn4Days.PredictDays, defaultRedisMemoryPredictDays)
+		}
+	})
+
+	t.Run("get error is returned", func(t *testing.T) {
+		mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+		mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj k8sclient.Object, opts ...k8sclient.GetOption) error {
+			return fmt.Errorf("generic error")
+		}
+		_, err := GetRedisMemoryAlertsConfig(context.TODO(), mockClient, namespace)
+		if err == nil {
+			t.Fatal("expected error from client.Get")
+		}
+	})
+}
+
+func TestValidDurationOrDefault(t *testing.T) {
+	tests := []struct {
+		value    string
+		fallback string
+		want     string
+	}{
+		{value: "", fallback: "30m", want: "30m"},
+		{value: "1h", fallback: "30m", want: "1h"},
+		{value: "1h30m", fallback: "30m", want: "1h30m"},
+		{value: "1d", fallback: "30m", want: "1d"},
+		{value: "1w", fallback: "30m", want: "1w"},
+		{value: "1us", fallback: "30m", want: "30m"},
+		{value: "1ns", fallback: "30m", want: "30m"},
+		{value: "-1h", fallback: "30m", want: "30m"},
+		{value: "0s", fallback: "30m", want: "30m"},
+		{value: "not-a-duration", fallback: "30m", want: "30m"},
+	}
+	for _, tt := range tests {
+		if got := validDurationOrDefault(tt.value, tt.fallback); got != tt.want {
+			t.Errorf("validDurationOrDefault(%q, %q) = %q, want %q", tt.value, tt.fallback, got, tt.want)
+		}
+	}
+}

--- a/pkg/resources/redisMemoryAlerts_test.go
+++ b/pkg/resources/redisMemoryAlerts_test.go
@@ -1,0 +1,144 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	crov1 "github.com/integr8ly/cloud-resource-operator/api/integreatly/v1alpha1"
+	"github.com/integr8ly/integreatly-operator/api/v1alpha1"
+	moqclient "github.com/integr8ly/integreatly-operator/pkg/client"
+	"github.com/integr8ly/integreatly-operator/pkg/config"
+	l "github.com/integr8ly/integreatly-operator/pkg/resources/logger"
+	"github.com/integr8ly/integreatly-operator/utils"
+	monv1 "github.com/rhobs/obo-prometheus-operator/pkg/apis/monitoring/v1"
+	corev1 "k8s.io/api/core/v1"
+	k8serr "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	k8sclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func TestCreateRedisMemoryUsageAlerts(t *testing.T) {
+	scheme, err := utils.NewTestScheme()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	inst := &v1alpha1.RHMI{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rhoam",
+			Namespace: "redhat-rhoam-operator",
+		},
+		Spec: v1alpha1.RHMISpec{
+			UseClusterStorage: "false",
+		},
+	}
+	redis := &crov1.Redis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-redis",
+			Namespace: inst.Namespace,
+			Labels: map[string]string{
+				"productName": "3scale",
+			},
+		},
+	}
+	ruleNs := config.GetOboNamespace(inst.Namespace)
+	log := l.NewLogger()
+
+	t.Run("defaults match current production predict windows", func(t *testing.T) {
+		client := utils.NewTestClient(scheme)
+		if err := createRedisMemoryUsageAlerts(context.TODO(), client, inst, redis, log); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertPrometheusRule(t, client, "redis-memory-usage-high", ruleNs, "RedisMemoryUsageHigh", "critical", redisMemoryUsageHighPending,
+			"avg_over_time(cro_redis_memory_usage_percentage_average[30m]) > 80")
+		assertPrometheusRule(t, client, "redis-memory-usage-will-max-in-4-hours", ruleNs, "RedisMemoryUsageMaxIn4Hours", "critical", alertFor30Mins,
+			"(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'})[1h:1m], 5 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'} > 75)")
+		assertPrometheusRule(t, client, "redis-memory-usage-max-fill-in-4-days", ruleNs, "RedisMemoryUsageMaxIn4Days", "critical", alertFor30Mins,
+			"(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'})[6h:1m], 4 * 24 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'} > 75)")
+	})
+
+	t.Run("configmap overrides threshold severity and growth window", func(t *testing.T) {
+		cfg := DefaultRedisMemoryAlertsConfig()
+		cfg.HighUsage.Threshold = 90
+		cfg.HighUsage.Severity = "warning"
+		cfg.HighUsage.For = "1h"
+		cfg.MaxIn4Hours.UsageThreshold = 85
+		cfg.MaxIn4Hours.PredictHours = 6
+		cfg.MaxIn4Hours.Lookback = "2h"
+		raw, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatal(err)
+		}
+		client := utils.NewTestClient(scheme, &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      RedisMemoryAlertsConfigMapName,
+				Namespace: inst.Namespace,
+			},
+			Data: map[string]string{
+				RedisMemoryAlertsConfigMapKey: string(raw),
+			},
+		})
+
+		if err := createRedisMemoryUsageAlerts(context.TODO(), client, inst, redis, log); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		assertPrometheusRule(t, client, "redis-memory-usage-high", ruleNs, "RedisMemoryUsageHigh", "warning", redisMemoryUsageHighPending,
+			"avg_over_time(cro_redis_memory_usage_percentage_average[1h]) > 90")
+		assertPrometheusRule(t, client, "redis-memory-usage-will-max-in-4-hours", ruleNs, "RedisMemoryUsageMaxIn4Hours", "critical", alertFor30Mins,
+			"(predict_linear(sum by (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'})[2h:1m], 6 * 3600) >= 100) and on (instanceID) (cro_redis_memory_usage_percentage_average{job='operator-metrics-service'} > 85)")
+	})
+
+	t.Run("skips when useClusterStorage is true", func(t *testing.T) {
+		clusterInst := inst.DeepCopy()
+		clusterInst.Spec.UseClusterStorage = "true"
+		client := utils.NewTestClient(scheme)
+		if err := createRedisMemoryUsageAlerts(context.TODO(), client, clusterInst, redis, log); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		rule := &monv1.PrometheusRule{}
+		err := client.Get(context.TODO(), types.NamespacedName{Name: "redis-memory-usage-high", Namespace: ruleNs}, rule)
+		if !k8serr.IsNotFound(err) {
+			t.Fatalf("expected no rules when useClusterStorage is true, got err=%v", err)
+		}
+	})
+
+	t.Run("returns error when configmap get fails", func(t *testing.T) {
+		mockClient := moqclient.NewSigsClientMoqWithScheme(scheme)
+		mockClient.GetFunc = func(ctx context.Context, key types.NamespacedName, obj k8sclient.Object, opts ...k8sclient.GetOption) error {
+			return fmt.Errorf("generic error")
+		}
+		if err := createRedisMemoryUsageAlerts(context.TODO(), mockClient, inst, redis, log); err == nil {
+			t.Fatal("expected error when config get fails")
+		}
+	})
+}
+
+func assertPrometheusRule(t *testing.T, client k8sclient.Client, name, ns, alertName, severity, alertFor, expr string) {
+	t.Helper()
+	rule := &monv1.PrometheusRule{}
+	if err := client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: ns}, rule); err != nil {
+		t.Fatalf("failed to get prometheus rule %s: %v", name, err)
+	}
+	if len(rule.Spec.Groups) != 1 || len(rule.Spec.Groups[0].Rules) != 1 {
+		t.Fatalf("rule %s: expected 1 group with 1 rule, got %+v", name, rule.Spec.Groups)
+	}
+	got := rule.Spec.Groups[0].Rules[0]
+	if got.Alert != alertName {
+		t.Errorf("rule %s alert = %s, want %s", name, got.Alert, alertName)
+	}
+	if got.Labels["severity"] != severity {
+		t.Errorf("rule %s severity = %s, want %s", name, got.Labels["severity"], severity)
+	}
+	if got.For == nil || string(*got.For) != alertFor {
+		t.Errorf("rule %s for = %v, want %s", name, got.For, alertFor)
+	}
+	if got.Expr != intstr.FromString(expr) {
+		t.Errorf("rule %s expr = %s, want %s", name, got.Expr.String(), expr)
+	}
+}


### PR DESCRIPTION
# Issue link
Jira: https://redhat.atlassian.net/browse/MGDAPI-7080

# What
- use `avg_over_time(...)` in RedisMemoryUsageHigh Alert
-  make RedisMemoryUsageHigh, RedisMemoryUsageMaxIn4Days, RedisMemoryUsageMaxIn4Hours Alerts configurable via new `redis-memory-alerts` ConfigMap 

# Verification steps
<details>
Fresh CCS, AWS Redis (not in-cluster storage). Alerts are skipped when `useClusterStorage: true`.

1. Create a CCS cluster (OSD/ROSA).
2. Install RHOAM via **OLM** from this PR (`USE_CLUSTER_STORAGE=false`).
   2.1 Create Catalog Source:

```
kubectl apply -f - <<EOF
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: rhoam-operators
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: quay.io/vmogilev_rhmi/managed-api-service-index:1.45.0 
EOF
```

2.2  Cluster prepare local
LOCAL=false USE_CLUSTER_STORAGE=false INSTALLATION_TYPE=managed-api make cluster/prepare/local

2.3 Install RHOAM Operator from OperatorHub

2.4 Deploy RHMI

INSTALLATION_TYPE=managed-api USE_CLUSTER_STORAGE=false make deploy/integreatly-rhmi-cr.yml   

2.5 check status:  
```
oc get rhmi -n redhat-rhoam-operator -o json | jq ' .items[0] | {addon:.metadata.name} + (.status | {version, toVersion, stage}), (.status | .. | select(.status?) | [.name?,.status?, .version?])' -c

# Expect:

{"addon":"rhoam","version":"1.45.0","toVersion":null,"stage":"complete"}
["3scale","completed","2.16.4"]
["cloud-resources","completed","1.1.8"]
["grafana","completed","9.8.0"]
["marin3r","completed","0.13.4"]
["rhsso","completed","7.6"]
["rhssouser","completed","7.6"]
```


3. Check the ConfigMap (created at bootstrap; later edits are preserved):

```
$ oc describe cm redis-memory-alerts -n redhat-rhoam-operator
Name:         redis-memory-alerts
Namespace:    redhat-rhoam-operator
Labels:       <none>
Annotations:  integreatly-name: rhoam
              integreatly-namespace: redhat-rhoam-operator

Data
====
alerts:
----
{
  "RedisMemoryUsageHigh": {
    "threshold": 80,
    "for": "30m",
    "severity": "critical"
  },
  "RedisMemoryUsageMaxIn4Hours": {
    "usageThreshold": 75,
    "predictHours": 5,
    "lookback": "1h",
    "for": "30m",
    "severity": "critical"
  },
  "RedisMemoryUsageMaxIn4Days": {
    "usageThreshold": 75,
    "predictDays": 4,
    "lookback": "6h",
    "for": "30m",
    "severity": "critical"
  }
}


BinaryData
====

Events:  <none>
$

```
 

4. Check PrometheusRules in the OBO namespace (redhat-rhoam-operator + -observability):

```
oc -n redhat-rhoam-operator-observability get prometheusrules.monitoring.rhobs \
  redis-memory-usage-high \
  redis-memory-usage-will-max-in-4-hours \
  redis-memory-usage-max-fill-in-4-days \
  -o yaml

# Expect:

RedisMemoryUsageHigh expr contains avg_over_time(...[30m]) > 80

RedisMemoryUsageMaxIn4Hours / MaxIn4Days use predict_linear with the default windows

#Optional UI: port-forward OBO Prometheus and open Alerts (rules need not be firing):

oc -n redhat-rhoam-operator-observability get svc
oc -n redhat-rhoam-operator-observability port-forward svc/prometheus-operated 9090:9090

#Change the ConfigMap and confirm rules update after the next Redis reconcile (wait a few minutes, or restart rhmi-operator):

oc -n redhat-rhoam-operator edit cm redis-memory-alerts
#Example: set RedisMemoryUsageHigh.threshold to 90 and severity to warning. Then re-check the redis-memory-usage-high PrometheusRule: expr > 90, label severity=warning.

#Confirm the operator does not overwrite customer edits:

oc -n redhat-rhoam-operator rollout restart deploy/rhmi-operator
oc -n redhat-rhoam-operator get cm redis-memory-alerts -o jsonpath='{.data.alerts}'
#The edited JSON must still be present.
```

**NOTE** On OCP 4.20+ (Kubernetes 1.33+), many `*EndpointDown` alerts fire because `kube_endpoint_address` is no longer exported. 
That is unrelated to this PR (Redis memory alerts use CRO metrics). 
Fix will be done in follow-up Jira: replace with `kube_endpointslice_endpoints`.
.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable Redis memory alerts for high usage and predictive capacity warnings.
  * Redis alert thresholds, severities, durations, lookback windows, and prediction periods can now be customized.
  * Default alert settings are created automatically when no configuration exists.
* **Bug Fixes**
  * Existing customer-provided Redis alert settings are preserved during reconciliation.
  * Invalid or incomplete settings safely fall back to supported defaults.
  * Redis alerts are skipped when cluster storage is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->